### PR TITLE
Document BlinkStick and make it a core dependency

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -46,6 +46,12 @@ PyYAML (settings export/import) is pure Python and is picked up automatically by
 PyInstaller; if a frozen build ever fails to import `yaml`, add
 `--hidden-import yaml`.
 
+The `blinkstick` driver (BlinkStick visual cues) and its Windows backend
+`pywinusb` are pure Python and bundle the same way. PyInstaller may warn that
+`usb.core` is missing — that is BlinkStick's non-Windows backend, which SMACC
+never uses, so the warning is harmless. If a frozen build ever fails to import
+the driver, add `--hidden-import pywinusb`.
+
 Releases are built automatically: pushing a `v*` tag (e.g. `v0.0.7`) triggers the
 [release workflow](https://github.com/remrama/smacc/blob/main/.github/workflows/release.yaml),
 which builds `SMACC.exe` and attaches it to the GitHub Release.

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -1,0 +1,44 @@
+# Compatible devices
+
+SMACC can drive a small number of external devices for cueing. This page lists
+the supported hardware and what each one needs.
+
+## BlinkStick
+
+[BlinkStick](https://www.blinkstick.com/) is a USB-controlled RGB LED device.
+SMACC uses it for **visual cues** — lighting up a chosen color for a set duration
+— which is handy for light-based cueing in sleep and lucid-dreaming experiments.
+
+### What you need
+
+* **A BlinkStick device.** They are sold directly from
+  [blinkstick.com](https://www.blinkstick.com/). SMACC drives them through the
+  [`blinkstick`](https://pypi.org/project/BlinkStick/) Python library, so any
+  model that library supports (BlinkStick Square, Strip, Nano, Flex, …) will work.
+* **Nothing else to install.** The BlinkStick driver is bundled inside
+  `SMACC.exe`, so you only need to plug the device into a USB port before
+  launching SMACC.
+
+### Using it in SMACC
+
+1. Plug the BlinkStick into a USB port, then launch SMACC.
+2. Click **Visual stimulation** in the *Open tools* column.
+3. Select your device from the **Device** dropdown — connected BlinkSticks are
+   detected automatically when SMACC starts.
+4. Pick a **Color** and a **Length** (how long the light stays on, in seconds).
+5. Click **Play BlinkStick** to fire the cue.
+
+Your chosen color and length are saved in the study `.smacc` file (see
+[Usage › Study config](usage.md#study-config-smacc)), so the visual-cue setup
+travels with the rest of your configuration.
+
+!!! note
+    The device list is scanned once when SMACC starts. If SMACC reports that no
+    BlinkStick was found, connect it **before** launching SMACC (or restart SMACC
+    after plugging it in).
+
+## More devices
+
+Support for additional hardware is planned — for example a
+[Philips Hue](https://github.com/remrama/smacc/issues/53) bridge for ambient room
+lighting. This page will grow as devices are added.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ running sleep-related experiments.
 
 * [Installation](installation.md) — download and run SMACC.
 * [Usage](usage.md) — trigger cues, record dream reports, send portcodes, and more.
+* [Devices](devices.md) — connect compatible hardware such as a BlinkStick.
 * [Contributing](contributing.md) — develop SMACC and build these docs locally.
 
 SMACC is free software released under the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,4 +37,5 @@ nav:
   - Home: index.md
   - Installation: installation.md
   - Usage: usage.md
+  - Devices: devices.md
   - Contributing: contributing.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ classifiers = [
     "Intended Audience :: Science/Research",
 ]
 dependencies = [
+    # BlinkStick LED device (visual cues). Its backend, pywinusb, is Windows-only,
+    # so scope to win32 to keep the cross-platform lock resolving everywhere.
+    "blinkstick; sys_platform == 'win32'",
     "numpy",
     "pylsl",
     "pyyaml",
@@ -34,7 +37,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-visual = ["blinkstick"]
 docs = [
     "mkdocs-material",
     "mike",

--- a/src/smacc/panels/visual.py
+++ b/src/smacc/panels/visual.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
+from blinkstick import blinkstick
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 from ..session import SmaccSession
 from .base import ModalityWindow, make_section_title
-
-try:
-    from blinkstick import blinkstick
-except ImportError:
-    blinkstick = None
 
 
 class VisualWindow(ModalityWindow):
@@ -86,7 +82,7 @@ class VisualWindow(ModalityWindow):
         _ensure_blinkstick), so non-BlinkStick users aren't nagged at startup.
         """
         self.available_blinksticks_dropdown.clear()
-        devices = [] if blinkstick is None else blinkstick.find_all()
+        devices = blinkstick.find_all()
         for d in devices:
             product_name = d.device.product_name
             serial_number = d.device.serial_number
@@ -124,13 +120,12 @@ class VisualWindow(ModalityWindow):
         self.colorpickerButton.setIconSize(QtCore.QSize(size, size))
 
     def _ensure_blinkstick(self) -> bool:
-        """Return True if a BlinkStick is usable, else show one error popup."""
-        if blinkstick is not None and self.bstick is not None:
+        """Return True if a BlinkStick device is selected, else show one error popup."""
+        if self.bstick is not None:
             return True
         self.session.show_error_popup(
             "Visual stimulation unavailable.",
-            "No BlinkStick device was found and/or the `blinkstick` Python "
-            "package is not installed.",
+            "No BlinkStick device was found. Connect one and restart SMACC.",
             parent=self,
         )
         return False

--- a/uv.lock
+++ b/uv.lock
@@ -1153,6 +1153,7 @@ wheels = [
 name = "smacc"
 source = { editable = "." }
 dependencies = [
+    { name = "blinkstick", marker = "sys_platform == 'win32'" },
     { name = "numpy" },
     { name = "pylsl" },
     { name = "pyqt5" },
@@ -1177,13 +1178,10 @@ docs = [
     { name = "mike" },
     { name = "mkdocs-material" },
 ]
-visual = [
-    { name = "blinkstick" },
-]
 
 [package.metadata]
 requires-dist = [
-    { name = "blinkstick", marker = "extra == 'visual'" },
+    { name = "blinkstick", marker = "sys_platform == 'win32'" },
     { name = "mike", marker = "extra == 'docs'" },
     { name = "mkdocs-material", marker = "extra == 'docs'" },
     { name = "mypy", marker = "extra == 'dev'" },
@@ -1202,7 +1200,7 @@ requires-dist = [
     { name = "soundfile", specifier = ">=0.12" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
 ]
-provides-extras = ["visual", "docs", "dev"]
+provides-extras = ["docs", "dev"]
 
 [[package]]
 name = "sounddevice"


### PR DESCRIPTION
Closes #59 — adds a "Compatible devices" docs page for BlinkStick, and makes the BlinkStick driver a regular dependency so it ships in `SMACC.exe`.

## Docs
- New `docs/devices.md` ("Compatible devices"): what BlinkStick is, where to buy it, what's required, and how to use it in SMACC. Ends with a "More devices" section noting planned Philips Hue support (#53), so the page is ready to grow.
- Wired into the nav (`mkdocs.yml`) and linked from the home page.

## Dependency
- Moved `blinkstick` from the `visual` optional extra to a core dependency, scoped `; sys_platform == 'win32'` (its `pywinusb` backend is Windows-only). This always bundles it into the Windows build while keeping the cross-platform lock and the Linux `quality` CI job clean — same philosophy as the existing `PyQt5-Qt5` pin.
- Simplified `visual.py`: dropped the `try/except ImportError` import guard; the "no device" popup no longer mentions the package (now "No BlinkStick device was found. Connect one and restart SMACC.").
- Added a frozen-build note to `contributing.md` about `pywinusb` bundling (and the harmless `usb.core` warning).

## Verification
- `ruff check`, `ruff format --check`, `mypy`, and `pytest` (85 passed) all pass; `mkdocs build --strict` passes (all links resolve).
- Confirmed `blinkstick.find_all()` returns `[]` with no device attached (no crash) and `smacc.panels.visual` imports cleanly.
- **Not exe-tested:** the "bundled in `SMACC.exe`" claim relies on standard PyInstaller auto-detection of pure-Python `pywinusb`; `--hidden-import pywinusb` is documented as a fallback.