### PR TITLE
Improve audio device switching (#44)

### DIFF
--- a/src/smacc/panels/audio.py
+++ b/src/smacc/panels/audio.py
@@ -105,9 +105,19 @@ class AudioCueWindow(ModalityWindow):
     def _build(self) -> QtWidgets.QWidget:
         # Shared device + fade controls.
         available_speakers_dropdown = QtWidgets.QComboBox()
-        available_speakers_dropdown.setStatusTip("Select audio stimulation device")
         available_speakers_dropdown.setPlaceholderText("No speaker devices were found.")
-        available_speakers_dropdown.currentTextChanged.connect(self.set_new_speakers)
+        # Qt5's QSoundEffect has no output-device selection, so this picker can't
+        # route cues. Disabled (but populated) until the playback engine is moved
+        # onto a backend that supports device selection; see the follow-up issue.
+        available_speakers_dropdown.setEnabled(False)
+        available_speakers_dropdown.setStatusTip(
+            "Device selection isn't supported for cues yet; they play on the system "
+            "default output."
+        )
+        available_speakers_dropdown.setToolTip(
+            "Qt5 can't route cue playback to a specific device; cues use the system "
+            "default output."
+        )
         self.available_speakers_dropdown = available_speakers_dropdown
         self.refresh_available_speakers()
 
@@ -173,10 +183,6 @@ class AudioCueWindow(ModalityWindow):
         return central
 
     # ----- shared device + fade ---------------------------------------------
-
-    def set_new_speakers(self, text: str) -> None:
-        """Handle a new audio-stimulation speaker selection."""
-        self.session.logger.debug(f"New speakers {text} selected!")
 
     def refresh_available_speakers(self):
         """Populate the device dropdown with available audio outputs."""

--- a/src/smacc/panels/intercom.py
+++ b/src/smacc/panels/intercom.py
@@ -39,6 +39,10 @@ class IntercomWindow(ModalityWindow):
         )
         self.intercom_output_dropdown = intercom_output_dropdown
         self.refresh_intercom_outputs()
+        # Switch a live intercom over to a newly selected output device.
+        intercom_output_dropdown.currentTextChanged.connect(
+            self._on_intercom_device_changed
+        )
 
         intercomButton = QtWidgets.QPushButton("Intercom (talk)", self)
         intercomButton.setStatusTip(
@@ -87,34 +91,7 @@ class IntercomWindow(ModalityWindow):
         """
         if enabled:
             output_device = self.intercom_output_dropdown.currentText() or None
-            try:
-                in_rate = int(sd.query_devices(kind="input")["default_samplerate"])
-                out_info = (
-                    sd.query_devices(output_device, "output")
-                    if output_device
-                    else sd.query_devices(kind="output")
-                )
-                out_rate = int(out_info["default_samplerate"])
-                self._intercom_queue = queue.Queue(maxsize=32)
-                self._intercom_resampler = audio.LinearResampler(in_rate, out_rate)
-                self.intercom_input_stream = sd.InputStream(
-                    samplerate=in_rate,
-                    channels=1,
-                    callback=self._intercom_in_callback,
-                )
-                self.intercom_output_stream = sd.OutputStream(
-                    samplerate=out_rate,
-                    channels=1,
-                    device=output_device,
-                    callback=self._intercom_out_callback,
-                )
-                self.intercom_input_stream.start()
-                self.intercom_output_stream.start()
-            except Exception as exc:  # PortAudio errors, no device, etc.
-                self._stop_intercom_streams()
-                self.session.show_error_popup(
-                    "Could not start intercom.", str(exc), parent=self
-                )
+            if not self._start_intercom_streams(output_device):
                 self.intercomButton.setChecked(False)
                 return
             self.session.send_event_marker(
@@ -124,6 +101,58 @@ class IntercomWindow(ModalityWindow):
             self.session.send_event_marker(
                 self.session.portcodes["IntercomStopped"], "Intercom remuted"
             )
+
+    def _start_intercom_streams(self, output_device: str | None) -> bool:
+        """Build and start the mic/output streams; return True on success.
+
+        On any PortAudio error (no device, busy, etc.) the partial streams are torn
+        down and an error popup is shown; the caller is responsible for resetting any
+        UI state (e.g. unchecking the talk button).
+        """
+        try:
+            in_rate = int(sd.query_devices(kind="input")["default_samplerate"])
+            out_info = (
+                sd.query_devices(output_device, "output")
+                if output_device
+                else sd.query_devices(kind="output")
+            )
+            out_rate = int(out_info["default_samplerate"])
+            self._intercom_queue = queue.Queue(maxsize=32)
+            self._intercom_resampler = audio.LinearResampler(in_rate, out_rate)
+            self.intercom_input_stream = sd.InputStream(
+                samplerate=in_rate,
+                channels=1,
+                callback=self._intercom_in_callback,
+            )
+            self.intercom_output_stream = sd.OutputStream(
+                samplerate=out_rate,
+                channels=1,
+                device=output_device,
+                callback=self._intercom_out_callback,
+            )
+            self.intercom_input_stream.start()
+            self.intercom_output_stream.start()
+        except Exception as exc:  # PortAudio errors, no device, etc.
+            self._stop_intercom_streams()
+            self.session.show_error_popup(
+                "Could not start intercom.", str(exc), parent=self
+            )
+            return False
+        return True
+
+    def _on_intercom_device_changed(self, _text: str) -> None:
+        """Switch a live intercom over to the newly selected output device.
+
+        Only a device swap, not a talk toggle, so the streams are quietly restarted
+        without emitting Intercom start/stop markers (that would corrupt the EEG
+        record). A no-op when the intercom isn't running, which also covers the
+        programmatic dropdown population in ``refresh_intercom_outputs``.
+        """
+        if not self._stop_intercom_streams():
+            return  # intercom not running; nothing to switch over
+        output_device = self.intercom_output_dropdown.currentText() or None
+        if not self._start_intercom_streams(output_device):
+            self.intercomButton.setChecked(False)
 
     def _stop_intercom_streams(self) -> bool:
         """Tear down both intercom streams; return True if any were running."""

--- a/src/smacc/panels/noise.py
+++ b/src/smacc/panels/noise.py
@@ -175,6 +175,7 @@ class NoiseWindow(ModalityWindow):
     def set_new_noisespeakers(self, text: str) -> None:
         """Text is the device name, with host api string appended to the end."""
         self.noiseplayer_device = text
+        self._restart_if_playing()  # switch a live stream over to the new device
 
     def refresh_available_noisespeakers(self):
         """Populate the noise device selection menu with available speakers."""

--- a/src/smacc/panels/recording.py
+++ b/src/smacc/panels/recording.py
@@ -102,21 +102,24 @@ class RecordingWindow(ModalityWindow):
         self.microphone = microphone
 
     def set_new_microphone(self, text: str) -> None:
-        """Handle a new microphone selection."""
-        self.session.logger.debug(f"New microphone {text} selected!")
+        """Apply the selected microphone to the recorder and live level meter."""
+        name = self.available_microphones_dropdown.currentData()
+        if name:
+            self.microphone.setAudioInput(name)
+        self._restart_meter_if_monitoring()  # switch a live meter over too
 
     def refresh_available_microphones(self):
-        """Populate the microphone dropdown with available audio input devices."""
+        """Populate the microphone dropdown with available audio input devices.
+
+        Items carry the raw input name (the value ``setAudioInput`` expects) as data
+        and show a friendlier description as text.
+        """
         self.available_microphones_dropdown.clear()
-        devices = QtMultimedia.QAudioDeviceInfo.availableDevices(
-            QtMultimedia.QAudio.AudioInput
-        )
-        for device in devices:
-            device_name = device.deviceName()
-            device_realm = device.realm()
-            device_str = f"{device_name} [{device_realm}]"
-            self.available_microphones_dropdown.addItem(device_str)
-        if devices:
+        names = self.microphone.audioInputs()
+        for name in names:
+            description = self.microphone.audioInputDescription(name) or name
+            self.available_microphones_dropdown.addItem(description, name)
+        if names:
             self.available_microphones_dropdown.setCurrentIndex(0)
         else:
             self.session.show_error_popup("No microphones found.", parent=self)
@@ -164,12 +167,43 @@ class RecordingWindow(ModalityWindow):
         self.meter_timer.setInterval(50)  # ~20 Hz display refresh
         self.meter_timer.timeout.connect(self.update_level_meter)
 
+    def _meter_device(self) -> int | None:
+        """Best-effort PortAudio index for the selected recorder input.
+
+        Qt and PortAudio name devices differently, so match the selected input name
+        against PortAudio input devices by substring; return ``None`` (the default
+        input) when there's no confident match.
+        """
+        name = self.available_microphones_dropdown.currentData()
+        if not name:
+            return None
+        try:
+            devices = sd.query_devices()
+        except Exception:
+            return None
+        name_low = name.lower()
+        for idx, dev in enumerate(devices):
+            dev_low = dev["name"].lower()
+            if dev["max_input_channels"] > 0 and (
+                name_low in dev_low or dev_low in name_low
+            ):
+                return idx
+        return None
+
+    def _restart_meter_if_monitoring(self) -> None:
+        """Re-open the level meter on the current device if it's running."""
+        if self.meter_stream is not None:
+            self.toggle_level_monitor(False)
+            self.toggle_level_monitor(True)
+
     def toggle_level_monitor(self, enabled: bool) -> None:
-        """Start/stop monitoring the default input device's level."""
+        """Start/stop monitoring the selected input device's level."""
         if enabled:
             try:
                 self.meter_stream = sd.InputStream(
-                    channels=1, callback=self._meter_callback
+                    channels=1,
+                    device=self._meter_device(),
+                    callback=self._meter_callback,
                 )
                 self.meter_stream.start()
             except Exception as exc:  # PortAudio errors, no device, etc.


### PR DESCRIPTION
Closes #44.

Switching an audio device while it was in use was silently ignored. Each panel now switches over live where its backend allows it.

## Changes
- **Noise machine** `src/smacc/panels/noise.py` — `set_new_noisespeakers()` calls the existing `_restart_if_playing()`, so a mid-play switch moves the stream to the new device.
- **Intercom** `src/smacc/panels/intercom.py` — extracted the stream-start logic into `_start_intercom_streams()`; the output dropdown is wired to `_on_intercom_device_changed()`, which restarts the streams on the new device **without** emitting `IntercomStarted`/`IntercomStopped` markers (a device swap isn't a talk-state change, and spurious markers would corrupt the EEG record). No-op when not talking.
- **Recording mic** `src/smacc/panels/recording.py` — the dropdown now populates from `QAudioRecorder.audioInputs()` (raw input name as item data, description as text) and `set_new_microphone()` applies `setAudioInput()`. The `sounddevice` level meter follows the selection best-effort via `_meter_device()` (substring name match against PortAudio inputs, default fallback) and restarts live if monitoring is on.
- **Audio cue** `src/smacc/panels/audio.py` — Qt5's `QSoundEffect` exposes no output-device selection API (verified on Qt 5.15.2), so the dropdown is disabled with an explanatory tooltip and cues play on the system default. Backend rewrite onto `sounddevice` deferred to #50.

## Notes
- The level-meter routing is the one best-effort piece: Qt and PortAudio name devices differently, so it matches by substring and falls back to the default input when there's no confident match.

## Verification
- `uv run ruff check .`, `uv run ruff format --check .`, `uv run mypy`, `uv run pytest` — all pass (57 tests).
- Manual GUI/device testing (live switch on Noise/Intercom, mic apply + meter, disabled cue dropdown) not yet run; the test suite has no GUI/device coverage.

🤖 Generated with Claude