### PR TITLE
Add a gui-script entry point for SMACC

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,13 +15,17 @@ instructions live here once rather than being duplicated across files.
 
 ```sh
 uv sync --extra dev        # create the environment with dev tools
-uv run python entry.py     # launch the app
+uv run python -m smacc     # launch the app
 uv run pytest              # run the test suite
 uv run ruff check .        # lint
 uv run ruff format .       # format
 uv run mypy                # type-check
 pre-commit install         # enable the lint/format/type-check git hooks
 ```
+
+`uv run smacc` also works once the environment is synced — it's the installed GUI
+launcher and opens no console window, so prefer `python -m smacc` when you want
+terminal output (e.g. tracebacks).
 
 ## Building the executable
 

--- a/entry.py
+++ b/entry.py
@@ -1,4 +1,8 @@
-# > pyinstaller entry.py --name SMACC --onefile --noconsole
+# PyInstaller bootstrap. The frozen build targets this file:
+#   > pyinstaller entry.py --name SMACC --onefile --noconsole
+# It must use an absolute import: PyInstaller runs its target as the top-level
+# __main__, where smacc/__main__.py's relative imports would fail. For normal runs
+# use `python -m smacc` or the `smacc` GUI script (see pyproject.toml).
 from smacc.__main__ import main
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "GPL-3.0-or-later" }
 authors = [{ name = "Remington Mallett", email = "mallett.remy@gmail.com" }]
 dynamic = ["version"]
 classifiers = [
-    "Environment :: Console",
+    "Environment :: Win32 (MS Windows)",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",
@@ -48,6 +48,11 @@ dev = [
     "PyQt5-stubs",
     "types-PyYAML",
 ]
+
+# A GUI launcher (no console window): exposes a `smacc` command after install.
+# `python -m smacc` runs the same main(); see src/smacc/__main__.py.
+[project.gui-scripts]
+smacc = "smacc.__main__:main"
 
 [project.urls]
 Homepage = "https://github.com/remrama/smacc"


### PR DESCRIPTION
Exposes a proper packaging entry point instead of running `python entry.py`.

- `[project.gui-scripts] smacc = "smacc.__main__:main"` — a no-console `smacc` command (correct for a Qt GUI app). `python -m smacc` runs the same `main()`.
- `entry.py` kept as the PyInstaller bootstrap (absolute import so its run-as-`__main__` doesn't break the package's relative imports); comment expanded to say so.
- Docs: launch via `uv run python -m smacc` (console-visible for tracebacks); `uv run smacc` noted as the no-console alternative.
- Fixed the stale `Environment :: Console` classifier → `Environment :: Win32 (MS Windows)`.

No runtime code changed; `python -m smacc` already worked via `__main__.py`.