### PR TITLE
chore: add AI skills and contribution conventions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "hooks": {
     "Stop": [
       {

--- a/.claude/skills/audio-routing/SKILL.md
+++ b/.claude/skills/audio-routing/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: audio-routing
+description: SMACC's audio and device subsystem — sounddevice/PortAudio over Windows WASAPI, device enumeration and hot-plug, the roles-and-routing model, the Devices window, per-panel output/input streams (cues, noise, intercom, recorder, level meter), and the volume safety cap. Use when touching audio.py, devices.py, winvolume.py, gui.py, or any panels/*.py that opens a stream, or when debugging Windows audio device behavior.
+---
+
+# Audio & device routing
+
+The user-facing model is documented in `docs/audio.md`; this skill is the
+engineering view — the architecture and the Windows gotchas. Designing here means
+designing for "juggling six audio streams across two rooms, on Windows, at 3 a.m."
+
+## Roles and routing (not per-window pickers)
+
+Devices are chosen **once** in the **Devices window**, by binding **roles** to
+physical devices and routing **modalities** to roles:
+
+- Roles (physical endpoints): **Bedroom output**, **Control-room output**,
+  **Bedroom mic**, **BlinkStick**.
+- Modalities point at a role: audio cue, noise, intercom, dream-report recorder;
+  plus optional **cue monitor** (fan-out) and intercom **Listen**.
+- `panels/base.describe_target()` renders the read-only "Role → device" indicator
+  each panel shows; the binding/route live in `session.devices` and are saved in the
+  `.smacc`.
+- A bound-but-unplugged device is **flagged**, not silently swapped.
+
+## One audio engine: sounddevice over WASAPI
+
+- All real-time audio — cues, noise, intercom, recorder, and the input-level meter —
+  runs on [`sounddevice`](https://python-sounddevice.readthedocs.io/) (PortAudio).
+- SMACC enumerates **WASAPI only** (`sd.query_devices()` filtered to the WASAPI host
+  API). On Windows, PortAudio lists each device once per host API
+  (MME/DirectSound/WASAPI/WDM-KS) and truncates legacy MME names to 31 chars;
+  WASAPI-only means **each device appears once, with its full name**, on the
+  low-latency path.
+- Because everything shares one engine, a device name means the same thing
+  everywhere, and the cue **fan-out** (bedroom + control-room) is just two
+  `sd.OutputStream`s from one source.
+
+## Hot-plug: the QMediaDevices "doorbell"
+
+- SMACC keeps `sounddevice` as the audio engine but uses Qt's **`QMediaDevices`**
+  (`gui.py`) purely as a **change signal** — when Windows reports an audio device
+  added/removed, `QMediaDevices` fires and SMACC rescans via `sounddevice`.
+  QMediaDevices is the doorbell, not the audio path.
+- Manual rescan: **File ▸ Refresh devices** / **F5**.
+- **Gotcha:** re-initializing PortAudio invalidates any open stream, so a rescan
+  must run only while **nothing is streaming**. Panels report this via
+  `ModalityWindow.is_streaming()`; the refresh coordinator checks it first. Respect
+  this guard when adding a stream-owning panel.
+
+## Streams & sample rates
+
+- Each modality panel owns its stream(s): `panels/audio.py`, `noise.py`,
+  `intercom.py`, `recording.py` (and the meter). They open `sd.OutputStream` /
+  input streams on the resolved device.
+- Sample rate comes from the device:
+  `int(sd.query_devices(device, "output"|"input")["default_samplerate"])`. Don't
+  hardcode 44.1/48 kHz — match the device.
+- Panels persist their selection via `gather_state`/`apply_state`, re-render their
+  indicator via `refresh_device_indicator` when routing changes, and stop streams in
+  `cleanup` on quit (see `panels/base.py`).
+
+## Volume: a visible product, with a safety cap
+
+The level reaching the participant is a **product** of several stages, most hidden
+in the OS:
+
+```text
+per-cue volume × output safety cap × Windows app volume × Windows device volume × hardware knob
+```
+
+- **Output safety cap** — a single master ceiling applied **last** to every
+  cue/noise output, so no individual cue (however loud, however looped) can blast a
+  sleeping participant. It's a safety feature; treat it as load-bearing.
+- `winvolume.py` reads the **Windows** mixer stages (system output volume, SMACC's
+  app level) so the Volume window can *show* the otherwise-invisible OS stages.
+  Calibration guidance: pin the Windows device/app volumes to 100% and control
+  loudness entirely with per-cue volume + the cap.
+
+## Windows-only, on purpose
+
+WASAPI, the volume mixer, and Qt 6 (Windows 10+) make this subsystem
+Windows-specific by design — the OS sleep labs actually run on. Don't add
+cross-platform audio branches without a reason.
+
+## Gotchas checklist
+
+- Enumerate **WASAPI only**; identity is by **name** (hot-unplug → flag, don't fall
+  back silently).
+- **Never reinit PortAudio while a stream is open** — gate rescans on
+  `is_streaming()`.
+- Pull **sample rate per device**; don't assume a fixed rate.
+- `QMediaDevices` is only the change **signal**; the audio path is `sounddevice`.
+- Remember the **volume product**, and keep the safety cap last.
+- Design mode has no marker outlet; audio still plays.
+
+## Key files
+
+`audio.py`, `devices.py`, `winvolume.py`, `panels/base.py`, `panels/audio.py`,
+`panels/noise.py`, `panels/intercom.py`, `panels/recording.py`, `gui.py` (the
+QMediaDevices doorbell). User-facing: `docs/audio.md`. Related: the
+**dream-engineering** skill (why the cap and dark-room constraints exist) and the
+**portcodes** skill (markers fired alongside audio events).

--- a/.claude/skills/dream-engineering/SKILL.md
+++ b/.claude/skills/dream-engineering/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: dream-engineering
+description: The research use-case behind SMACC — dream engineering, targeted memory reactivation (TMR) and targeted lucidity reactivation (TLR), sleep-stage cueing, REM/NREM, lucidity signaling (LRLR), and overnight dream-report collection. Use when designing features, weighing UX, or interpreting requirements that depend on how sleep/dream researchers actually run a session.
+---
+
+# Dream engineering: the use-case behind SMACC
+
+SMACC ("Sleep Manipulation And Communication Clickything") is the control surface a
+researcher clicks during an **overnight sleep study** — to cue a sleeping
+participant, mark events on the EEG, and collect dream reports. It is used by the
+[Paller Lab](https://sites.northwestern.edu/pallerlab/) at Northwestern and the
+[DxE Lab](https://www.dreamengineeringlab.com/). Designing for SMACC means designing
+for that room at 3 a.m.
+
+## Core concepts
+
+- **Dream engineering** — deliberately influencing sleep and dreams (memory,
+  lucidity, content) with timed sensory cues and feedback, rather than just
+  observing them.
+- **TMR (targeted memory reactivation)** — re-presenting a cue (a sound or odor)
+  that was paired with learning *while the participant sleeps*, to reactivate and
+  strengthen that specific memory. The cue must land in the right sleep stage.
+- **TLR (targeted lucidity reactivation)** — a TMR-style protocol that re-presents
+  cues associated with "notice you're dreaming" training during REM, to prompt
+  **lucid dreaming**. SMACC's registry has explicit `TLRTrainingStart`/`End` markers.
+- **Cueing** — playing the audio (or light) cue at the moment that matters. Timing
+  relative to sleep stage is the whole game; a cue at the wrong time is wasted or
+  wakes the participant.
+
+## Sleep stages, briefly
+
+A night cycles through **NREM** (N1 → N2 → N3, light to deep) and **REM** (where
+most vivid dreaming and lucidity occur). A human (or another tool) scores the stage
+from live EEG — SMACC does not. But its **markers must align with the EEG** so cues
+and observations sit at the right point in that record.
+
+## Lucidity & two-way communication
+
+- A trained lucid dreamer can signal awareness from inside REM with a deliberate
+  **left-right-left-right (LRLR) eye-movement** pattern, visible on EOG/EEG (the
+  classic lucid-signaling paradigm). SMACC has an `LRLRDetected` marker.
+- The **intercom** lets the experimenter **Talk** to the participant (marked in the
+  EEG) and **Listen** back — two-way communication with a sleeping or lucid person.
+- After an awakening, the participant gives a **dream report** (recorded audio + an
+  optional survey). SMACC timestamps each report against the recording-start
+  reference clock.
+
+## A typical session, in SMACC terms
+
+1. Set up the rig and a `.smacc` settings file (cues, devices, event codes).
+2. Start the EEG recording → `RecordingStarted` marker sets the reference clock.
+3. Watch the participant fall asleep (`SleepOnset`), then monitor stages; mark
+   observations (`REMDetected`, `TechInRoom`, notes).
+4. At the target stage, fire a **cue** (audio, sometimes a **BlinkStick** light),
+   optionally with masking **noise**; each fires its marker.
+5. Watch for a lucidity signal (`LRLRDetected`); use the intercom as needed.
+6. **Wake** the participant and **record a dream report** (`DreamReportStarted`,
+   which increments so each report is unique); maybe open a survey.
+7. Repeat across the night, then review the event log.
+
+## Why this shapes design
+
+- **Timing & markers are sacred.** Anything that delays a cue or misaligns a marker
+  corrupts the science. Favor low-latency, predictable behavior; preserve the
+  portcode contract (see the **portcodes** skill).
+- **It runs in the dark, next to a sleeping person.** The operator is tired, the
+  room is dark, and a misclick can wake a participant and end a rare data point. So
+  the UI leans on:
+  - large, glanceable controls and a **dark theme**;
+  - **always-on-top**, so the control window never gets buried;
+  - an **audio safety cap**, so a cue can't blast a sleeper (see the
+    **audio-routing** skill);
+  - clear device/routing indicators (which speaker am I about to play to?);
+  - minimal, reversible interactions — confirm or cap the costly, irreversible ones.
+- **Labs are heterogeneous.** Different amps, trigger transports, speakers, and
+  protocols. Prefer *configuration over assumption*, and surface what's
+  connected/missing rather than failing silently.
+
+## Glossary (terms you'll meet in the code)
+
+TMR, TLR, REM/NREM, sleep onset, cue, masking noise, LRLR (lucid eye signal),
+dream report, clapper (a sync marker), portcode/trigger, intercom Talk/Listen.
+
+## Further reading
+
+The two labs' sites (linked above) describe their dream-engineering and TMR/TLR
+work; SMACC's own [docs site](https://remrama.github.io/smacc/) covers the app.
+Foundational background: Ken Paller and colleagues on TMR, and Stephen LaBerge's
+work on lucid eye-signaling — worth a look when a feature hinges on the science.

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: plan-issue
+description: Plan a GitHub issue before any code. Fetches the issue and all comments, reads the relevant code, pulls in the matching domain skill, and produces a careful implementation plan with your own expert opinions and open questions — for the user to evaluate, not to implement immediately. Use when the user runs /plan-issue <number> or asks to review an issue and make a plan.
+argument-hint: "[issue-number]"
+---
+
+# Plan a GitHub issue
+
+Turn a GitHub issue into a careful, opinionated implementation plan the user can
+evaluate — **without writing code yet**. The argument is the issue number (e.g.
+`/plan-issue 28`).
+
+## Steps
+
+1. **Read the whole issue.** Use the `gh` skill:
+   ```sh
+   gh issue view <N> --json number,title,body,labels,milestone,comments
+   ```
+   Read the body *and every comment* — in this repo the owner's follow-up comments
+   usually carry the real constraints (which hardware is required, pulsed vs held,
+   …), not just the original post.
+
+2. **Understand the code.** Find and **read** the modules the change touches; trace
+   the integration points and existing contracts (data shapes, persisted settings,
+   tests). Don't plan against a guess — open the files.
+
+3. **Load the domain context.** Pull in the relevant skill so the plan reflects
+   reality, not just the ticket:
+   - **portcodes** — triggers, markers, `events.py`, trigger hardware.
+   - **audio-routing** — devices, routing, streams, volume.
+   - **dream-engineering** — the research use-case, timing, night-time UX.
+
+4. **Write the plan.** Structure it:
+   - **Problem** — what's actually being asked, in your own words.
+   - **Approach** — the recommended design, plus alternatives you considered and
+     rejected (and why).
+   - **Changes** — concrete and file-by-file: what's added/edited, new
+     settings/contracts, migrations.
+   - **Risks & trade-offs** — what could break; compatibility with existing
+     data/markers; performance and timing.
+   - **Your opinions** — add genuine expertise: what you'd do differently, what the
+     issue under- or over-specifies, what to cut. Don't just restate the issue.
+   - **Open questions** — anything needing the user's or the lab's input *before*
+     building (hardware specifics, protocol choices). Surface these clearly.
+   - **Verification** — how it'll be tested, including what can only be validated on
+     real hardware.
+
+5. **Present for evaluation. Do not start implementing.** Wait for the user to react.
+
+## Conventions
+
+- Use `uv` for any commands you run (never naked `python`/`pip`).
+- When work is later approved, follow the repo's commit and PR style in
+  `docs/contributing.md` ("Commit and pull-request style"): one-line
+  Conventional-Commits subjects, brief PR bodies, no AI attribution.
+- This repo asks contributors to open an issue before building, so planning *from*
+  an issue fits the flow.

--- a/.claude/skills/portcodes/SKILL.md
+++ b/.claude/skills/portcodes/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: portcodes
+description: Reference for SMACC's EEG event markers ("portcodes") — the 8-bit trigger byte, transports (LSL marker stream, parallel/LPT port, USB-serial trigger box, serial TTL), the InpOut32/inpoutx64 driver landscape, PsychoPy's ParallelPort set-and-hold vs pulsed semantics, SMACC's marker history, the events.py code registry, and the issue #28 hardware-output design. Use when touching event markers, triggers, portcodes, trigger hardware or drivers, the marker-send path in session.py, or issue #28.
+---
+
+# Portcodes & EEG event markers
+
+A **portcode** is a small integer (an 8-bit byte, 1–255) that marks *when* an
+experiment event happened so it lines up with the EEG recording. The amplifier
+records markers on a dedicated **trigger channel** alongside the brain signal;
+analysis later finds events by their code. SMACC fires a portcode for events like a
+cue starting, observed REM, or a dream report (`src/smacc/events.py`).
+
+The 8-bit range isn't arbitrary: a hardware **TTL** trigger is one byte on 8
+physical lines, so every code must fit in 1–255. `events.py` enforces this
+(`CODE_MIN = 1`, `CODE_MAX = 255`).
+
+## How SMACC sends a marker today
+
+Every marker flows through one function — `SmaccSession.emit_event()` in
+`src/smacc/session.py`. It looks up the `EventDef`, computes the runtime code
+(incrementing events advance per firing), writes a log line, and — if the event is
+`trigger=True` and an outlet exists — pushes the code:
+
+```python
+self.outlet.push_sample([str(code)])   # session.py, ~line 239
+```
+
+The outlet is an **LSL** (Lab Streaming Layer) marker stream created in
+`init_lsl_stream()` (`StreamInfo("MyMarkerStream", "Markers", …)`). Design mode has
+no outlet, so triggers are logged but not sent. **This is the single integration
+point** for any additional transport: a parallel/serial write belongs right next to
+`push_sample`, with its handle created alongside `init_lsl_stream`.
+
+## The events.py contract (don't break it)
+
+- `EventDef`: `code` (1–255), `trigger`, `preview`, `category`
+  (`manual`/`control`/`system`), `increment`, plus `key`/`label`/`tooltip`.
+- `increment` events (e.g. `DreamReportStarted`, code 201) advance the code each
+  firing (`runtime_code`) so every occurrence is individually findable; clamped to
+  255.
+- `validate_events` **errors** on a code outside 1–255, a duplicate code among
+  *triggerable* events (they'd collide on the channel), or a duplicate key; it
+  **warns** on a code above a study's `safe_max` (older hardware) and on an
+  incrementing band overlapping another code.
+- A study persists code + routing overrides in its `.smacc`; labels/categories stay
+  app-defined. Existing EEG marker maps and recovered logs depend on these codes —
+  preserve the contract.
+
+## Transports & trigger hardware
+
+Rigs ingest markers differently; SMACC should support all *known* ones via
+configuration (issue #28):
+
+| Transport | What it is | How a byte goes out |
+|---|---|---|
+| **LSL marker stream** | Network marker recorded by an LSL-aware recorder (LabRecorder → XDF). Current default. | `StreamOutlet.push_sample`. Same- or cross-computer; no extra hardware. |
+| **Parallel port (LPT)** | Legacy 25-pin port; 8 data pins = the trigger byte, sampled by the amp. Still required by an active lab rig. | Write the byte to the port's data register. On modern Windows needs the **InpOut32 / inpoutx64** kernel driver. |
+| **USB-serial trigger box** | The modern LPT replacement; presents as a COM port and mirrors a received byte onto 8 TTL lines. | `pyserial` write to a configured COM port + baud. |
+| **Serial TTL** | A device that takes the byte directly over serial. | `pyserial`, same as above. |
+
+## Parallel port: the driver reality
+
+- Direct port I/O is blocked in user space on modern Windows; you need **InpOut32**
+  (`inpoutx64.dll`) or a similar kernel shim, plus admin rights to install it.
+- PsychoPy wraps this in `psychopy.parallel.ParallelPort`: `port.setData(0)` then
+  `port.setData(code)` writes the byte and **holds** it (set-and-hold — no automatic
+  strobe back to 0). To *pulse*, write `code`, wait the pulse width, then write `0`.
+- **Do not** resurrect SMACC's old runtime DLL download (see history). If a lab
+  needs LPT, document a manual driver install instead.
+
+## Pulse behavior
+
+Trigger boxes and amps differ:
+
+- **Set-and-hold** — leave the lines at `code` until the next event (old parallel
+  semantics).
+- **Pulsed** — raise `code` for a configurable width (e.g. ~5–10 ms), then drop to
+  0. SMACC's labs use **pulsed**; make the width configurable.
+
+## SMACC's marker history (so you don't relitigate it)
+
+- ≤ v0.0.5 SMACC sent triggers via `psychopy.parallel.ParallelPort(address=0x3FD8)`
+  as an 8-bit byte, with a startup connection-test marker (`TriggerInitialization`).
+  It even auto-downloaded InpOutBinaries from highrez.co.uk and copied the DLL into
+  `C:\Windows\System32` at runtime (admin-gated, fragile).
+- `56aa27c` (Oct 2023) swapped psychopy/pport → LSL; `09a0a63` (Feb 2024) removed
+  the inpout machinery entirely.
+- Motivation: parallel ports are vanishing and the runtime driver install was
+  brittle. LSL is cleaner and network-capable — but a **hardware-TTL-only
+  amplifier** gets nothing from an LSL-only build, which is the gap issue #28 closes.
+
+## Issue #28 — design constraints
+
+Add **opt-in hardware TTL output alongside LSL**, not instead of it:
+
+- **Dual emission** from the one `emit_event` path; LSL stays default-on.
+- Support **LSL + parallel TTL + serial TTL**, all selectable via **configuration**
+  (the owner confirmed LSL and parallel are both on active rigs, serial should be
+  supported too, and **LPT is still required** by an active rig).
+- **Pulsed** triggers with configurable width; preserve the **8-bit portcode
+  contract**.
+- **Graceful no-op** when unconfigured; never crash if a port is absent;
+  **informative error messages** (called out specifically by the owner).
+- **Persist** transport/port/baud/mode in the `.smacc` settings.
+- **No** runtime DLL download; document a manual LPT driver install.
+- Treat easy configuration + an intro docs page as part of the deliverable — the
+  owner considers good portcode handling one of SMACC's most valuable features.
+
+## Testing
+
+- The serial/parallel *send* path can be unit-tested against a **fake/loopback**
+  port (no hardware).
+- Real **TTL output must be validated on the lab hardware** before anyone relies on
+  it — a green unit test does not prove the amp saw the pulse.
+
+## Key files & references
+
+- `src/smacc/events.py` — the code registry, validation, `runtime_code`.
+- `src/smacc/session.py` — `emit_event`, `init_lsl_stream`, the `push_sample` send
+  point (where hardware output hooks in).
+- Issue #28 (`gh issue view 28 --comments`) — full design discussion and owner
+  constraints.
+- External: `psychopy.parallel.ParallelPort` (`setData`); InpOut32/inpoutx64
+  (highrez.co.uk) for LPT on modern Windows; `pyserial` for COM-port trigger boxes.
+- See also the **dream-engineering** skill (why markers must align with the EEG).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,24 @@ bug reports before starting work.
 
 - Always use `uv` when running Python scripts or installing dependencies. Never
   `pip install` or run naked `python`.
+- One-line commits with a [Conventional Commits](https://www.conventionalcommits.org)
+  prefix (`feat:`, `fix:`, `docs:`, …); no commit body and no AI attribution. Pull
+  request bodies stay brief. Full guide:
+  [Commit and pull-request style](./docs/contributing.md#commit-and-pull-request-style).
+
+## Architecture at a glance
+
+SMACC is a PyQt6 desktop app (`src/smacc/`). A launcher opens a settings (`.smacc`)
+file, then a set of per-modality **tool windows** — each a `ModalityWindow`
+([`panels/base.py`](./src/smacc/panels/base.py)) sharing one `SmaccSession`
+([`session.py`](./src/smacc/session.py)). Panels emit markers and log lines through
+the session (`emit_event`), persist via `gather_state`/`apply_state`, and own their
+own [`sounddevice`](https://python-sounddevice.readthedocs.io/) streams.
+
+Deeper subsystem and domain context lives in skills under
+[`.claude/skills/`](./.claude/skills/): **dream-engineering** (the research
+use-case), **portcodes** (EEG triggers/markers), and **audio-routing** (devices,
+routing, volume).
 
 ## Development
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,6 +17,39 @@
 * Always use [uv](https://docs.astral.sh/uv/) to run Python scripts and install
   dependencies. Never `pip install` or run naked `python`.
 
+## Commit and pull-request style
+
+Keep the history skimmable and merge commits clean.
+
+**Commits**
+
+* One line only — a subject, with no body or extended description.
+* Start with a [Conventional Commits](https://www.conventionalcommits.org/) prefix:
+  `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `build:`, `ci:`, or
+  `perf:`.
+* Imperative mood, lower-case after the prefix, no trailing period, and ideally
+  under ~72 characters.
+* No AI attribution or co-author trailers.
+
+```text
+feat: optional hardware TTL trigger output
+docs: document audio routing
+fix: clamp incrementing portcodes to 255
+```
+
+**Pull requests**
+
+* The title follows the same one-line Conventional-Commits rule — on a squash merge
+  it becomes the commit subject (GitHub appends the `(#NN)` PR number).
+* The body is a brief summary, not an exhaustive change list: what changed, why, and
+  how it was verified. A few sentences or bullets is plenty.
+* No AI attribution footer.
+
+**Merging**
+
+* Squash-merge, and clear the auto-generated commit body so the merged commit is the
+  one-line title alone — no bundled description or commit list.
+
 ## Development
 
 ```sh


### PR DESCRIPTION
Adds Claude Code skills and contribution conventions so AI tools work on SMACC with the right context.

- Skills under `.claude/skills/`: **portcodes** (EEG triggers, grounded for #28), **dream-engineering** (the research use-case), **audio-routing** (devices/routing/volume), and **plan-issue** (`/plan-issue NN` → issue-to-plan workflow).
- Commit/PR style added to `docs/contributing.md` and `AGENTS.md`: one-line Conventional Commits, brief PR bodies, no AI attribution.
- `settings.json`: blank commit/PR attribution.

Docs/tooling only — no app code touched. Strict MkDocs build passes locally.
