### PR TITLE
Migrate from PyQt5 to PyQt6

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A clickable interface for running sleep-related experiments.
 
 To install SMACC, go to the [releases page](https://github.com/remrama/smacc/releases), click the _Assets_ dropdown for the latest release, and download the _SMACC.exe_ file. Once downloaded, double-clicking this file will run SMACC.
 
-SMACC requires 64-bit Windows 8.1 or later.
+SMACC requires 64-bit Windows 10 or later.
 
 Note that for some features, you will need to open SMACC with Administrator privileges (Right-click to open and select `Run as administrator`).
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -87,10 +87,9 @@ on each `v*` release tag.
 * The single source of truth for the version is `__version__` in
   `src/smacc/__init__.py`; `config.py` and the packaging metadata both read from
   it.
-* The build/runtime Python is pinned to **3.12** in `.python-version`. This is
-  deliberate: 3.12 is the last Python line that supports Windows 8.1, so it keeps
-  SMACC runnable on older lab machines. Bumping to 3.13+ would raise the minimum
-  to Windows 10 — don't do it without accepting that trade-off.
+* The build/runtime Python is pinned to **3.12** in `.python-version`. The
+  minimum OS is **Windows 10**, set by Qt 6 (PyQt6) — Qt 5 was the last line that
+  still ran on Windows 8.1. Keep the pin unless you intend to move the Python floor.
 * SMACC is distributed only as a frozen `SMACC.exe` (no PyPI), so CI tests what
   ships rather than a version range: the `test` job in `ci.yaml` runs on the same
   `windows-2022` + Python 3.12 + locked dependencies as the release build

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,7 @@ click the _Assets_ dropdown for the latest release, and download the _SMACC.exe_
 file. Once downloaded, double-clicking this file will run SMACC.
 
 !!! note "System requirements"
-    SMACC runs on 64-bit Windows 8.1 or later.
+    SMACC runs on 64-bit Windows 10 or later.
 
 !!! note "Administrator privileges"
     For some features you will need to open SMACC with Administrator privileges

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,8 @@ build-backend = "setuptools.build_meta"
 name = "smacc"
 description = "Sleep manipulation and communication clickything"
 readme = "README.md"
-# Build/runtime Python is pinned to 3.12 via .python-version. 3.12 is the last
-# line supporting Windows 8.1; moving to 3.13+ would raise the floor to Win10.
+# Build/runtime Python is pinned to 3.12 via .python-version. The minimum OS is
+# Windows 10, set by Qt 6 (see the PyQt6 dependency note below).
 requires-python = ">=3.12"
 license = { text = "GPL-3.0-or-later" }
 authors = [{ name = "Remington Mallett", email = "mallett.remy@gmail.com" }]
@@ -15,6 +15,8 @@ dynamic = ["version"]
 classifiers = [
     "Environment :: Win32 (MS Windows)",
     "Operating System :: Microsoft :: Windows",
+    "Operating System :: Microsoft :: Windows :: Windows 10",
+    "Operating System :: Microsoft :: Windows :: Windows 11",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
@@ -27,10 +29,10 @@ dependencies = [
     "numpy",
     "pylsl",
     "pyyaml",
-    "PyQt5",
-    # pyqt5-qt5 5.15.19 dropped Windows wheels; pin to a version with
-    # wheels for all platforms (win/linux/macos) so uv resolves everywhere.
-    "PyQt5-Qt5==5.15.2",
+    # Qt 6 GUI toolkit. Qt 6 requires Windows 10+, which is why SMACC's floor is
+    # Windows 10 (Qt5/PyQt5 was the last line that still ran on Windows 8.1). PyQt6
+    # pulls in PyQt6-Qt6 (the Qt libraries, incl. QtMultimedia) and PyQt6-sip.
+    "PyQt6",
     "scipy",
     "sounddevice",
     "soundfile>=0.12",
@@ -47,7 +49,6 @@ dev = [
     "mypy",
     "pre-commit",
     "pyinstaller",
-    "PyQt5-stubs",
     "types-PyYAML",
 ]
 

--- a/src/smacc/__main__.py
+++ b/src/smacc/__main__.py
@@ -7,8 +7,8 @@ import traceback
 from pathlib import Path
 from types import TracebackType
 
-from PyQt5.QtGui import QIcon
-from PyQt5.QtWidgets import QApplication, QMessageBox
+from PyQt6.QtGui import QIcon
+from PyQt6.QtWidgets import QApplication, QMessageBox
 
 from . import preferences
 from .launcher import LauncherWindow, resolve_initial_settings

--- a/src/smacc/analyze.py
+++ b/src/smacc/analyze.py
@@ -14,7 +14,7 @@ import tempfile
 import zipfile
 from pathlib import Path
 
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 from . import bids, settings
 from .dialogs import ask_initial_or_final
@@ -108,11 +108,13 @@ class AnalyzeWindow(ToolWindow):
 
         self.sourceLabel = QtWidgets.QLabel("No session loaded.", self)
         self.sourceLabel.setWordWrap(True)
-        self.sourceLabel.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+        self.sourceLabel.setTextInteractionFlags(
+            QtCore.Qt.TextInteractionFlag.TextSelectableByMouse
+        )
         layout.addWidget(self.sourceLabel)
 
         self.summaryLabel = QtWidgets.QLabel("", self)
-        self.summaryLabel.setTextFormat(QtCore.Qt.RichText)
+        self.summaryLabel.setTextFormat(QtCore.Qt.TextFormat.RichText)
         layout.addWidget(self.summaryLabel)
 
         layout.addWidget(QtWidgets.QLabel("Dream reports:", self))
@@ -212,10 +214,12 @@ class AnalyzeWindow(ToolWindow):
             self.reportsList.addItem(report.name)
         if not reports:
             empty = QtWidgets.QListWidgetItem("(none)")
-            empty.setFlags(QtCore.Qt.NoItemFlags)
+            empty.setFlags(QtCore.Qt.ItemFlag.NoItemFlags)
             self.reportsList.addItem(empty)
         self._set_loaded(True)
-        self.statusBar().showMessage(f"Loaded {log_path.name}", 5000)
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.showMessage(f"Loaded {log_path.name}", 5000)
 
     # ----- actions ----------------------------------------------------------
 
@@ -291,17 +295,18 @@ class AnalyzeWindow(ToolWindow):
 
     def _error(self, short: str, detail: str | None = None) -> None:
         box = QtWidgets.QMessageBox(self)
-        box.setIcon(QtWidgets.QMessageBox.Warning)
+        box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
         box.setWindowTitle("Analyze")
         box.setText(short)
         if detail is not None:
             box.setInformativeText(detail)
         box.exec()
 
-    def closeEvent(self, event: QtGui.QCloseEvent) -> None:
+    def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         """Clean up any extracted zips and hand control back to the launcher."""
         for tmp in self._temp_dirs:
             shutil.rmtree(tmp, ignore_errors=True)
         self._temp_dirs.clear()
-        event.accept()
+        if event is not None:
+            event.accept()
         self.closed.emit()

--- a/src/smacc/dialogs.py
+++ b/src/smacc/dialogs.py
@@ -2,7 +2,7 @@
 
 from dataclasses import replace
 
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 from . import events
 from .utils import normalize_survey_url
@@ -21,7 +21,9 @@ class PreferencesDialog(QtWidgets.QDialog):
     def __init__(self, prefs: dict, parent=None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Preferences")
-        self.setWindowFlags(self.windowFlags() ^ QtCore.Qt.WindowContextHelpButtonHint)
+        self.setWindowFlags(
+            self.windowFlags() ^ QtCore.Qt.WindowType.WindowContextHelpButtonHint
+        )
 
         self.alwaysOnTop = QtWidgets.QCheckBox(
             "Keep SMACC windows above other applications", self
@@ -43,7 +45,9 @@ class PreferencesDialog(QtWidgets.QDialog):
             levelLayout.addWidget(box)
 
         buttonBox = QtWidgets.QDialogButtonBox(
-            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel, self
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
         )
         buttonBox.accepted.connect(self.accept)
         buttonBox.rejected.connect(self.reject)
@@ -79,9 +83,9 @@ def ask_initial_or_final(parent=None, title: str = "Settings snapshot") -> str |
     box = QtWidgets.QMessageBox(parent)
     box.setWindowTitle(title)
     box.setText("Use which settings snapshot from the log?")
-    initial_btn = box.addButton("Initial", QtWidgets.QMessageBox.AcceptRole)
-    final_btn = box.addButton("Final", QtWidgets.QMessageBox.AcceptRole)
-    box.addButton(QtWidgets.QMessageBox.Cancel)
+    initial_btn = box.addButton("Initial", QtWidgets.QMessageBox.ButtonRole.AcceptRole)
+    final_btn = box.addButton("Final", QtWidgets.QMessageBox.ButtonRole.AcceptRole)
+    box.addButton(QtWidgets.QMessageBox.StandardButton.Cancel)
     box.exec()
     clicked = box.clickedButton()
     if clicked is initial_btn:
@@ -109,7 +113,9 @@ class SessionInfoDialog(QtWidgets.QDialog):
         super().__init__(parent)
         self.setWindowTitle("Session information")
         # Removes the default "What's this?" question mark icon from the titlebar.
-        self.setWindowFlags(self.windowFlags() ^ QtCore.Qt.WindowContextHelpButtonHint)
+        self.setWindowFlags(
+            self.windowFlags() ^ QtCore.Qt.WindowType.WindowContextHelpButtonHint
+        )
         # Create subject and session text inputs, prefilled from current metadata.
         self.subject_id = QtWidgets.QLineEdit(self)
         self.session_id = QtWidgets.QLineEdit(self)
@@ -119,7 +125,9 @@ class SessionInfoDialog(QtWidgets.QDialog):
         self.session_id.setPlaceholderText("Optional")
         # Allow letters, numbers, underscores, and hyphens, up to 30 characters;
         # empty is allowed since the fields are optional.
-        id_validator = QtGui.QRegExpValidator(QtCore.QRegExp(r"[A-Za-z0-9_-]{0,30}"))
+        id_validator = QtGui.QRegularExpressionValidator(
+            QtCore.QRegularExpression(r"[A-Za-z0-9_-]{0,30}")
+        )
         for field in (self.subject_id, self.session_id):
             field.setValidator(id_validator)
             field.setMaxLength(30)
@@ -128,7 +136,9 @@ class SessionInfoDialog(QtWidgets.QDialog):
         self.notes.setPlaceholderText("Optional free-text notes")
         # Create buttons to accept values or cancel.
         buttonBox = QtWidgets.QDialogButtonBox(
-            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel, self
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
         )
         buttonBox.accepted.connect(self.accept)
         buttonBox.rejected.connect(self.reject)
@@ -156,7 +166,9 @@ class SurveyDialog(QtWidgets.QDialog):
         super().__init__(parent)
         self.setWindowTitle("Survey")
         # Removes the default "What's this?" question mark icon from the titlebar.
-        self.setWindowFlags(self.windowFlags() ^ QtCore.Qt.WindowContextHelpButtonHint)
+        self.setWindowFlags(
+            self.windowFlags() ^ QtCore.Qt.WindowType.WindowContextHelpButtonHint
+        )
         self.nameEdit = QtWidgets.QLineEdit(self)
         self.nameEdit.setText(name)
         self.nameEdit.setPlaceholderText("e.g. Post-dream survey")
@@ -164,7 +176,9 @@ class SurveyDialog(QtWidgets.QDialog):
         self.urlEdit.setText(url)
         self.urlEdit.setPlaceholderText("https://…")
         buttonBox = QtWidgets.QDialogButtonBox(
-            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel, self
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
         )
         buttonBox.accepted.connect(self._on_accept)
         buttonBox.rejected.connect(self.reject)
@@ -201,7 +215,9 @@ class ManageSurveysDialog(QtWidgets.QDialog):
     def __init__(self, options: dict[str, str], parent=None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Manage surveys")
-        self.setWindowFlags(self.windowFlags() ^ QtCore.Qt.WindowContextHelpButtonHint)
+        self.setWindowFlags(
+            self.windowFlags() ^ QtCore.Qt.WindowType.WindowContextHelpButtonHint
+        )
         self.resize(440, 260)
 
         self.listWidget = QtWidgets.QListWidget(self)
@@ -222,7 +238,9 @@ class ManageSurveysDialog(QtWidgets.QDialog):
         buttonCol.addStretch(1)
 
         buttonBox = QtWidgets.QDialogButtonBox(
-            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel, self
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
         )
         buttonBox.accepted.connect(self.accept)
         buttonBox.rejected.connect(self.reject)
@@ -237,7 +255,7 @@ class ManageSurveysDialog(QtWidgets.QDialog):
     def _add_row(self, name: str, url: str) -> None:
         """Append a list row labeled ``name — url`` carrying ``(name, url)`` as data."""
         item = QtWidgets.QListWidgetItem(f"{name} — {url}")
-        item.setData(QtCore.Qt.UserRole, (name, url))
+        item.setData(QtCore.Qt.ItemDataRole.UserRole, (name, url))
         self.listWidget.addItem(item)
 
     def _add_new(self) -> None:
@@ -250,12 +268,12 @@ class ManageSurveysDialog(QtWidgets.QDialog):
         item = self.listWidget.currentItem()
         if item is None:
             return
-        name, url = item.data(QtCore.Qt.UserRole)
+        name, url = item.data(QtCore.Qt.ItemDataRole.UserRole)
         dialog = SurveyDialog(name, url, parent=self)
         if dialog.exec():
             new_name, new_url = dialog.get_inputs()
             item.setText(f"{new_name} — {new_url}")
-            item.setData(QtCore.Qt.UserRole, (new_name, new_url))
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, (new_name, new_url))
 
     def _remove_selected(self) -> None:
         row = self.listWidget.currentRow()
@@ -269,7 +287,7 @@ class ManageSurveysDialog(QtWidgets.QDialog):
             item = self.listWidget.item(i)
             if item is None:
                 continue
-            name, url = item.data(QtCore.Qt.UserRole)
+            name, url = item.data(QtCore.Qt.ItemDataRole.UserRole)
             options[name] = url
         return options
 
@@ -280,7 +298,9 @@ class AddEventDialog(QtWidgets.QDialog):
     def __init__(self, default_code: int, parent=None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Add event")
-        self.setWindowFlags(self.windowFlags() ^ QtCore.Qt.WindowContextHelpButtonHint)
+        self.setWindowFlags(
+            self.windowFlags() ^ QtCore.Qt.WindowType.WindowContextHelpButtonHint
+        )
         self.labelEdit = QtWidgets.QLineEdit(self)
         self.labelEdit.setPlaceholderText("e.g. Spontaneous arousal")
         self.codeSpin = QtWidgets.QSpinBox(self)
@@ -292,7 +312,9 @@ class AddEventDialog(QtWidgets.QDialog):
             "Increment the code on each press", self
         )
         buttonBox = QtWidgets.QDialogButtonBox(
-            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel, self
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
         )
         buttonBox.accepted.connect(self._on_accept)
         buttonBox.rejected.connect(self.reject)
@@ -337,7 +359,9 @@ class EventCodesDialog(QtWidgets.QDialog):
     def __init__(self, event_list, safe_max: int, parent=None) -> None:
         super().__init__(parent)
         self.setWindowTitle("Event codes")
-        self.setWindowFlags(self.windowFlags() ^ QtCore.Qt.WindowContextHelpButtonHint)
+        self.setWindowFlags(
+            self.windowFlags() ^ QtCore.Qt.WindowType.WindowContextHelpButtonHint
+        )
         self.resize(600, 560)
         self._events = [replace(e) for e in event_list]  # working copies
 
@@ -356,14 +380,25 @@ class EventCodesDialog(QtWidgets.QDialog):
             header_item = self.table.horizontalHeaderItem(col)
             if header_item is not None:
                 header_item.setToolTip(tip)
-        self.table.verticalHeader().setVisible(False)
-        self.table.setSelectionMode(QtWidgets.QAbstractItemView.SingleSelection)
-        self.table.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectRows)
-        self.table.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+        vheader = self.table.verticalHeader()
+        assert vheader is not None
+        vheader.setVisible(False)
+        self.table.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
+        )
+        self.table.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        self.table.setEditTriggers(
+            QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers
+        )
         header = self.table.horizontalHeader()
-        header.setSectionResizeMode(0, QtWidgets.QHeaderView.Stretch)
+        assert header is not None
+        header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeMode.Stretch)
         for col in range(1, 5):
-            header.setSectionResizeMode(col, QtWidgets.QHeaderView.ResizeToContents)
+            header.setSectionResizeMode(
+                col, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+            )
 
         addButton = QtWidgets.QPushButton("Add event…", self)
         addButton.setStatusTip("Add a custom event button.")
@@ -389,7 +424,9 @@ class EventCodesDialog(QtWidgets.QDialog):
         safeRow.addStretch(1)
 
         buttonBox = QtWidgets.QDialogButtonBox(
-            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel, self
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
         )
         buttonBox.accepted.connect(self._on_accept)
         buttonBox.rejected.connect(self.reject)
@@ -421,7 +458,9 @@ class EventCodesDialog(QtWidgets.QDialog):
         for row, event in enumerate(self._events):
             if event.builtin:
                 label_item = QtWidgets.QTableWidgetItem(event.label)
-                label_item.setFlags(label_item.flags() & ~QtCore.Qt.ItemIsEditable)
+                label_item.setFlags(
+                    label_item.flags() & ~QtCore.Qt.ItemFlag.ItemIsEditable
+                )
                 if event.tooltip:
                     label_item.setToolTip(event.tooltip)
                 self.table.setItem(row, 0, label_item)
@@ -472,7 +511,7 @@ class EventCodesDialog(QtWidgets.QDialog):
         box.setChecked(checked)
         lay = QtWidgets.QHBoxLayout(container)
         lay.addWidget(box)
-        lay.setAlignment(QtCore.Qt.AlignCenter)
+        lay.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         lay.setContentsMargins(0, 0, 0, 0)
         return container, box
 
@@ -537,6 +576,6 @@ class EventCodesDialog(QtWidgets.QDialog):
             reply = QtWidgets.QMessageBox.question(
                 self, "Event codes", "Save anyway?\n\n" + "\n".join(warnings)
             )
-            if reply != QtWidgets.QMessageBox.Yes:
+            if reply != QtWidgets.QMessageBox.StandardButton.Yes:
                 return
         self.accept()

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import cast
 
 import sounddevice as sd
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 from smacc import bids, preferences, settings, winassoc
 
@@ -132,7 +132,7 @@ class SmaccWindow(ToolWindow):
             windowIcon = QtGui.QIcon(str(LOGO_PATH))
         else:
             windowIcon = self.style().standardIcon(
-                QtWidgets.QStyle.SP_ToolBarHorizontalExtensionButton
+                QtWidgets.QStyle.StandardPixmap.SP_ToolBarHorizontalExtensionButton
             )
         self.setWindowIcon(windowIcon)
         # Window size/position, theme, always-on-top, and log-preview levels come
@@ -147,7 +147,7 @@ class SmaccWindow(ToolWindow):
         and stays legible when the dark theme toggles.
         """
         label = QtWidgets.QLabel(text)
-        label.setAlignment(QtCore.Qt.AlignCenter)
+        label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         font = QtGui.QFont()
         font.setPointSize(18)
         label.setFont(font)
@@ -186,7 +186,8 @@ class SmaccWindow(ToolWindow):
         self.lightswitchButton.setCheckable(True)
         self.lightswitchButton.setShortcut("L")  # still toggles with L
         self.lightswitchButton.setSizePolicy(
-            QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Expanding
+            QtWidgets.QSizePolicy.Policy.Preferred,
+            QtWidgets.QSizePolicy.Policy.Expanding,
         )
         self.lightswitchButton.setMinimumHeight(64)
         self.lightswitchButton.setStatusTip(
@@ -214,16 +215,20 @@ class SmaccWindow(ToolWindow):
 
     def _build_menu_bar(self) -> None:
         """Build the consolidated File menu (actions + log-preview levels)."""
-        aboutAction = QtWidgets.QAction(
-            self.style().standardIcon(QtWidgets.QStyle.SP_MessageBoxInformation),
+        style = self.style()
+        assert style is not None
+        aboutAction = QtGui.QAction(
+            style.standardIcon(
+                QtWidgets.QStyle.StandardPixmap.SP_MessageBoxInformation
+            ),
             "&About",
             self,
         )
         aboutAction.setStatusTip("About SMACC")
         aboutAction.triggered.connect(self.show_about_popup)
 
-        quitAction = QtWidgets.QAction(
-            self.style().standardIcon(QtWidgets.QStyle.SP_BrowserStop),
+        quitAction = QtGui.QAction(
+            style.standardIcon(QtWidgets.QStyle.StandardPixmap.SP_BrowserStop),
             "Close &editor" if self.design else "End sessio&n",
             self,
         )
@@ -235,20 +240,20 @@ class SmaccWindow(ToolWindow):
         )
         quitAction.triggered.connect(self.close)  # close goes to closeEvent
 
-        sessionInfoAction = QtWidgets.QAction("Session &info…", self)
+        sessionInfoAction = QtGui.QAction("Session &info…", self)
         sessionInfoAction.setStatusTip(
             "Edit optional subject/session/notes metadata recorded with the session."
         )
         sessionInfoAction.triggered.connect(self.session_info)
 
-        eventCodesAction = QtWidgets.QAction("&Event codes…", self)
+        eventCodesAction = QtGui.QAction("&Event codes…", self)
         eventCodesAction.setStatusTip(
             "View/edit event-marker port codes and what's logged vs. triggered."
         )
         eventCodesAction.triggered.connect(self.edit_event_codes)
         self._event_codes_action = eventCodesAction
 
-        exportEventsAction = QtWidgets.QAction("&Export events (BIDS)…", self)
+        exportEventsAction = QtGui.QAction("&Export events (BIDS)…", self)
         exportEventsAction.setStatusTip(
             "Export this session's events log as a BIDS events.tsv."
         )
@@ -257,7 +262,7 @@ class SmaccWindow(ToolWindow):
         # Always-on-top is an interface preference (also in the launcher's
         # Preferences). Built in both modes so _apply_preferences can set its state,
         # but only surfaced in a session's menu.
-        alwaysOnTopAction = QtWidgets.QAction("Always on &top", self)
+        alwaysOnTopAction = QtGui.QAction("Always on &top", self)
         alwaysOnTopAction.setStatusTip(
             "Keep the SMACC window above other applications."
         )
@@ -266,22 +271,25 @@ class SmaccWindow(ToolWindow):
         alwaysOnTopAction.toggled.connect(self.toggle_always_on_top)
         self._always_on_top_action = alwaysOnTopAction
 
-        associateAction = QtWidgets.QAction("&Associate .smacc files (Windows)", self)
+        associateAction = QtGui.QAction("&Associate .smacc files (Windows)", self)
         associateAction.setStatusTip(
             "Register SMACC as the handler for .smacc files (double-click to open)."
         )
         associateAction.triggered.connect(self.associate_files)
 
         # Available in both modes (devices are configured in the editor and a session).
-        refreshDevicesAction = QtWidgets.QAction("&Refresh devices", self)
+        refreshDevicesAction = QtGui.QAction("&Refresh devices", self)
         refreshDevicesAction.setShortcut("F5")
         refreshDevicesAction.setStatusTip(
             "Rescan for audio devices and BlinkSticks (e.g. after plugging one in)."
         )
         refreshDevicesAction.triggered.connect(self.refresh_all_devices)
 
-        fileMenu = self.menuBar().addMenu("&File")
-        self._preview_level_actions: dict[int, QtWidgets.QAction] = {}
+        menu_bar = self.menuBar()
+        assert menu_bar is not None
+        fileMenu = menu_bar.addMenu("&File")
+        assert fileMenu is not None
+        self._preview_level_actions: dict[int, QtGui.QAction] = {}
         if self.design:
             self._build_editor_file_menu(fileMenu, sessionInfoAction, eventCodesAction)
         else:
@@ -302,23 +310,24 @@ class SmaccWindow(ToolWindow):
     def _add_surveys_menu(self, fileMenu: QtWidgets.QMenu) -> None:
         """Add File → Surveys (rebuilt on show, since the saved list changes)."""
         surveysMenu = fileMenu.addMenu("Sur&veys")
+        assert surveysMenu is not None
         surveysMenu.aboutToShow.connect(lambda: self._rebuild_surveys_menu(surveysMenu))
 
     def _build_editor_file_menu(self, fileMenu, sessionInfoAction, eventCodesAction):
         """Editor File menu: save/import settings + the config editors (no live run)."""
-        saveAction = QtWidgets.QAction("&Save settings", self)
+        saveAction = QtGui.QAction("&Save settings", self)
         saveAction.setShortcut("Ctrl+S")
         saveAction.setStatusTip("Save to the current .smacc (or choose a name if new).")
         saveAction.triggered.connect(self.save_settings_in_place)
-        saveAsAction = QtWidgets.QAction("Save &as…", self)
+        saveAsAction = QtGui.QAction("Save &as…", self)
         saveAsAction.setStatusTip("Save these settings to a new .smacc file.")
         saveAsAction.triggered.connect(self.export_settings)
-        importAction = QtWidgets.QAction("&Import settings (.smacc)…", self)
+        importAction = QtGui.QAction("&Import settings (.smacc)…", self)
         importAction.setStatusTip(
             "Load another .smacc's settings into the editor as a starting point."
         )
         importAction.triggered.connect(self.load_settings)
-        importLogAction = QtWidgets.QAction("Import settings from &log…", self)
+        importLogAction = QtGui.QAction("Import settings from &log…", self)
         importLogAction.setStatusTip(
             "Load the settings recorded in a SMACC .log into the editor."
         )
@@ -360,7 +369,7 @@ class SmaccWindow(ToolWindow):
             ("Error", logging.ERROR),
             ("Critical", logging.CRITICAL),
         ):
-            levelAction = QtWidgets.QAction(levelname, self)
+            levelAction = QtGui.QAction(levelname, self)
             levelAction.setCheckable(True)
             levelAction.setChecked(levelno != logging.DEBUG)  # all but Debug
             levelAction.toggled.connect(self._update_preview_levels)
@@ -375,13 +384,16 @@ class SmaccWindow(ToolWindow):
         if surveys:
             for name, url in surveys.items():
                 action = menu.addAction(name)
+                assert action is not None
                 action.setStatusTip(url)
                 action.triggered.connect(partial(recording.open_survey_url, url, name))
         else:
             empty = menu.addAction("(no surveys saved)")
+            assert empty is not None
             empty.setEnabled(False)
         menu.addSeparator()
         manageAction = menu.addAction("Manage surveys…")
+        assert manageAction is not None
         manageAction.triggered.connect(recording.manage_surveys)
 
     def _build_log_viewer_section(self) -> QtWidgets.QLayout:
@@ -414,7 +426,7 @@ class SmaccWindow(ToolWindow):
         banner = QtWidgets.QLabel(
             "✎  Editing settings — no session is being recorded.", self
         )
-        banner.setAlignment(QtCore.Qt.AlignCenter)
+        banner.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         banner.setStyleSheet(
             "background-color: #f0d000; color: black; font: bold 11pt;"
             " padding: 6px; border-radius: 4px;"
@@ -473,7 +485,7 @@ class SmaccWindow(ToolWindow):
 
     def toggle_always_on_top(self, enabled: bool) -> None:
         """Toggle the window's always-on-top hint (from the View menu)."""
-        self.setWindowFlag(QtCore.Qt.WindowStaysOnTopHint, enabled)
+        self.setWindowFlag(QtCore.Qt.WindowType.WindowStaysOnTopHint, enabled)
         # Re-applying window flags hides the window on some platforms; re-show it.
         self.show()
         self.session.log_info_msg(
@@ -482,10 +494,10 @@ class SmaccWindow(ToolWindow):
 
     def show_about_popup(self):
         win = QtWidgets.QMessageBox(self)  # parent to self so it stacks above
-        # win.setIcon(QtWidgets.QMessageBox.Question)
+        # win.setIcon(QtWidgets.QMessageBox.Icon.Question)
         # win.setWindowIcon(QtGui.QIcon("./thumb-small.png"))
         # win.setIconPixmap(QtGui.QPixmap("./thumb.png"))
-        win.setStandardButtons(QtWidgets.QMessageBox.Ok)
+        win.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
         win.setWindowTitle("About SMACC")
         win.setText("Sleep Manipulation and Communication Clickything")
         win.setInformativeText(f"version: v{VERSION}\nhttps://github.com/remrama/smacc")
@@ -544,23 +556,23 @@ class SmaccWindow(ToolWindow):
         text = QtGui.QColor(220, 220, 220)
         disabled = QtGui.QColor(127, 127, 127)
         highlight = QtGui.QColor(42, 130, 218)
-        p.setColor(QtGui.QPalette.Window, base)
-        p.setColor(QtGui.QPalette.WindowText, text)
-        p.setColor(QtGui.QPalette.Base, QtGui.QColor(35, 35, 35))
-        p.setColor(QtGui.QPalette.AlternateBase, QtGui.QColor(45, 45, 45))
-        p.setColor(QtGui.QPalette.ToolTipBase, base)
-        p.setColor(QtGui.QPalette.ToolTipText, text)
-        p.setColor(QtGui.QPalette.Text, text)
-        p.setColor(QtGui.QPalette.Button, base)
-        p.setColor(QtGui.QPalette.ButtonText, text)
-        p.setColor(QtGui.QPalette.Highlight, highlight)
-        p.setColor(QtGui.QPalette.HighlightedText, QtGui.QColor(0, 0, 0))
+        p.setColor(QtGui.QPalette.ColorRole.Window, base)
+        p.setColor(QtGui.QPalette.ColorRole.WindowText, text)
+        p.setColor(QtGui.QPalette.ColorRole.Base, QtGui.QColor(35, 35, 35))
+        p.setColor(QtGui.QPalette.ColorRole.AlternateBase, QtGui.QColor(45, 45, 45))
+        p.setColor(QtGui.QPalette.ColorRole.ToolTipBase, base)
+        p.setColor(QtGui.QPalette.ColorRole.ToolTipText, text)
+        p.setColor(QtGui.QPalette.ColorRole.Text, text)
+        p.setColor(QtGui.QPalette.ColorRole.Button, base)
+        p.setColor(QtGui.QPalette.ColorRole.ButtonText, text)
+        p.setColor(QtGui.QPalette.ColorRole.Highlight, highlight)
+        p.setColor(QtGui.QPalette.ColorRole.HighlightedText, QtGui.QColor(0, 0, 0))
         for role in (
-            QtGui.QPalette.WindowText,
-            QtGui.QPalette.Text,
-            QtGui.QPalette.ButtonText,
+            QtGui.QPalette.ColorRole.WindowText,
+            QtGui.QPalette.ColorRole.Text,
+            QtGui.QPalette.ColorRole.ButtonText,
         ):
-            p.setColor(QtGui.QPalette.Disabled, role, disabled)
+            p.setColor(QtGui.QPalette.ColorGroup.Disabled, role, disabled)
         return p
 
     ############################################################################
@@ -679,7 +691,7 @@ class SmaccWindow(ToolWindow):
         self._always_on_top_action.setChecked(bool(prefs["always_on_top"]))
         self._always_on_top_action.blockSignals(False)
         if prefs["always_on_top"]:
-            self.setWindowFlag(QtCore.Qt.WindowStaysOnTopHint, True)
+            self.setWindowFlag(QtCore.Qt.WindowType.WindowStaysOnTopHint, True)
 
         # Log-preview levels (preview_handler exists now, built in init_main_window).
         wanted = preferences.names_to_levels(prefs.get("preview_levels", []))
@@ -786,7 +798,7 @@ class SmaccWindow(ToolWindow):
             "Associate .smacc settings files with SMACC so double-clicking one opens "
             "the app already configured?",
         )
-        if reply == QtWidgets.QMessageBox.Yes:
+        if reply == QtWidgets.QMessageBox.StandardButton.Yes:
             try:
                 winassoc.register_smacc()
                 self.session.log_info_msg("Associated .smacc files with SMACC")
@@ -825,7 +837,9 @@ class SmaccWindow(ToolWindow):
         self.settings_path = path  # subsequent saves update this file
         self.session.log_info_msg(f"Saved settings to {path}")
         # Status-bar confirmation: the editor has no log viewer to show the line.
-        self.statusBar().showMessage(f"Saved settings to {Path(path).name}", 5000)
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.showMessage(f"Saved settings to {Path(path).name}", 5000)
         return True
 
     def load_settings(self) -> None:
@@ -1017,17 +1031,17 @@ class SmaccWindow(ToolWindow):
             box.setWindowTitle("Close editor")
             box.setText("Save changes to the settings before closing?")
             box.setStandardButtons(
-                QtWidgets.QMessageBox.Save
-                | QtWidgets.QMessageBox.Discard
-                | QtWidgets.QMessageBox.Cancel
+                QtWidgets.QMessageBox.StandardButton.Save
+                | QtWidgets.QMessageBox.StandardButton.Discard
+                | QtWidgets.QMessageBox.StandardButton.Cancel
             )
-            box.setDefaultButton(QtWidgets.QMessageBox.Save)
+            box.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Save)
             choice = box.exec()
-            if choice == QtWidgets.QMessageBox.Cancel:
+            if choice == QtWidgets.QMessageBox.StandardButton.Cancel:
                 event.ignore()
                 return
             if (
-                choice == QtWidgets.QMessageBox.Save
+                choice == QtWidgets.QMessageBox.StandardButton.Save
                 and not self.save_settings_in_place()
             ):
                 event.ignore()  # save was cancelled/failed → keep the editor open
@@ -1042,7 +1056,7 @@ class SmaccWindow(ToolWindow):
         response = QtWidgets.QMessageBox.question(
             self, "End session", "End this session and return to the SMACC menu?"
         )
-        if response == QtWidgets.QMessageBox.Yes:
+        if response == QtWidgets.QMessageBox.StandardButton.Yes:
             self._teardown_panels()
             # Persist this window's operator/UI preferences for next launch, merging
             # so we don't clobber keys other windows own (best-effort, never raises).

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 from . import preferences, settings
 from .analyze import AnalyzeWindow
@@ -81,17 +81,17 @@ class LauncherWindow(QtWidgets.QMainWindow):
             logo = QtWidgets.QLabel()
             logo.setPixmap(
                 QtGui.QPixmap(str(LOGO_PATH)).scaledToHeight(
-                    72, QtCore.Qt.SmoothTransformation
+                    72, QtCore.Qt.TransformationMode.SmoothTransformation
                 )
             )
-            logo.setAlignment(QtCore.Qt.AlignCenter)
+            logo.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
             layout.addWidget(logo)
         title = QtWidgets.QLabel("SMACC")
         title_font = QtGui.QFont()
         title_font.setPointSize(20)
         title_font.setBold(True)
         title.setFont(title_font)
-        title.setAlignment(QtCore.Qt.AlignCenter)
+        title.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(title)
 
         # One row to choose the settings, then Start / Edit / New acting on it.
@@ -110,7 +110,7 @@ class LauncherWindow(QtWidgets.QMainWindow):
 
         layout.addStretch(1)
         footer = QtWidgets.QLabel(f"v{VERSION} — github.com/remrama/smacc")
-        footer.setAlignment(QtCore.Qt.AlignCenter)
+        footer.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         footer.setEnabled(False)
         layout.addWidget(footer)
 
@@ -119,12 +119,17 @@ class LauncherWindow(QtWidgets.QMainWindow):
         self.resize(420, 360)
 
     def _build_menu(self) -> None:
-        fileMenu = self.menuBar().addMenu("&File")
+        menu_bar = self.menuBar()
+        assert menu_bar is not None
+        fileMenu = menu_bar.addMenu("&File")
+        assert fileMenu is not None
         prefsAction = fileMenu.addAction("&Preferences…")
+        assert prefsAction is not None
         prefsAction.setStatusTip("Edit interface preferences (theme, log preview, …).")
         prefsAction.triggered.connect(self.edit_preferences)
         fileMenu.addSeparator()
         quitAction = fileMenu.addAction("&Quit")
+        assert quitAction is not None
         quitAction.setShortcut("Ctrl+Q")
         quitAction.setStatusTip("Quit SMACC.")
         quitAction.triggered.connect(self.close)
@@ -171,14 +176,18 @@ class LauncherWindow(QtWidgets.QMainWindow):
         combo.blockSignals(True)  # programmatic fill: don't fire activated
         combo.clear()
         combo.addItem("default", default)
-        combo.setItemData(0, default, QtCore.Qt.ToolTipRole)  # full path on hover
+        combo.setItemData(
+            0, default, QtCore.Qt.ItemDataRole.ToolTipRole
+        )  # full path on hover
         seen = {default}
         for path in recents:
             if path in seen:
                 continue
             seen.add(path)
             combo.addItem(Path(path).stem, path)  # name only — no extension/path
-            combo.setItemData(combo.count() - 1, path, QtCore.Qt.ToolTipRole)
+            combo.setItemData(
+                combo.count() - 1, path, QtCore.Qt.ItemDataRole.ToolTipRole
+            )
         combo.insertSeparator(combo.count())
         combo.addItem("Browse…", _BROWSE_SENTINEL)
         target = self._settings_path or default
@@ -281,9 +290,10 @@ class LauncherWindow(QtWidgets.QMainWindow):
         self.raise_()
         self.activateWindow()
 
-    def closeEvent(self, event: QtGui.QCloseEvent) -> None:
+    def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
         """Closing the launcher quits SMACC (it is the app's root window)."""
         app = QtWidgets.QApplication.instance()
         if app is not None:
             app.quit()
-        event.accept()
+        if event is not None:
+            event.accept()

--- a/src/smacc/panels/audio.py
+++ b/src/smacc/panels/audio.py
@@ -16,8 +16,9 @@ import tempfile
 from dataclasses import dataclass, field
 from functools import partial
 from pathlib import Path
+from typing import cast
 
-from PyQt5 import QtCore, QtMultimedia, QtWidgets
+from PyQt6 import QtCore, QtMultimedia, QtWidgets
 
 from ..session import SmaccSession
 from ..utils import ensure_wav, pick_random_demo_cue
@@ -131,17 +132,17 @@ class AudioCueWindow(ModalityWindow):
         # Shared device + fade controls.
         available_speakers_dropdown = QtWidgets.QComboBox()
         available_speakers_dropdown.setPlaceholderText("No speaker devices were found.")
-        # Qt5's QSoundEffect has no output-device selection, so this picker can't
-        # route cues. Disabled (but populated) until the playback engine is moved
-        # onto a backend that supports device selection; see the follow-up issue.
+        # Cue playback (QSoundEffect) isn't routed to a chosen device yet, so this
+        # picker is populated for reference but disabled until cue playback moves
+        # onto the unified sounddevice engine; see the follow-up issue.
         available_speakers_dropdown.setEnabled(False)
         available_speakers_dropdown.setStatusTip(
             "Device selection isn't supported for cues yet; they play on the system "
             "default output."
         )
         available_speakers_dropdown.setToolTip(
-            "Qt5 can't route cue playback to a specific device; cues use the system "
-            "default output."
+            "Cue playback can't be routed to a specific device yet; cues use the "
+            "system default output."
         )
         self.available_speakers_dropdown = available_speakers_dropdown
         self.refresh_available_speakers()
@@ -169,14 +170,14 @@ class AudioCueWindow(ModalityWindow):
         self.releaseSpinBox = releaseSpinBox
 
         header = QtWidgets.QFormLayout()
-        header.setLabelAlignment(QtCore.Qt.AlignRight)
+        header.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         header.addRow("Device:", available_speakers_dropdown)
         header.addRow("Fade in:", attackSpinBox)
         header.addRow("Fade out:", releaseSpinBox)
 
         # "Now playing" indicator on top of the slot table (mixing-board style).
         self.nowPlayingLabel = QtWidgets.QLabel("■ stopped", self)  # ■
-        self.nowPlayingLabel.setAlignment(QtCore.Qt.AlignCenter)
+        self.nowPlayingLabel.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
 
         # Cue table: a persistent header row, then one rebuildable row per slot,
         # then an "add" row. The header labels and add button are created once and
@@ -294,21 +295,16 @@ class AudioCueWindow(ModalityWindow):
     # ----- shared device + fade ---------------------------------------------
 
     def refresh_available_speakers(self):
-        """Populate the device dropdown with available audio outputs."""
+        """Populate the (disabled) device dropdown with available audio outputs.
+
+        QSoundEffect can't route to a chosen device, so this list is shown for
+        reference only (the picker is disabled); it mirrors Qt's current outputs.
+        """
         self.available_speakers_dropdown.clear()
-        devices = QtMultimedia.QAudioDeviceInfo.availableDevices(
-            QtMultimedia.QAudio.AudioOutput
-        )
-        devices = [d for d in devices if d.realm() != "default"]
-        for device in devices:
-            device_name = device.deviceName()
-            device_realm = device.realm()  # differentiates the default-output dupe
-            device_str = f"{device_name} [{device_realm}]"
-            self.available_speakers_dropdown.addItem(device_str)
-        if devices:
+        for device in QtMultimedia.QMediaDevices.audioOutputs():
+            self.available_speakers_dropdown.addItem(device.description())
+        if self.available_speakers_dropdown.count():
             self.available_speakers_dropdown.setCurrentIndex(0)
-        else:
-            self.session.show_error_popup("No audio devices found.", parent=self)
 
     def update_cue_attack(self, value: float) -> None:
         """Set the shared cue fade-in (attack) time in seconds."""
@@ -381,7 +377,10 @@ class AudioCueWindow(ModalityWindow):
     def update_slot_loop(self, slot: CueSlot, enabled: bool | None = None) -> None:
         """Set a slot player's loop count from its checkbox."""
         looping = slot.loopCheckBox.isChecked()
-        count = QtMultimedia.QSoundEffect.Infinite if looping else 1
+        # QSoundEffect.Loop is a plain Enum here; its .value is the int (-2) that
+        # setLoopCount expects (mypy mistypes the member, so coerce to int).
+        infinite = cast(int, QtMultimedia.QSoundEffect.Loop.Infinite.value)
+        count = infinite if looping else 1
         slot.player.setLoopCount(count)
         self.session.log_interaction(
             f"Cue '{slot.nameEdit.text()}' loop {'on' if looping else 'off'}"

--- a/src/smacc/panels/base.py
+++ b/src/smacc/panels/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import utils
 from ..paths import LOGO_PATH
@@ -49,7 +49,7 @@ def make_section_title(text: str) -> QtWidgets.QLabel:
     stays legible when the dark theme toggles.
     """
     label = QtWidgets.QLabel(text)
-    label.setAlignment(QtCore.Qt.AlignCenter)
+    label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
     font = QtGui.QFont()
     font.setPointSize(18)
     label.setFont(font)

--- a/src/smacc/panels/events.py
+++ b/src/smacc/panels/events.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from functools import partial
 
-from PyQt5 import QtWidgets
+from PyQt6 import QtWidgets
 
 from ..session import SmaccSession
 from .base import ModalityWindow, make_section_title
@@ -40,7 +40,7 @@ class EventsWindow(ModalityWindow):
         """
         while self._grid.count():
             item = self._grid.takeAt(0)
-            widget = item.widget()
+            widget = item.widget() if item is not None else None
             if widget is not None:
                 widget.deleteLater()
         manual = [e for e in self.session.events.values() if e.category == "manual"]

--- a/src/smacc/panels/intercom.py
+++ b/src/smacc/panels/intercom.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import queue
 
 import sounddevice as sd
-from PyQt5 import QtCore, QtWidgets
+from PyQt6 import QtCore, QtWidgets
 
 from .. import audio
 from ..session import SmaccSession
@@ -59,7 +59,7 @@ class IntercomWindow(ModalityWindow):
         self.intercomButton = intercomButton
 
         layout = QtWidgets.QFormLayout()
-        layout.setLabelAlignment(QtCore.Qt.AlignRight)
+        layout.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         layout.addRow(make_section_title("Intercom"))
         layout.addRow("To participant:", intercom_output_dropdown)
         layout.addRow(intercomButton)
@@ -230,11 +230,11 @@ class IntercomWindow(ModalityWindow):
         """
         etype = event.type()
         if (
-            etype in (QtCore.QEvent.KeyPress, QtCore.QEvent.KeyRelease)
-            and event.key() == QtCore.Qt.Key_Space
+            etype in (QtCore.QEvent.Type.KeyPress, QtCore.QEvent.Type.KeyRelease)
+            and event.key() == QtCore.Qt.Key.Key_Space
             and not self._is_text_widget_focused()
         ):
-            if etype == QtCore.QEvent.KeyPress:
+            if etype == QtCore.QEvent.Type.KeyPress:
                 if not event.isAutoRepeat() and not self.intercomButton.isChecked():
                     self._intercom_push_to_talk = True
                     self.intercomButton.setChecked(True)  # -> toggle_intercom(True)

--- a/src/smacc/panels/noise.py
+++ b/src/smacc/panels/noise.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import numpy as np
 import sounddevice as sd
 import soundfile as sf
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import utils
 from ..session import SmaccSession
@@ -45,7 +45,7 @@ class NoiseWindow(ModalityWindow):
     def _build(self) -> QtWidgets.QWidget:
         # "Now playing" indicator on top (mixing-board style).
         self.noiseStatusLabel = QtWidgets.QLabel("■ stopped", self)
-        self.noiseStatusLabel.setAlignment(QtCore.Qt.AlignCenter)
+        self.noiseStatusLabel.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
 
         # Noise device picker: QComboBox signal --> update device slot
         available_noisespeakers_dropdown = QtWidgets.QComboBox()
@@ -118,7 +118,7 @@ class NoiseWindow(ModalityWindow):
         transport.addWidget(stopnoiseButton)
 
         form = QtWidgets.QFormLayout()
-        form.setLabelAlignment(QtCore.Qt.AlignRight)
+        form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         form.addRow("Device:", available_noisespeakers_dropdown)
         form.addRow("Source:", sourceRow)
         form.addRow("Color/Type:", available_noisecolors_dropdown)

--- a/src/smacc/panels/recording.py
+++ b/src/smacc/panels/recording.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import webbrowser
 
 import sounddevice as sd
-from PyQt5 import QtCore, QtMultimedia, QtWidgets
+import soundfile as sf
+from PyQt6 import QtCore, QtWidgets
 
 from .. import audio
 from ..config import SURVEY_OPTIONS
@@ -21,14 +22,20 @@ from .base import (
 
 
 class RecordingWindow(ModalityWindow):
-    """Record a spoken dream report, monitor input level, and open a survey."""
+    """Record a spoken dream report, monitor input level, and open a survey.
+
+    Capture and the level meter both run on sounddevice (PortAudio), so the
+    microphone is identified the same way everywhere — one device string, no
+    Qt-name-to-PortAudio matching. A report is written straight to a WAV in the
+    run folder as it records.
+    """
 
     TITLE = "Dream recording"
 
     def __init__(self, session: SmaccSession, parent: QtWidgets.QWidget | None = None):
         super().__init__(session, parent)
         self.n_report_counter = 0  # cumulative counter for determining filenames
-        self.init_microphone()
+        self.init_recorder()
         self.init_level_meter()
         self.setCentralWidget(self._build())
 
@@ -47,6 +54,7 @@ class RecordingWindow(ModalityWindow):
         micrecordButton.setStatusTip("Ask for a dream report and start recording.")
         micrecordButton.setCheckable(True)
         micrecordButton.clicked.connect(self.start_or_stop_recording)
+        self.micrecordButton = micrecordButton
         if not self.session.can_record:
             # The study designer has no run folder to record into; configuring the
             # device and surveys still works, so only the recording itself is off.
@@ -57,12 +65,12 @@ class RecordingWindow(ModalityWindow):
 
         # Recording indicator (replaces the old log-viewer red border).
         self.recordingIndicatorLabel = QtWidgets.QLabel("■ idle", self)
-        self.recordingIndicatorLabel.setAlignment(QtCore.Qt.AlignCenter)
+        self.recordingIndicatorLabel.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
 
         # Live input level meter (#25): monitor microphone/room level in dBFS.
         monitorCheckBox = QtWidgets.QCheckBox(self)
         monitorCheckBox.setStatusTip(
-            "Show the live input level from the default microphone, in dBFS."
+            "Show the live input level from the selected microphone, in dBFS."
         )
         monitorCheckBox.toggled.connect(self.toggle_level_monitor)
         self.monitorCheckBox = monitorCheckBox
@@ -81,7 +89,7 @@ class RecordingWindow(ModalityWindow):
         # Survey selector: editable dropdown of named presets (or a typed-in URL).
         surveyComboBox = QtWidgets.QComboBox(self)
         surveyComboBox.setEditable(True)
-        surveyComboBox.setInsertPolicy(QtWidgets.QComboBox.NoInsert)
+        surveyComboBox.setInsertPolicy(QtWidgets.QComboBox.InsertPolicy.NoInsert)
         surveyComboBox.setStatusTip(
             "Survey opened in the browser when a dream report starts. "
             "Pick a preset or type a URL (leave blank for none)."
@@ -100,7 +108,7 @@ class RecordingWindow(ModalityWindow):
         surveyRow.addWidget(manageSurveysButton)
 
         layout = QtWidgets.QFormLayout()
-        layout.setLabelAlignment(QtCore.Qt.AlignRight)
+        layout.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         layout.addRow(make_section_title("Dream recording"))
         layout.addRow("Device:", available_microphones_dropdown)
         layout.addRow("Survey:", surveyRow)
@@ -113,36 +121,45 @@ class RecordingWindow(ModalityWindow):
 
     # ----- microphone / recording -------------------------------------------
 
-    def init_microphone(self):
-        """Initialize the microphone/recorder used to collect dream reports."""
-        settings = QtMultimedia.QAudioEncoderSettings()
-        settings.setEncodingMode(QtMultimedia.QMultimedia.ConstantQualityEncoding)
-        settings.setQuality(QtMultimedia.QMultimedia.NormalQuality)
-        microphone = QtMultimedia.QAudioRecorder()
-        microphone.setEncodingSettings(settings)
-        microphone.stateChanged.connect(self.update_microphone_status)
-        self.microphone = microphone
+    def init_recorder(self) -> None:
+        """Initialize the dream-report recorder state (a sounddevice input stream)."""
+        self._record_stream: sd.InputStream | None = None
+        self._record_file: sf.SoundFile | None = None
+
+    def _selected_input_device(self) -> str | None:
+        """The sounddevice device string for the selected mic (None == default)."""
+        return self.available_microphones_dropdown.currentText() or None
 
     def set_new_microphone(self, text: str) -> None:
-        """Apply the selected microphone to the recorder and live level meter."""
-        name = self.available_microphones_dropdown.currentData()
-        if name:
-            self.microphone.setAudioInput(name)
+        """Log the selected microphone and switch a live level meter over to it."""
         self.session.log_interaction(f"Microphone set to {text}")
         self._restart_meter_if_monitoring()  # switch a live meter over too
 
     def refresh_available_microphones(self):
-        """Populate the microphone dropdown with available audio input devices.
+        """Populate the microphone dropdown with available WASAPI input devices.
 
-        Items carry the raw input name (the value ``setAudioInput`` expects) as data
-        and show a friendlier description as text.
+        Each item shows (and is keyed by) the sounddevice device string — the same
+        value passed to the recording and level-meter streams — so there is a single
+        device identity throughout the panel.
         """
         self.available_microphones_dropdown.clear()
-        names = self.microphone.audioInputs()
-        for name in names:
-            description = self.microphone.audioInputDescription(name) or name
-            self.available_microphones_dropdown.addItem(description, name)
-        if names:
+        host_api_name = "Windows WASAPI"
+        host_api_names = [api["name"] for api in sd.query_hostapis()]
+        hostapi = (
+            host_api_names.index(host_api_name)
+            if host_api_name in host_api_names
+            else None
+        )
+        count = 0
+        for device in sd.query_devices():
+            if device["max_input_channels"] <= 0:
+                continue
+            if hostapi is not None and device["hostapi"] != hostapi:
+                continue
+            suffix = f", {host_api_name}" if hostapi is not None else ""
+            self.available_microphones_dropdown.addItem(f"{device['name']}{suffix}")
+            count += 1
+        if count:
             self.available_microphones_dropdown.setCurrentIndex(0)
         elif self.session.can_record:
             # In the designer there's no recording, so don't nag about missing mics.
@@ -157,37 +174,14 @@ class RecordingWindow(ModalityWindow):
 
     def is_streaming(self) -> bool:
         """True while the level meter is open or a dream report is recording."""
-        return (
-            self.meter_stream is not None
-            or self.microphone.state() == QtMultimedia.QMediaRecorder.RecordingState
-        )
-
-    def record(self):
-        state = self.microphone.state()  # recording / paused / stopped
-        if state == QtMultimedia.QMediaRecorder.StoppedState:
-            self.n_report_counter += 1
-            # Reports live in this run's session folder; the folder already
-            # namespaces them, so a short report-NN name is enough.
-            basename = f"report-{self.n_report_counter:02d}.wav"
-            export_fname = self.session.session_dir / basename
-            self.microphone.setOutputLocation(
-                QtCore.QUrl.fromLocalFile(str(export_fname))
-            )
-            self.microphone.record()
-        elif state == QtMultimedia.QMediaRecorder.RecordingState:
-            self.microphone.stop()
-
-    def update_microphone_status(self, state):
-        if state == QtMultimedia.QMediaRecorder.RecordingState:
-            self.recordingIndicatorLabel.setText("● recording")
-            self.recordingIndicatorLabel.setStyleSheet("color: red; font-weight: bold;")
-        else:
-            self.recordingIndicatorLabel.setText("■ idle")
-            self.recordingIndicatorLabel.setStyleSheet("")
+        return self.meter_stream is not None or self._record_stream is not None
 
     def start_or_stop_recording(self):
-        self.record()  # starts OR stops, whichever isn't currently happening
-        if self.sender().isChecked():
+        """Start or stop a dream report (the button's checked state is the intent)."""
+        if self.micrecordButton.isChecked():
+            if not self._start_recording():
+                self.micrecordButton.setChecked(False)  # start failed; revert
+                return
             if survey_url := self.current_survey_url():
                 self.open_survey_url(survey_url, self.surveyComboBox.currentText())
             # Stamp the report with the time since the "Start recording" marker so
@@ -210,7 +204,75 @@ class RecordingWindow(ModalityWindow):
                     "DreamReportStarted", detail=f"t+{format_elapsed(elapsed)}"
                 )
         else:
+            self._stop_recording()
             self.session.emit_event("DreamReportStopped")
+
+    def _start_recording(self) -> bool:
+        """Open the mic stream and the report WAV; return True on success.
+
+        Reports live in this run's session folder; the folder already namespaces
+        them, so a short report-NN name is enough.
+        """
+        device = self._selected_input_device()
+        self.n_report_counter += 1
+        assert self.session.session_dir is not None  # recording is gated on can_record
+        export_path = (
+            self.session.session_dir / f"report-{self.n_report_counter:02d}.wav"
+        )
+        try:
+            rate = int(sd.query_devices(device, "input")["default_samplerate"])
+            self._record_file = sf.SoundFile(
+                str(export_path),
+                mode="w",
+                samplerate=rate,
+                channels=1,
+                subtype="PCM_16",
+            )
+            self._record_stream = sd.InputStream(
+                device=device,
+                channels=1,
+                samplerate=rate,
+                callback=self._record_callback,
+            )
+            self._record_stream.start()
+        except Exception as exc:  # PortAudio / file-open errors
+            self._teardown_recording()
+            self.n_report_counter -= 1  # this attempt produced no report
+            self.session.show_error_popup(
+                "Could not start recording.", str(exc), parent=self
+            )
+            return False
+        self._set_recording_indicator(True)
+        return True
+
+    def _stop_recording(self) -> None:
+        """Stop the mic stream and finalize the report WAV."""
+        self._teardown_recording()
+        self._set_recording_indicator(False)
+
+    def _teardown_recording(self) -> None:
+        """Close the recording stream and file if open (safe to call repeatedly)."""
+        if self._record_stream is not None:
+            self._record_stream.abort()
+            self._record_stream.close()
+            self._record_stream = None
+        if self._record_file is not None:
+            self._record_file.close()
+            self._record_file = None
+
+    def _record_callback(self, indata, frames, time, status) -> None:
+        """sounddevice callback (audio thread): append captured frames to the WAV."""
+        if self._record_file is not None:
+            self._record_file.write(indata.copy())
+
+    def _set_recording_indicator(self, recording: bool) -> None:
+        """Reflect the recording state in the on-panel indicator label."""
+        if recording:
+            self.recordingIndicatorLabel.setText("● recording")
+            self.recordingIndicatorLabel.setStyleSheet("color: red; font-weight: bold;")
+        else:
+            self.recordingIndicatorLabel.setText("■ idle")
+            self.recordingIndicatorLabel.setStyleSheet("")
 
     # ----- input level meter (#25) ------------------------------------------
 
@@ -221,29 +283,6 @@ class RecordingWindow(ModalityWindow):
         self.meter_timer = QtCore.QTimer(self)
         self.meter_timer.setInterval(50)  # ~20 Hz display refresh
         self.meter_timer.timeout.connect(self.update_level_meter)
-
-    def _meter_device(self) -> int | None:
-        """Best-effort PortAudio index for the selected recorder input.
-
-        Qt and PortAudio name devices differently, so match the selected input name
-        against PortAudio input devices by substring; return ``None`` (the default
-        input) when there's no confident match.
-        """
-        name = self.available_microphones_dropdown.currentData()
-        if not name:
-            return None
-        try:
-            devices = sd.query_devices()
-        except Exception:
-            return None
-        name_low = name.lower()
-        for idx, dev in enumerate(devices):
-            dev_low = dev["name"].lower()
-            if dev["max_input_channels"] > 0 and (
-                name_low in dev_low or dev_low in name_low
-            ):
-                return idx
-        return None
 
     def _restart_meter_if_monitoring(self) -> None:
         """Re-open the level meter on the current device if it's running."""
@@ -258,7 +297,7 @@ class RecordingWindow(ModalityWindow):
             try:
                 self.meter_stream = sd.InputStream(
                     channels=1,
-                    device=self._meter_device(),
+                    device=self._selected_input_device(),
                     callback=self._meter_callback,
                 )
                 self.meter_stream.start()
@@ -367,5 +406,4 @@ class RecordingWindow(ModalityWindow):
             self.meter_stream.abort()
             self.meter_stream.close()
             self.meter_stream = None
-        if self.microphone.state() == QtMultimedia.QMediaRecorder.RecordingState:
-            self.microphone.stop()
+        self._teardown_recording()

--- a/src/smacc/panels/visual.py
+++ b/src/smacc/panels/visual.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from blinkstick import blinkstick
-from PyQt5 import QtCore, QtGui, QtWidgets
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 from ..session import SmaccSession
 from .base import (
@@ -62,7 +62,7 @@ class VisualWindow(ModalityWindow):
         self.freqSpinBox = freqSpinBox
 
         layout = QtWidgets.QFormLayout()
-        layout.setLabelAlignment(QtCore.Qt.AlignRight)
+        layout.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         layout.addRow(make_section_title("Visual stimulation"))
         layout.addRow("Device:", available_blinksticks_dropdown)
         layout.addRow("Color:", colorpickerButton)

--- a/src/smacc/qtlog.py
+++ b/src/smacc/qtlog.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from PyQt5 import QtCore, QtWidgets
+from PyQt6 import QtCore, QtWidgets
 
 
 class _LogSignaller(QtCore.QObject):

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -15,7 +15,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 
 from pylsl import StreamInfo, StreamOutlet
-from PyQt5 import QtWidgets
+from PyQt6 import QtWidgets
 
 from . import bids, events, settings
 from .config import PPORT_ADDRESS, VERSION
@@ -290,7 +290,7 @@ class SmaccSession:
         """Record an info line and show an information dialog (parented if given)."""
         self.log_info_msg(short_msg if long_msg is None else f"{short_msg} {long_msg}")
         win = QtWidgets.QMessageBox(parent)
-        win.setIcon(QtWidgets.QMessageBox.Information)
+        win.setIcon(QtWidgets.QMessageBox.Icon.Information)
         win.setText(short_msg)
         if long_msg is not None:
             win.setInformativeText(long_msg)

--- a/src/smacc/toolwindow.py
+++ b/src/smacc/toolwindow.py
@@ -7,7 +7,7 @@ one base lets the launcher manage every tool through the same small contract.
 
 from __future__ import annotations
 
-from PyQt5 import QtCore, QtWidgets
+from PyQt6 import QtCore, QtWidgets
 
 
 class ToolWindow(QtWidgets.QMainWindow):

--- a/uv.lock
+++ b/uv.lock
@@ -857,63 +857,56 @@ wheels = [
 ]
 
 [[package]]
-name = "pyqt5"
-version = "5.15.11"
+name = "pyqt6"
+version = "6.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyqt5-qt5" },
-    { name = "pyqt5-sip" },
+    { name = "pyqt6-qt6" },
+    { name = "pyqt6-sip" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0e/07/c9ed0bd428df6f87183fca565a79fee19fa7c88c7f00a7f011ab4379e77a/PyQt5-5.15.11.tar.gz", hash = "sha256:fda45743ebb4a27b4b1a51c6d8ef455c4c1b5d610c90d2934c7802b5c1557c52", size = 3216775, upload-time = "2024-07-19T08:39:57.756Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/47/b25c13eca5bebc6505394d0223e46d7ebf0c57dcac2ed908d7d19b18ab6b/pyqt6-6.11.0.tar.gz", hash = "sha256:45dd60aa69976de1918b5ced6b4e7b6a25abd2a919ecef5fd5826ecc76718889", size = 1087430, upload-time = "2026-03-30T09:16:13.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/64/42ec1b0bd72d87f87bde6ceb6869f444d91a2d601f2e67cd05febc0346a1/PyQt5-5.15.11-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:c8b03dd9380bb13c804f0bdb0f4956067f281785b5e12303d529f0462f9afdc2", size = 6579776, upload-time = "2024-07-19T08:39:19.775Z" },
-    { url = "https://files.pythonhosted.org/packages/49/f5/3fb696f4683ea45d68b7e77302eff173493ac81e43d63adb60fa760b9f91/PyQt5-5.15.11-cp38-abi3-macosx_11_0_x86_64.whl", hash = "sha256:6cd75628f6e732b1ffcfe709ab833a0716c0445d7aec8046a48d5843352becb6", size = 7016415, upload-time = "2024-07-19T08:39:32.977Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/8c/4065950f9d013c4b2e588fe33cf04e564c2322842d84dbcbce5ba1dc28b0/PyQt5-5.15.11-cp38-abi3-manylinux_2_17_x86_64.whl", hash = "sha256:cd672a6738d1ae33ef7d9efa8e6cb0a1525ecf53ec86da80a9e1b6ec38c8d0f1", size = 8188103, upload-time = "2024-07-19T08:39:40.561Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/f0/ae5a5b4f9b826b29ea4be841b2f2d951bcf5ae1d802f3732b145b57c5355/PyQt5-5.15.11-cp38-abi3-win32.whl", hash = "sha256:76be0322ceda5deecd1708a8d628e698089a1cea80d1a49d242a6d579a40babd", size = 5433308, upload-time = "2024-07-19T08:39:46.932Z" },
-    { url = "https://files.pythonhosted.org/packages/56/d5/68eb9f3d19ce65df01b6c7b7a577ad3bbc9ab3a5dd3491a4756e71838ec9/PyQt5-5.15.11-cp38-abi3-win_amd64.whl", hash = "sha256:bdde598a3bb95022131a5c9ea62e0a96bd6fb28932cc1619fd7ba211531b7517", size = 6865864, upload-time = "2024-07-19T08:39:53.572Z" },
-]
-
-[[package]]
-name = "pyqt5-qt5"
-version = "5.15.2"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/09/99a222b0360616250fb2e6003a54e43a2a06b0774f0f8d5daafb86a2c375/PyQt5_Qt5-5.15.2-py3-none-macosx_10_13_intel.whl", hash = "sha256:76980cd3d7ae87e3c7a33bfebfaee84448fd650bad6840471d6cae199b56e154", size = 40546019, upload-time = "2021-03-10T13:52:47.763Z" },
-    { url = "https://files.pythonhosted.org/packages/83/d4/241a6a518d0bcf0a9fcdcbad5edfed18d43e884317eab8d5230a2b27e206/PyQt5_Qt5-5.15.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:1988f364ec8caf87a6ee5d5a3a5210d57539988bf8e84714c7d60972692e2f4a", size = 59921716, upload-time = "2021-03-10T13:57:39.485Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/7e/ce7c66a541a105fa98b41d6405fe84940564695e29fc7dccf6d9e8c5f898/PyQt5_Qt5-5.15.2-py3-none-win32.whl", hash = "sha256:9cc7a768b1921f4b982ebc00a318ccb38578e44e45316c7a4a850e953e1dd327", size = 43447358, upload-time = "2021-03-10T14:01:17.827Z" },
-    { url = "https://files.pythonhosted.org/packages/37/97/5d3b222b924fa2ed4c2488925155cd0b03fd5d09ee1cfcf7c553c11c9f66/PyQt5_Qt5-5.15.2-py3-none-win_amd64.whl", hash = "sha256:750b78e4dba6bdf1607febedc08738e318ea09e9b10aea9ff0d73073f11f6962", size = 50075158, upload-time = "2021-03-10T14:05:20.868Z" },
+    { url = "https://files.pythonhosted.org/packages/33/44/fcd3dd3f64c83c96bf9bce76ec16cca64bd9b91702c3d08fd8e3dafc73d9/pyqt6-6.11.0-cp310-abi3-macosx_10_14_universal2.whl", hash = "sha256:f7100bc7f72b12581ec479a733f4ad11b8002668e6786e8a445ab6f4d1c743d4", size = 12429735, upload-time = "2026-03-30T09:16:03.713Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/a0/bd1399740dfa80c0a94d20b02d89962a31458233dcf70eaa09bfbccf3d0f/pyqt6-6.11.0-cp310-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:8555277989fa7d114cb3c3443fd261d566909f7268ceedd41d93a5f02d37ec05", size = 8334632, upload-time = "2026-03-30T09:16:06.066Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/db/425b184ac2430ba1978bb507ffd285ec007a872644e2ae5df13332dbcb05/pyqt6-6.11.0-cp310-abi3-manylinux_2_39_aarch64.whl", hash = "sha256:0734959955adde095af9a074213a7f73386d1bbbddfc27346b4c0621641a692e", size = 8321484, upload-time = "2026-03-30T09:16:08.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/85/dd9f03d78d87460e109e0121cd6201c5802bdd655656bf2780e964870fea/pyqt6-6.11.0-cp310-abi3-win_amd64.whl", hash = "sha256:bd11b459c54dca068e988a42cf838303334f0d441b9d16d92ae6719fcb5ac6ba", size = 6844358, upload-time = "2026-03-30T09:16:09.766Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/75/970b041bde4372cc6739c5ef9db1de83a6b36e788e4992e598baa35b2255/pyqt6-6.11.0-cp310-abi3-win_arm64.whl", hash = "sha256:b6324e3501b19b4292c7a55b1f22e82d3e80e519e383ce4fe79b4a754c6f0288", size = 5933984, upload-time = "2026-03-30T09:16:11.817Z" },
 ]
 
 [[package]]
-name = "pyqt5-sip"
-version = "12.18.0"
+name = "pyqt6-qt6"
+version = "6.11.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f3/31/5ef342de9faee0f3801088946ae103db9b9eaeba3d6a64fefd5ce74df244/pyqt5_sip-12.18.0.tar.gz", hash = "sha256:71c37db75a0664325de149f43e2a712ec5fa1f90429a21dafbca005cb6767f94", size = 104143, upload-time = "2026-01-13T15:53:19.576Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/61/6d78d702016ac23d2b97634a3b6a831c3f7735f0552a1c8b058db96005d1/pyqt5_sip-12.18.0-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:b29e4cda24748e59e5bd1bdad4812091a86b4b5b08c38b7f781eb55a5166f2b7", size = 124614, upload-time = "2026-01-13T15:52:57.59Z" },
-    { url = "https://files.pythonhosted.org/packages/19/bf/8f3efa10ddd3e76c1253865340ab7c2960ef96681d732b1f666c77430612/pyqt5_sip-12.18.0-cp312-cp312-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:163c2bba5e637c2222ec17d82a2c5aa158184a191923eb7d137cf4cfa0399529", size = 339412, upload-time = "2026-01-13T15:53:00.563Z" },
-    { url = "https://files.pythonhosted.org/packages/72/48/f1bcf6729d01bae6729cd790b22fd579dbe34014e8be031e6f10c5b9b2aa/pyqt5_sip-12.18.0-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:ead5e0a64ad852ac60797989d8444a6a5bd834768536b04a07b40b2937d922f6", size = 282376, upload-time = "2026-01-13T15:52:59.172Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/b7/d84c764ac9f1366be561255ec9bd88ee224fefdbdb349aee250f3003f0ca/pyqt5_sip-12.18.0-cp312-cp312-win32.whl", hash = "sha256:993fe3ed9a62a92e770f32d5344e3df56c2cacf1471f01b7feaf04818a2df1c4", size = 49523, upload-time = "2026-01-13T15:53:03.068Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/e7/ef87178d5afa5f63be38556dc0df8af89f9bf74f2555f4dab6824c0fd150/pyqt5_sip-12.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:9b689e02e400abd1ce0a30cd6eae8eceabcf1bbba0395cb5c86e64ba74351d68", size = 58001, upload-time = "2026-01-13T15:53:02.15Z" },
-    { url = "https://files.pythonhosted.org/packages/79/67/8d43d0fea10ff48ddecc8534aead8b855dc80df80653b8b1bf9e1f993063/pyqt5_sip-12.18.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:9254e5dd7676b76503ba20edcc919e7ac4a97b6c70a6fb2f9dba9e13b4c60509", size = 124605, upload-time = "2026-01-13T15:53:04.991Z" },
-    { url = "https://files.pythonhosted.org/packages/48/2a/b08bc8efeb49c50c6cdac11417dc2c8eaefcac2f0a6382eae7b26dc0f232/pyqt5_sip-12.18.0-cp313-cp313-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c969631ada7293a81e1012b2264a62d69a91995b517586489dfe24421b87b9af", size = 339918, upload-time = "2026-01-13T15:53:08.502Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/99/24f82437b2f073cf39296b7c731b6a8bc0f5207911fdd93841a0ea9abe42/pyqt5_sip-12.18.0-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:d84ac384a63285132e67762c87681191c25e28a1df7560287ec3889d9eb223b5", size = 282088, upload-time = "2026-01-13T15:53:06.632Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/27/20d3924943df34361fae9c6a0489ae89d0b07571693245c61678d185e4a4/pyqt5_sip-12.18.0-cp313-cp313-win32.whl", hash = "sha256:95bba4670ecf5cba73958b85aa2087c17838a402ed251c38e68060c7665c998b", size = 49501, upload-time = "2026-01-13T15:53:11.159Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/36/e251623c12968730730512a9e5150430e36246afbe64894610190b896f61/pyqt5_sip-12.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:aac4adc37df2f2ac1dc259409be1900f07332d140a12c9db7c84112cef64ff59", size = 58076, upload-time = "2026-01-13T15:53:09.928Z" },
-    { url = "https://files.pythonhosted.org/packages/37/3a/b46a0116b1aacbb6156b2957eb5cb928c94b49f4626eb2540ca8d16ee757/pyqt5_sip-12.18.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8372ec8704bfd5e09942d0d055a1657eb4f702f4b30847a5e59df0496f99d67f", size = 124594, upload-time = "2026-01-13T15:53:13.159Z" },
-    { url = "https://files.pythonhosted.org/packages/58/63/df3037f11391c25c5b0ab233d22e58b8f056cb1ce16d7ecadb844421ce75/pyqt5_sip-12.18.0-cp314-cp314-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fdb45c7cd2af7eccd7370b994d432bfc7965079f845392760724f26771bb59dc", size = 339056, upload-time = "2026-01-13T15:53:16.558Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/e7/4f96b84520b8f8b7502682fd43f68f63ca6572b5858f56e5f61c76a54fe2/pyqt5_sip-12.18.0-cp314-cp314-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:92abe984becbde768954d6d0951f56d80a9868d2fd9e738e61fc944f0ff83dd6", size = 282439, upload-time = "2026-01-13T15:53:14.856Z" },
-    { url = "https://files.pythonhosted.org/packages/79/8e/ccdf20d373ceba83e1d1b7f818505c375208ffde4a96376dc7dbe592406c/pyqt5_sip-12.18.0-cp314-cp314-win32.whl", hash = "sha256:bd9e3c6f81346f1b08d6db02305cdee20c009b43aa083d44ee2de47a7da0e123", size = 50713, upload-time = "2026-01-13T15:53:18.634Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/21/8486ed45977be615ec5371b24b47298b1cb0e1a455b419eddd0215078dba/pyqt5_sip-12.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:6d948f1be619c645cd3bda54952bfdc1aef7c79242dccea6a6858748e61114b9", size = 59622, upload-time = "2026-01-13T15:53:17.714Z" },
+    { url = "https://files.pythonhosted.org/packages/38/cb/ef930289bcd3b4be77a619d6b89ccdd0f53d753053a45f69ed590fd49777/pyqt6_qt6-6.11.1-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:694486f18b7ab9b1edcdb50e0c9f5cb726e096107da90ae7b0e810f18e2002b3", size = 70402836, upload-time = "2026-05-15T11:18:24.893Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/d016af2de1975a0d90c9a911e3d82b2e8c8fe899f8af746ade42186f3845/pyqt6_qt6-6.11.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fd05b31a3c83111b6eb82bb472ccfe531ef823f70d085b82fd1edc5ad2553c54", size = 64167714, upload-time = "2026-05-15T11:18:48.848Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/be/21d0df9bde717131f4245f8801676120d466afe198c4641c9e4982cf85fe/pyqt6_qt6-6.11.1-py3-none-manylinux_2_34_x86_64.whl", hash = "sha256:254af349e0ef4b2fa581f86ee9d65eb797bb1d4f0c01ae5ceaa7b2446b458be9", size = 85897589, upload-time = "2026-05-15T11:19:21.864Z" },
+    { url = "https://files.pythonhosted.org/packages/08/69/f6b9cafceed9790c62a7ca3044562d38545bbfcfaf222846482ac2f9bd56/pyqt6_qt6-6.11.1-py3-none-manylinux_2_39_aarch64.whl", hash = "sha256:039b1ab619d63d06a87cacf84b581a2b61a30c9ad5bb677553e738afe4dc433a", size = 84996419, upload-time = "2026-05-15T11:19:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f1/70e83c23bf897c7f5025aa100482f482038ef70232dc27b407659d941fbf/pyqt6_qt6-6.11.1-py3-none-win_amd64.whl", hash = "sha256:7486c80512e823f2d3087e67f854f0556b345f4368040a853c8dc4d30fd3fe69", size = 78416766, upload-time = "2026-05-15T11:20:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b0/9183ec9c206a0c3cba5719f0911e88a3486167137456a0f9318f07ce000d/pyqt6_qt6-6.11.1-py3-none-win_arm64.whl", hash = "sha256:120efbedf833e5bbbc3d64ebdb139b44ff34e60f34410c7b1c2c26d230380bda", size = 59961004, upload-time = "2026-05-15T11:20:49.065Z" },
 ]
 
 [[package]]
-name = "pyqt5-stubs"
-version = "5.15.6.0"
+name = "pyqt6-sip"
+version = "13.11.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/5b/f96312e01661dff7320366fc948f7597d3e3e28ff7116e9e77dbf41ab937/PyQt5-stubs-5.15.6.0.tar.gz", hash = "sha256:91270ac23ebf38a1dc04cd97aa852cd08af82dc839100e5395af1447e3e99707", size = 395647, upload-time = "2022-04-23T09:53:56.785Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/24/a753e1af94b9ae5b2da63d4598457308da3cdbf0838c959381db086ccc86/pyqt6_sip-13.11.1.tar.gz", hash = "sha256:869c5b48afe38e55b1ee0dd72182b0886e968cc509b98023ff50010b013ce1be", size = 92574, upload-time = "2026-03-09T13:01:35.418Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/d5/9b8482ed572be40d51c3fcbb87451e446e56b5e19487cd60340b8ef51eb4/PyQt5_stubs-5.15.6.0-py3-none-any.whl", hash = "sha256:7fb8177c72489a8911f021b7bd7c33f12c87f6dba92dcef3fdcdb5d9400f0f3f", size = 433328, upload-time = "2022-04-23T09:53:52.107Z" },
+    { url = "https://files.pythonhosted.org/packages/46/27/47598e701d284497216bf97bf8b6a69f5e61412e716c232ff2b7e6cb2100/pyqt6_sip-13.11.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:ba9d362dd1e54b43bc2594f8841e1e39d24789716d28f08e5c9282af9fca342c", size = 112564, upload-time = "2026-03-09T13:01:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/95/cb/116f9b328636765f3bce97d9e10ec041c54bbe92beb0617edb86c2b615c1/pyqt6_sip-13.11.1-cp312-cp312-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0df15849946cea969d3ff2b24b76149262b6044aea2c5403e4f70c24c973a4c8", size = 299564, upload-time = "2026-03-09T13:01:17.292Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/be/fe2321285e8f683e705d199dbb458131f1850dc5966155a19c40100c85bb/pyqt6_sip-13.11.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c52b2b27fc77d9447a8dc1c6de1aaccc22d41e48697aafb2f2f20b8984bb02a5", size = 321210, upload-time = "2026-03-09T13:01:15.904Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9b/7d4b10f9cba1b6f581dfb4860b9d11898da55a5ed3b8a6e7a1bf9f7084d0/pyqt6_sip-13.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:1d1c67179c1924b28e3d7f04585639e7a7c0946f62390efc6ccf2a6206e595d3", size = 53351, upload-time = "2026-03-09T13:01:19.327Z" },
+    { url = "https://files.pythonhosted.org/packages/06/72/6c4e6f21cafa4bed40d2b0c1563525b0d8bfcb5734493696f4cfd043b45f/pyqt6_sip-13.11.1-cp312-cp312-win_arm64.whl", hash = "sha256:d83543125fe9fdb153e7e446c3b4d056d80ab5953644660633ab3f80e7784194", size = 48746, upload-time = "2026-03-09T13:01:20.248Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/0b/dc76c463c203e630b2c6417d4d5e337e919a265ac1c10127ef413551f5de/pyqt6_sip-13.11.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0c6d097aae7df312519e2b36e001bd796f6a2ce060ab8b9ed793daa8f407fe2e", size = 112552, upload-time = "2026-03-09T13:01:21.493Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e3/65b605759859d38231ce7544065d4c61f891eb7766c351318e2a0b08a473/pyqt6_sip-13.11.1-cp313-cp313-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a72f4ebdab16a8a484019ff593de90d8013d3286b678c6ba1c0bdb117f4fcb13", size = 299932, upload-time = "2026-03-09T13:01:24.912Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f7/c10d2dd5bf503a1de83bd163467bd323f12af016866c2814743b5b1efe1c/pyqt6_sip-13.11.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b68e442efc4275651bf63f2c43713e242924fd948909e31cf8f20d783ca505e9", size = 321497, upload-time = "2026-03-09T13:01:22.724Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/1f/e7e5ad77a76c00db5c8c1b9960f2b0672ec1978b971bb3509858cd7a9458/pyqt6_sip-13.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:ca24bfd4d5d8274e338433df9ac41930650088c00018d3313c6bd8de21772a02", size = 53371, upload-time = "2026-03-09T13:01:26.286Z" },
+    { url = "https://files.pythonhosted.org/packages/36/ef/a7acaf44980aed6fe26f1320e265db528fecb6a47ac67829c7cd011e9821/pyqt6_sip-13.11.1-cp313-cp313-win_arm64.whl", hash = "sha256:f532144c43f2fddcccf2e25df50cdb4a744edb4ce4ba5ed2d0f2cef825197f2f", size = 48745, upload-time = "2026-03-09T13:01:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1d/62c633faedef5bb3b8c7486a72e8a6466adaa2a14efcfccf85bb23426748/pyqt6_sip-13.11.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:cb931c1af45294bbe8039c5cfda184e3023f5dc766fc884964010eedd8fd85db", size = 112678, upload-time = "2026-03-09T13:01:28.15Z" },
+    { url = "https://files.pythonhosted.org/packages/03/72/5a3d9ffef0caa7e1bc7a35d6300f6099bfccd1d8a485b4320ba20013a2d9/pyqt6_sip-13.11.1-cp314-cp314-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:353d613129316e9f7eda6bbe821deb7b7ffa14483499189171fd8a246873f9ac", size = 299560, upload-time = "2026-03-09T13:01:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/98/f4/886f901f1e04da717a11e180ba19a9c7fc62da170966d57206006f173bda/pyqt6_sip-13.11.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fcadd68e09ee24cdda8f8bfcba52e59c9b297055d2c450f0eb89afa61a8dc31a", size = 321846, upload-time = "2026-03-09T13:01:29.817Z" },
+    { url = "https://files.pythonhosted.org/packages/96/f2/b68fd566f7f86dbb53d933489e70487cabaea0e0161690e4899653bbc7fb/pyqt6_sip-13.11.1-cp314-cp314-win_amd64.whl", hash = "sha256:581e287bf42587593b88b30d9db06ed0fccbf40f345a5bd3ec3f00a5692e2430", size = 55055, upload-time = "2026-03-09T13:01:33.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/42/efb7ced69f7d1d31eb8f19b2d778aeb182be7e070569d02b9057ac478e3e/pyqt6_sip-13.11.1-cp314-cp314-win_arm64.whl", hash = "sha256:42b62530a9b6a9c6e29c2941b8ab78258652da0aeae4eb1fc9a0631d19a7a7b2", size = 49597, upload-time = "2026-03-09T13:01:34.49Z" },
 ]
 
 [[package]]
@@ -1156,8 +1149,7 @@ dependencies = [
     { name = "blinkstick", marker = "sys_platform == 'win32'" },
     { name = "numpy" },
     { name = "pylsl" },
-    { name = "pyqt5" },
-    { name = "pyqt5-qt5" },
+    { name = "pyqt6" },
     { name = "pyyaml" },
     { name = "scipy" },
     { name = "sounddevice" },
@@ -1169,7 +1161,6 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pyinstaller" },
-    { name = "pyqt5-stubs" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "types-pyyaml" },
@@ -1189,9 +1180,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pyinstaller", marker = "extra == 'dev'" },
     { name = "pylsl" },
-    { name = "pyqt5" },
-    { name = "pyqt5-qt5", specifier = "==5.15.2" },
-    { name = "pyqt5-stubs", marker = "extra == 'dev'" },
+    { name = "pyqt6" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pyyaml" },
     { name = "ruff", marker = "extra == 'dev'" },


### PR DESCRIPTION
## Migrate from PyQt5 to PyQt6

Closes #41. Phase 1 of the [#39](https://github.com/remrama/smacc/issues/39) plan — a **behavior-preserving** toolkit port that gets SMACC off end-of-life Qt 5 and onto the maintained Qt 6 line, with no new user-facing features. Built on the latest `main` (includes #71).

### Why now

Qt 5 is end-of-life (5.15 is frozen). Qt 6 is where security/maintenance lives, and it's the prerequisite for the device/routing work in later phases. Qt 6 requires **Windows 10+**, so SMACC's floor moves from 8.1 → 10 (this is what #39 flagged; it's a necessary consequence of the upgrade, not an optional extra).

### What changed

**Mechanical (the bulk):**
- `PyQt5` → `PyQt6` across all imports.
- **Scoped enums** everywhere Qt 6 now requires them (`Qt.AlignCenter` → `Qt.AlignmentFlag.AlignCenter`, `QMessageBox.Yes` → `QMessageBox.StandardButton.Yes`, `QPalette.Window` → `QPalette.ColorRole.Window`, etc.). mypy with PyQt6's bundled stubs statically validates that every scoped member exists, so the enum work is type-checked, not eyeballed.
- `QAction`/`QShortcut` moved `QtWidgets` → `QtGui`.

**Forced API rewrites (Qt 6 removed these):**
- **Dream recording moved to `sounddevice`** — `QAudioRecorder` is gone in Qt 6. This is the Phase-2 recording swap pulled forward by necessity (as planned): capture now runs on an `sd.InputStream` writing a WAV via `soundfile`, the mic is enumerated like the other panels (WASAPI), and the brittle Qt-name↔PortAudio `_meter_device` matching is deleted. QtMultimedia is no longer imported by this panel.
- **Cue device list** uses `QMediaDevices.audioOutputs()` (`QAudioDeviceInfo` is gone). The picker stays disabled — cue *playback* is still `QSoundEffect` and isn't routed yet (that's Phase 2).
- `QRegExp`/`QRegExpValidator` → `QRegularExpression`/`QRegularExpressionValidator` (subject/session ID validator).

**PyQt6 stricter stubs:** Qt 6's `menuBar()`/`statusBar()`/`style()`/`addMenu()`/`addAction(text)`/`horizontalHeader()` are typed `Optional`. Handled with `assert ... is not None` locals (idiomatic, and a real runtime sanity check), plus `closeEvent` signatures widened to `QCloseEvent | None`.

**Windows floor → 10:** `pyproject` deps (`PyQt6`, drop the `PyQt5-Qt5` pin and `PyQt5-stubs` — PyQt6 ships its own stubs), Win10/11 classifiers, and the README/installation/contributing notes.

### Validation

- `ruff check`, `ruff format --check`, `mypy` (26 files), `pytest` (**155 passed**) all green.
- **Offscreen runtime smoke** (local, not committed): constructed every top-level window (launcher, live + design session, analyze), all six panels, the refresh coordinator, the dark-palette path, and all six dialogs — everything builds and runs under Qt 6.

### Risks / follow-ups

- **The packaged `SMACC.exe` isn't exercised by CI** (release builds only on tag). PyInstaller's PyQt6 hook should bundle the Qt 6 libraries and QtMultimedia plugins, but **the frozen build should be smoke-tested before the next release** — that's the main thing this PR can't verify here.
- The persisted `recording_device` key format changed (Qt mic name → sounddevice WASAPI string), so a mic saved under #71 won't match after this and falls back to default — the existing missing-device notice surfaces it, and re-picking once re-saves it.
