### PR TITLE
Configurable event/trigger codes: registry, editor, custom events (#47)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -49,12 +49,23 @@ can set:
 hardware only accepts a limited range (some older systems do). Codes must be unique
 among triggered events and within 1–255; the editor blocks anything else.
 
+**Custom events.** Use **Add event…** to create your own button events (a label and a
+code); they appear in the **Event logging** panel alongside the built-ins and can be
+removed again with **Remove**. Built-in events can be retuned but not removed or renamed.
+
 The editor stays available throughout a session. If you change a code mid-study, the
 change is written to the log with a timestamp, so the code-to-event mapping for that
 session is always recoverable.
 
 Beyond portcodes, SMACC logs the important interactions too — volume, color, device,
 and fade changes — as plain log lines (no portcode), so the session record is complete.
+
+### Event logging panel
+
+The manual event buttons (REM detected, Sleep onset, your custom events, …) live in the
+**Event logging** panel — open it from the launcher; the first nine buttons take the
+1–9 keyboard shortcuts while it's focused. The **Lights** toggle stays on the main
+window (it also flips the dark theme).
 
 ### Where codes live
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -38,12 +38,12 @@ can set:
 
 - **Code** — the 8-bit portcode (1–255) sent when the event triggers.
 - **Trigger** — whether the event is sent to the marker stream at all.
-- **Log** — whether the event is written to the session log. A *triggered* event is
-  always logged (so a sent marker is never untraceable), so this only matters for
-  events you don't trigger.
-- **Increment** — for **dream reports**, give each report a unique, increasing code
-  (201, 202, 203, …) so individual reports are findable in the trigger channel. Turn
-  it off to use one fixed code for every report.
+- **Preview** — whether the event shows in the live log viewer. The session log
+  *file* always records every event regardless; this only controls the on-screen
+  preview.
+- **Increment** — give an event a unique, increasing code on each firing (e.g. **dream
+  reports**: 201, 202, 203, …) so individual occurrences are findable in the trigger
+  channel. Off uses one fixed code each time.
 
 **Safe max code** raises a soft warning for codes above it — handy when your trigger
 hardware only accepts a limited range (some older systems do). Codes must be unique

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,8 +27,41 @@ survey on its own from **File &rsaquo; Surveys** (each open is logged as a
 
 ## EEG portcodes
 
-SMACC can trigger EEG portcodes to mark events in your recording, keeping cue
-delivery and your neural data in sync.
+SMACC marks experiment events — a cue played, a dream report, observed REM, the
+lights toggled — by sending a numeric **portcode** to its marker stream and writing a
+matching line to the session log, keeping cue delivery and your neural data in sync.
+
+### Configuring codes
+
+Open **File &rsaquo; Event codes…** to see every event in one table. For each event you
+can set:
+
+- **Code** — the 8-bit portcode (1–255) sent when the event triggers.
+- **Trigger** — whether the event is sent to the marker stream at all.
+- **Log** — whether the event is written to the session log. A *triggered* event is
+  always logged (so a sent marker is never untraceable), so this only matters for
+  events you don't trigger.
+- **Increment** — for **dream reports**, give each report a unique, increasing code
+  (201, 202, 203, …) so individual reports are findable in the trigger channel. Turn
+  it off to use one fixed code for every report.
+
+**Safe max code** raises a soft warning for codes above it — handy when your trigger
+hardware only accepts a limited range (some older systems do). Codes must be unique
+among triggered events and within 1–255; the editor blocks anything else.
+
+The editor stays available throughout a session. If you change a code mid-study, the
+change is written to the log with a timestamp, so the code-to-event mapping for that
+session is always recoverable.
+
+Beyond portcodes, SMACC logs the important interactions too — volume, color, device,
+and fade changes — as plain log lines (no portcode), so the session record is complete.
+
+### Where codes live
+
+Your codes are saved in the study `.smacc` file (so they travel with the study) and
+written into every session `.log` (both the initial and final settings blocks), so any
+session is self-documenting: you can decode its markers later even if the codes changed
+mid-study.
 
 ## Event log
 
@@ -38,8 +71,8 @@ Every run writes a detailed `.log` to its own timestamped folder under
 ## Study config (`.smacc`)
 
 A **study** captures your reusable setup — cue files, volumes, noise, BlinkStick
-color, survey presets — in a single portable `.smacc` file (plain YAML you can read
-and edit). Save it with **File &rsaquo; Export study (.smacc)…** and reload it with
+color, survey presets, event codes — in a single portable `.smacc` file (plain YAML you
+can read and edit). Save it with **File &rsaquo; Export study (.smacc)…** and reload it with
 **File &rsaquo; Load study (.smacc)…**. You can also pull the initial or final setup
 back out of a session `.log` with **File &rsaquo; Load study from log…**.
 

--- a/src/smacc/bids.py
+++ b/src/smacc/bids.py
@@ -91,7 +91,11 @@ def events_sidecar() -> dict[str, Any]:
             "Units": "second",
         },
         "trial_type": {"Description": "Event label as logged by SMACC."},
-        "value": {"Description": "SMACC portcode / LSL marker value."},
+        "value": {
+            "Description": "SMACC event-marker port code. The full code-to-event "
+            "map for the session is recorded in its .log settings block "
+            "(under event_codes)."
+        },
     }
 
 

--- a/src/smacc/config.py
+++ b/src/smacc/config.py
@@ -11,48 +11,6 @@ DEFAULT_VOLUME = 0.5
 # Maps a display label to its URL. Extend per study (persisted in settings YAML).
 SURVEY_OPTIONS: dict[str, str] = {}
 
+# Legacy parallel-port address, kept for the future hardware-trigger path (#28).
+# Event-marker codes now live in smacc.events as a configurable registry.
 PPORT_ADDRESS = "0x3FD8"
-PPORT_CODES = {
-    "TriggerInitialization": 200,
-    "Note": 201,
-    "LightsOff": 202,
-    "LightsOn": 203,
-    "DreamReportStarted": 204,
-    "DreamReportStopped": 205,
-    "NoiseStarted": 206,
-    "NoiseStopped": 207,
-    "CueStopped": 208,
-    "IntercomStarted": 209,
-    "IntercomStopped": 210,
-    "CueStarted": 211,
-    "SurveyOpened": 212,
-}
-
-# LSL event-marker codes, looked up by name in send_event_marker.
-COMMON_EVENT_CODES = {
-    "REM detected": 41,
-    "Tech in room": 42,
-    "TLR training start": 43,
-    "TLR training end": 44,
-    "LRLR detected": 45,
-    "Sleep onset": 46,
-    "Lights off": 47,
-    "Lights on": 48,
-    "Clapper": 49,
-}
-
-# Event names shown as buttons in the event-logging grid, mapped to tooltips.
-COMMON_EVENT_TIPS = {
-    # "Lights off"/"Lights on" are intentionally omitted here: they are driven
-    # by the dedicated lightswitch toggle (which also flips the dark theme), not
-    # by the auto-generated event-marker grid. Their codes remain in
-    # COMMON_EVENT_CODES so send_event_marker still resolves them.
-    "TLR training start": "Mark the start of Targeted Lucidity Reactivation training",
-    "TLR training end": "Mark the end of Targeted Lucidity Reactivation training",
-    "Tech in room": "Mark the entry of an experimenter/technician in the participant bedroom",
-    "Sleep onset": "Mark observed sleep onset",
-    "REM detected": "Mark observed REM",
-    "LRLR detected": "Mark an observed left-right-left-right lucid signal",
-    "Clapper": "Synchronize a marker with EEG",
-    "Note": "Mark a note and enter free text",
-}

--- a/src/smacc/dialogs.py
+++ b/src/smacc/dialogs.py
@@ -191,15 +191,61 @@ class ManageSurveysDialog(QtWidgets.QDialog):
         return options
 
 
-class EventCodesDialog(QtWidgets.QDialog):
-    """View and edit the event-marker registry: codes and per-event routing.
+class AddEventDialog(QtWidgets.QDialog):
+    """Define a new custom event button: a label, a port code, and options."""
 
-    One row per event shows its (editable) port code plus two independent
-    checkboxes — Trigger (send to the marker stream) and Preview (show in the live
-    log viewer) — and an Increment toggle (advance the code on each firing). The
-    log *file* always records every event regardless of Preview. Codes are unique
-    8-bit values (1-255); a soft "safe max" flags values older trigger hardware may
-    not accept.
+    def __init__(self, default_code: int, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Add event")
+        self.setWindowFlags(self.windowFlags() ^ QtCore.Qt.WindowContextHelpButtonHint)
+        self.labelEdit = QtWidgets.QLineEdit(self)
+        self.labelEdit.setPlaceholderText("e.g. Spontaneous arousal")
+        self.codeSpin = QtWidgets.QSpinBox(self)
+        self.codeSpin.setRange(events.CODE_MIN, events.CODE_MAX)
+        self.codeSpin.setValue(default_code)
+        self.tooltipEdit = QtWidgets.QLineEdit(self)
+        self.tooltipEdit.setPlaceholderText("Optional status-bar hint")
+        self.incrementBox = QtWidgets.QCheckBox(
+            "Increment the code on each press", self
+        )
+        buttonBox = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel, self
+        )
+        buttonBox.accepted.connect(self._on_accept)
+        buttonBox.rejected.connect(self.reject)
+        form = QtWidgets.QFormLayout(self)
+        form.addRow("Label", self.labelEdit)
+        form.addRow("Code", self.codeSpin)
+        form.addRow("Tooltip", self.tooltipEdit)
+        form.addRow("", self.incrementBox)
+        form.addWidget(buttonBox)
+
+    def _on_accept(self) -> None:
+        if not self.labelEdit.text().strip():
+            QtWidgets.QMessageBox.warning(self, "Add event", "Please enter a label.")
+            return
+        self.accept()
+
+    def get_inputs(self) -> tuple[str, int, str, bool]:
+        """Return ``(label, code, tooltip, increment)``."""
+        return (
+            self.labelEdit.text().strip(),
+            self.codeSpin.value(),
+            self.tooltipEdit.text().strip(),
+            self.incrementBox.isChecked(),
+        )
+
+
+class EventCodesDialog(QtWidgets.QDialog):
+    """View and edit the event-marker registry: codes, routing, and custom events.
+
+    One row per event shows its port code plus independent Trigger (send to the
+    marker stream) and Preview (show in the live log viewer) checkboxes, and an
+    Increment toggle (advance the code on each firing). The log *file* always
+    records every event regardless of Preview. Built-in events can be retuned but
+    not removed or renamed; custom events (added here) have an editable label, can
+    be removed, and appear as buttons in the Event logging panel. Codes are unique
+    8-bit values (1-255); a soft "safe max" flags values older hardware may reject.
 
     The dialog edits copies; the caller reads :meth:`get_events` /
     :meth:`get_safe_max` only when the dialog is accepted.
@@ -209,10 +255,10 @@ class EventCodesDialog(QtWidgets.QDialog):
         super().__init__(parent)
         self.setWindowTitle("Event codes")
         self.setWindowFlags(self.windowFlags() ^ QtCore.Qt.WindowContextHelpButtonHint)
-        self.resize(560, 540)
+        self.resize(600, 560)
         self._events = [replace(e) for e in event_list]  # working copies
 
-        self.table = QtWidgets.QTableWidget(len(self._events), 5, self)
+        self.table = QtWidgets.QTableWidget(0, 5, self)
         self.table.setHorizontalHeaderLabels(
             ["Event", "Code", "Trigger", "Preview", "Increment"]
         )
@@ -228,40 +274,24 @@ class EventCodesDialog(QtWidgets.QDialog):
             if header_item is not None:
                 header_item.setToolTip(tip)
         self.table.verticalHeader().setVisible(False)
-        self.table.setSelectionMode(QtWidgets.QAbstractItemView.NoSelection)
+        self.table.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
+        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
         self.table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
-
-        self._code_spins: list[QtWidgets.QSpinBox] = []
-        self._trigger_boxes: list[QtWidgets.QCheckBox] = []
-        self._preview_boxes: list[QtWidgets.QCheckBox] = []
-        self._increment_boxes: list[QtWidgets.QCheckBox] = []
-        for row, event in enumerate(self._events):
-            label_item = QtWidgets.QTableWidgetItem(event.label)
-            label_item.setFlags(label_item.flags() & ~QtCore.Qt.ItemIsEditable)
-            if event.tooltip:
-                label_item.setToolTip(event.tooltip)
-            self.table.setItem(row, 0, label_item)
-
-            code_spin = QtWidgets.QSpinBox(self)
-            code_spin.setRange(events.CODE_MIN, events.CODE_MAX)
-            code_spin.setValue(event.code)
-            self.table.setCellWidget(row, 1, code_spin)
-            self._code_spins.append(code_spin)
-
-            trig_cell, trig_box = self._checkbox_cell(event.trigger)
-            preview_cell, preview_box = self._checkbox_cell(event.preview)
-            inc_cell, inc_box = self._checkbox_cell(event.increment)
-            self.table.setCellWidget(row, 2, trig_cell)
-            self.table.setCellWidget(row, 3, preview_cell)
-            self.table.setCellWidget(row, 4, inc_cell)
-            self._trigger_boxes.append(trig_box)
-            self._preview_boxes.append(preview_box)
-            self._increment_boxes.append(inc_box)
-
         header = self.table.horizontalHeader()
         header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
         for col in range(1, 5):
             header.setSectionResizeMode(col, QtWidgets.QHeaderView.ResizeToContents)
+
+        addButton = QtWidgets.QPushButton("Add event…", self)
+        addButton.setStatusTip("Add a custom event button.")
+        addButton.clicked.connect(self._add_event)
+        self.removeButton = QtWidgets.QPushButton("Remove", self)
+        self.removeButton.setStatusTip("Remove the selected custom event.")
+        self.removeButton.clicked.connect(self._remove_selected)
+        addRemoveRow = QtWidgets.QHBoxLayout()
+        addRemoveRow.addWidget(addButton)
+        addRemoveRow.addWidget(self.removeButton)
+        addRemoveRow.addStretch(1)
 
         self.safeMaxSpin = QtWidgets.QSpinBox(self)
         self.safeMaxSpin.setRange(events.CODE_MIN, events.CODE_MAX)
@@ -289,8 +319,67 @@ class EventCodesDialog(QtWidgets.QDialog):
         layout = QtWidgets.QVBoxLayout(self)
         layout.addWidget(hint)
         layout.addWidget(self.table, 1)
+        layout.addLayout(addRemoveRow)
         layout.addLayout(safeRow)
         layout.addWidget(buttonBox)
+
+        self._populate()
+
+    # ----- table build / sync ------------------------------------------------
+
+    def _populate(self) -> None:
+        """(Re)build the table rows from ``self._events`` (called after add/remove)."""
+        self._code_spins: list[QtWidgets.QSpinBox] = []
+        self._trigger_boxes: list[QtWidgets.QCheckBox] = []
+        self._preview_boxes: list[QtWidgets.QCheckBox] = []
+        self._increment_boxes: list[QtWidgets.QCheckBox] = []
+        self._label_edits: list[QtWidgets.QLineEdit | None] = []
+        self.table.setRowCount(len(self._events))
+        for row, event in enumerate(self._events):
+            if event.builtin:
+                label_item = QtWidgets.QTableWidgetItem(event.label)
+                label_item.setFlags(label_item.flags() & ~QtCore.Qt.ItemIsEditable)
+                if event.tooltip:
+                    label_item.setToolTip(event.tooltip)
+                self.table.setItem(row, 0, label_item)
+                self._label_edits.append(None)
+            else:
+                label_edit = QtWidgets.QLineEdit(event.label, self)
+                label_edit.setPlaceholderText("Custom event label")
+                self.table.setCellWidget(row, 0, label_edit)
+                self._label_edits.append(label_edit)
+
+            code_spin = QtWidgets.QSpinBox(self)
+            code_spin.setRange(events.CODE_MIN, events.CODE_MAX)
+            code_spin.setValue(event.code)
+            self.table.setCellWidget(row, 1, code_spin)
+            self._code_spins.append(code_spin)
+
+            trig_cell, trig_box = self._checkbox_cell(event.trigger)
+            preview_cell, preview_box = self._checkbox_cell(event.preview)
+            inc_cell, inc_box = self._checkbox_cell(event.increment)
+            self.table.setCellWidget(row, 2, trig_cell)
+            self.table.setCellWidget(row, 3, preview_cell)
+            self.table.setCellWidget(row, 4, inc_cell)
+            self._trigger_boxes.append(trig_box)
+            self._preview_boxes.append(preview_box)
+            self._increment_boxes.append(inc_box)
+
+    def _sync(self) -> None:
+        """Read widget values back into ``self._events`` before add/remove/accept."""
+        for i, event in enumerate(self._events):
+            label = event.label
+            edit = self._label_edits[i]
+            if edit is not None:
+                label = edit.text().strip() or event.label
+            self._events[i] = replace(
+                event,
+                label=label,
+                code=self._code_spins[i].value(),
+                trigger=self._trigger_boxes[i].isChecked(),
+                preview=self._preview_boxes[i].isChecked(),
+                increment=self._increment_boxes[i].isChecked(),
+            )
 
     @staticmethod
     def _checkbox_cell(checked: bool):
@@ -304,27 +393,49 @@ class EventCodesDialog(QtWidgets.QDialog):
         lay.setContentsMargins(0, 0, 0, 0)
         return container, box
 
+    # ----- add / remove ------------------------------------------------------
+
+    def _suggested_code(self) -> int:
+        """A free-ish default code for a new event (one past the current max)."""
+        used = [e.code for e in self._events if isinstance(e.code, int)]
+        return min((max(used) + 1) if used else events.CODE_MIN, events.CODE_MAX)
+
+    def _add_event(self) -> None:
+        self._sync()
+        dialog = AddEventDialog(self._suggested_code(), parent=self)
+        if not dialog.exec():
+            return
+        label, code, tooltip, increment = dialog.get_inputs()
+        event = events.make_custom_event(
+            label,
+            code,
+            [e.key for e in self._events],
+            tooltip=tooltip,
+            increment=increment,
+        )
+        self._events.append(event)
+        self._populate()
+        self.table.selectRow(len(self._events) - 1)
+
+    def _remove_selected(self) -> None:
+        row = self.table.currentRow()
+        if row < 0:
+            return
+        self._sync()
+        if self._events[row].builtin:
+            QtWidgets.QMessageBox.information(
+                self, "Event codes", "Built-in events can't be removed."
+            )
+            return
+        del self._events[row]
+        self._populate()
+
+    # ----- result ------------------------------------------------------------
+
     def get_events(self) -> list:
         """Return the edits as new EventDef objects (the originals are untouched)."""
-        out = []
-        for event, code_spin, trig, preview, inc in zip(
-            self._events,
-            self._code_spins,
-            self._trigger_boxes,
-            self._preview_boxes,
-            self._increment_boxes,
-            strict=True,
-        ):
-            out.append(
-                replace(
-                    event,
-                    code=code_spin.value(),
-                    trigger=trig.isChecked(),
-                    preview=preview.isChecked(),
-                    increment=inc.isChecked(),
-                )
-            )
-        return out
+        self._sync()
+        return [replace(e) for e in self._events]
 
     def get_safe_max(self) -> int:
         """Return the chosen soft maximum code."""

--- a/src/smacc/dialogs.py
+++ b/src/smacc/dialogs.py
@@ -1,7 +1,11 @@
 """Dialogs shown by SMACC outside the main window."""
 
+from dataclasses import replace
+from functools import partial
+
 from PyQt5 import QtCore, QtGui, QtWidgets
 
+from . import events
 from .utils import normalize_survey_url
 
 
@@ -186,3 +190,162 @@ class ManageSurveysDialog(QtWidgets.QDialog):
             name, url = item.data(QtCore.Qt.UserRole)
             options[name] = url
         return options
+
+
+class EventCodesDialog(QtWidgets.QDialog):
+    """View and edit the event-marker registry: codes and per-event routing.
+
+    One row per event shows its (editable) port code plus two checkboxes —
+    Trigger (send to the marker stream) and Log (write to the session log) — and
+    an Increment toggle for events that support it (the dream-report start). A
+    triggered event is always logged, so Log is forced on and disabled while
+    Trigger is checked. Codes are unique 8-bit values (1-255); a soft "safe max"
+    flags values that older trigger hardware may not accept.
+
+    The dialog edits copies; the caller reads :meth:`get_events` /
+    :meth:`get_safe_max` only when the dialog is accepted.
+    """
+
+    def __init__(self, event_list, safe_max: int, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Event codes")
+        self.setWindowFlags(self.windowFlags() ^ QtCore.Qt.WindowContextHelpButtonHint)
+        self.resize(560, 540)
+        self._events = [replace(e) for e in event_list]  # working copies
+
+        self.table = QtWidgets.QTableWidget(len(self._events), 5, self)
+        self.table.setHorizontalHeaderLabels(
+            ["Event", "Code", "Trigger", "Log", "Increment"]
+        )
+        self.table.verticalHeader().setVisible(False)
+        self.table.setSelectionMode(QtWidgets.QAbstractItemView.NoSelection)
+        self.table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+
+        self._code_spins: list[QtWidgets.QSpinBox] = []
+        self._trigger_boxes: list[QtWidgets.QCheckBox] = []
+        self._log_boxes: list[QtWidgets.QCheckBox] = []
+        self._increment_boxes: list[QtWidgets.QCheckBox] = []
+        for row, event in enumerate(self._events):
+            label_item = QtWidgets.QTableWidgetItem(event.label)
+            label_item.setFlags(label_item.flags() & ~QtCore.Qt.ItemIsEditable)
+            if event.tooltip:
+                label_item.setToolTip(event.tooltip)
+            self.table.setItem(row, 0, label_item)
+
+            code_spin = QtWidgets.QSpinBox(self)
+            code_spin.setRange(events.CODE_MIN, events.CODE_MAX)
+            code_spin.setValue(event.code)
+            self.table.setCellWidget(row, 1, code_spin)
+            self._code_spins.append(code_spin)
+
+            trig_cell, trig_box = self._checkbox_cell(event.trigger)
+            log_cell, log_box = self._checkbox_cell(event.log)
+            inc_cell, inc_box = self._checkbox_cell(event.increment)
+            inc_box.setEnabled(event.key in events.INCREMENTABLE_KEYS)
+            self.table.setCellWidget(row, 2, trig_cell)
+            self.table.setCellWidget(row, 3, log_cell)
+            self.table.setCellWidget(row, 4, inc_cell)
+            self._trigger_boxes.append(trig_box)
+            self._log_boxes.append(log_box)
+            self._increment_boxes.append(inc_box)
+            # A triggered event is always logged (keep markers traceable).
+            trig_box.toggled.connect(partial(self._sync_log_enabled, log_box))
+            self._sync_log_enabled(log_box, trig_box.isChecked())
+
+        header = self.table.horizontalHeader()
+        header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        for col in range(1, 5):
+            header.setSectionResizeMode(col, QtWidgets.QHeaderView.ResizeToContents)
+
+        self.safeMaxSpin = QtWidgets.QSpinBox(self)
+        self.safeMaxSpin.setRange(events.CODE_MIN, events.CODE_MAX)
+        self.safeMaxSpin.setValue(int(safe_max))
+        self.safeMaxSpin.setStatusTip(
+            "Codes above this raise a soft warning (some older trigger hardware "
+            "accepts only a limited range)."
+        )
+        safeRow = QtWidgets.QHBoxLayout()
+        safeRow.addWidget(QtWidgets.QLabel("Safe max code:"))
+        safeRow.addWidget(self.safeMaxSpin)
+        safeRow.addStretch(1)
+
+        buttonBox = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel, self
+        )
+        buttonBox.accepted.connect(self._on_accept)
+        buttonBox.rejected.connect(self.reject)
+
+        hint = QtWidgets.QLabel(
+            "Codes are 8-bit (1-255) and must be unique among triggered events. "
+            "A triggered event is always logged."
+        )
+        hint.setWordWrap(True)
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(hint)
+        layout.addWidget(self.table, 1)
+        layout.addLayout(safeRow)
+        layout.addWidget(buttonBox)
+
+    @staticmethod
+    def _checkbox_cell(checked: bool):
+        """Return a ``(container, checkbox)`` with the box centered in its cell."""
+        container = QtWidgets.QWidget()
+        box = QtWidgets.QCheckBox(container)
+        box.setChecked(checked)
+        lay = QtWidgets.QHBoxLayout(container)
+        lay.addWidget(box)
+        lay.setAlignment(QtCore.Qt.AlignCenter)
+        lay.setContentsMargins(0, 0, 0, 0)
+        return container, box
+
+    @staticmethod
+    def _sync_log_enabled(log_box: QtWidgets.QCheckBox, triggered: bool) -> None:
+        """Force Log on+disabled while Trigger is checked; free it otherwise."""
+        if triggered:
+            log_box.setChecked(True)
+            log_box.setEnabled(False)
+        else:
+            log_box.setEnabled(True)
+
+    def get_events(self) -> list:
+        """Return the edits as new EventDef objects (the originals are untouched)."""
+        out = []
+        for event, code_spin, trig, log, inc in zip(
+            self._events,
+            self._code_spins,
+            self._trigger_boxes,
+            self._log_boxes,
+            self._increment_boxes,
+            strict=True,
+        ):
+            out.append(
+                replace(
+                    event,
+                    code=code_spin.value(),
+                    trigger=trig.isChecked(),
+                    log=log.isChecked(),
+                    increment=inc.isChecked(),
+                )
+            )
+        return out
+
+    def get_safe_max(self) -> int:
+        """Return the chosen soft maximum code."""
+        return self.safeMaxSpin.value()
+
+    def _on_accept(self) -> None:
+        """Validate before accepting: block on hard errors, confirm soft warnings."""
+        candidate = self.get_events()
+        errors, warnings = events.validate_events(candidate, self.get_safe_max())
+        if errors:
+            QtWidgets.QMessageBox.warning(
+                self, "Event codes", "Please fix these first:\n\n" + "\n".join(errors)
+            )
+            return
+        if warnings:
+            reply = QtWidgets.QMessageBox.question(
+                self, "Event codes", "Save anyway?\n\n" + "\n".join(warnings)
+            )
+            if reply != QtWidgets.QMessageBox.Yes:
+                return
+        self.accept()

--- a/src/smacc/dialogs.py
+++ b/src/smacc/dialogs.py
@@ -1,7 +1,6 @@
 """Dialogs shown by SMACC outside the main window."""
 
 from dataclasses import replace
-from functools import partial
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
@@ -195,12 +194,12 @@ class ManageSurveysDialog(QtWidgets.QDialog):
 class EventCodesDialog(QtWidgets.QDialog):
     """View and edit the event-marker registry: codes and per-event routing.
 
-    One row per event shows its (editable) port code plus two checkboxes —
-    Trigger (send to the marker stream) and Log (write to the session log) — and
-    an Increment toggle for events that support it (the dream-report start). A
-    triggered event is always logged, so Log is forced on and disabled while
-    Trigger is checked. Codes are unique 8-bit values (1-255); a soft "safe max"
-    flags values that older trigger hardware may not accept.
+    One row per event shows its (editable) port code plus two independent
+    checkboxes — Trigger (send to the marker stream) and Preview (show in the live
+    log viewer) — and an Increment toggle (advance the code on each firing). The
+    log *file* always records every event regardless of Preview. Codes are unique
+    8-bit values (1-255); a soft "safe max" flags values older trigger hardware may
+    not accept.
 
     The dialog edits copies; the caller reads :meth:`get_events` /
     :meth:`get_safe_max` only when the dialog is accepted.
@@ -215,15 +214,26 @@ class EventCodesDialog(QtWidgets.QDialog):
 
         self.table = QtWidgets.QTableWidget(len(self._events), 5, self)
         self.table.setHorizontalHeaderLabels(
-            ["Event", "Code", "Trigger", "Log", "Increment"]
+            ["Event", "Code", "Trigger", "Preview", "Increment"]
         )
+        for col, tip in (
+            (2, "Send this event's code to the marker stream (EEG)."),
+            (
+                3,
+                "Show this event in the live log viewer (the log file always records it).",
+            ),
+            (4, "Advance the code on each firing (e.g. dream reports: 201, 202, …)."),
+        ):
+            header_item = self.table.horizontalHeaderItem(col)
+            if header_item is not None:
+                header_item.setToolTip(tip)
         self.table.verticalHeader().setVisible(False)
         self.table.setSelectionMode(QtWidgets.QAbstractItemView.NoSelection)
         self.table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
 
         self._code_spins: list[QtWidgets.QSpinBox] = []
         self._trigger_boxes: list[QtWidgets.QCheckBox] = []
-        self._log_boxes: list[QtWidgets.QCheckBox] = []
+        self._preview_boxes: list[QtWidgets.QCheckBox] = []
         self._increment_boxes: list[QtWidgets.QCheckBox] = []
         for row, event in enumerate(self._events):
             label_item = QtWidgets.QTableWidgetItem(event.label)
@@ -239,18 +249,14 @@ class EventCodesDialog(QtWidgets.QDialog):
             self._code_spins.append(code_spin)
 
             trig_cell, trig_box = self._checkbox_cell(event.trigger)
-            log_cell, log_box = self._checkbox_cell(event.log)
+            preview_cell, preview_box = self._checkbox_cell(event.preview)
             inc_cell, inc_box = self._checkbox_cell(event.increment)
-            inc_box.setEnabled(event.key in events.INCREMENTABLE_KEYS)
             self.table.setCellWidget(row, 2, trig_cell)
-            self.table.setCellWidget(row, 3, log_cell)
+            self.table.setCellWidget(row, 3, preview_cell)
             self.table.setCellWidget(row, 4, inc_cell)
             self._trigger_boxes.append(trig_box)
-            self._log_boxes.append(log_box)
+            self._preview_boxes.append(preview_box)
             self._increment_boxes.append(inc_box)
-            # A triggered event is always logged (keep markers traceable).
-            trig_box.toggled.connect(partial(self._sync_log_enabled, log_box))
-            self._sync_log_enabled(log_box, trig_box.isChecked())
 
         header = self.table.horizontalHeader()
         header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
@@ -277,7 +283,7 @@ class EventCodesDialog(QtWidgets.QDialog):
 
         hint = QtWidgets.QLabel(
             "Codes are 8-bit (1-255) and must be unique among triggered events. "
-            "A triggered event is always logged."
+            "The log file records every event; Preview only controls the live viewer."
         )
         hint.setWordWrap(True)
         layout = QtWidgets.QVBoxLayout(self)
@@ -298,23 +304,14 @@ class EventCodesDialog(QtWidgets.QDialog):
         lay.setContentsMargins(0, 0, 0, 0)
         return container, box
 
-    @staticmethod
-    def _sync_log_enabled(log_box: QtWidgets.QCheckBox, triggered: bool) -> None:
-        """Force Log on+disabled while Trigger is checked; free it otherwise."""
-        if triggered:
-            log_box.setChecked(True)
-            log_box.setEnabled(False)
-        else:
-            log_box.setEnabled(True)
-
     def get_events(self) -> list:
         """Return the edits as new EventDef objects (the originals are untouched)."""
         out = []
-        for event, code_spin, trig, log, inc in zip(
+        for event, code_spin, trig, preview, inc in zip(
             self._events,
             self._code_spins,
             self._trigger_boxes,
-            self._log_boxes,
+            self._preview_boxes,
             self._increment_boxes,
             strict=True,
         ):
@@ -323,7 +320,7 @@ class EventCodesDialog(QtWidgets.QDialog):
                     event,
                     code=code_spin.value(),
                     trigger=trig.isChecked(),
-                    log=log.isChecked(),
+                    preview=preview.isChecked(),
                     increment=inc.isChecked(),
                 )
             )

--- a/src/smacc/events.py
+++ b/src/smacc/events.py
@@ -10,14 +10,14 @@ Each :class:`EventDef` carries:
 
 * ``code`` — the 8-bit portcode (``1..255``) sent on a trigger.
 * ``trigger`` — whether to push the code to the marker stream.
-* ``log`` — whether to write a log line. A *triggered* event is always logged (a
-  sent marker must stay traceable), so this flag only matters when ``trigger`` is
-  off.
+* ``preview`` — whether the event shows in the live log preview. Everything is
+  written to the session log file regardless; this flag only gates the on-screen
+  viewer.
 * ``category`` — ``"manual"`` (the auto-built event-grid buttons), ``"control"``
   (panel/lightswitch driven), or ``"system"`` (startup/init; not shown in the grid).
-* ``increment`` — when set (the dream-report start), successive firings use an
-  increasing code (``code``, ``code + 1``, …) so each report is individually
-  findable in the trigger channel.
+* ``increment`` — when set, successive firings use an increasing code (``code``,
+  ``code + 1``, …) so each occurrence is individually findable in the trigger
+  channel (e.g. the dream-report start).
 
 Pure data and helpers, no Qt — directly unit-testable.
 """
@@ -34,10 +34,6 @@ CODE_MAX = 255
 # Default soft ceiling; a study can lower it to match older trigger hardware.
 DEFAULT_SAFE_MAX = 255
 
-# Only these events meaningfully take an ``ordinal`` at emit time, so only they
-# expose the "increment" toggle in the editor.
-INCREMENTABLE_KEYS = frozenset({"DreamReportStarted"})
-
 
 @dataclass
 class EventDef:
@@ -47,7 +43,7 @@ class EventDef:
     label: str
     code: int
     trigger: bool = True
-    log: bool = True
+    preview: bool = True
     category: str = "control"
     tooltip: str = ""
     increment: bool = False
@@ -55,7 +51,7 @@ class EventDef:
 
 # The fields a study may override (keyed by ``key``); labels/tooltips/categories
 # stay app-defined so improvements to them reach old studies on load.
-_PERSIST_FIELDS = ("key", "code", "trigger", "log", "increment")
+_PERSIST_FIELDS = ("key", "code", "trigger", "preview", "increment")
 _FIELD_NAMES = {f.name for f in fields(EventDef)}
 
 
@@ -141,7 +137,7 @@ def default_events() -> list[EventDef]:
             "SMACC initialized",
             100,
             trigger=False,
-            log=False,
+            preview=False,
             category="system",
             tooltip="Optional connection-test marker sent once at startup",
         ),
@@ -186,7 +182,7 @@ def merge_event_codes(loaded: Any) -> list[EventDef]:
                         value = int(value)
                     except (TypeError, ValueError):
                         continue
-                elif name in ("trigger", "log", "increment"):
+                elif name in ("trigger", "preview", "increment"):
                     value = bool(value)
                 overrides[name] = value
             defaults[key] = replace(defaults[key], **overrides)

--- a/src/smacc/events.py
+++ b/src/smacc/events.py
@@ -1,0 +1,258 @@
+"""The configurable event-marker registry: codes, labels, and per-event routing.
+
+SMACC marks experiment events (a cue played, a dream report, observed REM, …) by
+pushing a numeric *portcode* to its marker stream and writing a matching log line.
+Those codes used to live as hardcoded dicts in :mod:`smacc.config`; this module
+makes them a single editable registry a study can tune, persist in its ``.smacc``
+file, and recover from any session log.
+
+Each :class:`EventDef` carries:
+
+* ``code`` — the 8-bit portcode (``1..255``) sent on a trigger.
+* ``trigger`` — whether to push the code to the marker stream.
+* ``log`` — whether to write a log line. A *triggered* event is always logged (a
+  sent marker must stay traceable), so this flag only matters when ``trigger`` is
+  off.
+* ``category`` — ``"manual"`` (the auto-built event-grid buttons), ``"control"``
+  (panel/lightswitch driven), or ``"system"`` (startup/init; not shown in the grid).
+* ``increment`` — when set (the dream-report start), successive firings use an
+  increasing code (``code``, ``code + 1``, …) so each report is individually
+  findable in the trigger channel.
+
+Pure data and helpers, no Qt — directly unit-testable.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, fields, replace
+from typing import Any
+
+# 8-bit parallel/serial trigger byte: the universally safe portcode range.
+CODE_MIN = 1
+CODE_MAX = 255
+# Default soft ceiling; a study can lower it to match older trigger hardware.
+DEFAULT_SAFE_MAX = 255
+
+# Only these events meaningfully take an ``ordinal`` at emit time, so only they
+# expose the "increment" toggle in the editor.
+INCREMENTABLE_KEYS = frozenset({"DreamReportStarted"})
+
+
+@dataclass
+class EventDef:
+    """One marker event: its code, label, routing flags, and category."""
+
+    key: str
+    label: str
+    code: int
+    trigger: bool = True
+    log: bool = True
+    category: str = "control"
+    tooltip: str = ""
+    increment: bool = False
+
+
+# The fields a study may override (keyed by ``key``); labels/tooltips/categories
+# stay app-defined so improvements to them reach old studies on load.
+_PERSIST_FIELDS = ("key", "code", "trigger", "log", "increment")
+_FIELD_NAMES = {f.name for f in fields(EventDef)}
+
+
+def default_events() -> list[EventDef]:
+    """Return a fresh copy of the built-in event definitions (safe to mutate).
+
+    Dream-report *starts* occupy a reserved 201+ band (they increment), so the
+    other control codes sit in a compact low band that leaves that band clear.
+    """
+    return [
+        # --- Manual / observational: the auto-built event-grid buttons --------
+        EventDef(
+            "TLRTrainingStart",
+            "TLR training start",
+            43,
+            category="manual",
+            tooltip="Mark the start of Targeted Lucidity Reactivation training",
+        ),
+        EventDef(
+            "TLRTrainingEnd",
+            "TLR training end",
+            44,
+            category="manual",
+            tooltip="Mark the end of Targeted Lucidity Reactivation training",
+        ),
+        EventDef(
+            "TechInRoom",
+            "Tech in room",
+            42,
+            category="manual",
+            tooltip="Mark the entry of an experimenter/technician in the bedroom",
+        ),
+        EventDef(
+            "SleepOnset",
+            "Sleep onset",
+            46,
+            category="manual",
+            tooltip="Mark observed sleep onset",
+        ),
+        EventDef(
+            "REMDetected",
+            "REM detected",
+            41,
+            category="manual",
+            tooltip="Mark observed REM",
+        ),
+        EventDef(
+            "LRLRDetected",
+            "LRLR detected",
+            45,
+            category="manual",
+            tooltip="Mark an observed left-right-left-right lucid signal",
+        ),
+        EventDef(
+            "Clapper",
+            "Clapper",
+            49,
+            category="manual",
+            tooltip="Synchronize a marker with EEG",
+        ),
+        EventDef(
+            "Note",
+            "Note",
+            50,
+            category="manual",
+            tooltip="Mark a note and enter free text",
+        ),
+        # --- Lights: driven by the lightswitch toggle, not the grid -----------
+        EventDef("LightsOff", "Lights off", 47),
+        EventDef("LightsOn", "Lights on", 48),
+        # --- Control: panel-driven --------------------------------------------
+        EventDef("CueStarted", "Cue started", 60),
+        EventDef("CueStopped", "Cue stopped", 61),
+        EventDef("NoiseStarted", "Noise started", 62),
+        EventDef("NoiseStopped", "Noise stopped", 63),
+        EventDef("IntercomStarted", "Intercom started", 64),
+        EventDef("IntercomStopped", "Intercom stopped", 65),
+        EventDef("VisualStarted", "Visual stimulation", 66),
+        EventDef("SurveyOpened", "Survey opened", 67),
+        # --- System -----------------------------------------------------------
+        EventDef(
+            "TriggerInitialization",
+            "SMACC initialized",
+            100,
+            trigger=False,
+            log=False,
+            category="system",
+            tooltip="Optional connection-test marker sent once at startup",
+        ),
+        # --- Dream reports: the start increments so each report is unique ------
+        EventDef("DreamReportStopped", "Dream report stopped", 200),
+        EventDef("DreamReportStarted", "Dream report started", 201, increment=True),
+    ]
+
+
+def events_to_list(events: Iterable[EventDef]) -> list[dict[str, Any]]:
+    """Serialize to the compact, user-editable subset persisted in a study file.
+
+    Only the fields a study can change (the code and routing flags, keyed by
+    ``key``) are written, so the ``.smacc`` stays readable and label/tooltip
+    improvements apply to old studies automatically.
+    """
+    return [{name: getattr(e, name) for name in _PERSIST_FIELDS} for e in events]
+
+
+def merge_event_codes(loaded: Any) -> list[EventDef]:
+    """Return the default registry with any saved per-event overrides applied.
+
+    Mirrors the merge-over-DEFAULTS approach in :mod:`smacc.preferences`: a study
+    with no ``event_codes`` (older schema) yields the full defaults, and a study
+    that overrides only a few codes keeps the rest. Saved entries for keys SMACC
+    no longer defines are ignored; default ordering is preserved.
+    """
+    defaults = {e.key: e for e in default_events()}
+    if isinstance(loaded, list):
+        for item in loaded:
+            if not isinstance(item, dict):
+                continue
+            key = item.get("key")
+            if key not in defaults:
+                continue
+            overrides: dict[str, Any] = {}
+            for name, value in item.items():
+                if name == "key" or name not in _FIELD_NAMES:
+                    continue
+                if name == "code":
+                    try:
+                        value = int(value)
+                    except (TypeError, ValueError):
+                        continue
+                elif name in ("trigger", "log", "increment"):
+                    value = bool(value)
+                overrides[name] = value
+            defaults[key] = replace(defaults[key], **overrides)
+    return list(defaults.values())
+
+
+def validate_events(
+    events: Iterable[EventDef], safe_max: int = DEFAULT_SAFE_MAX
+) -> tuple[list[str], list[str]]:
+    """Return ``(errors, warnings)`` for a registry.
+
+    Hard errors (block saving): a code outside ``1..255``, a duplicate code among
+    *triggerable* events (they would collide on the marker channel), or a
+    duplicate key. Soft warnings (allowed, but surfaced): a code above
+    ``safe_max`` (older hardware), or an incrementing event whose band
+    (``code..255``) overlaps another triggerable code.
+    """
+    events = list(events)
+    errors: list[str] = []
+    warnings: list[str] = []
+    seen_keys: set[str] = set()
+    trig_codes: dict[int, str] = {}  # code -> label, for triggerable events only
+    for e in events:
+        if e.key in seen_keys:
+            errors.append(f"Duplicate event key {e.key!r}.")
+        seen_keys.add(e.key)
+        if isinstance(e.code, bool) or not isinstance(e.code, int):
+            errors.append(f"{e.label}: code must be a whole number.")
+            continue
+        if not (CODE_MIN <= e.code <= CODE_MAX):
+            errors.append(f"{e.label}: code {e.code} is outside {CODE_MIN}–{CODE_MAX}.")
+            continue
+        if e.code > safe_max:
+            warnings.append(
+                f"{e.label}: code {e.code} is above the safe max {safe_max}."
+            )
+        if e.trigger:
+            if e.code in trig_codes:
+                errors.append(
+                    f"{e.label}: code {e.code} duplicates {trig_codes[e.code]!r}."
+                )
+            else:
+                trig_codes[e.code] = e.label
+    for e in events:
+        if (
+            e.increment
+            and e.trigger
+            and isinstance(e.code, int)
+            and not isinstance(e.code, bool)
+        ):
+            for code, label in trig_codes.items():
+                if label != e.label and e.code <= code <= CODE_MAX:
+                    warnings.append(
+                        f"{e.label}: incrementing codes {e.code}–{CODE_MAX} "
+                        f"overlap {label!r} (code {code})."
+                    )
+    return errors, warnings
+
+
+def runtime_code(event: EventDef, ordinal: int | None = None) -> int:
+    """Return the code to send for this firing.
+
+    For an incrementing event the 1-based ``ordinal`` shifts the code: ``code``
+    for the 1st firing, ``code + 1`` for the 2nd, … clamped to ``255`` so SMACC
+    never emits an out-of-range byte. Non-incrementing events ignore ``ordinal``.
+    """
+    if event.increment and ordinal and ordinal > 1:
+        return min(event.code + (ordinal - 1), CODE_MAX)
+    return event.code

--- a/src/smacc/events.py
+++ b/src/smacc/events.py
@@ -24,6 +24,7 @@ Pure data and helpers, no Qt — directly unit-testable.
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 from dataclasses import dataclass, fields, replace
 from typing import Any
@@ -47,6 +48,7 @@ class EventDef:
     category: str = "control"
     tooltip: str = ""
     increment: bool = False
+    builtin: bool = True  # False for user-added custom events
 
 
 # The fields a study may override (keyed by ``key``); labels/tooltips/categories
@@ -148,45 +150,134 @@ def default_events() -> list[EventDef]:
 
 
 def events_to_list(events: Iterable[EventDef]) -> list[dict[str, Any]]:
-    """Serialize to the compact, user-editable subset persisted in a study file.
+    """Serialize the registry for a study file.
 
-    Only the fields a study can change (the code and routing flags, keyed by
-    ``key``) are written, so the ``.smacc`` stays readable and label/tooltip
-    improvements apply to old studies automatically.
+    A built-in event persists only the editable subset (code + routing flags,
+    keyed by ``key``), so the ``.smacc`` stays readable and label/tooltip
+    improvements reach old studies. A custom (user-added) event persists its full
+    definition so it can be reconstructed on load.
     """
-    return [{name: getattr(e, name) for name in _PERSIST_FIELDS} for e in events]
+    out: list[dict[str, Any]] = []
+    for e in events:
+        if e.builtin:
+            out.append({name: getattr(e, name) for name in _PERSIST_FIELDS})
+        else:
+            out.append(
+                {
+                    "key": e.key,
+                    "label": e.label,
+                    "code": e.code,
+                    "trigger": e.trigger,
+                    "preview": e.preview,
+                    "category": e.category,
+                    "tooltip": e.tooltip,
+                    "increment": e.increment,
+                    "builtin": False,
+                }
+            )
+    return out
+
+
+# A built-in entry only ever overrides these (its label/category/tooltip stay
+# app-defined); a hand-edited file can't rewrite them onto a built-in.
+_BUILTIN_OVERRIDE_FIELDS = ("code", "trigger", "preview", "increment")
+
+
+def _builtin_overrides(item: dict) -> dict[str, Any]:
+    """Coerce the overridable fields from a saved built-in entry."""
+    out: dict[str, Any] = {}
+    for name in _BUILTIN_OVERRIDE_FIELDS:
+        if name not in item:
+            continue
+        value = item[name]
+        if name == "code":
+            try:
+                value = int(value)
+            except (TypeError, ValueError):
+                continue
+        else:
+            value = bool(value)
+        out[name] = value
+    return out
+
+
+def _custom_from_dict(key: str, item: dict) -> EventDef | None:
+    """Reconstruct a custom EventDef from a saved full definition (or None)."""
+    try:
+        code = int(item["code"])
+    except (TypeError, ValueError, KeyError):
+        return None
+    return EventDef(
+        key=key,
+        label=str(item.get("label") or key),
+        code=code,
+        trigger=bool(item.get("trigger", True)),
+        preview=bool(item.get("preview", True)),
+        category=str(item.get("category") or "manual"),
+        tooltip=str(item.get("tooltip") or ""),
+        increment=bool(item.get("increment", False)),
+        builtin=False,
+    )
 
 
 def merge_event_codes(loaded: Any) -> list[EventDef]:
-    """Return the default registry with any saved per-event overrides applied.
+    """Return the default registry with saved overrides + custom events applied.
 
     Mirrors the merge-over-DEFAULTS approach in :mod:`smacc.preferences`: a study
-    with no ``event_codes`` (older schema) yields the full defaults, and a study
-    that overrides only a few codes keeps the rest. Saved entries for keys SMACC
-    no longer defines are ignored; default ordering is preserved.
+    with no ``event_codes`` (older schema) yields the full defaults; a study that
+    overrides only a few built-in codes keeps the rest; saved custom events
+    (``builtin: false``) are appended after the built-ins. Default ordering is
+    preserved.
     """
     defaults = {e.key: e for e in default_events()}
+    custom: list[EventDef] = []
+    seen_custom: set[str] = set()
     if isinstance(loaded, list):
         for item in loaded:
             if not isinstance(item, dict):
                 continue
             key = item.get("key")
-            if key not in defaults:
+            if not isinstance(key, str):
                 continue
-            overrides: dict[str, Any] = {}
-            for name, value in item.items():
-                if name == "key" or name not in _FIELD_NAMES:
-                    continue
-                if name == "code":
-                    try:
-                        value = int(value)
-                    except (TypeError, ValueError):
-                        continue
-                elif name in ("trigger", "preview", "increment"):
-                    value = bool(value)
-                overrides[name] = value
-            defaults[key] = replace(defaults[key], **overrides)
-    return list(defaults.values())
+            if key in defaults:
+                defaults[key] = replace(defaults[key], **_builtin_overrides(item))
+            elif item.get("builtin") is False and key not in seen_custom:
+                event = _custom_from_dict(key, item)
+                if event is not None:
+                    custom.append(event)
+                    seen_custom.add(key)
+    return list(defaults.values()) + custom
+
+
+def make_custom_event(
+    label: str,
+    code: int,
+    existing_keys: Iterable[str],
+    *,
+    tooltip: str = "",
+    increment: bool = False,
+    trigger: bool = True,
+    preview: bool = True,
+) -> EventDef:
+    """Build a custom (button) event with a unique key derived from ``label``."""
+    base = "custom" + (re.sub(r"[^A-Za-z0-9]+", "", label.title()) or "Event")
+    existing = set(existing_keys)
+    key = base
+    suffix = 2
+    while key in existing:
+        key = f"{base}{suffix}"
+        suffix += 1
+    return EventDef(
+        key=key,
+        label=label,
+        code=code,
+        trigger=trigger,
+        preview=preview,
+        category="manual",
+        tooltip=tooltip,
+        increment=increment,
+        builtin=False,
+    )
 
 
 def validate_events(
@@ -209,6 +300,8 @@ def validate_events(
         if e.key in seen_keys:
             errors.append(f"Duplicate event key {e.key!r}.")
         seen_keys.add(e.key)
+        if not (e.label and str(e.label).strip()):
+            errors.append(f"Event {e.key!r}: a label is required.")
         if isinstance(e.code, bool) or not isinstance(e.code, int):
             errors.append(f"{e.label}: code must be a whole number.")
             continue

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -11,12 +11,8 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 
 from smacc import bids, preferences, settings, winassoc
 
-from .config import (
-    COMMON_EVENT_CODES,
-    COMMON_EVENT_TIPS,
-    VERSION,
-)
-from .dialogs import SessionInfoDialog
+from .config import VERSION
+from .dialogs import EventCodesDialog, SessionInfoDialog
 from .panels.audio import AudioCueWindow
 from .panels.base import ModalityWindow
 from .panels.intercom import IntercomWindow
@@ -68,6 +64,8 @@ class SmaccWindow(QtWidgets.QMainWindow):
         # initial state into the log header (also emits the "Opened SMACC" line).
         self.session.begin_log(self.gather_settings())
         self._maybe_prompt_association()
+        # Startup widget setup is done; from here on, log soft interactions.
+        self.session.log_interactions = True
 
     def show_error_popup(self, short_msg, long_msg=None):
         """Show an error dialog parented to this window (logs via the session)."""
@@ -191,6 +189,13 @@ class SmaccWindow(QtWidgets.QMainWindow):
         )
         sessionInfoAction.triggered.connect(self.session_info)
 
+        eventCodesAction = QtWidgets.QAction("&Event codes…", self)
+        eventCodesAction.setStatusTip(
+            "View/edit event-marker port codes and what's logged vs. triggered."
+        )
+        eventCodesAction.triggered.connect(self.edit_event_codes)
+        self._event_codes_action = eventCodesAction
+
         exportEventsAction = QtWidgets.QAction("&Export events (BIDS)…", self)
         exportEventsAction.setStatusTip(
             "Export this session's events log as a BIDS events.tsv."
@@ -228,6 +233,7 @@ class SmaccWindow(QtWidgets.QMainWindow):
         fileMenu.addAction(loadSettingsFromLogAction)
         fileMenu.addSeparator()
         fileMenu.addAction(sessionInfoAction)
+        fileMenu.addAction(eventCodesAction)
         # File -> Surveys: open any saved survey standalone (not tied to a dream
         # report). Rebuilt each time it opens, since the saved list changes as
         # surveys are added/edited/removed.
@@ -299,18 +305,22 @@ class SmaccWindow(QtWidgets.QMainWindow):
         eventsLayout = QtWidgets.QGridLayout()
         eventsLayout.addWidget(eventmarkertitleLabel, 0, 0, 1, 2)
         eventsLayout.addWidget(self.lightswitchButton, 1, 0, 1, 2)
-        n_events = len(COMMON_EVENT_TIPS)
-        for i, (event, tip) in enumerate(COMMON_EVENT_TIPS.items()):
+        # Buttons are generated from the registry's "manual" events; the lights
+        # codes also live in the registry but are driven by the switch above, so
+        # they're excluded here. Codes/labels edit via File -> Event codes….
+        manual_events = [
+            e for e in self.session.events.values() if e.category == "manual"
+        ]
+        n_events = len(manual_events)
+        for i, event in enumerate(manual_events):
             shortcut = str(i + 1)
-            label = f"{event} ({shortcut})"
-            button = QtWidgets.QPushButton(label, self)
-            button.setStatusTip(tip)
+            button = QtWidgets.QPushButton(f"{event.label} ({shortcut})", self)
+            button.setStatusTip(event.tooltip)
             button.setShortcut(shortcut)
-            # button.setCheckable(False)
-            if event == "Note":
+            if event.key == "Note":
                 button.clicked.connect(self.open_note_marker_dialogue)
             else:
-                button.clicked.connect(self.handle_event_button)
+                button.clicked.connect(partial(self.handle_event_button, event.key))
             row = 2 + i
             if i >= (halfsize := int(n_events / 2)):
                 row -= halfsize
@@ -366,11 +376,9 @@ class SmaccWindow(QtWidgets.QMainWindow):
         # win.setGeometry(200, 150, 100, 40)
         win.exec()
 
-    def handle_event_button(self):
-        sender = self.sender()
-        text = sender.text().split("(")[0].strip()
-        code = COMMON_EVENT_CODES[text]
-        self.session.send_event_marker(code, text)
+    def handle_event_button(self, key: str, _checked: bool = False) -> None:
+        """Emit the registry event bound to a clicked manual event button."""
+        self.session.emit_event(key)
 
     def on_lightswitch_toggled(self, checked: bool) -> None:
         """Handle a user toggle of the lightswitch (``checked`` == lights on)."""
@@ -386,8 +394,7 @@ class SmaccWindow(QtWidgets.QMainWindow):
         self._refresh_lightswitch_label()
         self.apply_theme(dark=not lights_on)
         if send_marker:
-            name = "Lights on" if lights_on else "Lights off"
-            self.session.send_event_marker(COMMON_EVENT_CODES[name], name)
+            self.session.emit_event("LightsOn" if lights_on else "LightsOff")
 
     def _refresh_lightswitch_label(self) -> None:
         """Sync the lightswitch text/style to the current state."""
@@ -452,12 +459,29 @@ class SmaccWindow(QtWidgets.QMainWindow):
         state: dict = {}
         for panel in self.panels.values():
             state.update(panel.gather_state())
+        # The event-code registry isn't a panel; persist it at the window level.
+        state["event_codes"] = self.session.event_codes_as_list()
+        state["event_code_safe_max"] = self.session.event_code_safe_max
         return state
 
     def apply_settings(self, state: dict) -> None:
-        """Apply a settings ``state`` dict to every panel (each reads its own keys)."""
-        for panel in self.panels.values():
-            panel.apply_state(state)
+        """Apply a settings ``state`` dict to every panel (each reads its own keys).
+
+        Soft interaction logging is suppressed while panels reload their widgets,
+        so a study load doesn't spam the log with volume/color/device lines.
+        """
+        was_logging = self.session.log_interactions
+        self.session.log_interactions = False
+        try:
+            for panel in self.panels.values():
+                panel.apply_state(state)
+            # Apply the study's event-code registry (or defaults for a pre-v4
+            # study with no event_codes) to the live session.
+            self.session.set_event_codes(
+                state.get("event_codes"), state.get("event_code_safe_max")
+            )
+        finally:
+            self.session.log_interactions = was_logging
 
     # ----- preferences / launch-file / file association ----------------------
 
@@ -690,6 +714,48 @@ class SmaccWindow(QtWidgets.QMainWindow):
             meta["notes"] = notes
             self.session.log_info_msg("Updated session metadata")
 
+    def edit_event_codes(self) -> None:
+        """Open the event-code editor; apply edits live and log every change.
+
+        The editor stays available throughout a session (there's no reliable
+        lock point yet), so each change is logged loudly (WARNING) to keep the
+        code map traceable for the session even if it changes mid-study.
+        """
+        before = {e.key: e for e in self.session.events.values()}
+        dialog = EventCodesDialog(
+            list(self.session.events.values()),
+            self.session.event_code_safe_max,
+            parent=self,
+        )
+        if not dialog.exec():
+            return
+        new_events = dialog.get_events()
+        safe_max = dialog.get_safe_max()
+        for event in new_events:
+            old = before.get(event.key)
+            if old is None:
+                continue
+            changes = []
+            if old.code != event.code:
+                changes.append(f"code {old.code}->{event.code}")
+            if old.trigger != event.trigger:
+                changes.append(f"trigger {'on' if event.trigger else 'off'}")
+            if old.log != event.log:
+                changes.append(f"log {'on' if event.log else 'off'}")
+            if old.increment != event.increment:
+                changes.append(f"increment {'on' if event.increment else 'off'}")
+            if changes:
+                self.session.logger.warning(
+                    f"Port code changed: {event.label} ({', '.join(changes)})"
+                )
+        if safe_max != self.session.event_code_safe_max:
+            self.session.logger.warning(
+                f"Event-code safe max changed: "
+                f"{self.session.event_code_safe_max} -> {safe_max}"
+            )
+        self.session.events = {e.key: e for e in new_events}
+        self.session.event_code_safe_max = safe_max
+
     def export_events_bids(self) -> None:
         """Convert this session's log to a BIDS events.tsv (+ JSON sidecar)."""
         if not self.session.log_path.is_file():
@@ -747,10 +813,8 @@ class SmaccWindow(QtWidgets.QMainWindow):
             self, "Text Input Dialog", "Custom note (no commas):"
         )
         # self.subject_id.setValidator(QtGui.QIntValidator(0, 999)) # must be a 3-digit number
-        if ok:  # True of OK button was hit, False otherwise (cancel button)
-            portcode = self.session.portcodes["Note"]
-            port_msg = f"Note [{text}]"
-            self.session.send_event_marker(portcode, port_msg)
+        if ok:  # True if OK was hit, False otherwise (cancel button)
+            self.session.emit_event("Note", detail=text)
 
     def closeEvent(self, event):
         """customize exit.

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -381,9 +381,7 @@ class SmaccWindow(QtWidgets.QMainWindow):
         the narrow single-column button.
         """
         if self.lights_on:
-            self.lightswitchButton.setText(
-                "Lights are ON\n\U0001f31e\nclick to turn OFF"
-            )
+            self.lightswitchButton.setText("Lights are ON\n☀️\nclick to turn OFF")
             self.lightswitchButton.setStyleSheet(
                 "font: bold 13pt; padding: 8px; background-color: #f0d000; color: black;"
             )

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -494,12 +494,12 @@ class SmaccWindow(QtWidgets.QMainWindow):
             action.blockSignals(False)
         self._update_preview_levels()
 
-        # Lights/theme startup state (no event marker; keep the switch in sync).
-        lights_on = bool(prefs["lights_on"])
+        # Lights always start ON each launch — the dark theme is per-session
+        # state, not a saved preference. Keep the switch in sync, fire no marker.
         self.lightswitchButton.blockSignals(True)
-        self.lightswitchButton.setChecked(lights_on)
+        self.lightswitchButton.setChecked(True)
         self.lightswitchButton.blockSignals(False)
-        self.set_lights(lights_on, send_marker=False)
+        self.set_lights(True, send_marker=False)
 
         self._restore_geometry(prefs.get("window") or {})
 
@@ -529,7 +529,6 @@ class SmaccWindow(QtWidgets.QMainWindow):
         prefs.update(
             {
                 "always_on_top": self._always_on_top_action.isChecked(),
-                "lights_on": self.lights_on,
                 "preview_levels": preferences.levels_to_names(checked),
                 "window": {
                     "x": self.x(),

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -86,12 +86,13 @@ class SmaccWindow(QtWidgets.QMainWindow):
         self._build_menu_bar()
         self.statusBar().showMessage("Ready")
 
-        # 3x2 grid of panels; menu must be built first (the log-viewer panel
-        # syncs the preview handler to the Log preview menu checkboxes).
+        # Two columns: the launcher tools (with the lights toggle filling the
+        # bottom) and the log viewer. The menu is built first so the log-viewer
+        # panel can sync the preview handler to the Log preview menu checkboxes.
         central_layout = QtWidgets.QGridLayout()
         central_layout.addLayout(self._build_launcher_buttons(), 0, 0)
         central_layout.addLayout(self._build_log_viewer_section(), 0, 1)
-        central_layout.addLayout(self._build_events_section(), 1, 0, 1, 2)
+        central_layout.setColumnStretch(1, 1)  # the log viewer takes the extra width
         central_widget = QtWidgets.QWidget()
         central_widget.setContentsMargins(5, 5, 5, 5)
         central_widget.setLayout(central_layout)
@@ -134,7 +135,12 @@ class SmaccWindow(QtWidgets.QMainWindow):
     }
 
     def _build_launcher_buttons(self) -> QtWidgets.QLayout:
-        """Build the 'Open tools' column with a button per extracted panel."""
+        """Build the 'Open tools' column: panel launchers + the lights toggle.
+
+        The lights toggle sits at the bottom and expands to fill the column's
+        leftover height (so it lines up with the log viewer); it sends the lights
+        event marker and flips the dark theme.
+        """
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(self._make_section_title("Open tools"))
         for key, label in self.PANEL_LABELS.items():
@@ -143,7 +149,24 @@ class SmaccWindow(QtWidgets.QMainWindow):
             button = QtWidgets.QPushButton(label, self)
             button.clicked.connect(partial(self._open_panel, key))
             layout.addWidget(button)
-        layout.addStretch(1)
+        layout.addSpacing(8)
+
+        # Connect the toggled signal only after setChecked so construction fires
+        # no marker. Expanding vertical policy + stretch fills the empty space.
+        self.lightswitchButton = QtWidgets.QPushButton(self)
+        self.lightswitchButton.setCheckable(True)
+        self.lightswitchButton.setShortcut("L")  # still toggles with L
+        self.lightswitchButton.setSizePolicy(
+            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Expanding
+        )
+        self.lightswitchButton.setMinimumHeight(64)
+        self.lightswitchButton.setStatusTip(
+            "Toggle lights off/on (sends the lights event marker and switches theme)"
+        )
+        self.lightswitchButton.setChecked(True)
+        self._refresh_lightswitch_label()
+        self.lightswitchButton.toggled.connect(self.on_lightswitch_toggled)
+        layout.addWidget(self.lightswitchButton, 1)
         return layout
 
     def _open_panel(self, key: str) -> None:
@@ -287,32 +310,6 @@ class SmaccWindow(QtWidgets.QMainWindow):
         manageAction = menu.addAction("Manage surveys…")
         manageAction.triggered.connect(recording.manage_surveys)
 
-    def _build_events_section(self) -> QtWidgets.QLayout:
-        """Build the lights toggle (the event buttons live in the Event logging panel)."""
-        lightsTitleLabel = self._make_section_title("Lights")
-
-        # Lights toggle: a single switch replacing the two lights event buttons.
-        # It sends the lights marker and flips the dark theme. Connect the
-        # toggled signal only after setChecked so construction fires no marker.
-        self.lightswitchButton = QtWidgets.QPushButton(self)
-        self.lightswitchButton.setCheckable(True)
-        self.lightswitchButton.setShortcut("L")
-        self.lightswitchButton.setMinimumHeight(48)
-        self.lightswitchButton.setStatusTip(
-            "Toggle lights off/on (sends the lights event marker and switches theme)"
-        )
-        self.lightswitchButton.setChecked(True)
-        self._refresh_lightswitch_label()
-        self.lightswitchButton.toggled.connect(self.on_lightswitch_toggled)
-
-        # The manual event buttons live in the Event logging panel (openable from
-        # the launcher) so a study's custom buttons can be added/removed and the
-        # grid resized; the lights switch stays here, double-wide.
-        eventsLayout = QtWidgets.QGridLayout()
-        eventsLayout.addWidget(lightsTitleLabel, 0, 0, 1, 2)
-        eventsLayout.addWidget(self.lightswitchButton, 1, 0, 1, 2)
-        return eventsLayout
-
     def _build_log_viewer_section(self) -> QtWidgets.QLayout:
         """Build the log-viewer panel and attach the preview log handler."""
         logviewertitleLabel = self._make_section_title("Log viewer")
@@ -378,20 +375,24 @@ class SmaccWindow(QtWidgets.QMainWindow):
             self.session.emit_event("LightsOn" if lights_on else "LightsOff")
 
     def _refresh_lightswitch_label(self) -> None:
-        """Sync the lightswitch text/style to the current state."""
+        """Sync the lightswitch text/style to the current state.
+
+        Three centered lines — state, a sun/moon glyph, and the action — to suit
+        the narrow single-column button.
+        """
         if self.lights_on:
             self.lightswitchButton.setText(
-                "\U0001f4a1 Lights ON  (L) — click to turn OFF"
+                "Lights are ON\n\U0001f31e\nclick to turn OFF"
             )
             self.lightswitchButton.setStyleSheet(
-                "font: bold 14pt; padding: 8px; background-color: #f0d000; color: black;"
+                "font: bold 13pt; padding: 8px; background-color: #f0d000; color: black;"
             )
         else:
             self.lightswitchButton.setText(
-                "\U0001f319 Lights OFF  (L) — click to turn ON"
+                "Lights are OFF\n\U0001f319\nclick to turn ON"
             )
             self.lightswitchButton.setStyleSheet(
-                "font: bold 14pt; padding: 8px; background-color: #303030; color: #dddddd;"
+                "font: bold 13pt; padding: 8px; background-color: #303030; color: #dddddd;"
             )
 
     def apply_theme(self, dark: bool) -> None:

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -15,6 +15,7 @@ from .config import VERSION
 from .dialogs import EventCodesDialog, SessionInfoDialog
 from .panels.audio import AudioCueWindow
 from .panels.base import ModalityWindow
+from .panels.events import EventsWindow
 from .panels.intercom import IntercomWindow
 from .panels.noise import NoiseWindow
 from .panels.recording import RecordingWindow
@@ -46,6 +47,7 @@ class SmaccWindow(QtWidgets.QMainWindow):
         # Modality windows, constructed up front (hidden) and opened on demand
         # from the launcher buttons. Each holds its own state for settings save/load.
         self.panels: dict[str, ModalityWindow] = {
+            "events": EventsWindow(self.session),
             "visual": VisualWindow(self.session),
             "audio": AudioCueWindow(self.session),
             "noise": NoiseWindow(self.session),
@@ -123,6 +125,7 @@ class SmaccWindow(QtWidgets.QMainWindow):
 
     # Modality windows openable from the launcher (key -> button label).
     PANEL_LABELS = {
+        "events": "Event logging",
         "visual": "Visual stimulation",
         "audio": "Audio cue",
         "noise": "Noise machine",
@@ -285,8 +288,8 @@ class SmaccWindow(QtWidgets.QMainWindow):
         manageAction.triggered.connect(recording.manage_surveys)
 
     def _build_events_section(self) -> QtWidgets.QLayout:
-        """Build the event-marker grid (lightswitch + common event buttons)."""
-        eventmarkertitleLabel = self._make_section_title("Event logging")
+        """Build the lights toggle (the event buttons live in the Event logging panel)."""
+        lightsTitleLabel = self._make_section_title("Lights")
 
         # Lights toggle: a single switch replacing the two lights event buttons.
         # It sends the lights marker and flips the dark theme. Connect the
@@ -302,30 +305,12 @@ class SmaccWindow(QtWidgets.QMainWindow):
         self._refresh_lightswitch_label()
         self.lightswitchButton.toggled.connect(self.on_lightswitch_toggled)
 
+        # The manual event buttons live in the Event logging panel (openable from
+        # the launcher) so a study's custom buttons can be added/removed and the
+        # grid resized; the lights switch stays here, double-wide.
         eventsLayout = QtWidgets.QGridLayout()
-        eventsLayout.addWidget(eventmarkertitleLabel, 0, 0, 1, 2)
+        eventsLayout.addWidget(lightsTitleLabel, 0, 0, 1, 2)
         eventsLayout.addWidget(self.lightswitchButton, 1, 0, 1, 2)
-        # Buttons are generated from the registry's "manual" events; the lights
-        # codes also live in the registry but are driven by the switch above, so
-        # they're excluded here. Codes/labels edit via File -> Event codes….
-        manual_events = [
-            e for e in self.session.events.values() if e.category == "manual"
-        ]
-        n_events = len(manual_events)
-        for i, event in enumerate(manual_events):
-            shortcut = str(i + 1)
-            button = QtWidgets.QPushButton(f"{event.label} ({shortcut})", self)
-            button.setStatusTip(event.tooltip)
-            button.setShortcut(shortcut)
-            if event.key == "Note":
-                button.clicked.connect(self.open_note_marker_dialogue)
-            else:
-                button.clicked.connect(partial(self.handle_event_button, event.key))
-            row = 2 + i
-            if i >= (halfsize := int(n_events / 2)):
-                row -= halfsize
-            col = 1 if i >= halfsize else 0
-            eventsLayout.addWidget(button, row, col)
         return eventsLayout
 
     def _build_log_viewer_section(self) -> QtWidgets.QLayout:
@@ -375,10 +360,6 @@ class SmaccWindow(QtWidgets.QMainWindow):
         # win.setStyleSheet("QLabel{min-width:500 px; font-size: 24px;} QPushButton{ width:250px; font-size: 18px; }");
         # win.setGeometry(200, 150, 100, 40)
         win.exec()
-
-    def handle_event_button(self, key: str, _checked: bool = False) -> None:
-        """Emit the registry event bound to a clicked manual event button."""
-        self.session.emit_event(key)
 
     def on_lightswitch_toggled(self, checked: bool) -> None:
         """Handle a user toggle of the lightswitch (``checked`` == lights on)."""
@@ -480,8 +461,15 @@ class SmaccWindow(QtWidgets.QMainWindow):
             self.session.set_event_codes(
                 state.get("event_codes"), state.get("event_code_safe_max")
             )
+            self._rebuild_events_panel()  # a loaded study may add/remove buttons
         finally:
             self.session.log_interactions = was_logging
+
+    def _rebuild_events_panel(self) -> None:
+        """Rebuild the Event logging panel's buttons after the registry changes."""
+        panel = self.panels.get("events")
+        if isinstance(panel, EventsWindow):
+            panel.rebuild()
 
     # ----- preferences / launch-file / file association ----------------------
 
@@ -731,9 +719,13 @@ class SmaccWindow(QtWidgets.QMainWindow):
             return
         new_events = dialog.get_events()
         safe_max = dialog.get_safe_max()
+        new_by_key = {e.key: e for e in new_events}
         for event in new_events:
             old = before.get(event.key)
             if old is None:
+                self.session.logger.warning(
+                    f"Event added: {event.label} (code {event.code})"
+                )
                 continue
             changes = []
             if old.code != event.code:
@@ -748,13 +740,17 @@ class SmaccWindow(QtWidgets.QMainWindow):
                 self.session.logger.warning(
                     f"Port code changed: {event.label} ({', '.join(changes)})"
                 )
+        for key, old in before.items():
+            if key not in new_by_key:
+                self.session.logger.warning(f"Event removed: {old.label}")
         if safe_max != self.session.event_code_safe_max:
             self.session.logger.warning(
                 f"Event-code safe max changed: "
                 f"{self.session.event_code_safe_max} -> {safe_max}"
             )
-        self.session.events = {e.key: e for e in new_events}
+        self.session.events = new_by_key
         self.session.event_code_safe_max = safe_max
+        self._rebuild_events_panel()
 
     def export_events_bids(self) -> None:
         """Convert this session's log to a BIDS events.tsv (+ JSON sidecar)."""
@@ -806,15 +802,6 @@ class SmaccWindow(QtWidgets.QMainWindow):
             self.show_error_popup("Could not export events.", str(exc))
             return
         self.session.log_info_msg(f"Exported {len(events)} events to {out_path}")
-
-    @QtCore.pyqtSlot()
-    def open_note_marker_dialogue(self):
-        text, ok = QtWidgets.QInputDialog.getText(
-            self, "Text Input Dialog", "Custom note (no commas):"
-        )
-        # self.subject_id.setValidator(QtGui.QIntValidator(0, 999)) # must be a 3-digit number
-        if ok:  # True if OK was hit, False otherwise (cancel button)
-            self.session.emit_event("Note", detail=text)
 
     def closeEvent(self, event):
         """customize exit.

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -740,8 +740,8 @@ class SmaccWindow(QtWidgets.QMainWindow):
                 changes.append(f"code {old.code}->{event.code}")
             if old.trigger != event.trigger:
                 changes.append(f"trigger {'on' if event.trigger else 'off'}")
-            if old.log != event.log:
-                changes.append(f"log {'on' if event.log else 'off'}")
+            if old.preview != event.preview:
+                changes.append(f"preview {'on' if event.preview else 'off'}")
             if old.increment != event.increment:
                 changes.append(f"increment {'on' if event.increment else 'off'}")
             if changes:

--- a/src/smacc/panels/audio.py
+++ b/src/smacc/panels/audio.py
@@ -204,10 +204,12 @@ class AudioCueWindow(ModalityWindow):
     def update_cue_attack(self, value: float) -> None:
         """Set the shared cue fade-in (attack) time in seconds."""
         self.cue_attack_s = value
+        self.session.log_interaction(f"Cue fade-in set to {value:.1f}s")
 
     def update_cue_release(self, value: float) -> None:
         """Set the shared cue fade-out (release) time in seconds."""
         self.cue_release_s = value
+        self.session.log_interaction(f"Cue fade-out set to {value:.1f}s")
 
     def _fade_volume(
         self,
@@ -261,13 +263,22 @@ class AudioCueWindow(ModalityWindow):
 
     def update_slot_volume(self, index: int, value: float | None = None) -> None:
         """Set a slot player's volume (0-1) from its spinbox."""
-        self.slots[index].player.setVolume(self.slots[index].volumeSpinBox.value())
+        slot = self.slots[index]
+        vol = slot.volumeSpinBox.value()
+        slot.player.setVolume(vol)
+        self.session.log_interaction(
+            f"Cue '{slot.nameEdit.text()}' volume set to {vol:.2f}"
+        )
 
     def update_slot_loop(self, index: int, enabled: bool | None = None) -> None:
         """Set a slot player's loop count from its checkbox."""
-        looping = self.slots[index].loopCheckBox.isChecked()
+        slot = self.slots[index]
+        looping = slot.loopCheckBox.isChecked()
         count = QtMultimedia.QSoundEffect.Infinite if looping else 1
-        self.slots[index].player.setLoopCount(count)
+        slot.player.setLoopCount(count)
+        self.session.log_interaction(
+            f"Cue '{slot.nameEdit.text()}' loop {'on' if looping else 'off'}"
+        )
 
     def play_slot(self, index: int) -> None:
         """Play one slot (stopping any other playing slot first) with fade-in."""
@@ -286,9 +297,7 @@ class AudioCueWindow(ModalityWindow):
         else:
             slot.player.setVolume(target)
             slot.player.play()
-        self.session.send_event_marker(
-            self.session.portcodes["CueStarted"], f"Cue started: {slot.nameEdit.text()}"
-        )
+        self.session.emit_event("CueStarted", detail=slot.nameEdit.text())
 
     def stop_slot(self, index: int) -> None:
         """Stop a slot (with fade-out) if it is the one currently playing."""
@@ -323,10 +332,7 @@ class AudioCueWindow(ModalityWindow):
             self.nowPlayingLabel.setStyleSheet("color: red; font-weight: bold;")
         elif not playing and slot.was_playing:
             slot.was_playing = False
-            self.session.send_event_marker(
-                self.session.portcodes["CueStopped"],
-                f"Cue stopped: {slot.nameEdit.text()}",
-            )
+            self.session.emit_event("CueStopped", detail=slot.nameEdit.text())
             if self._playing_index == index:
                 self._playing_index = None
                 self.nowPlayingLabel.setText("■ stopped")

--- a/src/smacc/panels/events.py
+++ b/src/smacc/panels/events.py
@@ -1,0 +1,72 @@
+"""Event-logging window: the manual event-marker buttons (built-in + custom).
+
+The lights toggle stays on the main window (it also drives the dark theme); every
+other manual event button lives here so a study's custom buttons can be added or
+removed (via File ▸ Event codes…) and the grid resized to fit. The grid is rebuilt
+whenever the registry changes.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+
+from PyQt5 import QtWidgets
+
+from ..session import SmaccSession
+from .base import ModalityWindow, make_section_title
+
+
+class EventsWindow(ModalityWindow):
+    """A rebuildable grid of manual event-marker buttons."""
+
+    TITLE = "Event logging"
+
+    def __init__(self, session: SmaccSession, parent: QtWidgets.QWidget | None = None):
+        super().__init__(session, parent)
+        self._grid = QtWidgets.QGridLayout()
+        container = QtWidgets.QWidget()
+        outer = QtWidgets.QVBoxLayout(container)
+        outer.addWidget(make_section_title("Event logging"))
+        outer.addLayout(self._grid)
+        outer.addStretch(1)
+        self.setCentralWidget(container)
+        self.rebuild()
+
+    def rebuild(self) -> None:
+        """Regenerate the buttons from the session's manual-category events.
+
+        Two-column layout sized to the button count; the first nine buttons get a
+        1–9 keyboard shortcut (active while this window is focused).
+        """
+        while self._grid.count():
+            item = self._grid.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+        manual = [e for e in self.session.events.values() if e.category == "manual"]
+        half = (len(manual) + 1) // 2
+        for i, event in enumerate(manual):
+            label = event.label
+            button = QtWidgets.QPushButton(label, self)
+            button.setStatusTip(event.tooltip)
+            if i < 9:  # single-key shortcuts only go 1..9
+                button.setText(f"{label} ({i + 1})")
+                button.setShortcut(str(i + 1))
+            if event.key == "Note":
+                button.clicked.connect(self.open_note_marker_dialogue)
+            else:
+                button.clicked.connect(partial(self._emit, event.key))
+            row, col = (i, 0) if i < half else (i - half, 1)
+            self._grid.addWidget(button, row, col)
+        self.adjustSize()
+
+    def _emit(self, key: str, _checked: bool = False) -> None:
+        self.session.emit_event(key)
+
+    def open_note_marker_dialogue(self, _checked: bool = False) -> None:
+        """Prompt for free text and emit a Note marker with it."""
+        text, ok = QtWidgets.QInputDialog.getText(
+            self, "Note", "Custom note (no commas):"
+        )
+        if ok:
+            self.session.emit_event("Note", detail=text)

--- a/src/smacc/panels/intercom.py
+++ b/src/smacc/panels/intercom.py
@@ -94,13 +94,9 @@ class IntercomWindow(ModalityWindow):
             if not self._start_intercom_streams(output_device):
                 self.intercomButton.setChecked(False)
                 return
-            self.session.send_event_marker(
-                self.session.portcodes["IntercomStarted"], "Intercom unmuted (talking)"
-            )
+            self.session.emit_event("IntercomStarted")
         elif self._stop_intercom_streams():
-            self.session.send_event_marker(
-                self.session.portcodes["IntercomStopped"], "Intercom remuted"
-            )
+            self.session.emit_event("IntercomStopped")
 
     def _start_intercom_streams(self, output_device: str | None) -> bool:
         """Build and start the mic/output streams; return True on success.
@@ -148,6 +144,9 @@ class IntercomWindow(ModalityWindow):
         record). A no-op when the intercom isn't running, which also covers the
         programmatic dropdown population in ``refresh_intercom_outputs``.
         """
+        self.session.log_interaction(
+            f"Intercom output set to {self.intercom_output_dropdown.currentText()}"
+        )
         if not self._stop_intercom_streams():
             return  # intercom not running; nothing to switch over
         output_device = self.intercom_output_dropdown.currentText() or None

--- a/src/smacc/panels/noise.py
+++ b/src/smacc/panels/noise.py
@@ -105,10 +105,10 @@ class NoiseWindow(ModalityWindow):
         # Stacked Play/Stop transport (mixing-board style).
         playnoiseButton = QtWidgets.QPushButton("Play noise", self)
         playnoiseButton.setStatusTip("Play the selected noise.")
-        playnoiseButton.clicked.connect(self.play_noise)
+        playnoiseButton.clicked.connect(self.on_play_noise_clicked)
         stopnoiseButton = QtWidgets.QPushButton("Stop noise", self)
         stopnoiseButton.setStatusTip("Stop the noise.")
-        stopnoiseButton.clicked.connect(self.stop_noise)
+        stopnoiseButton.clicked.connect(self.on_stop_noise_clicked)
         transport = QtWidgets.QVBoxLayout()
         transport.addWidget(playnoiseButton)
         transport.addWidget(stopnoiseButton)
@@ -152,6 +152,8 @@ class NoiseWindow(ModalityWindow):
     def on_noise_source_changed(self, checked: bool) -> None:
         """Built-in/file toggled: update enabled controls and restart if playing."""
         self._sync_source_enabled()
+        source = "file" if self._use_file_source() else "built-in"
+        self.session.log_interaction(f"Noise source set to {source}")
         self._restart_if_playing()
 
     def on_noise_file_changed(self) -> None:
@@ -170,11 +172,13 @@ class NoiseWindow(ModalityWindow):
     def set_new_noisecolor(self, text: str) -> None:
         """Restart noise playback when the noise color changes (``text``)."""
         if not self._use_file_source():
+            self.session.log_interaction(f"Noise color set to {text}")
             self._restart_if_playing()
 
     def set_new_noisespeakers(self, text: str) -> None:
         """Text is the device name, with host api string appended to the end."""
         self.noiseplayer_device = text
+        self.session.log_interaction(f"Noise device set to {text}")
         self._restart_if_playing()  # switch a live stream over to the new device
 
     def refresh_available_noisespeakers(self):
@@ -239,6 +243,24 @@ class NoiseWindow(ModalityWindow):
         chunk, self._noise_pos = utils.read_loop(buf, self._noise_pos, frames)
         np.multiply(chunk, self.noise_stream_volume, out=outdata[:, 0])
 
+    def on_play_noise_clicked(self, _checked: bool = False) -> None:
+        """User pressed Play: start the noise and mark it (NoiseStarted).
+
+        The marker fires only on a real user start, not on the silent stop+start
+        restart used when the color/device/source changes mid-playback.
+        """
+        already_playing = self.noise_stream is not None
+        self.play_noise()
+        if not already_playing and self.noise_stream is not None:
+            self.session.emit_event("NoiseStarted")
+
+    def on_stop_noise_clicked(self, _checked: bool = False) -> None:
+        """User pressed Stop: stop the noise and mark it (NoiseStopped)."""
+        was_playing = self.noise_stream is not None
+        self.stop_noise()
+        if was_playing:
+            self.session.emit_event("NoiseStopped")
+
     def play_noise(self) -> None:
         """Start streaming the selected noise (built-in color or file) on loop."""
         if self.noise_stream is not None:
@@ -286,6 +308,7 @@ class NoiseWindow(ModalityWindow):
     def update_noise_volume(self, value: float) -> None:
         """Catch the noise volume spinbox signal (value is a 0-1 float)."""
         self.noise_stream_volume = value
+        self.session.log_interaction(f"Noise volume set to {value:.2f}")
 
     def gather_state(self) -> dict:
         return {

--- a/src/smacc/panels/recording.py
+++ b/src/smacc/panels/recording.py
@@ -115,6 +115,7 @@ class RecordingWindow(ModalityWindow):
         name = self.available_microphones_dropdown.currentData()
         if name:
             self.microphone.setAudioInput(name)
+        self.session.log_interaction(f"Microphone set to {text}")
         self._restart_meter_if_monitoring()  # switch a live meter over too
 
     def refresh_available_microphones(self):
@@ -161,10 +162,11 @@ class RecordingWindow(ModalityWindow):
         if self.sender().isChecked():
             if survey_url := self.current_survey_url():
                 self.open_survey_url(survey_url, self.surveyComboBox.currentText())
-            port_msg = "DreamReportStarted"
+            # Each report's start increments its code (201, 202, …) when the
+            # registry's increment flag is on, so reports are individually findable.
+            self.session.emit_event("DreamReportStarted", ordinal=self.n_report_counter)
         else:
-            port_msg = "DreamReportStopped"
-        self.session.send_event_marker(self.session.portcodes[port_msg], port_msg)
+            self.session.emit_event("DreamReportStopped")
 
     # ----- input level meter (#25) ------------------------------------------
 
@@ -207,6 +209,7 @@ class RecordingWindow(ModalityWindow):
 
     def toggle_level_monitor(self, enabled: bool) -> None:
         """Start/stop monitoring the selected input device's level."""
+        self.session.log_interaction(f"Input level meter {'on' if enabled else 'off'}")
         if enabled:
             try:
                 self.meter_stream = sd.InputStream(
@@ -258,9 +261,7 @@ class RecordingWindow(ModalityWindow):
         open, so every survey launch surfaces a marker (``name`` labels the line).
         """
         webbrowser.open(url, new=1, autoraise=False)
-        self.session.send_event_marker(
-            self.session.portcodes["SurveyOpened"], f"Survey opened: {name or url}"
-        )
+        self.session.emit_event("SurveyOpened", detail=name or url)
 
     def _current_survey_options(self) -> dict[str, str]:
         """The dropdown's saved presets as a ``{name: url}`` mapping."""

--- a/src/smacc/panels/recording.py
+++ b/src/smacc/panels/recording.py
@@ -162,9 +162,9 @@ class RecordingWindow(ModalityWindow):
         if self.sender().isChecked():
             if survey_url := self.current_survey_url():
                 self.open_survey_url(survey_url, self.surveyComboBox.currentText())
-            # Each report's start increments its code (201, 202, …) when the
-            # registry's increment flag is on, so reports are individually findable.
-            self.session.emit_event("DreamReportStarted", ordinal=self.n_report_counter)
+            # When the registry's increment flag is on, each start advances its
+            # code (201, 202, …) automatically, so reports are individually findable.
+            self.session.emit_event("DreamReportStarted")
         else:
             self.session.emit_event("DreamReportStopped")
 

--- a/src/smacc/panels/visual.py
+++ b/src/smacc/panels/visual.py
@@ -110,6 +110,7 @@ class VisualWindow(ModalityWindow):
         # Keep the color picker's swatch in sync (once the button exists).
         if hasattr(self, "colorpickerButton"):
             self._update_color_swatch()
+        self.session.log_interaction(f"Blink color set to {self.bstick_hexcode}")
 
     def _update_color_swatch(self) -> None:
         """Show the currently selected blink color on the color picker button."""
@@ -144,8 +145,9 @@ class VisualWindow(ModalityWindow):
             self.set_blink_color(r, g, b)
 
     def handle_freq_change(self, freq: float) -> None:
-        """Takes frequency as a float, coming from user selection. In Hz."""
+        """Takes the blink length in seconds from the spinbox."""
         self.bstick_blink_freq = freq
+        self.session.log_interaction(f"Blink length set to {freq:.1f}s")
 
     def stimulate_visual(self):
         if not self._ensure_blinkstick():
@@ -154,6 +156,7 @@ class VisualWindow(ModalityWindow):
 
         black = [0, 0, 0] * 32
         freq = self.bstick_blink_freq
+        self.session.emit_event("VisualStarted")
         self.bstick.set_led_data(channel=0, data=self.bstick_led_data)
         sleep(freq)
         self.bstick.set_led_data(channel=0, data=black)

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -1,6 +1,6 @@
 """Persist and restore operator/machine preferences as ``preferences.yaml``.
 
-Preferences are the *operator/machine* layer — window geometry, theme, always-on-top,
+Preferences are the *operator/machine* layer — window geometry, always-on-top, and
 which log levels show in the preview pane — distinct from a portable study config
 (:mod:`smacc.settings`) and from a per-run session record. They are auto-loaded at
 startup and saved on quit, and must never break the app: a missing or corrupt file
@@ -23,7 +23,8 @@ SCHEMA_VERSION = 1
 # file's keys over a copy of this, so older/partial files still yield every key.
 DEFAULTS: dict[str, Any] = {
     "always_on_top": False,
-    "lights_on": True,
+    # Lights state is intentionally NOT persisted: SMACC always opens with lights
+    # on (the dark theme is per-session, not a saved preference).
     "preview_levels": ["INFO", "WARNING", "ERROR", "CRITICAL"],  # names, not ints
     "window": {"x": None, "y": None, "w": 640, "h": 560},
     "association_prompted": False,

--- a/src/smacc/qtlog.py
+++ b/src/smacc/qtlog.py
@@ -16,9 +16,11 @@ class QtLogHandler(logging.Handler):
 
     Which records appear is governed by ``enabled_levels`` (an explicit set of
     level numbers), driven by the File ▸ Log preview checkboxes so any subset of
-    levels can be shown. The file handler still receives every record. The widget
-    update is marshalled to the GUI thread via a Qt signal, so logging from a
-    non-GUI thread (e.g. the audio callback) is safe.
+    levels can be shown. A record may also opt out of the preview with a falsey
+    ``smacc_preview`` attribute (set per event in the Event codes editor); the file
+    handler still receives every record regardless. The widget update is marshalled
+    to the GUI thread via a Qt signal, so logging from a non-GUI thread (e.g. the
+    audio callback) is safe.
     """
 
     def __init__(self, list_widget: QtWidgets.QListWidget) -> None:
@@ -35,6 +37,9 @@ class QtLogHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         if record.levelno not in self.enabled_levels:
+            return
+        # An event may be sent/logged to file but hidden from the live preview.
+        if not getattr(record, "smacc_preview", True):
             return
         try:
             msg = self.format(record)

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -61,6 +61,8 @@ class SmaccSession:
         # key. Defaults here; a loaded study overrides them via set_event_codes().
         self.events = {e.key: e for e in events.default_events()}
         self.event_code_safe_max = events.DEFAULT_SAFE_MAX
+        # Per-event firing counts so an incrementing event advances its code.
+        self._event_counts: dict[str, int] = {}
         # Soft interaction logs (volume/color/device/…) are gated off until the
         # main window finishes startup, so construction and study loads don't
         # spam the log; the window flips this on afterwards.
@@ -121,33 +123,34 @@ class SmaccSession:
         self.info = StreamInfo("MyMarkerStream", "Markers", 1, 0, "string", stream_id)
         self.outlet = StreamOutlet(self.info)
 
-    def emit_event(
-        self, key: str, detail: str | None = None, ordinal: int | None = None
-    ) -> None:
-        """Route a registry event: push its marker and/or log it per its flags.
+    def emit_event(self, key: str, detail: str | None = None) -> None:
+        """Route a registry event: send its marker (if triggered) and log it.
 
         ``detail`` appends a free-text suffix to the log label (e.g. a cue name).
-        ``ordinal`` is the 1-based firing count for incrementing events (dream
-        reports). A *triggered* event is always logged so the sent marker stays
-        traceable; a non-triggered event is logged only when its ``log`` flag is
-        on (and never carries a portcode).
+        Every event is written to the log file; the event's ``preview`` flag (with
+        the level filter) controls whether it also shows in the live preview. An
+        ``increment`` event advances its code on each firing (by the per-key firing
+        count), so each occurrence is individually findable in the trigger channel.
         """
         event = self.events.get(key)
         if event is None:
             self.logger.warning(f"Unknown event {key!r}; nothing emitted.")
             return
+        self._event_counts[key] = self._event_counts.get(key, 0) + 1
+        ordinal = self._event_counts[key]
         code = events.runtime_code(event, ordinal)
-        if event.increment and ordinal and event.code + (ordinal - 1) > events.CODE_MAX:
+        if event.increment and event.code + (ordinal - 1) > events.CODE_MAX:
             self.logger.warning(
                 f"{event.label}: code band exhausted (>{events.CODE_MAX}); "
                 f"reusing {code}."
             )
         label = f"{event.label}: {detail}" if detail else event.label
+        line = f"{label} - portcode {code}" if event.trigger else label
         if event.trigger:
             self.outlet.push_sample([str(code)])
-            self.log_info_msg(f"{label} - portcode {code}")
-        elif event.log:
-            self.log_info_msg(label)
+        # Every event is written to the log file; the preview flag (+ level filter)
+        # gates whether it also appears in the live log viewer.
+        self.logger.info(line, extra={"smacc_preview": event.preview})
 
     def set_event_codes(self, event_codes, safe_max: int | None = None) -> None:
         """Replace the live registry from a loaded/edited list of code overrides."""

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -16,8 +16,8 @@ from pathlib import Path
 from pylsl import StreamInfo, StreamOutlet
 from PyQt5 import QtWidgets
 
-from . import bids, settings
-from .config import PPORT_ADDRESS, PPORT_CODES, VERSION
+from . import bids, events, settings
+from .config import PPORT_ADDRESS, VERSION
 from .paths import sessions_directory
 
 
@@ -57,7 +57,14 @@ class SmaccSession:
         self.stem = self.session_dir.name
         self.log_path = self.session_dir / f"{self.stem}.log"
         self.pport_address = PPORT_ADDRESS
-        self.portcodes = PPORT_CODES
+        # The live event-marker registry (codes + routing flags), keyed by event
+        # key. Defaults here; a loaded study overrides them via set_event_codes().
+        self.events = {e.key: e for e in events.default_events()}
+        self.event_code_safe_max = events.DEFAULT_SAFE_MAX
+        # Soft interaction logs (volume/color/device/…) are gated off until the
+        # main window finishes startup, so construction and study loads don't
+        # spam the log; the window flips this on afterwards.
+        self.log_interactions = False
         self.init_logger()
         self.init_lsl_stream()
 
@@ -87,6 +94,8 @@ class SmaccSession:
         """
         self._append_settings_block(settings_state, "initial")
         self.log_info_msg("Opened SMACC v" + VERSION)
+        # Optional connection-test marker; a no-op unless a study enables it.
+        self.emit_event("TriggerInitialization")
 
     def end_log(self, settings_state: dict) -> None:
         """Append the final settings (post-edits) as the log's tail, at quit."""
@@ -112,14 +121,60 @@ class SmaccSession:
         self.info = StreamInfo("MyMarkerStream", "Markers", 1, 0, "string", stream_id)
         self.outlet = StreamOutlet(self.info)
 
-    def send_event_marker(self, portcode: int, port_msg: str) -> None:
-        """Push an LSL marker and log it to the file + preview."""
-        self.outlet.push_sample([str(portcode)])
-        self.log_info_msg(f"{port_msg} - portcode {portcode}")
+    def emit_event(
+        self, key: str, detail: str | None = None, ordinal: int | None = None
+    ) -> None:
+        """Route a registry event: push its marker and/or log it per its flags.
+
+        ``detail`` appends a free-text suffix to the log label (e.g. a cue name).
+        ``ordinal`` is the 1-based firing count for incrementing events (dream
+        reports). A *triggered* event is always logged so the sent marker stays
+        traceable; a non-triggered event is logged only when its ``log`` flag is
+        on (and never carries a portcode).
+        """
+        event = self.events.get(key)
+        if event is None:
+            self.logger.warning(f"Unknown event {key!r}; nothing emitted.")
+            return
+        code = events.runtime_code(event, ordinal)
+        if event.increment and ordinal and event.code + (ordinal - 1) > events.CODE_MAX:
+            self.logger.warning(
+                f"{event.label}: code band exhausted (>{events.CODE_MAX}); "
+                f"reusing {code}."
+            )
+        label = f"{event.label}: {detail}" if detail else event.label
+        if event.trigger:
+            self.outlet.push_sample([str(code)])
+            self.log_info_msg(f"{label} - portcode {code}")
+        elif event.log:
+            self.log_info_msg(label)
+
+    def set_event_codes(self, event_codes, safe_max: int | None = None) -> None:
+        """Replace the live registry from a loaded/edited list of code overrides."""
+        self.events = {e.key: e for e in events.merge_event_codes(event_codes)}
+        if safe_max is not None:
+            try:
+                self.event_code_safe_max = int(safe_max)
+            except (TypeError, ValueError):
+                self.event_code_safe_max = events.DEFAULT_SAFE_MAX
+
+    def event_codes_as_list(self) -> list[dict]:
+        """Return the current registry as the compact list persisted in a study."""
+        return events.events_to_list(self.events.values())
 
     def log_info_msg(self, msg: str) -> None:
         """Log an INFO message (always to file; to the preview if INFO is on)."""
         self.logger.info(msg)
+
+    def log_interaction(self, msg: str) -> None:
+        """Log a soft interaction (volume/color/device/…) once the session is live.
+
+        Gated by ``log_interactions`` so the programmatic widget setup that runs
+        during construction or a study load doesn't spam the log; the main window
+        flips the gate on after startup. These lines never carry a portcode.
+        """
+        if self.log_interactions:
+            self.log_info_msg(msg)
 
     def show_error_popup(self, short_msg, long_msg=None, parent=None) -> None:
         """Record an error in the log and show a dialog (parented if given)."""

--- a/src/smacc/settings.py
+++ b/src/smacc/settings.py
@@ -9,7 +9,7 @@ reject YAML that wasn't written by it.
 The on-disk shape (a ``.smacc`` file is YAML text with a leading comment header)::
 
     kind: smacc/settings
-    schema_version: 3
+    schema_version: 4
     smacc_version: "0.0.7"
     metadata: {subject: "", session: "", notes: "", created: "..."}
     settings: { ...the panel state from SmaccWindow.gather_settings()... }
@@ -43,8 +43,9 @@ _FILE_HEADER = "# SMACC study config — YAML (.smacc). Edit with care.\n"
 
 # Bump when the serialized layout changes incompatibly. Files written by older
 # (lower) versions are still accepted on load; panels handle field-level
-# back-compat (e.g. a v1 single cue maps into the first multi-slot cue).
-SCHEMA_VERSION = 3
+# back-compat (e.g. a v1 single cue maps into the first multi-slot cue, and a
+# pre-v4 file with no event_codes falls back to the default registry).
+SCHEMA_VERSION = 4
 
 
 def build_payload(settings: dict[str, Any], metadata: dict) -> dict[str, Any]:

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -34,6 +34,24 @@ def test_empty_log_yields_no_events():
     assert bids.log_to_events("") == []
 
 
+INCREMENT_LOG = """2026-06-05 22:00:00.000, INFO, Opened SMACC v0.0.7
+2026-06-05 22:01:00.000, INFO, Noise volume set to 0.30
+2026-06-05 22:02:00.000, INFO, Dream report started - portcode 201
+2026-06-05 22:05:00.000, INFO, Dream report stopped - portcode 200
+2026-06-05 22:40:00.000, INFO, Dream report started - portcode 202
+2026-06-05 22:43:00.000, INFO, Dream report stopped - portcode 200
+"""
+
+
+def test_incrementing_dream_codes_and_soft_logs():
+    events = bids.log_to_events(INCREMENT_LOG)
+    # The soft "Noise volume set to" line has no portcode, so it's not an event.
+    assert len(events) == 4  # 2 starts + 2 stops only
+    assert all("set to" not in e["trial_type"] for e in events)
+    started = [e["value"] for e in events if e["trial_type"] == "Dream report started"]
+    assert started == [201, 202]  # distinct, incrementing codes per report
+
+
 def test_write_events_tsv_round_trip(tmp_path):
     events = bids.log_to_events(SAMPLE_LOG)
     path = tmp_path / "sub-001_ses-001_events.tsv"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -81,7 +81,7 @@ def test_merge_event_codes_coerces_types():
 def test_events_to_list_is_compact_and_round_trips():
     compact = events.events_to_list(events.default_events())
     assert all(
-        set(d) == {"key", "code", "trigger", "log", "increment"} for d in compact
+        set(d) == {"key", "code", "trigger", "preview", "increment"} for d in compact
     )
     merged = {e.key: e for e in events.merge_event_codes(compact)}
     for e in events.default_events():

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -125,3 +125,55 @@ def test_validate_events_warns_on_increment_band_overlap():
     ]
     _, warnings = events.validate_events(defs)
     assert warnings  # the 60..255 band overlaps Other's code 62
+
+
+def test_validate_events_requires_label():
+    errors, _ = events.validate_events([events.EventDef("k", "", 50)])
+    assert any("label" in e.lower() for e in errors)
+
+
+# ----- custom events --------------------------------------------------------
+
+
+def test_default_events_are_all_builtin():
+    assert all(e.builtin for e in events.default_events())
+
+
+def test_make_custom_event_is_manual_and_unique():
+    existing = {e.key for e in events.default_events()}
+    e1 = events.make_custom_event("My Event", 70, existing)
+    assert e1.builtin is False
+    assert e1.category == "manual"
+    assert e1.key.startswith("customMyEvent")
+    e2 = events.make_custom_event("My Event", 71, existing | {e1.key})
+    assert e2.key != e1.key  # a uniqueness suffix is appended on collision
+
+
+def test_custom_event_round_trips_through_persistence():
+    custom = events.make_custom_event(
+        "Spont arousal", 70, set(), tooltip="hi", increment=True
+    )
+    registry = events.default_events() + [custom]
+    compact = events.events_to_list(registry)
+    # The custom entry persists its full definition (incl. builtin=False)...
+    custom_dict = next(d for d in compact if d["key"] == custom.key)
+    assert custom_dict["builtin"] is False
+    assert custom_dict["label"] == "Spont arousal"
+    assert custom_dict["category"] == "manual"
+    # ...while built-ins stay compact (no label key).
+    builtin_dict = next(d for d in compact if d["key"] == "REMDetected")
+    assert "label" not in builtin_dict
+    # Round-trip reconstructs the custom event.
+    merged = {e.key: e for e in events.merge_event_codes(compact)}
+    assert merged[custom.key].label == "Spont arousal"
+    assert merged[custom.key].increment is True
+    assert merged[custom.key].builtin is False
+
+
+def test_merge_ignores_unknown_key_without_custom_flag():
+    # An unknown key not marked builtin:false is dropped (e.g. a removed built-in),
+    # so stale entries don't resurrect as phantom buttons.
+    merged = {
+        e.key: e for e in events.merge_event_codes([{"key": "Ghost", "code": 90}])
+    }
+    assert "Ghost" not in merged

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,0 +1,127 @@
+"""Tests for the configurable event-marker registry (no GUI/LSL needed)."""
+
+from smacc import events
+
+
+def test_default_events_codes_unique_and_8bit():
+    defs = events.default_events()
+    for e in defs:
+        assert isinstance(e.code, int) and not isinstance(e.code, bool)
+        assert events.CODE_MIN <= e.code <= events.CODE_MAX
+    keys = [e.key for e in defs]
+    assert len(keys) == len(set(keys))  # unique keys
+    triggered = [e.code for e in defs if e.trigger]
+    assert len(triggered) == len(set(triggered))  # no triggered-code collisions
+
+
+def test_default_events_validate_clean():
+    errors, warnings = events.validate_events(events.default_events())
+    assert errors == []
+    assert warnings == []
+
+
+def test_dream_start_increments_and_others_dont():
+    defs = {e.key: e for e in events.default_events()}
+    start = defs["DreamReportStarted"]
+    assert start.increment is True
+    assert events.runtime_code(start, 1) == start.code
+    assert events.runtime_code(start, 2) == start.code + 1
+    assert events.runtime_code(start, 3) == start.code + 2
+    # A non-incrementing event ignores the ordinal.
+    stopped = defs["DreamReportStopped"]
+    assert events.runtime_code(stopped, 5) == stopped.code
+
+
+def test_runtime_code_clamps_at_255():
+    e = events.EventDef("X", "X", 254, increment=True)
+    assert events.runtime_code(e, 1) == 254
+    assert events.runtime_code(e, 2) == 255
+    assert events.runtime_code(e, 3) == 255  # clamped; never exceeds the 8-bit max
+
+
+def test_merge_event_codes_none_yields_defaults():
+    merged = events.merge_event_codes(None)
+    assert [e.key for e in merged] == [e.key for e in events.default_events()]
+    assert [e.code for e in merged] == [e.code for e in events.default_events()]
+
+
+def test_merge_event_codes_overlays_overrides():
+    merged = {
+        e.key: e
+        for e in events.merge_event_codes(
+            [{"key": "REMDetected", "code": 99, "trigger": False}]
+        )
+    }
+    assert merged["REMDetected"].code == 99
+    assert merged["REMDetected"].trigger is False
+    assert merged["Clapper"].code == 49  # untouched events keep their defaults
+
+
+def test_merge_event_codes_ignores_unknown_keys():
+    merged = {
+        e.key: e
+        for e in events.merge_event_codes([{"key": "NotARealEvent", "code": 123}])
+    }
+    assert "NotARealEvent" not in merged
+    assert len(merged) == len(events.default_events())  # still the full default set
+
+
+def test_merge_event_codes_coerces_types():
+    # YAML / hand edits may yield stringy/inty values; merge should coerce them.
+    merged = {
+        e.key: e
+        for e in events.merge_event_codes(
+            [{"key": "Clapper", "code": "49", "trigger": 1}]
+        )
+    }
+    assert merged["Clapper"].code == 49
+    assert merged["Clapper"].trigger is True
+
+
+def test_events_to_list_is_compact_and_round_trips():
+    compact = events.events_to_list(events.default_events())
+    assert all(
+        set(d) == {"key", "code", "trigger", "log", "increment"} for d in compact
+    )
+    merged = {e.key: e for e in events.merge_event_codes(compact)}
+    for e in events.default_events():
+        assert merged[e.key].code == e.code
+        assert merged[e.key].trigger == e.trigger
+
+
+def test_validate_events_rejects_out_of_range_and_dupes():
+    errors, _ = events.validate_events([events.EventDef("A", "A", 0)])
+    assert errors  # 0 is below CODE_MIN
+
+    dupes = [
+        events.EventDef("A", "A", 50, trigger=True),
+        events.EventDef("B", "B", 50, trigger=True),
+    ]
+    errors, _ = events.validate_events(dupes)
+    assert errors  # two triggered events share code 50
+
+
+def test_validate_events_allows_dupe_when_not_triggered():
+    pair = [
+        events.EventDef("A", "A", 50, trigger=True),
+        events.EventDef("B", "B", 50, trigger=False),
+    ]
+    errors, _ = events.validate_events(pair)
+    assert errors == []  # only one can ever be sent, so no real collision
+
+
+def test_validate_events_warns_above_safe_max():
+    errors, warnings = events.validate_events(
+        [events.EventDef("A", "A", 200, trigger=True)], safe_max=127
+    )
+    assert errors == []
+    assert warnings  # 200 > safe_max 127 is a soft warning, not an error
+
+
+def test_validate_events_warns_on_increment_band_overlap():
+    defs = [
+        events.EventDef("Start", "Start", 60, trigger=True, increment=True),
+        events.EventDef("Other", "Other", 62, trigger=True),
+    ]
+    _, warnings = events.validate_events(defs)
+    assert warnings  # the 60..255 band overlaps Other's code 62

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -35,7 +35,12 @@ def test_partial_file_merges_over_defaults(tmp_path):
     preferences.save_preferences(path, {"always_on_top": True})
     prefs = preferences.load_preferences(path)
     assert prefs["always_on_top"] is True  # from file
-    assert prefs["lights_on"] is True  # default still present
+    assert prefs["preview_levels"] == [
+        "INFO",
+        "WARNING",
+        "ERROR",
+        "CRITICAL",
+    ]  # default
     assert "association_prompted" in prefs  # every default key present
 
 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -45,68 +45,82 @@ class _FakeOutlet:
 
 
 def _stub_session():
-    """A SmaccSession wired to fakes so emit_event runs without LSL/file/GUI."""
+    """A SmaccSession wired to fakes so emit_event runs without LSL/file/GUI.
+
+    Returns ``(session, records)`` where ``records`` collects ``(message,
+    preview)`` for each logged line (preview = the smacc_preview attribute).
+    """
     sess = SmaccSession.__new__(SmaccSession)
     sess.events = {e.key: e for e in events.default_events()}
     sess.event_code_safe_max = events.DEFAULT_SAFE_MAX
     sess.log_interactions = True
+    sess._event_counts = {}
     sess.outlet = _FakeOutlet()
     logger = logging.getLogger("smacc-test-emit")
     logger.handlers.clear()
     logger.setLevel(logging.DEBUG)
     logger.propagate = False
-    messages: list[str] = []
+    records: list[tuple[str, bool]] = []
 
     class _Capture(logging.Handler):
         def emit(self, record):
-            messages.append(record.getMessage())
+            records.append(
+                (record.getMessage(), getattr(record, "smacc_preview", True))
+            )
 
     logger.addHandler(_Capture())
     sess.logger = logger
-    return sess, messages
+    return sess, records
 
 
 def test_emit_event_triggers_and_logs_with_code():
-    sess, messages = _stub_session()
-    sess.emit_event("REMDetected")  # default trigger=True
+    sess, records = _stub_session()
+    sess.emit_event("REMDetected")  # default trigger=True, preview=True
     assert sess.outlet.samples == [["41"]]
-    assert messages == ["REM detected - portcode 41"]
+    assert records == [("REM detected - portcode 41", True)]
 
 
-def test_emit_event_log_only_when_not_triggered():
-    sess, messages = _stub_session()
-    sess.events["REMDetected"] = replace(
-        sess.events["REMDetected"], trigger=False, log=True
-    )
+def test_emit_event_not_triggered_still_logs_to_file():
+    sess, records = _stub_session()
+    sess.events["REMDetected"] = replace(sess.events["REMDetected"], trigger=False)
     sess.emit_event("REMDetected")
     assert sess.outlet.samples == []  # not sent to the marker stream
-    assert messages == ["REM detected"]  # logged, but without a portcode
+    assert records == [("REM detected", True)]  # logged to file, without a portcode
 
 
-def test_emit_event_silent_when_neither_trigger_nor_log():
-    sess, messages = _stub_session()
-    # TriggerInitialization defaults to trigger=False, log=False -> a no-op.
+def test_emit_event_files_but_hides_from_preview():
+    sess, records = _stub_session()
+    # TriggerInitialization defaults to trigger=False, preview=False: it's written
+    # to the log file but kept out of the live preview.
     sess.emit_event("TriggerInitialization")
     assert sess.outlet.samples == []
-    assert messages == []
+    assert records == [("SMACC initialized", False)]
 
 
 def test_emit_event_detail_suffix():
-    sess, messages = _stub_session()
+    sess, records = _stub_session()
     sess.emit_event("CueStarted", detail="Cue 1")
     assert sess.outlet.samples == [["60"]]
-    assert messages == ["Cue started: Cue 1 - portcode 60"]
+    assert records == [("Cue started: Cue 1 - portcode 60", True)]
 
 
-def test_emit_event_dream_increment():
+def test_emit_event_dream_increment_auto_counts():
     sess, _ = _stub_session()
-    for ordinal in (1, 2, 3):
-        sess.emit_event("DreamReportStarted", ordinal=ordinal)
+    for _ in range(3):
+        sess.emit_event("DreamReportStarted")  # no manual ordinal needed
     assert sess.outlet.samples == [["201"], ["202"], ["203"]]
 
 
+def test_emit_event_increment_works_for_any_event():
+    sess, _ = _stub_session()
+    sess.events["SurveyOpened"] = replace(sess.events["SurveyOpened"], increment=True)
+    sess.emit_event("SurveyOpened")
+    sess.emit_event("SurveyOpened")
+    assert sess.outlet.samples == [["67"], ["68"]]  # base 67 advances per firing
+
+
 def test_emit_event_unknown_key_warns_without_crashing():
-    sess, messages = _stub_session()
+    sess, records = _stub_session()
     sess.emit_event("Nonexistent")  # should warn, not raise
     assert sess.outlet.samples == []
-    assert any("Unknown event" in m for m in messages)
+    assert any("Unknown event" in m for m, _ in records)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,8 +1,11 @@
-"""Tests for the per-run session-folder helper (no LSL/GUI needed)."""
+"""Tests for the session-folder helper and emit_event routing (no LSL/GUI needed)."""
 
+import logging
+from dataclasses import replace
 from datetime import datetime
 
-from smacc.session import make_session_dir
+from smacc import events
+from smacc.session import SmaccSession, make_session_dir
 
 
 def test_make_session_dir_uses_timestamp_stem(tmp_path):
@@ -26,3 +29,84 @@ def test_make_session_dir_resolves_same_second_collision(tmp_path):
     assert second.name == "smacc-20260607-223015-2"
     assert third.name == "smacc-20260607-223015-3"
     assert len({first, second, third}) == 3
+
+
+# ----- emit_event routing ---------------------------------------------------
+
+
+class _FakeOutlet:
+    """Stand-in for the LSL outlet that records pushed marker samples."""
+
+    def __init__(self):
+        self.samples = []
+
+    def push_sample(self, sample):
+        self.samples.append(sample)
+
+
+def _stub_session():
+    """A SmaccSession wired to fakes so emit_event runs without LSL/file/GUI."""
+    sess = SmaccSession.__new__(SmaccSession)
+    sess.events = {e.key: e for e in events.default_events()}
+    sess.event_code_safe_max = events.DEFAULT_SAFE_MAX
+    sess.log_interactions = True
+    sess.outlet = _FakeOutlet()
+    logger = logging.getLogger("smacc-test-emit")
+    logger.handlers.clear()
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    messages: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            messages.append(record.getMessage())
+
+    logger.addHandler(_Capture())
+    sess.logger = logger
+    return sess, messages
+
+
+def test_emit_event_triggers_and_logs_with_code():
+    sess, messages = _stub_session()
+    sess.emit_event("REMDetected")  # default trigger=True
+    assert sess.outlet.samples == [["41"]]
+    assert messages == ["REM detected - portcode 41"]
+
+
+def test_emit_event_log_only_when_not_triggered():
+    sess, messages = _stub_session()
+    sess.events["REMDetected"] = replace(
+        sess.events["REMDetected"], trigger=False, log=True
+    )
+    sess.emit_event("REMDetected")
+    assert sess.outlet.samples == []  # not sent to the marker stream
+    assert messages == ["REM detected"]  # logged, but without a portcode
+
+
+def test_emit_event_silent_when_neither_trigger_nor_log():
+    sess, messages = _stub_session()
+    # TriggerInitialization defaults to trigger=False, log=False -> a no-op.
+    sess.emit_event("TriggerInitialization")
+    assert sess.outlet.samples == []
+    assert messages == []
+
+
+def test_emit_event_detail_suffix():
+    sess, messages = _stub_session()
+    sess.emit_event("CueStarted", detail="Cue 1")
+    assert sess.outlet.samples == [["60"]]
+    assert messages == ["Cue started: Cue 1 - portcode 60"]
+
+
+def test_emit_event_dream_increment():
+    sess, _ = _stub_session()
+    for ordinal in (1, 2, 3):
+        sess.emit_event("DreamReportStarted", ordinal=ordinal)
+    assert sess.outlet.samples == [["201"], ["202"], ["203"]]
+
+
+def test_emit_event_unknown_key_warns_without_crashing():
+    sess, messages = _stub_session()
+    sess.emit_event("Nonexistent")  # should warn, not raise
+    assert sess.outlet.samples == []
+    assert any("Unknown event" in m for m in messages)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -47,7 +47,7 @@ def test_saved_file_is_tagged_yaml(tmp_path):
     assert text.splitlines()[0].startswith("#")  # self-identifying header comment
     payload = yaml.safe_load(text)  # comment is ignored, so it still parses
     assert payload["kind"] == settings.KIND
-    assert payload["schema_version"] == settings.SCHEMA_VERSION == 3
+    assert payload["schema_version"] == settings.SCHEMA_VERSION == 4
     assert payload["smacc_version"] == smacc.__version__
     assert payload["settings"] == {"cue_attack": 0.2}
 
@@ -69,6 +69,24 @@ def test_load_accepts_current_schema(tmp_path):
     settings.save_settings(path, {"cue_attack": 1.0}, {})
     state, _ = settings.load_settings(path)
     assert state == {"cue_attack": 1.0}
+
+
+def test_load_accepts_older_schema_without_event_codes(tmp_path):
+    # A pre-v4 study (no event_codes) must still load; the GUI fills the default
+    # registry on apply via events.merge_event_codes.
+    path = tmp_path / "old.smacc"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "kind": settings.KIND,
+                "schema_version": 3,
+                "settings": {"cue_attack": 0.5},
+            }
+        ),
+        encoding="utf-8",
+    )
+    state, _ = settings.load_settings(path)
+    assert state == {"cue_attack": 0.5}
 
 
 def test_load_rejects_unsupported_schema(tmp_path):

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import smacc
-from smacc import config
+from smacc import config, events
 
 
 def test_package_exposes_version():
@@ -16,7 +16,8 @@ def test_config_version_is_single_sourced():
     assert config.VERSION == smacc.__version__
 
 
-def test_portcodes_are_unique_ints():
-    codes = list(config.PPORT_CODES.values())
+def test_default_event_codes_are_unique_ints():
+    codes = [e.code for e in events.default_events()]
     assert all(isinstance(code, int) for code in codes)
-    assert len(codes) == len(set(codes))
+    triggered = [e.code for e in events.default_events() if e.trigger]
+    assert len(triggered) == len(set(triggered))  # no triggered-code collisions


### PR DESCRIPTION
Addresses #47 — makes SMACC's EEG event/trigger codes a configurable, traceable, per-study registry instead of hardcoded dicts.

## What changed

**Configurable event registry.** The two hardcoded code dicts in `config.py` are replaced by a single `EventDef` registry (`events.py`) — the source of truth for every marker's code, routing, and label. It persists in the portable `.smacc` study bundle (schema v4, back-compatible with v1–3) and is written into every session `.log` (initial + final settings blocks), so any session is self-decoding even if codes change mid-study.

**Event codes editor** (File ▸ Event codes…). A table with per-event **Code**, **Trigger** (send to the marker stream), **Preview** (show in the live log viewer — the log *file* always records everything), and **Increment**. Validates 8-bit (1–255) + uniqueness, with a configurable **Safe max** soft-warning for older trigger hardware. Edits apply live and are logged loudly (WARNING) for traceability.

**Coverage.** Wired up the previously-dead triggers (noise on/off, visual stimulation, optional startup init) and routed every emitter through one `session.emit_event(key)` chokepoint. Added log-only lines (no portcode) for interactions like volume/color/device/fade changes.

**Incrementing codes.** Any event can advance its code on each firing (dream reports default to 201, 202, 203…), auto-counted per event key, so individual occurrences are findable in the trigger channel. A soft band-overlap warning flags potential collisions.

**Custom events + Event logging panel.** The editor's **Add event… / Remove** lets a study define its own button events (built-ins can be retuned but not removed). The manual event buttons moved into a dedicated, rebuildable **Event logging** panel sized to its button count; the **Lights** toggle stays on the main window (now a tall single-column button with a sun/moon glyph) and always opens ON.

## Maps to the issue checklist

- ✅ Codes changeable via a settings popup
- ✅ All relevant events send triggers (noise/visual/init wired up)
- ✅ Every important event/interaction logged (volume etc. logged without a portcode)
- ✅ Codes clear & traceable in the log (per-event code + full map in each `.log`; mid-study changes logged)
- ✅ Works on old systems with limited ranges (Safe max warning)
- ✅ Unique, systematic code per dream report ("201" fixed or "201+" incrementing)
- ✅ Trigger / Log (Preview) checkboxes, two columns
- ⏸️ Mid-session lock — intentionally deferred (no reliable lock timepoint yet); we rely on loud change-logging for now

## Notable behavior changes

- Default code map renumbered into a coherent scheme (dream reports reserve the 201+ band; other control codes compacted to 41–67). Codes are now per-study configurable and recorded in every log.
- Cleaner log labels (e.g. `Dream report started`, `Intercom started`) — these become the BIDS `trial_type` values.
- The manual event buttons now live in the Event logging panel (1–9 shortcuts active while it's focused); the Lights toggle (and `L`) stays on the main window and always starts on.

## Testing

`uv run --extra dev pytest` — 112 tests pass (new `test_events.py`; extended session/settings/bids/preferences/smoke). `ruff`, `ruff format`, and `mypy` all clean. Main window layout verified via an offscreen render.

Related: complements the LSL marker stream and sets up the future hardware-trigger path (#28) behind the same `emit_event` chokepoint.
