### PR TITLE
Recording-start marker with dream-report timestamps (#60) and add/removable cues (#65)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -39,13 +39,18 @@ returns to the launcher.
 Place sound files where your settings expect them — by default the data directory's
 `cues/` folder (e.g. `~/SMACC/data/cues/`; `.wav`, `.mp3`, `.flac`, `.ogg`, and
 `.aiff` are supported) — and trigger them from the cue controls. SMACC seeds a few
-`demo-*` cues there so there is always something to test with.
+`demo-*` cues there so there is always something to test with. You start with one
+cue — prefilled with a random demo — and use **+ Add cue** and each row's **✕** to
+add or remove cues to match a protocol (one minimum, up to 20).
 
 ## Dream reports
 
 Use the **Record Dream Report** button to record from the selected input device.
 Choose the device from **Audio &rsaquo; Input device &rsaquo; [choose device]**.
-Recordings are saved into the current session folder.
+Recordings are saved into the current session folder. Each report is also stamped
+with the time elapsed since you pressed **Start recording** (in the Event logging
+panel), so it is easy to locate in the EEG file; if recording has not been marked
+yet, the report is still logged and SMACC reminds you to mark it.
 
 Surveys (e.g. a dream-report questionnaire on Qualtrics or REDCap) open in your
 browser. Manage your saved surveys with the **Manage…** button next to the survey
@@ -91,7 +96,7 @@ and fade changes — as plain log lines (no portcode), so the session record is 
 
 ### Event logging panel
 
-The manual event buttons (REM detected, Sleep onset, your custom events, …) live in the
+The manual event buttons (Start recording, REM detected, Sleep onset, your custom events, …) live in the
 **Event logging** panel — open it from the session window's **Open tools** column; the
 first nine buttons take the 1–9 keyboard shortcuts while it's focused. The **Lights**
 toggle stays on the main window (it also flips the dark theme).

--- a/src/smacc/assets/default.smacc
+++ b/src/smacc/assets/default.smacc
@@ -35,6 +35,11 @@ settings:
   survey_url: ''
   survey_options: {}
   event_codes:
+  - key: RecordingStarted
+    code: 51
+    trigger: true
+    preview: true
+    increment: false
   - key: TLRTrainingStart
     code: 43
     trigger: true

--- a/src/smacc/assets/default.smacc
+++ b/src/smacc/assets/default.smacc
@@ -9,23 +9,8 @@ metadata:
 settings:
   blink_color: '#000000'
   blink_length: 1.0
-  cues:
-  - name: Cue 1
-    file: ''
-    volume: 0.2
-    loop: false
-  - name: Cue 2
-    file: ''
-    volume: 0.2
-    loop: false
-  - name: Cue 3
-    file: ''
-    volume: 0.2
-    loop: false
-  - name: Cue 4
-    file: ''
-    volume: 0.2
-    loop: false
+  # cues omitted on purpose: the one required cue autofills a random demo on first
+  # launch (#65); saving from the app writes the configured cue list back here.
   cue_attack: 0.0
   cue_release: 0.0
   noise_volume: 0.2

--- a/src/smacc/events.py
+++ b/src/smacc/events.py
@@ -66,6 +66,16 @@ def default_events() -> list[EventDef]:
     return [
         # --- Manual / observational: the auto-built event-grid buttons --------
         EventDef(
+            "RecordingStarted",
+            "Start recording",
+            51,
+            category="manual",
+            tooltip=(
+                "Mark the start of the EEG recording; sets the reference clock "
+                "for dream-report timestamps"
+            ),
+        ),
+        EventDef(
             "TLRTrainingStart",
             "TLR training start",
             43,

--- a/src/smacc/panels/audio.py
+++ b/src/smacc/panels/audio.py
@@ -3,7 +3,10 @@
 Each slot preloads its own sound with its own volume and loop setting, so a
 protocol that uses several sounds (e.g. cue vs. sham) can keep them ready and
 fire any one with a click. Playback is one-at-a-time (playing a slot stops
-whatever was playing); fade-in/out is shared at the panel level.
+whatever was playing); fade-in/out is shared at the panel level. Slots can be
+added and removed on the fly — one is always required, up to a generous cap — and
+the first slot autofills with a random demo cue so a fresh study is immediately
+playable (#65).
 """
 
 from __future__ import annotations
@@ -17,17 +20,23 @@ from pathlib import Path
 from PyQt5 import QtCore, QtMultimedia, QtWidgets
 
 from ..session import SmaccSession
-from ..utils import ensure_wav
+from ..utils import ensure_wav, pick_random_demo_cue
 from .base import ModalityWindow, make_section_title
 
-N_CUE_SLOTS = 4
+# One cue is always required; the upper bound is generous (a session typically
+# uses 2-5) but capped so the grid and playback stay manageable (#65).
+MIN_CUE_SLOTS = 1
+MAX_CUE_SLOTS = 20
 
 
 @dataclass
 class CueSlot:
-    """One preloaded cue: its player plus the row of widgets that control it."""
+    """One preloaded cue: its player plus the row of widgets that control it.
 
-    index: int
+    Signal handlers bind to the slot *object*, never a row index, so adding or
+    removing rows can't misroute another slot's controls.
+    """
+
     player: QtMultimedia.QSoundEffect
     nameEdit: QtWidgets.QLineEdit
     fileEdit: QtWidgets.QLineEdit
@@ -36,6 +45,7 @@ class CueSlot:
     loopCheckBox: QtWidgets.QCheckBox
     playButton: QtWidgets.QPushButton
     stopButton: QtWidgets.QPushButton
+    removeButton: QtWidgets.QPushButton
     was_playing: bool = field(default=False)
 
 
@@ -52,54 +62,70 @@ class AudioCueWindow(ModalityWindow):
         self.cue_attack_s = 0.0
         self.cue_release_s = 0.0
         self._cue_fade_anim: QtCore.QPropertyAnimation | None = None
-        self._playing_index: int | None = None
-        # Populated incrementally so the per-slot signal handlers (fired by the
-        # initial setValue below) can already index self.slots.
+        self._playing_slot: CueSlot | None = None
+        # Populated after the central widget exists so _rebuild_grid has its
+        # header labels and add button to work with.
         self.slots: list[CueSlot] = []
-        self._make_slots()
         self.setCentralWidget(self._build())
+        # Start with the one required slot, prefilled with a random demo so a fresh
+        # study can play something immediately; a loaded study overrides it.
+        self._add_initial_slot()
 
     # ----- construction ------------------------------------------------------
 
-    def _make_slots(self) -> None:
-        for i in range(N_CUE_SLOTS):
-            player = QtMultimedia.QSoundEffect()
-            player.setLoopCount(1)
-            nameEdit = QtWidgets.QLineEdit(f"Cue {i + 1}", self)
-            nameEdit.setMaximumWidth(90)
-            fileEdit = QtWidgets.QLineEdit(self)
-            fileEdit.setMinimumWidth(180)
-            browseButton = QtWidgets.QPushButton("Browse", self)
-            volumeSpinBox = QtWidgets.QDoubleSpinBox(self)
-            volumeSpinBox.setRange(0, 1)  # QSoundEffect only allows 0-1
-            volumeSpinBox.setSingleStep(0.01)
-            volumeSpinBox.setMaximumWidth(70)
-            loopCheckBox = QtWidgets.QCheckBox(self)
-            loopCheckBox.setStatusTip("Repeat this cue until stopped.")
-            loopCheckBox.setToolTip("Loop until stopped")
-            playButton = QtWidgets.QPushButton("Play", self)
-            stopButton = QtWidgets.QPushButton("Stop", self)
-            slot = CueSlot(
-                i,
-                player,
-                nameEdit,
-                fileEdit,
-                browseButton,
-                volumeSpinBox,
-                loopCheckBox,
-                playButton,
-                stopButton,
-            )
-            self.slots.append(slot)  # append before wiring so handlers can index it
-            player.playingChanged.connect(partial(self.on_slot_playing_change, i))
-            fileEdit.textChanged.connect(partial(self.update_slot_source, i))
-            fileEdit.editingFinished.connect(partial(self.update_slot_source, i))
-            volumeSpinBox.valueChanged.connect(partial(self.update_slot_volume, i))
-            loopCheckBox.toggled.connect(partial(self.update_slot_loop, i))
-            browseButton.clicked.connect(partial(self.open_audio_selector, i))
-            playButton.clicked.connect(partial(self.play_slot, i))
-            stopButton.clicked.connect(partial(self.stop_slot, i))
-            volumeSpinBox.setValue(0.2)  # fires update_slot_volume -> player
+    def _make_slot(self, name: str) -> CueSlot:
+        """Build one fully-wired cue slot and append it to ``self.slots``."""
+        player = QtMultimedia.QSoundEffect()
+        player.setLoopCount(1)
+        nameEdit = QtWidgets.QLineEdit(name, self)
+        nameEdit.setMaximumWidth(90)
+        fileEdit = QtWidgets.QLineEdit(self)
+        fileEdit.setMinimumWidth(180)
+        browseButton = QtWidgets.QPushButton("Browse", self)
+        volumeSpinBox = QtWidgets.QDoubleSpinBox(self)
+        volumeSpinBox.setRange(0, 1)  # QSoundEffect only allows 0-1
+        volumeSpinBox.setSingleStep(0.01)
+        volumeSpinBox.setMaximumWidth(70)
+        loopCheckBox = QtWidgets.QCheckBox(self)
+        loopCheckBox.setStatusTip("Repeat this cue until stopped.")
+        loopCheckBox.setToolTip("Loop until stopped")
+        playButton = QtWidgets.QPushButton("Play", self)
+        stopButton = QtWidgets.QPushButton("Stop", self)
+        removeButton = QtWidgets.QPushButton("✕", self)  # ✕
+        removeButton.setMaximumWidth(28)
+        removeButton.setStatusTip("Remove this cue.")
+        removeButton.setToolTip("Remove this cue")
+        slot = CueSlot(
+            player,
+            nameEdit,
+            fileEdit,
+            browseButton,
+            volumeSpinBox,
+            loopCheckBox,
+            playButton,
+            stopButton,
+            removeButton,
+        )
+        self.slots.append(slot)  # append before wiring so handlers can resolve it
+        player.playingChanged.connect(partial(self.on_slot_playing_change, slot))
+        fileEdit.textChanged.connect(partial(self.update_slot_source, slot))
+        fileEdit.editingFinished.connect(partial(self.update_slot_source, slot))
+        volumeSpinBox.valueChanged.connect(partial(self.update_slot_volume, slot))
+        loopCheckBox.toggled.connect(partial(self.update_slot_loop, slot))
+        browseButton.clicked.connect(partial(self.open_audio_selector, slot))
+        playButton.clicked.connect(partial(self.play_slot, slot))
+        stopButton.clicked.connect(partial(self.stop_slot, slot))
+        removeButton.clicked.connect(partial(self.remove_slot, slot))
+        volumeSpinBox.setValue(0.2)  # fires update_slot_volume -> player
+        return slot
+
+    def _add_initial_slot(self) -> None:
+        """Create the single required slot and prefill a random demo cue (#65)."""
+        slot = self._make_slot("Cue 1")
+        demo = pick_random_demo_cue(self.session.cues_dir)
+        if demo is not None:
+            slot.fileEdit.setText(str(demo))
+        self._rebuild_grid()
 
     def _build(self) -> QtWidgets.QWidget:
         # Shared device + fade controls.
@@ -149,37 +175,121 @@ class AudioCueWindow(ModalityWindow):
         header.addRow("Fade out:", releaseSpinBox)
 
         # "Now playing" indicator on top of the slot table (mixing-board style).
-        self.nowPlayingLabel = QtWidgets.QLabel("■ stopped", self)
+        self.nowPlayingLabel = QtWidgets.QLabel("■ stopped", self)  # ■
         self.nowPlayingLabel.setAlignment(QtCore.Qt.AlignCenter)
 
-        # Cue table: a header row + one row per slot.
-        grid = QtWidgets.QGridLayout()
-        for col, title in enumerate(["Name", "Sound", "Vol", "Loop", "", ""]):
-            label = QtWidgets.QLabel(title, self)
-            label.setStyleSheet("font-weight: bold;")
-            grid.addWidget(label, 0, col)
-        for slot in self.slots:
-            row = slot.index + 1
-            grid.addWidget(slot.nameEdit, row, 0)
-            sound = QtWidgets.QHBoxLayout()
-            sound.addWidget(slot.fileEdit)
-            sound.addWidget(slot.browseButton)
-            grid.addLayout(sound, row, 1)
-            grid.addWidget(slot.volumeSpinBox, row, 2)
-            grid.addWidget(slot.loopCheckBox, row, 3)
-            grid.addWidget(slot.playButton, row, 4)
-            grid.addWidget(slot.stopButton, row, 5)
-        grid.setColumnStretch(1, 1)
+        # Cue table: a persistent header row, then one rebuildable row per slot,
+        # then an "add" row. The header labels and add button are created once and
+        # reused across rebuilds, so a rebuild only reparents widgets (never deletes
+        # them) and live slot controls survive untouched.
+        self._grid = QtWidgets.QGridLayout()
+        self._header_labels = [
+            self._make_header_label(title)
+            for title in ("Name", "Sound", "", "Vol", "Loop", "", "", "")
+        ]
+        self._addButton = QtWidgets.QPushButton("+ Add cue", self)
+        self._addButton.setStatusTip(f"Add another cue (up to {MAX_CUE_SLOTS}).")
+        self._addButton.setToolTip("Add another cue")
+        self._addButton.clicked.connect(self.add_slot)
+        self._rebuild_grid()
 
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(make_section_title("Audio cue"))
         layout.addLayout(header)
         layout.addWidget(self.nowPlayingLabel)
-        layout.addLayout(grid)
+        layout.addLayout(self._grid)
         layout.addStretch(1)
         central = QtWidgets.QWidget()
         central.setLayout(layout)
         return central
+
+    def _make_header_label(self, text: str) -> QtWidgets.QLabel:
+        label = QtWidgets.QLabel(text, self)
+        label.setStyleSheet("font-weight: bold;")
+        return label
+
+    def _rebuild_grid(self) -> None:
+        """Re-lay the cue table: header row, one row per slot, then the add row.
+
+        Every widget here is persistent (the header labels, the add button, and
+        each slot's controls), so clearing only reparents them out of the grid —
+        nothing is deleted — and they're re-added in their new positions.
+        """
+        while self._grid.count():
+            self._grid.takeAt(0)  # drop the layout item only; widgets are reused
+        for col, label in enumerate(self._header_labels):
+            self._grid.addWidget(label, 0, col)
+        for row, slot in enumerate(self.slots, start=1):
+            self._grid.addWidget(slot.nameEdit, row, 0)
+            self._grid.addWidget(slot.fileEdit, row, 1)
+            self._grid.addWidget(slot.browseButton, row, 2)
+            self._grid.addWidget(slot.volumeSpinBox, row, 3)
+            self._grid.addWidget(slot.loopCheckBox, row, 4)
+            self._grid.addWidget(slot.playButton, row, 5)
+            self._grid.addWidget(slot.stopButton, row, 6)
+            self._grid.addWidget(slot.removeButton, row, 7)
+            # The lone required slot can't be removed: keep the button in place (so
+            # the column doesn't jump) but disabled.
+            slot.removeButton.setEnabled(len(self.slots) > MIN_CUE_SLOTS)
+        self._grid.addWidget(self._addButton, len(self.slots) + 1, 0, 1, 2)
+        self._addButton.setEnabled(len(self.slots) < MAX_CUE_SLOTS)
+        self._grid.setColumnStretch(1, 1)
+
+    # ----- add / remove slots ------------------------------------------------
+
+    def add_slot(self) -> None:
+        """Append a new (empty) cue slot, up to the cap (#65)."""
+        if len(self.slots) >= MAX_CUE_SLOTS:
+            return
+        slot = self._make_slot(f"Cue {len(self.slots) + 1}")
+        self._rebuild_grid()
+        self.adjustSize()
+        self.session.log_interaction(f"Added cue '{slot.nameEdit.text()}'")
+
+    def remove_slot(self, slot: CueSlot) -> None:
+        """Remove a cue slot (never the last one), stopping it first (#65)."""
+        if len(self.slots) <= MIN_CUE_SLOTS or slot not in self.slots:
+            return
+        name = slot.nameEdit.text()
+        self.slots.remove(slot)
+        self._destroy_slot_widgets(slot)
+        self._rebuild_grid()
+        self.adjustSize()
+        self.session.log_interaction(f"Removed cue '{name}'")
+
+    def _destroy_slot_widgets(self, slot: CueSlot) -> None:
+        """Tear down a removed slot: silence it, drop late signals, free widgets."""
+        if self._playing_slot is slot:
+            self._playing_slot = None
+            self._set_now_playing_stopped()
+        # Drop the playing-edge connection before deleting so a late edge can't fire
+        # into a half-torn-down slot, then stop any sound it was making.
+        try:
+            slot.player.playingChanged.disconnect()
+        except TypeError:
+            pass  # nothing connected
+        slot.player.stop()
+        for widget in (
+            slot.nameEdit,
+            slot.fileEdit,
+            slot.browseButton,
+            slot.volumeSpinBox,
+            slot.loopCheckBox,
+            slot.playButton,
+            slot.stopButton,
+            slot.removeButton,
+        ):
+            widget.hide()  # leave no orphan visible before deferred deletion
+            widget.deleteLater()
+
+    def _resize_slots(self, count: int) -> None:
+        """Grow/shrink the slot list to ``count`` (clamped to ``1..MAX``) (#65)."""
+        count = max(MIN_CUE_SLOTS, min(count, MAX_CUE_SLOTS))
+        while len(self.slots) < count:
+            self._make_slot(f"Cue {len(self.slots) + 1}")
+        while len(self.slots) > count:
+            self._destroy_slot_widgets(self.slots.pop())
+        self._rebuild_grid()
 
     # ----- shared device + fade ---------------------------------------------
 
@@ -228,7 +338,7 @@ class AudioCueWindow(ModalityWindow):
 
     # ----- per-slot controls -------------------------------------------------
 
-    def open_audio_selector(self, index: int) -> None:
+    def open_audio_selector(self, slot: CueSlot) -> None:
         filename, _ = QtWidgets.QFileDialog.getOpenFileName(
             self,
             "Select a File",
@@ -236,17 +346,17 @@ class AudioCueWindow(ModalityWindow):
             "Audio (*.wav *.mp3 *.flac *.ogg *.oga *.aif *.aiff);;All files (*)",
         )
         if filename:
-            self.slots[index].fileEdit.setText(str(Path(filename)))
+            slot.fileEdit.setText(str(Path(filename)))
 
-    def update_slot_source(self, index: int) -> None:
+    def update_slot_source(self, slot: CueSlot) -> None:
         """Set a slot player's source from its file line edit.
 
         Non-WAV files are decoded to a cached WAV first, since QSoundEffect only
         plays uncompressed WAV. Fired on every keystroke, so missing/partial paths
         are skipped silently; only a genuine decode failure raises a popup.
         """
-        player = self.slots[index].player
-        filepath = self.slots[index].fileEdit.text().strip()
+        player = slot.player
+        filepath = slot.fileEdit.text().strip()
         if not filepath or not Path(filepath).is_file():
             player.setSource(QtCore.QUrl())  # clear: nothing loaded
             return
@@ -260,18 +370,16 @@ class AudioCueWindow(ModalityWindow):
             return
         player.setSource(QtCore.QUrl.fromLocalFile(str(wav)))
 
-    def update_slot_volume(self, index: int, value: float | None = None) -> None:
+    def update_slot_volume(self, slot: CueSlot, value: float | None = None) -> None:
         """Set a slot player's volume (0-1) from its spinbox."""
-        slot = self.slots[index]
         vol = slot.volumeSpinBox.value()
         slot.player.setVolume(vol)
         self.session.log_interaction(
             f"Cue '{slot.nameEdit.text()}' volume set to {vol:.2f}"
         )
 
-    def update_slot_loop(self, index: int, enabled: bool | None = None) -> None:
+    def update_slot_loop(self, slot: CueSlot, enabled: bool | None = None) -> None:
         """Set a slot player's loop count from its checkbox."""
-        slot = self.slots[index]
         looping = slot.loopCheckBox.isChecked()
         count = QtMultimedia.QSoundEffect.Infinite if looping else 1
         slot.player.setLoopCount(count)
@@ -279,15 +387,14 @@ class AudioCueWindow(ModalityWindow):
             f"Cue '{slot.nameEdit.text()}' loop {'on' if looping else 'off'}"
         )
 
-    def play_slot(self, index: int) -> None:
+    def play_slot(self, slot: CueSlot) -> None:
         """Play one slot (stopping any other playing slot first) with fade-in."""
-        slot = self.slots[index]
         if not slot.fileEdit.text().strip():
             return  # nothing loaded in this slot
         # One-at-a-time: stop whatever else is playing (fires its CueStopped).
-        if self._playing_index is not None and self._playing_index != index:
-            self.slots[self._playing_index].player.stop()
-        self._playing_index = index
+        if self._playing_slot is not None and self._playing_slot is not slot:
+            self._playing_slot.player.stop()
+        self._playing_slot = slot
         target = slot.volumeSpinBox.value()
         if self.cue_attack_s > 0:
             slot.player.setVolume(0.0)
@@ -298,9 +405,8 @@ class AudioCueWindow(ModalityWindow):
             slot.player.play()
         self.session.emit_event("CueStarted", detail=slot.nameEdit.text())
 
-    def stop_slot(self, index: int) -> None:
+    def stop_slot(self, slot: CueSlot) -> None:
         """Stop a slot (with fade-out) if it is the one currently playing."""
-        slot = self.slots[index]
         if not slot.player.isPlaying():
             return
         if self.cue_release_s > 0:
@@ -311,18 +417,19 @@ class AudioCueWindow(ModalityWindow):
         else:
             slot.player.stop()
 
-    def on_slot_playing_change(self, index: int) -> None:
+    def on_slot_playing_change(self, slot: CueSlot) -> None:
         """Track each slot's play/stop edges: update the label, emit markers.
 
         CueStarted is emitted by play_slot (the user action); here we detect the
         playing->stopped edge per slot to emit CueStopped, so a natural end (a
         non-looping cue finishing) is marked too, with no double-fire.
         """
-        slot = self.slots[index]
+        if slot not in self.slots:
+            return  # a removed slot's late signal; ignore
         playing = slot.player.isPlaying()
         if playing and not slot.was_playing:
             slot.was_playing = True
-            self._playing_index = index
+            self._playing_slot = slot
             looping = slot.loopCheckBox.isChecked()
             name = slot.nameEdit.text()
             self.nowPlayingLabel.setText(
@@ -332,10 +439,13 @@ class AudioCueWindow(ModalityWindow):
         elif not playing and slot.was_playing:
             slot.was_playing = False
             self.session.emit_event("CueStopped", detail=slot.nameEdit.text())
-            if self._playing_index == index:
-                self._playing_index = None
-                self.nowPlayingLabel.setText("■ stopped")
-                self.nowPlayingLabel.setStyleSheet("")
+            if self._playing_slot is slot:
+                self._playing_slot = None
+                self._set_now_playing_stopped()
+
+    def _set_now_playing_stopped(self) -> None:
+        self.nowPlayingLabel.setText("■ stopped")  # ■
+        self.nowPlayingLabel.setStyleSheet("")
 
     # ----- settings state ----------------------------------------------------
 
@@ -356,11 +466,13 @@ class AudioCueWindow(ModalityWindow):
 
     def apply_state(self, state: dict) -> None:
         cues = state.get("cues")
-        if isinstance(cues, list):
+        if isinstance(cues, list) and cues:
+            self._resize_slots(len(cues))
             for slot, cue in zip(self.slots, cues, strict=False):
                 self._apply_cue(slot, cue)
         elif state.get("cue_file") is not None or state.get("cue_volume") is not None:
             # Back-compat: a v1 single cue maps into the first slot.
+            self._resize_slots(1)
             self._apply_cue(
                 self.slots[0],
                 {

--- a/src/smacc/panels/events.py
+++ b/src/smacc/panels/events.py
@@ -54,6 +54,8 @@ class EventsWindow(ModalityWindow):
                 button.setShortcut(str(i + 1))
             if event.key == "Note":
                 button.clicked.connect(self.open_note_marker_dialogue)
+            elif event.key == "RecordingStarted":
+                button.clicked.connect(self._mark_recording_start)
             else:
                 button.clicked.connect(partial(self._emit, event.key))
             row, col = (i, 0) if i < half else (i - half, 1)
@@ -62,6 +64,10 @@ class EventsWindow(ModalityWindow):
 
     def _emit(self, key: str, _checked: bool = False) -> None:
         self.session.emit_event(key)
+
+    def _mark_recording_start(self, _checked: bool = False) -> None:
+        """Stamp the recording-start reference clock and emit its marker (#60)."""
+        self.session.mark_recording_start()
 
     def open_note_marker_dialogue(self, _checked: bool = False) -> None:
         """Prompt for free text and emit a Note marker with it."""

--- a/src/smacc/panels/recording.py
+++ b/src/smacc/panels/recording.py
@@ -11,6 +11,7 @@ from .. import audio
 from ..config import SURVEY_OPTIONS
 from ..dialogs import ManageSurveysDialog
 from ..session import SmaccSession
+from ..utils import format_elapsed
 from .base import ModalityWindow, make_section_title
 
 
@@ -170,9 +171,25 @@ class RecordingWindow(ModalityWindow):
         if self.sender().isChecked():
             if survey_url := self.current_survey_url():
                 self.open_survey_url(survey_url, self.surveyComboBox.currentText())
-            # When the registry's increment flag is on, each start advances its
-            # code (201, 202, …) automatically, so reports are individually findable.
-            self.session.emit_event("DreamReportStarted")
+            # Stamp the report with the time since the "Start recording" marker so
+            # it can be found in the EEG file later (#60). With no marker yet, still
+            # log the report right away, then tell the user it's untimed. When the
+            # registry's increment flag is on, each start also advances its code
+            # (201, 202, …) automatically, so reports stay individually findable.
+            elapsed = self.session.elapsed_since_recording()
+            if elapsed is None:
+                self.session.emit_event("DreamReportStarted")
+                self.session.show_info_popup(
+                    "Recording start not marked.",
+                    "This dream report was logged, but the “Start recording” "
+                    "marker hasn’t been set, so it carries no time-since-recording "
+                    "stamp. Press “Start recording” when the EEG recording begins.",
+                    parent=self,
+                )
+            else:
+                self.session.emit_event(
+                    "DreamReportStarted", detail=f"t+{format_elapsed(elapsed)}"
+                )
         else:
             self.session.emit_event("DreamReportStopped")
 

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -11,7 +11,7 @@ baked into filenames.
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 
 from pylsl import StreamInfo, StreamOutlet
@@ -81,6 +81,9 @@ class SmaccSession:
         self.event_code_safe_max = events.DEFAULT_SAFE_MAX
         # Per-event firing counts so an incrementing event advances its code.
         self._event_counts: dict[str, int] = {}
+        # Wall-clock of the most recent "Start recording" marker (None until it is
+        # pressed); dream reports are timestamped relative to it (#60).
+        self.recording_start_time: datetime | None = None
         # Soft interaction logs (volume/color/device/…) are gated off until the
         # main window finishes startup, so construction and study loads don't
         # spam the log; the window flips this on afterwards.
@@ -225,6 +228,23 @@ class SmaccSession:
         # gates whether it also appears in the live log viewer.
         self.logger.info(line, extra={"smacc_preview": event.preview})
 
+    def mark_recording_start(self) -> None:
+        """Stamp the recording-start reference clock and emit its marker (#60).
+
+        The reference is what each dream report's "time since recording start" is
+        measured against; pressing again restarts it (matching a restarted EEG
+        acquisition). The marker routes through the normal event path, so it lands
+        in the trigger channel and the log like any other.
+        """
+        self.recording_start_time = datetime.now()
+        self.emit_event("RecordingStarted")
+
+    def elapsed_since_recording(self) -> timedelta | None:
+        """Return the time since the recording-start marker (None if unmarked)."""
+        if self.recording_start_time is None:
+            return None
+        return datetime.now() - self.recording_start_time
+
     def set_event_codes(self, event_codes, safe_max: int | None = None) -> None:
         """Replace the live registry from a loaded/edited list of code overrides."""
         self.events = {e.key: e for e in events.merge_event_codes(event_codes)}
@@ -251,6 +271,17 @@ class SmaccSession:
         """
         if self.log_interactions:
             self.log_info_msg(msg)
+
+    def show_info_popup(self, short_msg, long_msg=None, parent=None) -> None:
+        """Record an info line and show an information dialog (parented if given)."""
+        self.log_info_msg(short_msg if long_msg is None else f"{short_msg} {long_msg}")
+        win = QtWidgets.QMessageBox(parent)
+        win.setIcon(QtWidgets.QMessageBox.Information)
+        win.setText(short_msg)
+        if long_msg is not None:
+            win.setInformativeText(long_msg)
+        win.setWindowTitle("SMACC")
+        win.exec()
 
     def show_error_popup(self, short_msg, long_msg=None, parent=None) -> None:
         """Record an error in the log and show a dialog (parented if given)."""

--- a/src/smacc/utils.py
+++ b/src/smacc/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import random
 import shutil
 from collections.abc import Callable
 from datetime import timedelta
@@ -28,6 +29,26 @@ def format_elapsed(delta: timedelta) -> str:
     hours, rem = divmod(total, 3600)
     minutes, seconds = divmod(rem, 60)
     return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
+
+
+def pick_random_demo_cue(cues_dir: Path) -> Path | None:
+    """Return a random shipped ``demo-`` cue from ``cues_dir`` (None if none) (#65).
+
+    Used to prefill the one required cue slot so a fresh study is immediately
+    playable. Only the bundled ``demo-*`` clips are eligible, so a user's own cues
+    sitting in the same folder are never auto-selected.
+    """
+    try:
+        demos = sorted(
+            p
+            for p in cues_dir.iterdir()
+            if p.is_file()
+            and p.name.startswith("demo-")
+            and p.suffix.lower() in AUDIO_SUFFIXES
+        )
+    except OSError:
+        return None
+    return random.choice(demos) if demos else None
 
 
 def get_smacc_directory() -> Path:

--- a/src/smacc/utils.py
+++ b/src/smacc/utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import shutil
 from collections.abc import Callable
+from datetime import timedelta
 from os import environ
 from pathlib import Path
 
@@ -15,6 +16,18 @@ from scipy.io.wavfile import write
 _WAV_SUFFIXES = {".wav", ".wave"}
 AUDIO_SUFFIXES = {".wav", ".wave", ".mp3", ".flac", ".ogg", ".oga", ".aif", ".aiff"}
 DEMO_RATE = 44100
+
+
+def format_elapsed(delta: timedelta) -> str:
+    """Format a duration as ``HH:MM:SS`` for dream-report timestamps (#60).
+
+    Hours are not capped, so an overnight session that runs past 24h still renders
+    correctly; sub-second precision is truncated and negative inputs clamp to zero.
+    """
+    total = int(max(delta.total_seconds(), 0))
+    hours, rem = divmod(total, 3600)
+    minutes, seconds = divmod(rem, 60)
+    return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
 
 
 def get_smacc_directory() -> Path:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -20,6 +20,17 @@ def test_default_events_validate_clean():
     assert warnings == []
 
 
+def test_recording_started_is_a_default_manual_marker():
+    # #60: the "Start recording" button comes from a manual registry event so it
+    # auto-appears in the grid, sends a portcode, and persists in a study.
+    rec = {e.key: e for e in events.default_events()}["RecordingStarted"]
+    assert rec.label == "Start recording"
+    assert rec.code == 51
+    assert rec.category == "manual"
+    assert rec.trigger is True
+    assert rec.increment is False
+
+
 def test_dream_start_increments_and_others_dont():
     defs = {e.key: e for e in events.default_events()}
     start = defs["DreamReportStarted"]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -84,6 +84,7 @@ def _stub_session():
     sess.event_code_safe_max = events.DEFAULT_SAFE_MAX
     sess.log_interactions = True
     sess._event_counts = {}
+    sess.recording_start_time = None
     sess.outlet = _FakeOutlet()
     logger = logging.getLogger("smacc-test-emit")
     logger.handlers.clear()
@@ -153,3 +154,22 @@ def test_emit_event_unknown_key_warns_without_crashing():
     sess.emit_event("Nonexistent")  # should warn, not raise
     assert sess.outlet.samples == []
     assert any("Unknown event" in m for m, _ in records)
+
+
+# ----- recording-start reference clock (#60) --------------------------------
+
+
+def test_elapsed_since_recording_is_none_until_marked():
+    sess, _ = _stub_session()
+    assert sess.elapsed_since_recording() is None
+
+
+def test_mark_recording_start_stamps_clock_and_emits_marker():
+    sess, records = _stub_session()
+    sess.mark_recording_start()
+    assert sess.recording_start_time is not None
+    # Once marked, the elapsed time is a (non-negative) duration, not None.
+    assert sess.elapsed_since_recording() is not None
+    # The marker routes through emit_event: triggered with code 51 and logged.
+    assert sess.outlet.samples == [["51"]]
+    assert records == [("Start recording - portcode 51", True)]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
 from pathlib import Path
 
 import numpy as np
@@ -261,3 +262,25 @@ def test_normalize_survey_url_strips_surrounding_whitespace():
     assert (
         utils.normalize_survey_url("  https://example.com  ") == "https://example.com"
     )
+
+
+# ----- elapsed-time formatting (#60) ----------------------------------------
+
+
+@pytest.mark.parametrize(
+    "seconds, expected",
+    [
+        (0, "00:00:00"),
+        (5, "00:00:05"),
+        (65, "00:01:05"),
+        (3661, "01:01:01"),
+        (90061, "25:01:01"),  # past 24h keeps counting hours, never wraps
+    ],
+)
+def test_format_elapsed_renders_hms(seconds, expected):
+    assert utils.format_elapsed(timedelta(seconds=seconds)) == expected
+
+
+def test_format_elapsed_truncates_subseconds_and_clamps_negative():
+    assert utils.format_elapsed(timedelta(seconds=5, milliseconds=999)) == "00:00:05"
+    assert utils.format_elapsed(timedelta(seconds=-5)) == "00:00:00"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -284,3 +284,27 @@ def test_format_elapsed_renders_hms(seconds, expected):
 def test_format_elapsed_truncates_subseconds_and_clamps_negative():
     assert utils.format_elapsed(timedelta(seconds=5, milliseconds=999)) == "00:00:05"
     assert utils.format_elapsed(timedelta(seconds=-5)) == "00:00:00"
+
+
+# ----- random demo-cue prefill (#65) ----------------------------------------
+
+
+def test_pick_random_demo_cue_returns_a_seeded_demo(tmp_path):
+    cues = tmp_path / "cues"
+    utils.seed_demo_cues(cues, tmp_path / "missing")  # writes the synth demo-*.wav
+    picked = utils.pick_random_demo_cue(cues)
+    assert picked is not None
+    assert picked.parent == cues
+    assert picked.name.startswith("demo-")
+    assert picked.suffix.lower() in utils.AUDIO_SUFFIXES
+
+
+def test_pick_random_demo_cue_ignores_non_demo_user_files(tmp_path):
+    cues = tmp_path / "cues"
+    cues.mkdir()
+    write(cues / "mysong.wav", 8000, utils.note(440, 1, 1e4, 8000))  # not a demo-
+    assert utils.pick_random_demo_cue(cues) is None
+
+
+def test_pick_random_demo_cue_none_when_dir_missing(tmp_path):
+    assert utils.pick_random_demo_cue(tmp_path / "does-not-exist") is None


### PR DESCRIPTION
Closes #60.
Closes #65.

Two independent enhancements — one commit each, plus a docs commit.

## #60 — "Start recording" marker + dream-report timestamps
- Adds a built-in `RecordingStarted` event ("Start recording", portcode 51) to the configurable registry, so it auto-appears as a button in the **Event logging** panel, sends a portcode into the EEG file, and persists in `.smacc`.
- The session keeps a `recording_start_time` reference clock; pressing the button stamps it (re-pressing restarts it, matching a restarted EEG acquisition).
- Every dream-report start is logged with the elapsed time (e.g. `Dream report started: t+00:12:34`), making it easy to locate in the EEG file.
- If recording hasn't been marked yet, the report is **still logged**, then an info dialog reminds the user to mark it — per the issue.

## #65 — Add/removable cues
- The audio panel goes from a hardcoded 4 slots to **1–20 dynamic slots**: a **+ Add cue** button and a per-row **✕**; the last cue can't be removed and Add disables at 20.
- The single starting cue **autofills a random `demo-*` cue** so it's playable immediately.
- Internals: per-slot signal handlers moved from row-**index** binding (which misroutes once a row is removed) to **identity** binding.

## Verification
- `ruff check`, `ruff format --check`, `mypy`, and **150 tests pass** (10 new — elapsed-time formatter, recording-start clock, the new default event, and the random-demo picker).
- No Qt fixtures exist, so I also ran an offscreen-Qt smoke pass (autofill, 20/1 caps, mid-list removal, `apply_state` grow/shrink/clamp, the new button click) — all green.

## Note for existing installs
`default.smacc` now omits the `cues:` list so fresh installs get the 1-cue autofill. Existing machines keep their already-seeded `~/SMACC/default.smacc` (the seeder never overwrites it), so their explicit cue setup is preserved.
