### PR TITLE
Improve testing: headless GUI test harness + coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,10 +43,11 @@ jobs:
       - name: Run tests
         run: uv run --extra dev pytest --cov=smacc --cov-report=xml --cov-report=term-missing
       - name: Upload coverage to Codecov
-        # Runs even if a test failed, so coverage still posts on a red PR.
-        if: ${{ !cancelled() }}
+        # No `if:` — a step runs only when every prior step succeeded, so this
+        # uploads only when the tests (incl. the coverage floor) passed. Strict:
+        # an upload error fails the build rather than passing silently.
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
-          fail_ci_if_error: false
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,4 +41,12 @@ jobs:
         with:
           enable-cache: true
       - name: Run tests
-        run: uv run --extra dev pytest --cov=smacc --cov-report=term-missing
+        run: uv run --extra dev pytest --cov=smacc --cov-report=xml --cov-report=term-missing
+      - name: Upload coverage to Codecov
+        # Runs even if a test failed, so coverage still posts on a red PR.
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,8 +44,9 @@ jobs:
         run: uv run --extra dev pytest --cov=smacc --cov-report=xml --cov-report=term-missing
       - name: Upload coverage to Codecov
         # No `if:` — a step runs only when every prior step succeeded, so this
-        # uploads only when the tests (incl. the coverage floor) passed. Strict:
-        # an upload error fails the build rather than passing silently.
+        # uploads only when the tests passed. Coverage thresholds are enforced by
+        # Codecov (see codecov.yaml), not here. Strict: an upload error fails the
+        # build rather than passing silently.
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,10 +30,15 @@ jobs:
     # exactly what gets frozen into SMACC.exe. windows-2022 is the oldest hosted
     # runner available and avoids the in-progress windows-latest VS-2026 churn.
     runs-on: windows-2022
+    env:
+      # GUI tests run with no display via Qt's "offscreen" platform. conftest.py
+      # also sets this, but declaring it here keeps the intent visible in CI and
+      # holds even if a future test imports Qt before conftest runs.
+      QT_QPA_PLATFORM: offscreen
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
       - name: Run tests
-        run: uv run --extra dev pytest
+        run: uv run --extra dev pytest --cov=smacc --cov-report=term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ build/
 *.spec
 .venv/
 .*_cache/
+.coverage
+htmlcov/
 NOTES.txt
 site/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 .venv/
 .*_cache/
 .coverage
+coverage.xml
 htmlcov/
 NOTES.txt
 site/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI](https://github.com/remrama/smacc/actions/workflows/ci.yaml/badge.svg)](https://github.com/remrama/smacc/actions/workflows/ci.yaml)
 [![Release](https://github.com/remrama/smacc/actions/workflows/release.yaml/badge.svg)](https://github.com/remrama/smacc/actions/workflows/release.yaml)
+[![Codecov](https://codecov.io/gh/remrama/smacc/graph/badge.svg)](https://codecov.io/gh/remrama/smacc)
 [![Python](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,19 @@
+# Codecov configuration. Reference: https://docs.codecov.com/docs/codecov-yaml
+#
+# Single source of truth for coverage gating — this replaces the coverage.py
+# `fail_under` gate that used to live in pyproject.toml. The thresholds below are
+# enforced as Codecov status checks (codecov/project and codecov/patch) posted on
+# each PR after the report uploads. To make them *block* merges, add those two
+# checks as required status checks in the branch protection rule for `main`.
+coverage:
+  status:
+    project:
+      default:
+        # SMACC is a GUI-heavy desktop app where some glue is hard to cover
+        # headlessly, so 60% is a floor to ratchet up over time, not a ceiling.
+        target: 60%
+        threshold: 1% # tolerate a 1% dip before the check fails (anti-flap)
+    patch:
+      default:
+        target: 60% # ~60% of the lines a PR changes should be covered
+        # Set `informational: true` here if patch gating gets noisy on GUI PRs.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -33,6 +33,22 @@ pre-commit install         # enable the lint/format/type-check git hooks
 launcher and opens no console window, so prefer `python -m smacc` when you want
 terminal output (e.g. tracebacks).
 
+### Tests
+
+The suite runs headless. `tests/conftest.py` selects Qt's `offscreen` platform before
+any Qt import, so the GUI tests (built on
+[pytest-qt](https://pytest-qt.readthedocs.io/)) construct windows and panels with no
+display and no popups — there's no extra setup on your part. Hardware access (audio
+device enumeration, the Windows volume read-out) is stubbed in fixtures, so tests don't
+depend on the machine's audio setup.
+
+```sh
+uv run pytest --cov=smacc --cov-report=term-missing   # the coverage flags CI runs
+```
+
+To actually watch a test render, override the platform for that run (Windows:
+`$env:QT_QPA_PLATFORM = "windows"` before `uv run pytest`).
+
 ## Building the executable
 
 Build the standalone Windows executable:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,3 +104,9 @@ files = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["smacc"]
+# Store repo-relative paths so Codecov maps the Windows CI run onto the source
+# tree (src/smacc/…) instead of dropping the report for unmatched paths.
+relative_files = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,3 +110,10 @@ source = ["smacc"]
 # Store repo-relative paths so Codecov maps the Windows CI run onto the source
 # tree (src/smacc/…) instead of dropping the report for unmatched paths.
 relative_files = true
+
+[tool.coverage.report]
+# Regression floor, enforced by pytest-cov: the test run (and so CI) fails below
+# this. This is coverage.py's gate — Codecov's own target can't live in
+# pyproject and would need a codecov.yml. Total is ~70% today; a 65% floor leaves
+# headroom for honest churn, and is worth ratcheting up as coverage grows.
+fail_under = 65

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,10 +110,4 @@ source = ["smacc"]
 # Store repo-relative paths so Codecov maps the Windows CI run onto the source
 # tree (src/smacc/…) instead of dropping the report for unmatched paths.
 relative_files = true
-
-[tool.coverage.report]
-# Regression floor, enforced by pytest-cov: the test run (and so CI) fails below
-# this. This is coverage.py's gate — Codecov's own target can't live in
-# pyproject and would need a codecov.yml. Total is ~70% today; a 65% floor leaves
-# headroom for honest churn, and is worth ratcheting up as coverage grows.
-fail_under = 65
+# Coverage gating (project/patch targets) lives in codecov.yaml, not here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,12 @@ docs = [
 ]
 dev = [
     "pytest",
+    # GUI tests run headless via the Qt "offscreen" platform (set in
+    # tests/conftest.py); pytest-qt supplies the qtbot/qapp fixtures and manages
+    # the QApplication lifecycle. pytest-cov reports coverage of the now-tested
+    # Qt layer (see the test job in .github/workflows/ci.yaml).
+    "pytest-qt",
+    "pytest-cov",
     "ruff",
     "mypy",
     "pre-commit",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,109 @@
+"""Headless-GUI setup and shared fixtures for the SMACC test suite.
+
+GUI tests run with no display by forcing Qt's "offscreen" platform *before* any
+Qt import (pytest-qt imports Qt the first time its ``qtbot``/``qapp`` fixtures run,
+so this module — imported by pytest at collection — is the right place). pytest-qt
+then supplies ``qtbot``/``qapp`` and owns the ``QApplication`` lifecycle.
+
+Two things would otherwise make these tests non-deterministic or hang:
+
+* **Hardware enumeration.** ``DevicesWindow`` (and thus the whole ``SmaccWindow``)
+  fills its combos from :func:`smacc.panels.devices.wasapi_devices` /
+  ``blinkstick_devices`` at construction, which query sounddevice/BlinkStick. The
+  ``mock_devices`` fixture stubs both with fixed device lists.
+* **Blocking modal popups.** A few paths call the static ``QMessageBox`` /
+  ``QInputDialog`` helpers, which block on a real event loop. ``silence_dialogs``
+  replaces them with non-blocking stubs.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Must run before PyQt6 is imported anywhere. ``setdefault`` lets a developer
+# export QT_QPA_PLATFORM=windows (etc.) to actually watch a test render locally.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import pytest
+from PyQt6 import QtWidgets
+
+from smacc import devices
+from smacc.session import SmaccSession
+
+# Device strings the mock enumeration advertises. Window/settings tests bind roles
+# to these exact strings so a loaded study resolves them (no "missing device" notice).
+FAKE_OUTPUTS = ["Speakers (USB Audio), Windows WASAPI", "Headphones, Windows WASAPI"]
+FAKE_INPUTS = ["Microphone (USB Audio), Windows WASAPI"]
+FAKE_BLINKSTICKS = [("BlinkStick Square BS012345", "BS012345")]
+
+
+@pytest.fixture
+def mock_devices(monkeypatch):
+    """Stub the only construction-time hardware access: device enumeration.
+
+    Returns the advertised devices so a test can bind roles to known strings.
+    """
+    from smacc.panels import devices as devices_panel
+
+    def fake_wasapi_devices(kind: str) -> list[str]:
+        return list(FAKE_INPUTS) if kind == devices.INPUT else list(FAKE_OUTPUTS)
+
+    monkeypatch.setattr(devices_panel, "wasapi_devices", fake_wasapi_devices)
+    monkeypatch.setattr(
+        devices_panel, "blinkstick_devices", lambda: list(FAKE_BLINKSTICKS)
+    )
+    return {
+        "outputs": list(FAKE_OUTPUTS),
+        "inputs": list(FAKE_INPUTS),
+        "blinksticks": list(FAKE_BLINKSTICKS),
+    }
+
+
+@pytest.fixture
+def silence_dialogs(monkeypatch):
+    """Neutralize blocking modal popups so a headless run never hangs.
+
+    Two flavors block on a real event loop:
+
+    * The static helpers (``QMessageBox.information``/``warning``/``question`` and
+      ``QInputDialog.getText``) used by the missing-device notice, validation
+      warnings, and the note-marker prompt.
+    * Instance dialogs built and ``.exec()``-ed directly — notably the designer's
+      "save before closing?" prompt in ``SmaccWindow.closeEvent``, which pytest-qt
+      triggers when it closes the window at teardown. ``exec`` returns ``Discard``
+      so that path tears down cleanly without writing a file; ``question`` returns
+      ``No`` so the session window's close is declined (no preference writes).
+    """
+    box = QtWidgets.QMessageBox
+    monkeypatch.setattr(box, "information", lambda *a, **k: box.StandardButton.Ok)
+    monkeypatch.setattr(box, "warning", lambda *a, **k: box.StandardButton.Ok)
+    monkeypatch.setattr(box, "critical", lambda *a, **k: box.StandardButton.Ok)
+    monkeypatch.setattr(box, "question", lambda *a, **k: box.StandardButton.No)
+    monkeypatch.setattr(box, "exec", lambda self: box.StandardButton.Discard)
+    monkeypatch.setattr(QtWidgets.QInputDialog, "getText", lambda *a, **k: ("", False))
+
+
+@pytest.fixture
+def design_session(tmp_path):
+    """A study-designer session: no run folder, no hardware, no log file."""
+    session = SmaccSession(tmp_path / "study", design=True)
+    yield session
+    session.close()
+
+
+@pytest.fixture
+def live_session(tmp_path, monkeypatch):
+    """A recording session rooted at a temp data dir.
+
+    The real ``init_lsl_stream`` opens a network marker outlet; stub it so window
+    construction stays offline and deterministic. ``close()`` (teardown) detaches
+    the run's log-file handler so Windows can remove the temp dir.
+    """
+    monkeypatch.setattr(
+        SmaccSession,
+        "init_lsl_stream",
+        lambda self, *a, **k: setattr(self, "outlet", None),
+    )
+    session = SmaccSession(tmp_path / "data", design=False)
+    yield session
+    session.close()

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -1,0 +1,209 @@
+"""Tests for the dialogs in smacc.dialogs (need a QApplication, no hardware).
+
+Each dialog exposes a read-from-widget getter (``changes``/``get_inputs``/
+``get_options``/``get_events``) that the caller reads only on accept. The tests
+construct a dialog, drive its widgets, and assert the getter — no event loop and
+no ``.exec()``. The couple of paths that pop a blocking ``QMessageBox`` are
+exercised with that static call monkeypatched.
+"""
+
+from __future__ import annotations
+
+import pytest
+from PyQt6 import QtWidgets
+
+from smacc import dialogs, events
+
+# ----- PreferencesDialog -----------------------------------------------------
+
+
+def test_preferences_dialog_round_trips_prefs(qtbot):
+    prefs = {"always_on_top": True, "preview_levels": ["ERROR", "INFO"]}
+    dialog = dialogs.PreferencesDialog(prefs)
+    qtbot.addWidget(dialog)
+    changes = dialog.changes()
+    assert changes["always_on_top"] is True
+    # Returned in the canonical level order, not the input order.
+    assert changes["preview_levels"] == ["INFO", "ERROR"]
+
+
+def test_preferences_dialog_reflects_edits(qtbot):
+    dialog = dialogs.PreferencesDialog({"always_on_top": False, "preview_levels": []})
+    qtbot.addWidget(dialog)
+    dialog.alwaysOnTop.setChecked(True)
+    dialog._levelBoxes["WARNING"].setChecked(True)
+    changes = dialog.changes()
+    assert changes["always_on_top"] is True
+    assert changes["preview_levels"] == ["WARNING"]
+
+
+# ----- ask_initial_or_final --------------------------------------------------
+
+
+def _patch_choice(monkeypatch, index):
+    """Make the next QMessageBox 'click' resolve to buttons()[index] (None = cancel)."""
+    box_cls = QtWidgets.QMessageBox
+    monkeypatch.setattr(box_cls, "exec", lambda self: 0)
+
+    def clicked(self):
+        btns = self.buttons()
+        return btns[index] if index is not None and index < len(btns) else None
+
+    monkeypatch.setattr(box_cls, "clickedButton", clicked)
+
+
+@pytest.mark.parametrize(
+    "index, expected",
+    [(0, "initial"), (1, "final"), (None, None)],
+)
+def test_ask_initial_or_final(qtbot, monkeypatch, index, expected):
+    _patch_choice(monkeypatch, index)
+    assert dialogs.ask_initial_or_final() == expected
+
+
+# ----- SessionInfoDialog -----------------------------------------------------
+
+
+def test_session_info_dialog_returns_inputs(qtbot):
+    dialog = dialogs.SessionInfoDialog(subject="001", session="2", notes="a note")
+    qtbot.addWidget(dialog)
+    assert dialog.get_inputs() == ("001", "2", "a note")
+    dialog.subject_id.setText("042")
+    assert dialog.get_inputs() == ("042", "2", "a note")
+
+
+# ----- SurveyDialog ----------------------------------------------------------
+
+
+def test_survey_dialog_strips_name_and_normalizes_url(qtbot):
+    dialog = dialogs.SurveyDialog(name="  My survey  ", url="example.com/post")
+    qtbot.addWidget(dialog)
+    name, url = dialog.get_inputs()
+    assert name == "My survey"
+    # normalize_survey_url adds a scheme when none is given.
+    assert url.startswith("http") and "example.com/post" in url
+
+
+# ----- ManageSurveysDialog ---------------------------------------------------
+
+
+def test_manage_surveys_round_trips_options(qtbot):
+    options = {"Post survey": "https://a.example", "Pre survey": "https://b.example"}
+    dialog = dialogs.ManageSurveysDialog(options)
+    qtbot.addWidget(dialog)
+    assert dialog.get_options() == options
+
+
+def test_manage_surveys_remove_selected(qtbot):
+    options = {"Post survey": "https://a.example", "Pre survey": "https://b.example"}
+    dialog = dialogs.ManageSurveysDialog(options)
+    qtbot.addWidget(dialog)
+    dialog.listWidget.setCurrentRow(0)
+    dialog._remove_selected()
+    assert dialog.get_options() == {"Pre survey": "https://b.example"}
+
+
+# ----- AddEventDialog --------------------------------------------------------
+
+
+def test_add_event_dialog_returns_inputs(qtbot):
+    dialog = dialogs.AddEventDialog(default_code=42)
+    qtbot.addWidget(dialog)
+    dialog.labelEdit.setText("  Spontaneous arousal  ")
+    dialog.tooltipEdit.setText(" a hint ")
+    dialog.incrementBox.setChecked(True)
+    label, code, tooltip, increment = dialog.get_inputs()
+    assert label == "Spontaneous arousal"
+    assert code == 42
+    assert tooltip == "a hint"
+    assert increment is True
+
+
+def test_add_event_dialog_rejects_blank_label(qtbot, monkeypatch):
+    warned = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox, "warning", lambda *a, **k: warned.append(a)
+    )
+    dialog = dialogs.AddEventDialog(default_code=10)
+    qtbot.addWidget(dialog)
+    dialog.labelEdit.setText("   ")  # blank after strip
+    dialog._on_accept()
+    assert warned  # the warning fired
+    assert dialog.result() != QtWidgets.QDialog.DialogCode.Accepted
+
+
+# ----- EventCodesDialog ------------------------------------------------------
+
+
+def _custom(label, code):
+    return events.EventDef(
+        key=label.replace(" ", ""),
+        label=label,
+        code=code,
+        category="manual",
+        builtin=False,
+    )
+
+
+def test_event_codes_dialog_get_safe_max(qtbot):
+    dialog = dialogs.EventCodesDialog(events.default_events(), events.DEFAULT_SAFE_MAX)
+    qtbot.addWidget(dialog)
+    assert dialog.get_safe_max() == events.DEFAULT_SAFE_MAX
+    dialog.safeMaxSpin.setValue(200)
+    assert dialog.get_safe_max() == 200
+
+
+def test_event_codes_dialog_get_events_returns_untouched_copies(qtbot):
+    source = events.default_events()
+    original_first_code = source[0].code
+    dialog = dialogs.EventCodesDialog(source, events.DEFAULT_SAFE_MAX)
+    qtbot.addWidget(dialog)
+
+    result = dialog.get_events()
+    assert len(result) == len(source)
+    # Edit the first row's code in the dialog; the result reflects it...
+    dialog._code_spins[0].setValue(123)
+    assert dialog.get_events()[0].code == 123
+    # ...but the caller's original list is untouched (the dialog edits copies).
+    assert source[0].code == original_first_code
+
+
+def test_event_codes_dialog_suggested_code_is_one_past_max(qtbot):
+    source = events.default_events()
+    dialog = dialogs.EventCodesDialog(source, events.DEFAULT_SAFE_MAX)
+    qtbot.addWidget(dialog)
+    highest = max(e.code for e in source)
+    expected = min(highest + 1, events.CODE_MAX)
+    assert dialog._suggested_code() == expected
+
+
+def test_event_codes_dialog_remove_custom_event(qtbot):
+    source = events.default_events() + [_custom("Custom test", 150)]
+    dialog = dialogs.EventCodesDialog(source, events.DEFAULT_SAFE_MAX)
+    qtbot.addWidget(dialog)
+    dialog.table.selectRow(len(source) - 1)  # the custom row
+    dialog._remove_selected()
+    labels = [e.label for e in dialog.get_events()]
+    assert "Custom test" not in labels
+    assert len(dialog.get_events()) == len(source) - 1
+
+
+def test_event_codes_dialog_add_event(qtbot, monkeypatch):
+    class _StubAddDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def exec(self):
+            return 1  # accepted
+
+        def get_inputs(self):
+            return ("New event", 199, "tip", False)
+
+    monkeypatch.setattr(dialogs, "AddEventDialog", _StubAddDialog)
+    dialog = dialogs.EventCodesDialog(events.default_events(), events.DEFAULT_SAFE_MAX)
+    qtbot.addWidget(dialog)
+    before = len(dialog.get_events())
+    dialog._add_event()
+    after = dialog.get_events()
+    assert len(after) == before + 1
+    assert any(e.label == "New event" for e in after)

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -1,0 +1,131 @@
+"""Tests for the main window (SmaccWindow) — the whole GUI, built headless.
+
+Constructing SmaccWindow builds every panel (incl. the hardware-enumerating
+Devices window) and the menu/log/editor scaffolding, so these tests take
+``mock_devices`` and ``silence_dialogs``. The autouse winvolume stub keeps the
+embedded Volume panel off the Windows COM volume API. The settings round-trip is
+the save/load contract: gather → apply → gather must be a fixed point.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from smacc import winvolume
+from smacc.gui import SmaccWindow
+
+
+@pytest.fixture(autouse=True)
+def _stub_winvolume(monkeypatch):
+    monkeypatch.setattr(winvolume, "endpoint_volume", lambda: None)
+    monkeypatch.setattr(winvolume, "app_volume", lambda: None)
+
+
+# ----- construction ----------------------------------------------------------
+
+
+def test_window_builds_in_design_mode(
+    qtbot, design_session, mock_devices, silence_dialogs
+):
+    window = SmaccWindow(design_session)
+    qtbot.addWidget(window)
+    assert window.design is True
+    state = window.gather_settings()
+    # A representative spread of the keys the settings file persists.
+    for key in (
+        "devices",
+        "event_codes",
+        "event_code_safe_max",
+        "data_directory",
+        "volume_cap",
+        "noise_color",
+        "blink_color",
+        "cues",
+    ):
+        assert key in state
+
+
+def test_window_builds_in_session_mode(
+    qtbot, live_session, mock_devices, silence_dialogs
+):
+    window = SmaccWindow(live_session)
+    qtbot.addWidget(window)
+    assert window.design is False
+    # The session window has the lightswitch (the designer hides it).
+    assert hasattr(window, "lightswitchButton")
+
+
+# ----- settings gather/apply contract ----------------------------------------
+
+
+def test_settings_gather_apply_is_a_fixed_point(
+    qtbot, design_session, mock_devices, silence_dialogs
+):
+    window = SmaccWindow(design_session)
+    qtbot.addWidget(window)
+    first = window.gather_settings()
+    window.apply_settings(first)
+    second = window.gather_settings()
+    assert second == first
+
+
+def test_apply_settings_lands_values(
+    qtbot, design_session, mock_devices, silence_dialogs
+):
+    window = SmaccWindow(design_session)
+    qtbot.addWidget(window)
+    settings = window.gather_settings()
+    settings["volume_cap"] = 0.5
+    settings["noise_color"] = "brown"
+    settings["blink_color"] = "#abcdef"
+    settings["cues"] = [{"name": "Buzz", "file": "", "volume": 0.3, "loop": True}]
+    settings["devices"] = {
+        "bindings": {
+            "bedroom_out": mock_devices["outputs"][0],
+            "bedroom_mic": mock_devices["inputs"][0],
+            "blinkstick": mock_devices["blinksticks"][0][1],
+        },
+        "routing": {},
+    }
+
+    window.apply_settings(settings)
+    got = window.gather_settings()
+    assert got["volume_cap"] == pytest.approx(0.5)
+    assert got["noise_color"] == "brown"
+    assert got["blink_color"].lower() == "#abcdef"
+    assert got["cues"][0]["name"] == "Buzz"
+    assert got["devices"]["bindings"]["bedroom_out"] == mock_devices["outputs"][0]
+    # The bound devices all match advertised hardware, so none are flagged missing.
+    assert design_session.missing_devices == []
+
+
+# ----- theme / lights and owned preferences ----------------------------------
+
+
+def test_set_lights_toggles_state_and_label(
+    qtbot, live_session, mock_devices, silence_dialogs
+):
+    # set_lights drives the lights state, the switch label, and the theme. The
+    # offscreen platform doesn't reflect QStyleHints.colorScheme() back, so assert
+    # the observable state + label (which only update via the apply_theme path).
+    window = SmaccWindow(live_session)
+    qtbot.addWidget(window)
+
+    window.set_lights(False)
+    assert window.lights_on is False
+    assert "OFF" in window.lightswitchButton.text()
+
+    window.set_lights(True)
+    assert window.lights_on is True
+    assert "ON" in window.lightswitchButton.text()
+
+
+def test_preference_changes_reports_owned_keys(
+    qtbot, live_session, mock_devices, silence_dialogs
+):
+    window = SmaccWindow(live_session)
+    qtbot.addWidget(window)
+    changes = window._preference_changes()
+    assert set(changes) == {"always_on_top", "preview_levels", "window"}
+    assert isinstance(changes["preview_levels"], list)
+    assert set(changes["window"]) == {"x", "y", "w", "h"}

--- a/tests/test_panels_base.py
+++ b/tests/test_panels_base.py
@@ -1,0 +1,112 @@
+"""Tests for the pure helpers in panels.base (need a QApplication, no hardware).
+
+``describe_target`` is pure logic over a DeviceConfig; the combo helpers and
+``make_section_title`` build throwaway widgets, so they take the pytest-qt
+``qtbot`` fixture (which guarantees a QApplication) and register widgets for
+cleanup.
+"""
+
+from __future__ import annotations
+
+from PyQt6 import QtCore, QtWidgets
+
+from smacc import devices
+from smacc.panels import base
+
+# ----- describe_target -------------------------------------------------------
+
+
+def _session_with(design_session, bindings, routing=None):
+    design_session.devices = devices.DeviceConfig(
+        bindings=dict(bindings), routing=dict(routing or {})
+    )
+    return design_session
+
+
+def test_describe_target_bound_device_reads_role_arrow_device(design_session):
+    session = _session_with(design_session, {"bedroom_out": "Speakers (USB)"})
+    # cue_out defaults to the bedroom_out role, which is bound above.
+    assert base.describe_target(session, "cue_out") == "Bedroom output → Speakers (USB)"
+
+
+def test_describe_target_unbound_audio_reads_system_default(design_session):
+    session = _session_with(design_session, {})
+    assert base.describe_target(session, "report_in") == "Bedroom mic (system default)"
+
+
+def test_describe_target_unbound_visual_reads_not_set(design_session):
+    session = _session_with(design_session, {})
+    assert base.describe_target(session, "visual_out") == "BlinkStick (not set)"
+
+
+def test_describe_target_off_route_reads_off(design_session):
+    # cue_monitor is an optional route whose default role is "" (off).
+    session = _session_with(design_session, {})
+    assert base.describe_target(session, "cue_monitor") == "off"
+
+
+# ----- current_device_key ----------------------------------------------------
+
+
+def test_current_device_key_empty_combo_is_blank(qtbot):
+    combo = QtWidgets.QComboBox()
+    qtbot.addWidget(combo)
+    assert base.current_device_key(combo) == ""
+
+
+def test_current_device_key_prefers_item_data(qtbot):
+    combo = QtWidgets.QComboBox()
+    qtbot.addWidget(combo)
+    combo.addItem("Visible label", "stable-serial")
+    assert base.current_device_key(combo) == "stable-serial"
+
+
+def test_current_device_key_falls_back_to_text_when_no_data(qtbot):
+    combo = QtWidgets.QComboBox()
+    qtbot.addWidget(combo)
+    combo.addItem("Plain text device")  # no data
+    assert base.current_device_key(combo) == "Plain text device"
+    combo.clear()
+    combo.addItem("Empty-data device", "")  # blank data falls back to text too
+    assert base.current_device_key(combo) == "Empty-data device"
+
+
+# ----- select_saved_device ---------------------------------------------------
+
+
+def _combo_with_devices(qtbot):
+    combo = QtWidgets.QComboBox()
+    qtbot.addWidget(combo)
+    for name in ("Device A", "Device B", "Device C"):
+        combo.addItem(name, name)
+    combo.setCurrentIndex(0)
+    return combo
+
+
+def test_select_saved_device_selects_match_and_returns_true(qtbot):
+    combo = _combo_with_devices(qtbot)
+    assert base.select_saved_device(combo, "Device B") is True
+    assert combo.currentText() == "Device B"
+
+
+def test_select_saved_device_no_match_keeps_selection_and_returns_false(qtbot):
+    combo = _combo_with_devices(qtbot)
+    assert base.select_saved_device(combo, "Unplugged device") is False
+    assert combo.currentIndex() == 0  # selection untouched
+
+
+def test_select_saved_device_blank_returns_false(qtbot):
+    combo = _combo_with_devices(qtbot)
+    assert base.select_saved_device(combo, None) is False
+    assert base.select_saved_device(combo, "") is False
+
+
+# ----- make_section_title ----------------------------------------------------
+
+
+def test_make_section_title_is_centered_18pt(qtbot):
+    label = base.make_section_title("Hello")
+    qtbot.addWidget(label)
+    assert label.text() == "Hello"
+    assert label.alignment() == QtCore.Qt.AlignmentFlag.AlignCenter
+    assert label.font().pointSize() == 18

--- a/tests/test_panels_devices.py
+++ b/tests/test_panels_devices.py
@@ -1,0 +1,72 @@
+"""Tests for DevicesWindow: combo population and edits into session.devices.
+
+DevicesWindow enumerates audio/BlinkStick hardware when it builds its combos, so
+every test takes the ``mock_devices`` fixture (which advertises a fixed device
+set). Edits flow through the combos' ``currentIndexChanged`` signals into
+``session.devices``; selecting a row fires them synchronously.
+"""
+
+from __future__ import annotations
+
+from smacc.panels.devices import DevicesWindow
+
+
+def test_role_combos_populate_from_enumeration(qtbot, design_session, mock_devices):
+    window = DevicesWindow(design_session)
+    qtbot.addWidget(window)
+    out_combo = window._role_combos["bedroom_out"]
+    # Index 0 is the default/none entry, then one row per advertised output.
+    assert out_combo.count() == 1 + len(mock_devices["outputs"])
+    assert out_combo.itemData(1) == mock_devices["outputs"][0]
+
+    blink_combo = window._role_combos["blinkstick"]
+    assert blink_combo.count() == 1 + len(mock_devices["blinksticks"])
+    # BlinkStick rows carry the serial as item data.
+    assert blink_combo.itemData(1) == mock_devices["blinksticks"][0][1]
+
+
+def test_reload_from_config_selects_bound_device(qtbot, design_session, mock_devices):
+    bound = mock_devices["outputs"][1]
+    design_session.devices.bindings["bedroom_out"] = bound
+    window = DevicesWindow(design_session)
+    qtbot.addWidget(window)
+    window.reload_from_config()
+    assert window._role_combos["bedroom_out"].currentText() == bound
+
+
+def test_set_binding_writes_to_session(qtbot, design_session, mock_devices):
+    window = DevicesWindow(design_session)
+    qtbot.addWidget(window)
+    changed = []
+    window.changed.connect(lambda: changed.append(True))
+
+    # Selecting a real device row (index > 0) binds it to the role.
+    window._role_combos["bedroom_out"].setCurrentIndex(1)
+    assert design_session.devices.bindings["bedroom_out"] == mock_devices["outputs"][0]
+    assert changed  # the changed signal fired
+
+    # Returning to the default/none entry clears the binding.
+    window._role_combos["bedroom_out"].setCurrentIndex(0)
+    assert "bedroom_out" not in design_session.devices.bindings
+
+
+def test_set_routing_writes_to_session(qtbot, design_session, mock_devices):
+    window = DevicesWindow(design_session)
+    qtbot.addWidget(window)
+    combo = window._route_combos["cue_out"]
+    # Point cue_out at the control-room output role instead of its default.
+    index = combo.findData("control_out")
+    assert index >= 0
+    combo.setCurrentIndex(index)
+    assert design_session.devices.routing["cue_out"] == "control_out"
+
+
+def test_reload_flags_missing_bound_device(qtbot, design_session, mock_devices):
+    design_session.devices.bindings["bedroom_out"] = "Unplugged speaker"
+    window = DevicesWindow(design_session)
+    qtbot.addWidget(window)
+    window.reload_from_config()
+    # The bound device isn't among the advertised ones, so it's flagged and the
+    # combo falls back to the default entry.
+    assert window._role_combos["bedroom_out"].currentIndex() == 0
+    assert any("Unplugged speaker" in entry for entry in design_session.missing_devices)

--- a/tests/test_panels_state.py
+++ b/tests/test_panels_state.py
@@ -1,0 +1,121 @@
+"""gather_state / apply_state round-trips for every modality panel.
+
+Panels construct headlessly from a design session (no run folder, no hardware);
+streams open only on play/record, not at construction. The Devices panel
+enumerates hardware at build time, so it takes the ``mock_devices`` fixture. The
+five stateful panels round-trip their persisted keys; the three that keep no
+per-panel state (their config lives at the window/session level) just confirm an
+empty contribution.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from smacc import winvolume
+from smacc.panels.audio import AudioCueWindow
+from smacc.panels.devices import DevicesWindow
+from smacc.panels.events import EventsWindow
+from smacc.panels.intercom import IntercomWindow
+from smacc.panels.noise import NoiseWindow
+from smacc.panels.recording import RecordingWindow
+from smacc.panels.visual import VisualWindow
+from smacc.panels.volume import VolumeWindow
+
+# ----- stateful panels -------------------------------------------------------
+
+
+def test_audio_panel_round_trips_cues_and_envelope(qtbot, design_session):
+    panel = AudioCueWindow(design_session)
+    qtbot.addWidget(panel)
+    state = {
+        "cues": [
+            {"name": "Alarm", "file": "", "volume": 0.40, "loop": True},
+            {"name": "Chime", "file": "", "volume": 0.20, "loop": False},
+        ],
+        "cue_attack": 0.5,
+        "cue_release": 1.5,
+    }
+    panel.apply_state(state)
+    got = panel.gather_state()
+    assert got["cue_attack"] == pytest.approx(0.5)
+    assert got["cue_release"] == pytest.approx(1.5)
+    assert len(got["cues"]) == 2
+    assert got["cues"][0]["name"] == "Alarm"
+    assert got["cues"][0]["volume"] == pytest.approx(0.40)
+    assert got["cues"][0]["loop"] is True
+    assert got["cues"][1]["name"] == "Chime"
+    assert got["cues"][1]["loop"] is False
+
+
+def test_noise_panel_round_trips(qtbot, design_session):
+    panel = NoiseWindow(design_session)
+    qtbot.addWidget(panel)
+    state = {
+        "noise_volume": 0.30,
+        "noise_color": "pink",
+        "noise_source": "file",
+        "noise_file": "loop.wav",
+    }
+    panel.apply_state(state)
+    got = panel.gather_state()
+    assert got["noise_volume"] == pytest.approx(0.30)
+    assert got["noise_color"] == "pink"
+    assert got["noise_source"] == "file"
+    assert got["noise_file"] == "loop.wav"
+
+
+def test_recording_panel_round_trips_surveys(qtbot, design_session):
+    panel = RecordingWindow(design_session)
+    qtbot.addWidget(panel)
+    state = {
+        "survey_url": "https://survey.example/post",
+        "survey_options": {"Post survey": "https://survey.example/post"},
+    }
+    panel.apply_state(state)
+    got = panel.gather_state()
+    assert got["survey_url"] == "https://survey.example/post"
+    assert got["survey_options"] == {"Post survey": "https://survey.example/post"}
+
+
+def test_visual_panel_round_trips(qtbot, design_session):
+    panel = VisualWindow(design_session)
+    qtbot.addWidget(panel)
+    panel.apply_state({"blink_color": "#123456", "blink_length": 2.5})
+    got = panel.gather_state()
+    assert got["blink_color"].lower() == "#123456"
+    assert got["blink_length"] == pytest.approx(2.5)
+
+
+def test_volume_panel_round_trips_cap(qtbot, design_session, monkeypatch):
+    # The read-only Windows volume read-out uses COM; stub it so the panel builds
+    # deterministically off any audio endpoint.
+    monkeypatch.setattr(winvolume, "endpoint_volume", lambda: None)
+    monkeypatch.setattr(winvolume, "app_volume", lambda: None)
+    panel = VolumeWindow(design_session)
+    qtbot.addWidget(panel)
+    panel.apply_state({"volume_cap": 0.50})
+    assert panel.gather_state() == {"volume_cap": pytest.approx(0.50)}
+    # apply_state also drives the live session cap (read by the audio callbacks).
+    assert design_session.volume_cap == pytest.approx(0.50)
+
+
+# ----- stateless panels (their config lives at window/session level) ---------
+
+
+def test_events_panel_has_no_persisted_state(qtbot, design_session):
+    panel = EventsWindow(design_session)
+    qtbot.addWidget(panel)
+    assert panel.gather_state() == {}
+
+
+def test_intercom_panel_has_no_persisted_state(qtbot, design_session):
+    panel = IntercomWindow(design_session)
+    qtbot.addWidget(panel)
+    assert panel.gather_state() == {}
+
+
+def test_devices_panel_has_no_persisted_state(qtbot, design_session, mock_devices):
+    panel = DevicesWindow(design_session)
+    qtbot.addWidget(panel)
+    assert panel.gather_state() == {}

--- a/tests/test_qtlog.py
+++ b/tests/test_qtlog.py
@@ -1,0 +1,61 @@
+"""Tests for the GUI log-preview handler (needs a QApplication, no hardware).
+
+QtLogHandler marshals records onto the GUI thread via a Qt signal; in a test
+everything is on one thread, so the connected slot runs synchronously during
+``emit`` and the QListWidget is up to date immediately.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from PyQt6 import QtWidgets
+
+from smacc.qtlog import QtLogHandler
+
+
+def _logger_with_handler(list_widget, name):
+    logger = logging.getLogger(name)
+    logger.handlers.clear()  # fresh: getLogger returns a process-wide singleton
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    handler = QtLogHandler(list_widget)
+    logger.addHandler(handler)
+    return logger, handler
+
+
+def test_enabled_levels_gate_which_records_appear(qtbot):
+    widget = QtWidgets.QListWidget()
+    qtbot.addWidget(widget)
+    logger, _ = _logger_with_handler(widget, "smacc.test.levels")
+
+    logger.debug("debug line")  # DEBUG is not in the default enabled set
+    logger.info("info line")  # INFO is
+
+    assert widget.count() == 1
+    assert widget.item(0).text() == "info line"
+
+
+def test_enabled_levels_can_be_narrowed(qtbot):
+    widget = QtWidgets.QListWidget()
+    qtbot.addWidget(widget)
+    logger, handler = _logger_with_handler(widget, "smacc.test.narrow")
+    handler.enabled_levels = {logging.DEBUG}
+
+    logger.info("info line")  # now filtered out
+    logger.debug("debug line")  # now shown
+
+    assert widget.count() == 1
+    assert widget.item(0).text() == "debug line"
+
+
+def test_smacc_preview_false_hides_record_from_preview(qtbot):
+    widget = QtWidgets.QListWidget()
+    qtbot.addWidget(widget)
+    logger, _ = _logger_with_handler(widget, "smacc.test.preview")
+
+    logger.info("shown")
+    logger.info("hidden", extra={"smacc_preview": False})
+
+    assert widget.count() == 1
+    assert widget.item(0).text() == "shown"

--- a/uv.lock
+++ b/uv.lock
@@ -268,6 +268,90 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/fd/0ab2772530e946e1be1abd0bc09e647ec9b02e88f0867857601fefca8953/coverage-7.14.1.tar.gz", hash = "sha256:30c08f7d90415aa98b3c990385dea2939b0da55f38515e5b369b83655f8523be", size = 920132, upload-time = "2026-05-26T20:41:36.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b7/bdbb725ba02c5b42825b200c940f38b7a54fcad24627b7192f78f8110d76/coverage-7.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a06c76364a9360e33d6d23769aefdf7f66f38e2ffb60ceb1baaa4989d83b695c", size = 220022, upload-time = "2026-05-26T20:39:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/72/81/fdc0898a55c6219223291ec1a1fe89966ef212ce82276aa0899df84b5de0/coverage-7.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fad54e871165f6ec2f536063ac74c3104508a12963e64072ba44bd822de52b0c", size = 220379, upload-time = "2026-05-26T20:39:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/de/72/de048c4a25e13bce59ac6a339351c10bdf2515e07459afcdaf04dc3143a2/coverage-7.14.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:84b535f00655ecafe1d929d1fb00ed5d6fa3051ea643ab2c161a3887b86f294b", size = 251888, upload-time = "2026-05-26T20:39:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/28/30/300c343f68beb9d4cbb64ec81e58c5b6b80b56927f72d2b38654ac26e013/coverage-7.14.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6b6b0853b895fe0e98cbfc580d1ec3393d9302b4b1e96a77b3f5c91fdab899e6", size = 254624, upload-time = "2026-05-26T20:39:09.037Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/ed/7b25642496e8170b6bac14adce00537c6e5fa2d586159401a4de3e8b49e6/coverage-7.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442cc9c952b2df400cda54bb04ab87330cf2cd08a8692cbbea36773531eb6f37", size = 255739, upload-time = "2026-05-26T20:39:10.889Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/a2/abd210b8c4e29c24e4624916db97bb519097a91034aaeb767f937e7da794/coverage-7.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8270544c361ed405a27a060dbc9ed2c124b084d96dfdc2d9a2510482aef981ad", size = 257998, upload-time = "2026-05-26T20:39:12.722Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/24/7c50beed3792fe62f6ce0545c6686ce83379719e2c0276179333d97eae92/coverage-7.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:48b283b1dd6372e8de2a7a9a4c4d5dc06f4d4fd209b876f3c88a7a205a0c8f84", size = 252296, upload-time = "2026-05-26T20:39:14.259Z" },
+    { url = "https://files.pythonhosted.org/packages/15/05/0f874628ebcbfc77ead559ff210281ef06a97db08481832e7dd39274a135/coverage-7.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5b0c99ba93a07d56f6df340bb79be53202a082b2fdb81bfe6190b741a3470d54", size = 253658, upload-time = "2026-05-26T20:39:15.923Z" },
+    { url = "https://files.pythonhosted.org/packages/99/6f/ca6ad067364b337ef997802115e7ecad2abd2248b05471464b0dea02b4d4/coverage-7.14.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:e471bc5769ff073b058cfadb0d736b56ce067c8560eabeb0da88462df98c23e7", size = 251803, upload-time = "2026-05-26T20:39:17.537Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/30/b9b4d377cd9f40baf228068f5a81faf8450c6228503011bd499708483a50/coverage-7.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f497a1ea81d4cd7c10ddcaa685135b9aabd291af3d55775a9ddf3cb7a364cdd9", size = 255873, upload-time = "2026-05-26T20:39:19.414Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/21/7c721a9e5e6bb88547d30a787aefb97512d3f54c1324c7488d9b3743f7f9/coverage-7.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:2222be86d0b54f5dd5a38f45f17f315f737245e857bf0bdedc70734f84a13c02", size = 251372, upload-time = "2026-05-26T20:39:21.169Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f8ae5a2200130e1503cd7661a6cd3b2b7bacef98277fbf3571fb13f8b766/coverage-7.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:85e85586565842f6932abebd4c18bcb1074223dc0b3576e7d173ca710622813a", size = 253245, upload-time = "2026-05-26T20:39:23.097Z" },
+    { url = "https://files.pythonhosted.org/packages/34/62/70a9024672a5f6910517d9628c52c9afbdd3cf8f46426af52bb148a56fff/coverage-7.14.1-cp312-cp312-win32.whl", hash = "sha256:4a28fd227808366b196a75476dced2eb35b351d6766ba9c858dc93319e87f4f1", size = 222567, upload-time = "2026-05-26T20:39:24.868Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/8b7cd386839b039ebe1855733b9f9449a8dec5d79564018234f185a7fa70/coverage-7.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:54acdb6674a4661768d7bf7db32dfb9f46ab1d764f8aba6df75ce1a6a088724e", size = 223372, upload-time = "2026-05-26T20:39:26.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ba/b44d472022f620d289d95fa830143235c0c36461c6f2437ea8d51e5481ed/coverage-7.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:99cd41ff91afd94896fea3bc002706b6ae4ce95727d06e4a0f39c0a8d8bd8b1a", size = 221989, upload-time = "2026-05-26T20:39:28.242Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9e/5f6d56327c62b185225d145191c607e07515294a0aa6338e58805cd4a5ac/coverage-7.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:be9f2c802dcfce3f71298303aa5dad0dce440a76c52f2f60dacd8656dab78793", size = 220044, upload-time = "2026-05-26T20:39:29.902Z" },
+    { url = "https://files.pythonhosted.org/packages/75/92/e82aca356744cbbc0f77a0b623e38918c1872361963413a3bab5d0340393/coverage-7.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6223a72fd0e4c7156353ec0f08a5f93623e1d3034d0e2683b9bb8ea674131b1d", size = 220412, upload-time = "2026-05-26T20:39:31.561Z" },
+    { url = "https://files.pythonhosted.org/packages/27/c9/385bde0bf7ed0f4bf3a7ee5367060a86b5d218718cfd6fb943c0f836b34f/coverage-7.14.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:7279d2110a28cebc738b6459ecda2771735a4c18465fbbd36b3288fe5ed92247", size = 251412, upload-time = "2026-05-26T20:39:33.337Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8c/23faf6a2343a0d17f960a4bd56c43bc7eb4cf312f774dd6ceebd82c7d8fc/coverage-7.14.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9eeb3fcbc13ba40dfbdb22d01d196a28e9cef9ed4c29b60061a1e0e823a9929d", size = 254008, upload-time = "2026-05-26T20:39:35.009Z" },
+    { url = "https://files.pythonhosted.org/packages/42/06/36f4aa9ca8a815e6036156e80706a67828bb97bd826948244f6996dda957/coverage-7.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f0cfc27c539f07cf5c0a4cfe211d0b6cae039f8f40526dbaa71944e64b50a7b", size = 255241, upload-time = "2026-05-26T20:39:36.71Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/79/95266316352f90f6b1c6736bb413302edfde2453fb32422d3911642691b3/coverage-7.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:221c70f316241a78e77e607c227cefc8808d4e08f28d99c04f35694690e940be", size = 257373, upload-time = "2026-05-26T20:39:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9c/58316d1f66c488b5fca8a0eb3e98348807813efa8a0d0833b9021be27488/coverage-7.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:da028256b04ec30e5e0114b6f76172938c313991f0a2d3d894271315cf5d5e43", size = 251635, upload-time = "2026-05-26T20:39:40.268Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/5a/ca2398a568e16fed7bb713e84ba3603a7164fb65779abe645c565ec890d5/coverage-7.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76a085d7005236a767e3426148b2c407e53ad61695c562f8a81da2d373324901", size = 253373, upload-time = "2026-05-26T20:39:42.145Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/2c/0396562c32deaebe7be51d865b3a41e9a87d7561acafe1a28f53b07e019a/coverage-7.14.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:b553d04b5e778a8e56d57eb134aff42a92718ecba45e79c4764ecfa40efd92ff", size = 251341, upload-time = "2026-05-26T20:39:43.907Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8f/a94f9221184c9cae1ee115820e3798e48b6b17777a9f19e46fb9a0c8dc74/coverage-7.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:46f714d2fb8ae2f4f29f23ada7f1e79b759fff5a70f94a1dac23af204c3ec9e4", size = 255497, upload-time = "2026-05-26T20:39:46.166Z" },
+    { url = "https://files.pythonhosted.org/packages/71/69/505d70e47db1eaebcd002c39759707621ef184cd6b1ae084d9f41293f323/coverage-7.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:1896f5e19ff3f0431c7ce2172adc54890fd97f86b59ced8ca1649145d9ffe35d", size = 251159, upload-time = "2026-05-26T20:39:48.03Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/aa/58681c383aa33a9d2ed40a02d7a22fbf780d1fa4d575396365777828198c/coverage-7.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:62fd185ef9df3c33d1c8178c5af105f762afbad96038de9a4ae100aa6297ca33", size = 252934, upload-time = "2026-05-26T20:39:49.872Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fd/11c928cd6bdffc7074bb5965c173d9ebf517fb00205e1da524b98d29ef92/coverage-7.14.1-cp313-cp313-win32.whl", hash = "sha256:ab4af6352741a604c431c6072fce5bee33bf0f20dc7a56618d6bf6bb89e9810c", size = 222584, upload-time = "2026-05-26T20:39:51.68Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/92/fb416fc26d340dcba19518c418d6048e913186e17243982c5e435e41fa7a/coverage-7.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:7af486dabe8954d03b087f0021540897afe084f04e16ff5579e08cc46f871416", size = 223394, upload-time = "2026-05-26T20:39:53.472Z" },
+    { url = "https://files.pythonhosted.org/packages/73/c6/02d56e3867972f77d5036de924643f26c056e848f00452cafb4dbc3c29b4/coverage-7.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:2224f89ffd0c5605ccce1ed7a584da162bc7c55f601ab1c946bc9de31a486b42", size = 222015, upload-time = "2026-05-26T20:39:55.374Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9e/fcc77914050df73f7662fa1f00902774c79c075a8388ab334074574bf77e/coverage-7.14.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de286598cc65d2b489411174b1faec2f5a7775fb3201fd925db2a76b4030f37d", size = 220733, upload-time = "2026-05-26T20:39:57.189Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/67/2963cbdaf5cbadec44efa3a1e39eaa1f02df4079585f05387607a221e126/coverage-7.14.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:042c46ded7c288aeb07cf14a28b6c1e10b78fcba40171c3fa1e939377eeef0b5", size = 221086, upload-time = "2026-05-26T20:39:59.019Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c5/8701645574e11881f2f47d8930f98bc48b5d43b25eb5b4430dfc4a2f9f48/coverage-7.14.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f4ddbe407477f04c45115d1a4e5bc480f753553b534d338d4c3358b1cdd0ea52", size = 262381, upload-time = "2026-05-26T20:40:00.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/28/7a64d73598263e0c5abd5084211a8474488d31b3c552ff531c719dfcff62/coverage-7.14.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d13e6725992e2d2fd7d81d4f5241952d13740121dfd501da09201be39b2c003a", size = 264458, upload-time = "2026-05-26T20:40:02.506Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d8/4969179db9f7eb4df218e69540adf829d1c835f59452513d065d15446802/coverage-7.14.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f747dc8edcfe740130f28f32f3995e955494285717e86ee25af51db2219df08a", size = 266884, upload-time = "2026-05-26T20:40:04.421Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/78/a45d5794dbc9bafd97afc96a4377c86c7820d78b6cf51b89bc1d4e919275/coverage-7.14.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ced2f09ef276fd58611a1ef502164ad266d2b75174e5a40cabbdb4033f9f6cf2", size = 268022, upload-time = "2026-05-26T20:40:06.298Z" },
+    { url = "https://files.pythonhosted.org/packages/21/cb/4f5e354e9e3e67af96bd4e57113e6db6b22298c7168b13eec408a549903d/coverage-7.14.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b84800013769a78ccb9ef4659402e26d06867e337b61ec365f77ad008adea80e", size = 261631, upload-time = "2026-05-26T20:40:08.226Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/49/eced49af4cb996d5d8b7e94e736175c513e4facd3398507b89892b4326d8/coverage-7.14.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ea8cd6ca0ee9f616aaef3afc6882e32c2cbf18b00d96313ffd76af650574034d", size = 264443, upload-time = "2026-05-26T20:40:10.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/d8/5603a88a7c5913a6b54f6cb1a8c46f7b39cbb30f27cd3f492908da09b2d7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:aa5e304a873fabddc11e484e9b6b738bd38bd7bed17b09aa84eecf5332e8b8bb", size = 262069, upload-time = "2026-05-26T20:40:11.999Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/59/2ae3cb79da554a06c8619d6c88ea19dd1e4aed4b834b6a83bb1fa243bdc5/coverage-7.14.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5a1c5215be81035e629d5bc756650634d0bf31991038db7a0eccb90f025ce16d", size = 265780, upload-time = "2026-05-26T20:40:13.858Z" },
+    { url = "https://files.pythonhosted.org/packages/af/5f/b130c1dc999031f2648bd25317fbce505ad8d5562079b4ed81e736a84967/coverage-7.14.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:79058c47dae6788504b5effb319961bcd72d7240551464b91d474bc0ed186d69", size = 260970, upload-time = "2026-05-26T20:40:16.142Z" },
+    { url = "https://files.pythonhosted.org/packages/87/d1/ec13ccddeb48ec963bdfa72a11224bac2584bd045ba13beca82f8113e9c7/coverage-7.14.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:370c5afae3fa0658e11694a32b24c2778f6bc2d17718121f94ee185e69f26b54", size = 263157, upload-time = "2026-05-26T20:40:18.382Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c2/cd91ead503045161092d3845f7bb95ea2f25131ce96d3e314dd835d91b9c/coverage-7.14.1-cp313-cp313t-win32.whl", hash = "sha256:3758dd0a7f1fa57365ef2e781df0f0731d38b6e3772259d13dae4bd8a958d4b1", size = 223259, upload-time = "2026-05-26T20:40:20.381Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9f/1e28d97e6bd2c76b07f38b7c02870f1371255ff6717f54eca578fcbbdd0e/coverage-7.14.1-cp313-cp313t-win_amd64.whl", hash = "sha256:6ff665fb023a77386fe11685190cee1f60a7d635994a30d9b0a061533d470fce", size = 224320, upload-time = "2026-05-26T20:40:22.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/e0/d936e908f0e1efa55e52b91e01b52f1055cef5e1ab2718493390ed8e2fb8/coverage-7.14.1-cp313-cp313t-win_arm64.whl", hash = "sha256:17a5a241e5997621a956a7f402a7433ef4221e5152809b785bec79e2323799f1", size = 222577, upload-time = "2026-05-26T20:40:24.894Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/34/fc2f101b151af3799a101f0550b0454aa008afdc0add677394ec4aa8ea10/coverage-7.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d5ed429d0b8edaac649e889b4ffcedb6c80b06629a3f93050e3dddfb99235bee", size = 220091, upload-time = "2026-05-26T20:40:27.249Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a7/1ebae2ab5b961b5c79bb09fe7b3ac99edb190d8be4a8c510b2cf66f46468/coverage-7.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8011224a62280e50dab346960c03cf47aca1a1e09e608c0fb33fd6e0cc8e9500", size = 220421, upload-time = "2026-05-26T20:40:30.084Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/90/92aca9cf0acc95123c96cd1eb1f08917897a7f5dee01e15738922971ec31/coverage-7.14.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:12c42ec1e14f553c4f817e989365982e646e27211f10a0f717855b94a79c8906", size = 251466, upload-time = "2026-05-26T20:40:32.542Z" },
+    { url = "https://files.pythonhosted.org/packages/26/2b/78048cbe3b999f6cbf9cc0d90abba6a88a3e0863a8c1c6cbc762f3f8802f/coverage-7.14.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:06144cd511cf2624873a035c5069cf297144f6e77a73ee3d7a55b605ec5efb42", size = 253973, upload-time = "2026-05-26T20:40:34.473Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/21/c2e33b29d1cfde484a19d437afc343c6cd30b08d78cbbf9f5aff14e57b2b/coverage-7.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a311d8e1da24be5c1ccf85cbfb06315dbaa1703d5a1eab3f6432c72b837917c8", size = 255318, upload-time = "2026-05-26T20:40:38.154Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ee/aad2f108d63b769121005302f16bf66db8625c88ceaba466942e09a2607e/coverage-7.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c79cead5b5bc584d9c71451cb984d0e3a84e0c0937379c8efcbf27c8d661b851", size = 257633, upload-time = "2026-05-26T20:40:40.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f8/11a2c29b4fd76d9849f81d0bb812ec0017a9396df3217214e38934a8c837/coverage-7.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:dcbf65f1f66a26cdd88c35cf68fb4729c5d1cd2e88added72420541dfb212034", size = 251488, upload-time = "2026-05-26T20:40:42.631Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/9a5820de4b8ac2b71d85e3b5fb49108d7469c665f0e2ad0dd7569023e305/coverage-7.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fd86572566fb40189a8260446158235159bc7a82dfbc87a3b39cf4fb57fcec1c", size = 253329, upload-time = "2026-05-26T20:40:45.208Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/f33e4823667e27548e8fd8df44217515303f9808d0ff29817db56f87d990/coverage-7.14.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:7771b601718fdde84832c3a434ca9bbf4ae9adbc49d84198b4110700c3c77c36", size = 251291, upload-time = "2026-05-26T20:40:47.502Z" },
+    { url = "https://files.pythonhosted.org/packages/68/9b/489db0ebb209054766b90a9014a45f6d26eb724c02ec21311c3733b5a644/coverage-7.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:39b21e212c55af06fa375e3dbf90a8a8e38792f3a910c580066d23563830ddd5", size = 255564, upload-time = "2026-05-26T20:40:49.372Z" },
+    { url = "https://files.pythonhosted.org/packages/27/b5/16bc2d4c2409b23c7737edb68c83bc89e345f378050549fe1d75ac7d34d5/coverage-7.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:f2302660e32562a532b442480121aef8aa61a5bdb20b30bf0adab29f10a5a4b4", size = 251107, upload-time = "2026-05-26T20:40:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/0c/2629997469a00cd069d588a41c9dc887610f2775ae89d250c4791e65272a/coverage-7.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:03a6f93c1ec3b7f2e77b5dbcc5573a2c21f12529a5c6bbe0f16f72303cc2fa4d", size = 252764, upload-time = "2026-05-26T20:40:54.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ee/f78d63c8f079e0d7211c7e2401fa17e311514534ba61bae03e4b287ce4ab/coverage-7.14.1-cp314-cp314-win32.whl", hash = "sha256:8a3ce026d73290f42f08dafecbd82c193a74df280461fbf97300fec51fd133ee", size = 222837, upload-time = "2026-05-26T20:40:56.496Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b9/be539854f93a70dfbeec69117f33ec70dc42ff0b65b5b07ab8d40d04228e/coverage-7.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:114c95ef29302423b87d159075805f4ab973254a2638a5d7d046c94887cc87d7", size = 223650, upload-time = "2026-05-26T20:40:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9e/24e2842fef40f35ac82ba3a7719c8023d011bf3bf652d0675316a9d088a1/coverage-7.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:a07891c3f4805442b31b71e84ba3cf29ed1aa9a428284e06deeb4b23e5b46343", size = 222218, upload-time = "2026-05-26T20:41:00.321Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1d/ac0a9df5fe31c1e8bdd658074905fc12844a05c1a7e3fdb8417e97c31e23/coverage-7.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:1101a5ebb083aecb625ebb6209d4105b58f647b093cb2dc8122d7b33f743cfe1", size = 220822, upload-time = "2026-05-26T20:41:02.281Z" },
+    { url = "https://files.pythonhosted.org/packages/32/cf/f964fd9aff20323f9f1a726c97135f8a76bcd87b92dad141a456a43f3c64/coverage-7.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:851b9e1e4e8a4608e77c79714b2e77c0970d2ed7202a05e92ae407817481887b", size = 221084, upload-time = "2026-05-26T20:41:04.593Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5e/7e5ef2aba844de2b80d678619fcf0841b42e3f37f16411226f3fe4c1016f/coverage-7.14.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d5b89cdfb2ee051b71e8c3c70bd81a9eff81100f736a269136fe1a68efe00474", size = 262454, upload-time = "2026-05-26T20:41:06.641Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/75809bded87015cc4935524218a2a8ed8dd1a8498bfed30a2f4f7a4b4d34/coverage-7.14.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0177614a0370f227888b4e436a7c55686d6a9f90eb1ade2b624ba685a1686e86", size = 264578, upload-time = "2026-05-26T20:41:08.556Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/42/d33392dc14633525012d2d504fa1a33b05538bf535f5c1d64675e5754b78/coverage-7.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d69af5dea2de76fc485a83032a630523f985198b7e25be901ec60181587b01e", size = 266981, upload-time = "2026-05-26T20:41:10.824Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/49/0157c4428c2aca7f1e09d5565930586fd5ae36f1655f08b0daa7cf1fcae1/coverage-7.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:35ab22d91de736e8966b980dc355cbcdd2c6dbbcfe275f9a2991bc8a91b3df65", size = 268112, upload-time = "2026-05-26T20:41:12.966Z" },
+    { url = "https://files.pythonhosted.org/packages/96/26/86b9ce71f4092b1ed325ce1421698081df1286b833400b6836912834d6e0/coverage-7.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:357d4e32935c36588aaba057d734fa32428c360c9fc2e4442afbf1b646beee6e", size = 261558, upload-time = "2026-05-26T20:41:15Z" },
+    { url = "https://files.pythonhosted.org/packages/20/4c/c311210c5472cf5401d8422b0d7812cdd520f24417673afabda6c323faca/coverage-7.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:51bd64741cc6fa065abd300ede1afe5a5291ece9c31da8b24884deda48bcc3f8", size = 264447, upload-time = "2026-05-26T20:41:17.369Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/71/59513f8710ed3e6b0ac0a050a5b7e977bb9c9e880354863b5d00d8809256/coverage-7.14.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:9132cd363a68a4c3daa7c8704a654b1e39d3360f6f5b8ddd470608a945236c07", size = 262048, upload-time = "2026-05-26T20:41:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/84/8d/bceed32dc494f5bbf50f775cd2e78ca814953942b5ea28d3c1c3ac316f14/coverage-7.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:07c6290b1697b862c0478eab545eec949a0d0e4d6d03497f446d706da3b4f2de", size = 265781, upload-time = "2026-05-26T20:41:21.559Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c5/9348fe40dbfd4991aaf78df2c6c3098bfb2cc834d1fd362a64b4efef855a/coverage-7.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5ea0c297e27133853b4d8a3eb799bff5a2dbd9f2f41537a240d337ac9b4df890", size = 260896, upload-time = "2026-05-26T20:41:23.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/92/1ea0f03929da7cf87206b1fa24f4c8e9c158be0455481af29ec0a1f3503f/coverage-7.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:01b7733daad0237daa01ef80fe2dfceffc911e6a17fa7b55d14aa8214eaaaecd", size = 263214, upload-time = "2026-05-26T20:41:25.419Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/a9/b2493c054c0e01a643266742ab45e15744e60743f9260cd930c7142b1124/coverage-7.14.1-cp314-cp314t-win32.whl", hash = "sha256:6adc5a36984624a70bf11d7184e20fa0a49aa7c47ffab43804106a1a695ea22e", size = 223624, upload-time = "2026-05-26T20:41:27.795Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/bd/3e1e6a57fccd2d7c83fcdf338e93ba98eb85c6e877dd34731ac585375490/coverage-7.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ddf799247318f34dbcd2efa8c95a8d0642674e926bb1774cf9b63dfd2a389d1c", size = 224728, upload-time = "2026-05-26T20:41:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/d7/31066cf1d2f0c6c797fce911bcfa01dd35642dc6da992a950256097c5860/coverage-7.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:145986fe66647eb489f18d9a997567a3fd358584c4b5a808769113abc07466af", size = 222752, upload-time = "2026-05-26T20:41:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/3c/1a983b9a745d7f83d53f057bcc5bf79ba6a2bbc08266b3f0c7d6fe630c9b/coverage-7.14.1-py3-none-any.whl", hash = "sha256:a252f21c27e38347e60111a3266b03827422a7d5525951aceee313aa68bab1d2", size = 211815, upload-time = "2026-05-26T20:41:34.078Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -962,6 +1046,34 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-qt"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pluggy" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/61/8bdec02663c18bf5016709b909411dce04a868710477dc9b9844ffcf8dd2/pytest_qt-4.5.0.tar.gz", hash = "sha256:51620e01c488f065d2036425cbc1cbcf8a6972295105fd285321eb47e66a319f", size = 128702, upload-time = "2025-07-01T17:24:39.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/d0/8339b888ad64a3d4e508fed8245a402b503846e1972c10ad60955883dcbb/pytest_qt-4.5.0-py3-none-any.whl", hash = "sha256:ed21ea9b861247f7d18090a26bfbda8fb51d7a8a7b6f776157426ff2ccf26eff", size = 37214, upload-time = "2025-07-01T17:24:38.226Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1199,6 +1311,8 @@ dev = [
     { name = "pre-commit" },
     { name = "pyinstaller" },
     { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-qt" },
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
@@ -1220,6 +1334,8 @@ requires-dist = [
     { name = "pylsl" },
     { name = "pyqt6" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "pytest-qt", marker = "extra == 'dev'" },
     { name = "pyyaml" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "scipy" },


### PR DESCRIPTION
Closes #70.

## Problem

The suite was deliberately headless-only, so the entire Qt layer (~4,000 lines across `gui.py`, `dialogs.py`, `panels/*`, `qtlog.py`) was untested. #70 asked for "a better way to test at least some of it."

## Approach

Adopt the standard PyQt approach — [pytest-qt](https://pytest-qt.readthedocs.io/) driven by Qt's **offscreen** platform — so widgets construct and behave with no display, then cover the testable GUI seams.

### Harness
- Add `pytest-qt` + `pytest-cov` to the `dev` extra (lockfile regenerated).
- `tests/conftest.py` forces `QT_QPA_PLATFORM=offscreen` before any Qt import and provides fixtures: `mock_devices` (stubs the only construction-time hardware access — audio/BlinkStick enumeration in `panels.devices`), `silence_dialogs` (neutralizes blocking modal popups, incl. the designer's instance-`exec()` close prompt), and `design_session`/`live_session`.
- CI `test` job sets `QT_QPA_PLATFORM=offscreen` and runs `--cov=smacc --cov-report=term-missing`.
- `.gitignore` + contributing docs updated.

### Tests (49 new)
- **`test_dialogs.py`** — every dialog getter/validator (`PreferencesDialog`, `ask_initial_or_final`, `SessionInfoDialog`, `SurveyDialog`, `ManageSurveysDialog`, `AddEventDialog`, `EventCodesDialog`).
- **`test_panels_base.py`** — `describe_target`, `current_device_key`, `select_saved_device`, `make_section_title`.
- **`test_qtlog.py`** — `QtLogHandler` level + `smacc_preview` filtering.
- **`test_panels_state.py`** — `gather_state`/`apply_state` round-trips for all 8 panels.
- **`test_panels_devices.py`** — `DevicesWindow` population, selection, binding/routing writes, missing-device flagging.
- **`test_gui_window.py`** — `SmaccWindow` builds headless (editor + session modes), the `gather_settings`→`apply_settings` fixed-point contract, lights/theme, owned preferences.

## Verification

All **226** tests pass headless (was 177). The Qt layer goes from ~0% to meaningful coverage — `gui.py` 60%, `dialogs.py` 89%, `panels/base.py` 98%, `volume.py` + `devices.py` model 100% — **70% total**. `ruff check`, `ruff format --check`, and `mypy` all clean.
