### PR TITLE
Add publications to docs index

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 A clickable interface for running sleep-related experiments.
 
+Used for dream engineering by the [Paller Lab](https://sites.northwestern.edu/pallerlab/) at Northwestern University and the [DxE Lab](https://www.dreamengineeringlab.com/) at the Center for Advanced Research in Sleep Medicine.
+
 * Trigger audio cues
 * Collect dream reports
 * Trigger EEG portcodes

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,17 +28,17 @@ SMACC is used in dream engineering research, including by:
 
 * [Ken Paller's Cognitive Neuroscience Lab](https://sites.northwestern.edu/pallerlab/)
   at Northwestern University
-    * Torres-Platas et al. (2026). Intentional lucid dreaming with a transformative learning agenda. *Research Square* [10.21203/rs.3.rs-8745420/v1](https://doi.org/10.21203/rs.3.rs-8745420/v1)
-    * Konkoly et al. (2026). Using real-time reporting to investigate visual experiences in dreams. *J Cogn Neurosci* [10.1162/jocn.a.107](https://doi.org/10.1162/JOCN.a.107)
-    * Morris et al. (2026). Inducing lucid dreaming based on a contemplative practice of compassion. *Brain Sci* [10.3390/brainsci16030315](https://doi.org/10.3390/brainsci16030315)
-    * Konkoly et al. (2026). Creative problem-solving after experimentally provoking dreams of unsolved puzzles during REM sleep. *Neurosci Conscious* [10.1093/nc/niaf067](https://doi.org/10.1093/nc/niaf067)
-    * Konkoly et al. (2025). Investigating dreams by strategically presenting sounds during REM sleep to reactivate waking experiences. *Neuropsychologia* [10.1016/j.neuropsychologia.2025.109229](https://doi.org/10.1016/j.neuropsychologia.2025.109229)
-    * Morris et al. (2025). Lucid dreaming of a prior virtual-reality experience with ego-transcendent qualities: A proof-of-concept study. *Neurosci Conscious* [10.1093/nc/niaf017](https://doi.org/10.1093/nc/niaf017)
-    * Mundt et al. (2024). Treating narcolepsy-related nightmares with cognitive behavioural therapy and targeted lucidity reactivation: A pilot study. *J Sleep Res* [10.1111/jsr.14384](https://doi.org/10.1111/jsr.14384)
-    * Wolk et al. (2024). Lucid dreams from reactivating mindfulness during REM sleep: A pilot study. *Int J Dream Res* [10.11588/ijodr.2024.2.98233](https://doi.org/10.11588/ijodr.2024.2.98233)
+    * Torres-Platas et al. (2026). Intentional lucid dreaming with a transformative learning agenda. *Research Square* doi:[10.21203/rs.3.rs-8745420/v1](https://doi.org/10.21203/rs.3.rs-8745420/v1)
+    * Konkoly et al. (2026). Using real-time reporting to investigate visual experiences in dreams. *J Cogn Neurosci* doi:[10.1162/jocn.a.107](https://doi.org/10.1162/JOCN.a.107)
+    * Morris et al. (2026). Inducing lucid dreaming based on a contemplative practice of compassion. *Brain Sci* doi:[10.3390/brainsci16030315](https://doi.org/10.3390/brainsci16030315)
+    * Konkoly et al. (2026). Creative problem-solving after experimentally provoking dreams of unsolved puzzles during REM sleep. *Neurosci Conscious* doi:[10.1093/nc/niaf067](https://doi.org/10.1093/nc/niaf067)
+    * Konkoly et al. (2025). Investigating dreams by strategically presenting sounds during REM sleep to reactivate waking experiences. *Neuropsychologia* doi:[10.1016/j.neuropsychologia.2025.109229](https://doi.org/10.1016/j.neuropsychologia.2025.109229)
+    * Morris et al. (2025). Lucid dreaming of a prior virtual-reality experience with ego-transcendent qualities: A proof-of-concept study. *Neurosci Conscious* doi:[10.1093/nc/niaf017](https://doi.org/10.1093/nc/niaf017)
+    * Mundt et al. (2024). Treating narcolepsy-related nightmares with cognitive behavioural therapy and targeted lucidity reactivation: A pilot study. *J Sleep Res* doi:[10.1111/jsr.14384](https://doi.org/10.1111/jsr.14384)
+    * Wolk et al. (2024). Lucid dreams from reactivating mindfulness during REM sleep: A pilot study. *Int J Dream Res* doi:[10.11588/ijodr.2024.2.98233](https://doi.org/10.11588/ijodr.2024.2.98233)
 * [Michelle Carr's Dream Engineering Lab](https://www.dreamengineeringlab.com/)
   at the University of Montreal
-    * Jafarzadeh Esfahani et al. (2024). Highly effective verified lucid dream induction using combined cognitive-sensory training and wearable EEG: A multi-centre study. *bioRxiv* [10.1101/2024.06.21.600133](https://doi.org/10.1101/2024.06.21.600133)
+    * Jafarzadeh Esfahani et al. (2024). Highly effective verified lucid dream induction using combined cognitive-sensory training and wearable EEG: A multi-centre study. *bioRxiv* doi:[10.1101/2024.06.21.600133](https://doi.org/10.1101/2024.06.21.600133)
 
 SMACC is free software released under the
 [GPL-3.0-or-later](https://github.com/remrama/smacc/blob/main/LICENSE.txt) license.

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,8 +28,17 @@ SMACC is used in dream engineering research, including by:
 
 * [Ken Paller's Cognitive Neuroscience Lab](https://sites.northwestern.edu/pallerlab/)
   at Northwestern University
+    * Konkoly et al. (2026). Creative problem-solving after experimentally provoking dreams of unsolved puzzles during REM sleep. *Neurosci. Conscious.* [doi:10.1093/nc/niaf067](https://doi.org/10.1093/nc/niaf067)
+    * Konkoly et al. (2026). Using real-time reporting to investigate visual experiences in dreams. *J. Cogn. Neurosci.* [doi:10.1162/jocn.a.107](https://doi.org/10.1162/JOCN.a.107)
+    * Morris et al. (2026). Inducing lucid dreaming based on a contemplative practice of compassion. *Brain Sci.* [doi:10.3390/brainsci16030315](https://doi.org/10.3390/brainsci16030315)
+    * Torres-Platas et al. (2026). Intentional lucid dreaming with a transformative learning agenda. *Research Square* [doi:10.21203/rs.3.rs-8745420/v1](https://doi.org/10.21203/rs.3.rs-8745420/v1)
+    * Konkoly et al. (2025). Investigating dreams by strategically presenting sounds during REM sleep to reactivate waking experiences. *Neuropsychologia* [doi:10.1016/j.neuropsychologia.2025.109229](https://doi.org/10.1016/j.neuropsychologia.2025.109229)
+    * Morris et al. (2025). Lucid dreaming of a prior virtual-reality experience with ego-transcendent qualities: A proof-of-concept study. *Neurosci. Conscious.* [doi:10.1093/nc/niaf017](https://doi.org/10.1093/nc/niaf017)
+    * Mundt et al. (2024). Treating narcolepsy-related nightmares with cognitive behavioural therapy and targeted lucidity reactivation: A pilot study. *J. Sleep Res.* [doi:10.1111/jsr.14384](https://doi.org/10.1111/jsr.14384)
+    * Wolk et al. (2024). Lucid dreams from reactivating mindfulness during REM sleep: A pilot study. *Int. J. Dream Res.* [doi:10.11588/ijodr.2024.2.98233](https://doi.org/10.11588/ijodr.2024.2.98233)
 * [Michelle Carr's Dream Engineering Lab](https://www.dreamengineeringlab.com/)
   at the University of Montreal
+    * Jafarzadeh Esfahani et al. (2024). Highly effective verified lucid dream induction using combined cognitive-sensory training and wearable EEG: A multi-centre study. *bioRxiv* [doi:10.1101/2024.06.21.600133](https://doi.org/10.1101/2024.06.21.600133)
 
 SMACC is free software released under the
 [GPL-3.0-or-later](https://github.com/remrama/smacc/blob/main/LICENSE.txt) license.

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ SMACC is used in dream engineering research, including by:
     * Mundt et al. (2024). Treating narcolepsy-related nightmares with cognitive behavioural therapy and targeted lucidity reactivation: A pilot study. *J Sleep Res* doi:[10.1111/jsr.14384](https://doi.org/10.1111/jsr.14384)
     * Wolk et al. (2024). Lucid dreams from reactivating mindfulness during REM sleep: A pilot study. *Int J Dream Res* doi:[10.11588/ijodr.2024.2.98233](https://doi.org/10.11588/ijodr.2024.2.98233)
 * [Michelle Carr's Dream Engineering Lab](https://www.dreamengineeringlab.com/)
-  at the University of Montreal
+  at the University of Montreal and the Center for Advanced Research in Sleep Medicine
     * Jafarzadeh Esfahani et al. (2024). Highly effective verified lucid dream induction using combined cognitive-sensory training and wearable EEG: A multi-centre study. *bioRxiv* doi:[10.1101/2024.06.21.600133](https://doi.org/10.1101/2024.06.21.600133)
 
 SMACC is free software released under the

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,17 +28,17 @@ SMACC is used in dream engineering research, including by:
 
 * [Ken Paller's Cognitive Neuroscience Lab](https://sites.northwestern.edu/pallerlab/)
   at Northwestern University
-    * Konkoly et al. (2026). Creative problem-solving after experimentally provoking dreams of unsolved puzzles during REM sleep. *Neurosci. Conscious.* [doi:10.1093/nc/niaf067](https://doi.org/10.1093/nc/niaf067)
-    * Konkoly et al. (2026). Using real-time reporting to investigate visual experiences in dreams. *J. Cogn. Neurosci.* [doi:10.1162/jocn.a.107](https://doi.org/10.1162/JOCN.a.107)
-    * Morris et al. (2026). Inducing lucid dreaming based on a contemplative practice of compassion. *Brain Sci.* [doi:10.3390/brainsci16030315](https://doi.org/10.3390/brainsci16030315)
-    * Torres-Platas et al. (2026). Intentional lucid dreaming with a transformative learning agenda. *Research Square* [doi:10.21203/rs.3.rs-8745420/v1](https://doi.org/10.21203/rs.3.rs-8745420/v1)
-    * Konkoly et al. (2025). Investigating dreams by strategically presenting sounds during REM sleep to reactivate waking experiences. *Neuropsychologia* [doi:10.1016/j.neuropsychologia.2025.109229](https://doi.org/10.1016/j.neuropsychologia.2025.109229)
-    * Morris et al. (2025). Lucid dreaming of a prior virtual-reality experience with ego-transcendent qualities: A proof-of-concept study. *Neurosci. Conscious.* [doi:10.1093/nc/niaf017](https://doi.org/10.1093/nc/niaf017)
-    * Mundt et al. (2024). Treating narcolepsy-related nightmares with cognitive behavioural therapy and targeted lucidity reactivation: A pilot study. *J. Sleep Res.* [doi:10.1111/jsr.14384](https://doi.org/10.1111/jsr.14384)
-    * Wolk et al. (2024). Lucid dreams from reactivating mindfulness during REM sleep: A pilot study. *Int. J. Dream Res.* [doi:10.11588/ijodr.2024.2.98233](https://doi.org/10.11588/ijodr.2024.2.98233)
+    * Torres-Platas et al. (2026). Intentional lucid dreaming with a transformative learning agenda. *Research Square* [10.21203/rs.3.rs-8745420/v1](https://doi.org/10.21203/rs.3.rs-8745420/v1)
+    * Konkoly et al. (2026). Using real-time reporting to investigate visual experiences in dreams. *J Cogn Neurosci* [10.1162/jocn.a.107](https://doi.org/10.1162/JOCN.a.107)
+    * Morris et al. (2026). Inducing lucid dreaming based on a contemplative practice of compassion. *Brain Sci* [10.3390/brainsci16030315](https://doi.org/10.3390/brainsci16030315)
+    * Konkoly et al. (2026). Creative problem-solving after experimentally provoking dreams of unsolved puzzles during REM sleep. *Neurosci Conscious* [10.1093/nc/niaf067](https://doi.org/10.1093/nc/niaf067)
+    * Konkoly et al. (2025). Investigating dreams by strategically presenting sounds during REM sleep to reactivate waking experiences. *Neuropsychologia* [10.1016/j.neuropsychologia.2025.109229](https://doi.org/10.1016/j.neuropsychologia.2025.109229)
+    * Morris et al. (2025). Lucid dreaming of a prior virtual-reality experience with ego-transcendent qualities: A proof-of-concept study. *Neurosci Conscious* [10.1093/nc/niaf017](https://doi.org/10.1093/nc/niaf017)
+    * Mundt et al. (2024). Treating narcolepsy-related nightmares with cognitive behavioural therapy and targeted lucidity reactivation: A pilot study. *J Sleep Res* [10.1111/jsr.14384](https://doi.org/10.1111/jsr.14384)
+    * Wolk et al. (2024). Lucid dreams from reactivating mindfulness during REM sleep: A pilot study. *Int J Dream Res* [10.11588/ijodr.2024.2.98233](https://doi.org/10.11588/ijodr.2024.2.98233)
 * [Michelle Carr's Dream Engineering Lab](https://www.dreamengineeringlab.com/)
   at the University of Montreal
-    * Jafarzadeh Esfahani et al. (2024). Highly effective verified lucid dream induction using combined cognitive-sensory training and wearable EEG: A multi-centre study. *bioRxiv* [doi:10.1101/2024.06.21.600133](https://doi.org/10.1101/2024.06.21.600133)
+    * Jafarzadeh Esfahani et al. (2024). Highly effective verified lucid dream induction using combined cognitive-sensory training and wearable EEG: A multi-centre study. *bioRxiv* [10.1101/2024.06.21.600133](https://doi.org/10.1101/2024.06.21.600133)
 
 SMACC is free software released under the
 [GPL-3.0-or-later](https://github.com/remrama/smacc/blob/main/LICENSE.txt) license.


### PR DESCRIPTION
Adds a list of publications that have used SMACC as nested bullets under each lab in the "Used by" section. Papers are sorted newest-first within each lab.