### PR TITLE
feat: optional hardware TTL trigger output alongside LSL

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,11 +25,17 @@ jobs:
         run: uv run --extra dev mypy
 
   test:
-    # Mirror the release build (release.yaml): same OS (windows-2022), same
-    # Python (3.12, via .python-version), same locked deps — so CI exercises
-    # exactly what gets frozen into SMACC.exe. windows-2022 is the oldest hosted
-    # runner available and avoids the in-progress windows-latest VS-2026 churn.
-    runs-on: windows-2022
+    # windows-2022 mirrors the release build (release.yaml) — same OS, Python
+    # (3.12, via .python-version), and locked deps — so CI exercises exactly what
+    # gets frozen into SMACC.exe. windows-latest runs alongside as a
+    # forward-compatibility canary (it tracks the newest hosted image, e.g. the
+    # VS-2026 line), so toolchain/runtime drift is caught here rather than at
+    # release time. fail-fast is off so one image's result doesn't mask the other.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-2022, windows-latest]
+    runs-on: ${{ matrix.os }}
     env:
       # GUI tests run with no display via Qt's "offscreen" platform. conftest.py
       # also sets this, but declaring it here keeps the intent visible in CI and
@@ -43,10 +49,12 @@ jobs:
       - name: Run tests
         run: uv run --extra dev pytest --cov=smacc --cov-report=xml --cov-report=term-missing
       - name: Upload coverage to Codecov
-        # No `if:` — a step runs only when every prior step succeeded, so this
-        # uploads only when the tests passed. Coverage thresholds are enforced by
-        # Codecov (see codecov.yaml), not here. Strict: an upload error fails the
-        # build rather than passing silently.
+        # Upload only from the release-mirror runner, and only when the tests passed
+        # (`success()` — an explicit `if:` otherwise overrides the implicit
+        # run-on-success). One upload keeps the coverage signal and the Codecov gate
+        # (see codecov.yaml) stable rather than double-counting across matrix legs.
+        # Strict: an upload error fails the build rather than passing silently.
+        if: success() && matrix.os == 'windows-2022'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -1,0 +1,125 @@
+# Triggers & port codes
+
+This page explains what EEG **triggers** and **port codes** are, the ways SMACC can
+send them, and how to configure each one. If you just want the steps, jump to
+[Configuring trigger output in SMACC](#configuring-trigger-output-in-smacc).
+
+## What are port codes and triggers?
+
+When you run a sleep or dream study you want to know *exactly when* things happened —
+a cue played, REM was observed, a dream report began — and line those moments up with
+the EEG recording. The standard way to do this is a **trigger**: at the instant of an
+event, the stimulus computer sends a small number to the EEG amplifier, which records
+it on a dedicated **trigger channel** alongside the brain signal. That number is the
+**port code** (also called an event marker or trigger code). During analysis you find
+events by their code — e.g. "every 41 is an observed REM onset."
+
+A port code is an **8-bit value**, so it is always an integer from **1 to 255**. That
+range isn't arbitrary: a hardware trigger is physically **eight on/off lines** (eight
+bits), and the amplifier reads them as one byte. SMACC keeps every code inside 1–255
+for exactly this reason — see [Configuring codes](usage.md#configuring-codes) for how
+to view and edit which event sends which code.
+
+## How SMACC sends triggers
+
+SMACC always emits markers over **LSL** (Lab Streaming Layer), a network marker
+stream. On top of that, you can *optionally* enable **one** hardware transport so a
+physical trigger reaches an amplifier that doesn't read LSL. Both fire from the same
+place, so every event you log is sent the same way over every enabled path.
+
+| Transport | What it is | What you need |
+|---|---|---|
+| **LSL** (always on) | A network marker stream recorded by an LSL-aware recorder (e.g. LabRecorder → XDF). Works on the same computer or across the network. | Nothing extra. |
+| **Serial (USB trigger box)** | The modern replacement for the parallel port. The box appears as a COM port; SMACC writes the code as one byte and the box mirrors it onto 8 TTL lines. | A USB-serial trigger box and its COM port. |
+| **Parallel port (LPT)** | The classic 25-pin port. Eight data pins carry the code byte, sampled by the amplifier. | An LPT port (often an add-in card) and the **InpOut32** driver (see below). |
+
+!!! note "LSL stays on"
+    Enabling a hardware transport does **not** turn LSL off — you always get the LSL
+    marker stream as well. The hardware path is purely additional.
+
+## Pulsed vs. set-and-hold
+
+Amplifiers and trigger boxes differ in how they expect the code to appear on the
+lines, so SMACC offers two modes:
+
+* **Pulsed** — SMACC raises the code on the lines, waits a configurable **pulse
+  width** (e.g. 10 ms), then drops them back to 0. Each event is a brief, distinct
+  pulse. Choose this when the amplifier expects a momentary trigger, or when you want
+  SMACC to control the pulse length.
+* **Set-and-hold** — SMACC writes the code once and leaves it on the lines until the
+  next event. Choose this for amplifiers that sample a held level, **and** for boxes
+  that generate their own fixed-width pulse when they receive a byte (SMACC just sets
+  the value; the box shapes the pulse).
+
+If you're not sure which your hardware wants, start with **pulsed at 10 ms** and
+verify with the **Test** button (below); switch to set-and-hold if events don't
+register cleanly.
+
+## Configuring trigger output in SMACC
+
+1. Open **File ▸ Trigger output…** (available both in a live session and in the
+   settings editor).
+2. Tick **Enable hardware trigger output**.
+3. Choose a **Transport**:
+    * **Serial** — pick your box's **Port** from the dropdown (click **Refresh** if
+      you plugged it in after opening the dialog) and set the **Baud** rate. If the
+      rig isn't attached right now, you can type the port name (e.g. `COM3`) directly.
+    * **Parallel port** — enter the **Address** as hex (see
+      [Finding your parallel-port address](#finding-your-parallel-port-address)).
+4. Choose a **Mode** (pulsed or set-and-hold) and, for pulsed, a **Pulse width**.
+5. Click **Test** to send one pulse and confirm the amplifier sees it. The result
+   appears next to the button; an error explains what went wrong.
+6. Click **OK**.
+
+The whole configuration is saved in your `.smacc`
+[settings file](usage.md#settings-files-smacc), so it travels with the rest of your
+setup. Because a COM port name or LPT address is specific to one computer, SMACC
+reports a clear error if the saved port can't be opened on the machine you load it on
+— re-pick it in the dialog and save again.
+
+!!! warning "Always validate on the real hardware"
+    A successful **Test** confirms SMACC could open the port and write to it. It does
+    **not** prove the amplifier recorded the correct code on its trigger channel.
+    Before relying on triggers for a study, record a few test events and confirm they
+    appear, with the right codes, in the EEG.
+
+## Finding your parallel-port address
+
+A parallel port is addressed by a base **I/O address**, written in hexadecimal. The
+most common values are:
+
+* `0x378` — the usual address for the first parallel port (LPT1).
+* `0x278` — a common second port (LPT2).
+* `0x3BC` — older onboard ports.
+
+Add-in PCIe/PCI parallel cards are frequently mapped somewhere else entirely, so
+**don't assume** — look it up:
+
+1. Open **Device Manager** (press `Win+X`, then choose Device Manager).
+2. Expand **Ports (COM & LPT)** and double-click your parallel port.
+3. Go to the **Resources** tab and read the first **I/O Range** — the start of that
+   range is your address. Enter it in SMACC with a `0x` prefix (e.g. `0x378`).
+
+## Installing the InpOut32 driver (parallel port only)
+
+Modern Windows blocks direct port access from ordinary programs, so the parallel-port
+path needs a small kernel driver, **InpOut32 / inpoutx64**. SMACC does **not**
+download or install it for you (an earlier version did, and it proved fragile and
+required admin rights every launch). Install it once, manually:
+
+1. Download **InpOutBinaries** from [highrez.co.uk](https://www.highrez.co.uk/downloads/inpout32/).
+2. Run the included **`InstallDriver.exe`** once (as administrator) to install the
+   kernel driver.
+3. Make sure **`inpoutx64.dll`** is where SMACC can load it — on the system path, in
+   `C:\Windows\System32`, or beside `SMACC.exe`.
+
+If the driver isn't available, SMACC's parallel transport reports a clear error and
+falls back to LSL only — it never crashes a session over a missing driver.
+
+## Verifying
+
+* Use the **Test** button in the Trigger output dialog for a quick "can SMACC drive
+  the line?" check.
+* Then confirm end-to-end on the amplifier: record a short block, fire a few events
+  from the **Event logging** window, and check that the codes land on the EEG trigger
+  channel. Only the real recording proves the path works.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -49,4 +49,5 @@ nav:
   - Usage: usage.md
   - Audio & routing: audio.md
   - Devices: devices.md
+  - Triggers & port codes: triggers.md
   - Contributing: contributing.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
     # scope to win32 like blinkstick. Pulls in comtypes.
     "pycaw; sys_platform == 'win32'",
     "pylsl",
+    # Optional hardware TTL trigger output to a USB-serial trigger box (#28). Pure
+    # Python and cross-platform, so it isn't platform-scoped; imported lazily and a
+    # no-op unless a study enables serial triggers.
+    "pyserial",
     "pyyaml",
     # Qt 6 GUI toolkit. Qt 6 requires Windows 10+, which is why SMACC's floor is
     # Windows 10 (Qt5/PyQt5 was the last line that still ran on Windows 8.1). PyQt6

--- a/src/smacc/config.py
+++ b/src/smacc/config.py
@@ -10,7 +10,3 @@ DEFAULT_VOLUME = 0.5
 # Named survey presets shown in the dream-recording panel's survey dropdown.
 # Maps a display label to its URL. Extend per study (persisted in settings YAML).
 SURVEY_OPTIONS: dict[str, str] = {}
-
-# Legacy parallel-port address, kept for the future hardware-trigger path (#28).
-# Event-marker codes now live in smacc.events as a configurable registry.
-PPORT_ADDRESS = "0x3FD8"

--- a/src/smacc/dialogs.py
+++ b/src/smacc/dialogs.py
@@ -737,7 +737,10 @@ class TriggerOutputDialog(QtWidgets.QDialog):
             if index >= 0:
                 self.portCombo.setCurrentIndex(index)
             else:
-                self.portCombo.setEditText(selected)  # saved port not attached now
+                # Saved port not attached now: show it as free text, and clear the
+                # current index so it doesn't resolve back to a *listed* port.
+                self.portCombo.setCurrentIndex(-1)
+                self.portCombo.setEditText(selected)
 
     def _on_transport_changed(self) -> None:
         self.transportStack.setCurrentIndex(self.transportCombo.currentIndex())
@@ -749,8 +752,20 @@ class TriggerOutputDialog(QtWidgets.QDialog):
         self._config_widget.setEnabled(self.enabledBox.isChecked())
 
     def _current_port(self) -> str:
-        """The selected port device (itemData) or the typed text for an absent rig."""
-        return (self.portCombo.currentData() or self.portCombo.currentText()).strip()
+        """Resolve the chosen port to its device name.
+
+        The combo is editable and its labels may carry a description, so the shown
+        text isn't always the device. If it matches a listed entry, return that
+        entry's device (itemData); otherwise it's a free-typed port (a rig not
+        attached now), so return the text as-is. Avoids the stale ``currentData()``
+        an editable combo keeps when its edit text was set without changing index.
+        """
+        text = self.portCombo.currentText().strip()
+        index = self.portCombo.findText(text)
+        if index >= 0:
+            device = self.portCombo.itemData(index)
+            return str(device) if device else text
+        return text
 
     def _current_baud(self) -> int:
         try:

--- a/src/smacc/dialogs.py
+++ b/src/smacc/dialogs.py
@@ -1,10 +1,11 @@
 """Dialogs shown by SMACC outside the main window."""
 
+from collections.abc import Callable
 from dataclasses import replace
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from . import events
+from . import events, triggers
 from .utils import normalize_survey_url
 
 
@@ -579,3 +580,202 @@ class EventCodesDialog(QtWidgets.QDialog):
             if reply != QtWidgets.QMessageBox.StandardButton.Yes:
                 return
         self.accept()
+
+
+# Common serial baud rates offered in the dropdown (it stays editable for any other).
+_COMMON_BAUDS = (9600, 19200, 38400, 57600, 115200, 230400)
+
+
+class TriggerOutputDialog(QtWidgets.QDialog):
+    """Configure optional hardware TTL trigger output alongside LSL (#28).
+
+    LSL marker output is always on; this dialog edits the *opt-in* second path —
+    transport (serial USB box / parallel LPT), the port/address, and whether the
+    line is pulsed (SMACC times the pulse) or set-and-hold. A Test button sends one
+    pulse through the current settings and reports the result inline, so the rig can
+    be verified before relying on it. The dialog edits a copy; the caller reads
+    :meth:`get_config` only when accepted.
+    """
+
+    def __init__(
+        self,
+        config: triggers.TriggerConfig,
+        test_callback: Callable[[triggers.TriggerConfig], str | None] | None = None,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Trigger output")
+        self.setWindowFlags(
+            self.windowFlags() ^ QtCore.Qt.WindowType.WindowContextHelpButtonHint
+        )
+        self._test_callback = test_callback
+
+        hint = QtWidgets.QLabel(
+            "SMACC always emits markers over LSL. Optionally also drive a hardware "
+            "TTL trigger for amplifiers that read a physical pulse. One transport at "
+            "a time; see the Triggers docs."
+        )
+        hint.setWordWrap(True)
+
+        self.enabledBox = QtWidgets.QCheckBox("Enable hardware trigger output", self)
+        self.enabledBox.setChecked(config.enabled)
+        self.enabledBox.toggled.connect(self._update_enabled_state)
+
+        self.transportCombo = QtWidgets.QComboBox(self)
+        self.transportCombo.addItem("Serial (USB trigger box)", "serial")
+        self.transportCombo.addItem("Parallel port (LPT)", "parallel")
+        self.transportCombo.currentIndexChanged.connect(self._on_transport_changed)
+
+        # Serial page: COM port (editable, in case the rig isn't attached now) + baud.
+        self.portCombo = QtWidgets.QComboBox(self)
+        self.portCombo.setEditable(True)
+        self.portCombo.setMinimumWidth(220)
+        refreshButton = QtWidgets.QPushButton("Refresh", self)
+        refreshButton.setStatusTip("Rescan for attached serial ports.")
+        refreshButton.clicked.connect(self._refresh_ports)
+        portRow = QtWidgets.QHBoxLayout()
+        portRow.addWidget(self.portCombo, 1)
+        portRow.addWidget(refreshButton)
+        self.baudCombo = QtWidgets.QComboBox(self)
+        self.baudCombo.setEditable(True)
+        self.baudCombo.addItems([str(b) for b in _COMMON_BAUDS])
+        serialPage = QtWidgets.QWidget(self)
+        serialForm = QtWidgets.QFormLayout(serialPage)
+        serialForm.setContentsMargins(0, 0, 0, 0)
+        serialForm.addRow("Port", portRow)
+        serialForm.addRow("Baud", self.baudCombo)
+
+        # Parallel page: base address (hex), with help on finding it.
+        self.addressEdit = QtWidgets.QLineEdit(self)
+        self.addressEdit.setPlaceholderText(triggers.DEFAULT_LPT_ADDRESS)
+        addressHelp = QtWidgets.QLabel(
+            "Base I/O address as hex (e.g. 0x378). Find it in Device Manager → the "
+            "LPT port → Resources → I/O Range. Needs the InpOut32 driver installed "
+            "(see the Triggers docs)."
+        )
+        addressHelp.setWordWrap(True)
+        parallelPage = QtWidgets.QWidget(self)
+        parallelForm = QtWidgets.QFormLayout(parallelPage)
+        parallelForm.setContentsMargins(0, 0, 0, 0)
+        parallelForm.addRow("Address", self.addressEdit)
+        parallelForm.addRow("", addressHelp)
+
+        self.transportStack = QtWidgets.QStackedWidget(self)
+        self.transportStack.addWidget(serialPage)  # index 0 == serial
+        self.transportStack.addWidget(parallelPage)  # index 1 == parallel
+
+        self.modeCombo = QtWidgets.QComboBox(self)
+        self.modeCombo.addItem("Pulsed (SMACC times the pulse)", "pulsed")
+        self.modeCombo.addItem("Set-and-hold (until next event)", "hold")
+        self.modeCombo.currentIndexChanged.connect(self._update_pulse_enabled)
+        self.pulseSpin = QtWidgets.QSpinBox(self)
+        self.pulseSpin.setRange(1, 1000)
+        self.pulseSpin.setSuffix(" ms")
+        self.pulseSpin.setValue(config.pulse_ms)
+
+        self.testButton = QtWidgets.QPushButton("Test", self)
+        self.testButton.setStatusTip("Send one test pulse through these settings.")
+        self.testButton.clicked.connect(self._on_test)
+        self.testResult = QtWidgets.QLabel("", self)
+        self.testResult.setWordWrap(True)
+        testRow = QtWidgets.QHBoxLayout()
+        testRow.addWidget(self.testButton)
+        testRow.addWidget(self.testResult, 1)
+
+        # The transport/mode/pulse/test controls are gated behind the enable box.
+        self._config_widget = QtWidgets.QWidget(self)
+        configForm = QtWidgets.QFormLayout(self._config_widget)
+        configForm.setContentsMargins(0, 0, 0, 0)
+        configForm.addRow("Transport", self.transportCombo)
+        configForm.addRow(self.transportStack)
+        configForm.addRow("Mode", self.modeCombo)
+        configForm.addRow("Pulse width", self.pulseSpin)
+        configForm.addRow(testRow)
+
+        buttonBox = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        buttonBox.accepted.connect(self.accept)
+        buttonBox.rejected.connect(self.reject)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(hint)
+        layout.addWidget(self.enabledBox)
+        layout.addWidget(self._config_widget)
+        layout.addStretch(1)
+        layout.addWidget(buttonBox)
+
+        # Seed the widgets from the incoming config, then sync dependent states.
+        self._select_data(self.transportCombo, config.transport)
+        self._select_data(self.modeCombo, config.mode)
+        self._refresh_ports(selected=config.port)
+        self.baudCombo.setCurrentText(str(config.baud))
+        self.addressEdit.setText(config.address)
+        self._on_transport_changed()
+        self._update_pulse_enabled()
+        self._update_enabled_state()
+
+    @staticmethod
+    def _select_data(combo: QtWidgets.QComboBox, value: str) -> None:
+        """Select the combo entry whose itemData is ``value`` (no-op if absent)."""
+        index = combo.findData(value)
+        if index >= 0:
+            combo.setCurrentIndex(index)
+
+    def _refresh_ports(self, *, selected: str | None = None) -> None:
+        """Repopulate the serial-port dropdown, preserving the current selection."""
+        if selected is None:
+            selected = self._current_port()
+        self.portCombo.clear()
+        for device, description in triggers.list_serial_ports():
+            label = device if description == device else f"{device} — {description}"
+            self.portCombo.addItem(label, device)
+        if selected:
+            index = self.portCombo.findData(selected)
+            if index >= 0:
+                self.portCombo.setCurrentIndex(index)
+            else:
+                self.portCombo.setEditText(selected)  # saved port not attached now
+
+    def _on_transport_changed(self) -> None:
+        self.transportStack.setCurrentIndex(self.transportCombo.currentIndex())
+
+    def _update_pulse_enabled(self) -> None:
+        self.pulseSpin.setEnabled(self.modeCombo.currentData() == "pulsed")
+
+    def _update_enabled_state(self) -> None:
+        self._config_widget.setEnabled(self.enabledBox.isChecked())
+
+    def _current_port(self) -> str:
+        """The selected port device (itemData) or the typed text for an absent rig."""
+        return (self.portCombo.currentData() or self.portCombo.currentText()).strip()
+
+    def _current_baud(self) -> int:
+        try:
+            return int(self.baudCombo.currentText().strip())
+        except ValueError:
+            return triggers.DEFAULT_BAUD
+
+    def _on_test(self) -> None:
+        """Send one test pulse through the current settings and report the result."""
+        if self._test_callback is None:
+            return
+        error = self._test_callback(self.get_config())
+        if error:
+            self.testResult.setText(f"⚠ {error}")
+        else:
+            self.testResult.setText("✓ Sent test pulse — check the amplifier.")
+
+    def get_config(self) -> triggers.TriggerConfig:
+        """Return the edited config (read only when the dialog is accepted)."""
+        return triggers.TriggerConfig(
+            enabled=self.enabledBox.isChecked(),
+            transport=self.transportCombo.currentData(),
+            port=self._current_port(),
+            baud=self._current_baud(),
+            address=self.addressEdit.text().strip() or triggers.DEFAULT_LPT_ADDRESS,
+            mode=self.modeCombo.currentData(),
+            pulse_ms=self.pulseSpin.value(),
+        )

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -11,9 +11,14 @@ import sounddevice as sd
 from PyQt6 import QtCore, QtGui, QtWidgets
 from PyQt6.QtMultimedia import QMediaDevices
 
-from smacc import bids, devices, preferences, settings, winassoc
+from smacc import bids, devices, preferences, settings, triggers, winassoc
 
-from .dialogs import EventCodesDialog, SessionInfoDialog, ask_initial_or_final
+from .dialogs import (
+    EventCodesDialog,
+    SessionInfoDialog,
+    TriggerOutputDialog,
+    ask_initial_or_final,
+)
 from .panels.audio import AudioCueWindow
 from .panels.base import ModalityWindow
 from .panels.devices import DevicesWindow
@@ -300,6 +305,13 @@ class SmaccWindow(ToolWindow):
         eventCodesAction.triggered.connect(self.edit_event_codes)
         self._event_codes_action = eventCodesAction
 
+        triggerOutputAction = QtGui.QAction("&Trigger output…", self)
+        triggerOutputAction.setStatusTip(
+            "Configure optional hardware TTL trigger output (serial/parallel) "
+            "alongside LSL."
+        )
+        triggerOutputAction.triggered.connect(self.edit_trigger_output)
+
         exportEventsAction = QtGui.QAction("&Export events (BIDS)…", self)
         exportEventsAction.setStatusTip(
             "Export this session's events log as a BIDS events.tsv."
@@ -341,12 +353,15 @@ class SmaccWindow(ToolWindow):
         # _apply_preferences can iterate it uniformly in both modes.
         self._preview_level_boxes: dict[int, QtWidgets.QCheckBox] = {}
         if self.design:
-            self._build_editor_file_menu(fileMenu, sessionInfoAction, eventCodesAction)
+            self._build_editor_file_menu(
+                fileMenu, sessionInfoAction, eventCodesAction, triggerOutputAction
+            )
         else:
             self._build_session_file_menu(
                 fileMenu,
                 sessionInfoAction,
                 eventCodesAction,
+                triggerOutputAction,
                 exportEventsAction,
                 alwaysOnTopAction,
                 associateAction,
@@ -362,7 +377,9 @@ class SmaccWindow(ToolWindow):
         assert surveysMenu is not None
         surveysMenu.aboutToShow.connect(lambda: self._rebuild_surveys_menu(surveysMenu))
 
-    def _build_editor_file_menu(self, fileMenu, sessionInfoAction, eventCodesAction):
+    def _build_editor_file_menu(
+        self, fileMenu, sessionInfoAction, eventCodesAction, triggerOutputAction
+    ):
         """Editor File menu: save/import settings + the config editors (no live run)."""
         saveAction = QtGui.QAction("&Save settings", self)
         saveAction.setShortcut("Ctrl+S")
@@ -386,6 +403,7 @@ class SmaccWindow(ToolWindow):
         fileMenu.addSeparator()
         fileMenu.addAction(sessionInfoAction)
         fileMenu.addAction(eventCodesAction)
+        fileMenu.addAction(triggerOutputAction)
         self._add_surveys_menu(fileMenu)
 
     def _build_session_file_menu(
@@ -393,6 +411,7 @@ class SmaccWindow(ToolWindow):
         fileMenu,
         sessionInfoAction,
         eventCodesAction,
+        triggerOutputAction,
         exportEventsAction,
         alwaysOnTopAction,
         associateAction,
@@ -401,6 +420,7 @@ class SmaccWindow(ToolWindow):
         runs from the launcher. Here you record events and export this run."""
         fileMenu.addAction(sessionInfoAction)
         fileMenu.addAction(eventCodesAction)
+        fileMenu.addAction(triggerOutputAction)
         self._add_surveys_menu(fileMenu)
         fileMenu.addSeparator()
         fileMenu.addAction(exportEventsAction)
@@ -614,6 +634,8 @@ class SmaccWindow(ToolWindow):
         # The event-code registry isn't a panel; persist it at the window level.
         state["event_codes"] = self.session.event_codes_as_list()
         state["event_code_safe_max"] = self.session.event_code_safe_max
+        # Optional hardware-trigger config (transport/port/mode/…), also window-level.
+        state["trigger_output"] = self.session.trigger_config.to_dict()
         # The data directory (where runs are written) travels with the settings;
         # the editor can repoint it, so read the window's copy, not the session's.
         state["data_directory"] = str(self.data_dir)
@@ -630,6 +652,7 @@ class SmaccWindow(ToolWindow):
         self.session.missing_devices = []  # filled by the Devices reload below
         # Device roles/routing first, so panels resolve correctly (migrates old files).
         self.session.devices = devices.load(state)
+        trigger_error: str | None = None
         try:
             for panel in self.panels.values():
                 panel.apply_state(state)
@@ -638,12 +661,18 @@ class SmaccWindow(ToolWindow):
             self.session.set_event_codes(
                 state.get("event_codes"), state.get("event_code_safe_max")
             )
+            # Optional hardware-trigger config (disabled for a pre-v5 study). Open
+            # the transport now so a bad port/driver is reported at load, not mid-run.
+            self.session.trigger_config = triggers.load(state)
+            trigger_error = self.session.set_trigger_output(self.session.trigger_config)
             self._rebuild_events_panel()  # a loaded study may add/remove buttons
             self.devices_window.reload_from_config()  # sync widgets + flag missing
             self._refresh_device_indicators()
         finally:
             self.session.log_interactions = was_logging
         self._notify_missing_devices()
+        if trigger_error:
+            self.show_error_popup("Hardware trigger unavailable.", trigger_error)
 
     def _rebuild_events_panel(self) -> None:
         """Rebuild the Event logging panel's buttons after the registry changes."""
@@ -1039,6 +1068,28 @@ class SmaccWindow(ToolWindow):
         self.session.events = new_by_key
         self.session.event_code_safe_max = safe_max
         self._rebuild_events_panel()
+
+    def edit_trigger_output(self) -> None:
+        """Open the hardware-trigger editor; apply and (re)open the transport on OK.
+
+        A change is logged loudly (WARNING) like an event-code edit: the transport
+        can change mid-session, and the log is the record of what actually fired. In
+        the editor (design mode) no hardware is opened — the config is only authored
+        and saved with the study.
+        """
+        before = self.session.trigger_config
+        dialog = TriggerOutputDialog(
+            before, test_callback=self.session.test_trigger, parent=self
+        )
+        if not dialog.exec():
+            return
+        config = dialog.get_config()
+        if config != before:
+            self.session.logger.warning(f"Trigger output changed: {config.summary()}")
+        self.session.trigger_config = config
+        error = self.session.set_trigger_output(config)
+        if error:
+            self.show_error_popup("Hardware trigger unavailable.", error)
 
     def export_events_bids(self) -> None:
         """Convert this session's log to a BIDS events.tsv (+ JSON sidecar)."""

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -17,8 +17,8 @@ from pathlib import Path
 from pylsl import StreamInfo, StreamOutlet
 from PyQt6 import QtWidgets
 
-from . import bids, devices, events, settings
-from .config import PPORT_ADDRESS, VERSION
+from . import bids, devices, events, settings, triggers
+from .config import VERSION
 
 
 def make_session_dir(base: Path, now: datetime) -> Path:
@@ -74,7 +74,13 @@ class SmaccSession:
         }
         if metadata:
             self.metadata.update(metadata)
-        self.pport_address = PPORT_ADDRESS
+        # Optional hardware TTL trigger output alongside LSL (#28). ``trigger_config``
+        # is the configured intent (persisted with the study, edited in the Trigger
+        # output dialog); ``trigger_out`` is the live transport opened from it, or
+        # None when disabled, unconfigured, or in design mode. Each marker fires on
+        # both LSL and this transport from the single emit_event path.
+        self.trigger_config = triggers.TriggerConfig()
+        self.trigger_out: triggers.TriggerOutput | None = None
         # The live event-marker registry (codes + routing flags), keyed by event
         # key. Defaults here; a loaded study overrides them via set_event_codes().
         self.events = {e.key: e for e in events.default_events()}
@@ -174,6 +180,9 @@ class SmaccSession:
                 pass
             self._file_handler = None
         self.outlet = None
+        if self.trigger_out is not None:
+            self.trigger_out.close()
+            self.trigger_out = None
 
     def begin_log(self, settings_state: dict) -> None:
         """Record the initial settings near the top of the log, then log startup.
@@ -235,8 +244,25 @@ class SmaccSession:
         label = f"{event.label}: {detail}" if detail else event.label
         line = f"{label} - portcode {code}" if event.trigger else label
         # In design mode there is no outlet, so triggers are logged but not sent.
+        # LSL and the hardware line are written back-to-back (before any pulse-down
+        # sleep) so both edges land as close together as possible.
         if event.trigger and self.outlet is not None:
             self.outlet.push_sample([str(code)])
+        if event.trigger and self.trigger_out is not None:
+            try:
+                self.trigger_out.send(code)
+            except Exception as exc:
+                # A hardware fault must never take down a live night. Drop to
+                # LSL-only and say so once, loudly, rather than blocking on (or
+                # spamming the log for) every later event.
+                self.logger.error(
+                    f"Hardware trigger failed (code {code}); disabling it: {exc}"
+                )
+                try:
+                    self.trigger_out.close()
+                except Exception:
+                    pass
+                self.trigger_out = None
         # Every event is written to the log file; the preview flag (+ level filter)
         # gates whether it also appears in the live log viewer.
         self.logger.info(line, extra={"smacc_preview": event.preview})
@@ -270,6 +296,67 @@ class SmaccSession:
     def event_codes_as_list(self) -> list[dict]:
         """Return the current registry as the compact list persisted in a study."""
         return events.events_to_list(self.events.values())
+
+    def set_trigger_output(self, config: triggers.TriggerConfig) -> str | None:
+        """(Re)open the hardware trigger transport from ``config`` (#28).
+
+        Closes any existing transport first, then opens the new one. Returns an
+        error message when an *enabled* transport can't be opened (the window shows
+        it to the operator), or None on success or when disabled. Never raises: a
+        design session or a disabled config simply ends with no transport.
+        """
+        if self.trigger_out is not None:
+            self.trigger_out.close()
+            self.trigger_out = None
+        if self.design or not config.enabled:
+            return None
+        try:
+            self.trigger_out = triggers.open_trigger(config)
+        except triggers.TriggerError as exc:
+            self.logger.warning(f"Hardware trigger unavailable: {exc}")
+            return str(exc)
+        if self.trigger_out is not None:
+            self.log_info_msg(f"Hardware trigger ready: {config.summary()}")
+        return None
+
+    def test_trigger(self, config: triggers.TriggerConfig) -> str | None:
+        """Send one test pulse through ``config`` and report the outcome.
+
+        Returns None on success or a message on failure, for the dialog's Test
+        button. The test code reuses ``TriggerInitialization`` (the startup
+        connection-test marker). Any live transport is released for the test (a
+        serial/parallel port is exclusive) and then restored from the applied config.
+        """
+        live = self.trigger_out
+        self.trigger_out = None
+        if live is not None:
+            live.close()
+        init = self.events.get("TriggerInitialization")
+        test_code = init.code if init is not None else 100
+        try:
+            out = triggers.open_trigger(config)
+            if out is None:
+                return "Enable a transport to test."
+            try:
+                out.send(test_code)
+            finally:
+                out.close()
+            return None
+        except triggers.TriggerError as exc:
+            return str(exc)
+        except Exception as exc:
+            return f"Trigger test failed: {exc}"
+        finally:
+            self._restore_trigger_output()
+
+    def _restore_trigger_output(self) -> None:
+        """Best-effort reopen of the applied trigger config (used after a test)."""
+        if self.design or not self.trigger_config.enabled:
+            return
+        try:
+            self.trigger_out = triggers.open_trigger(self.trigger_config)
+        except triggers.TriggerError:
+            self.trigger_out = None
 
     def log_info_msg(self, msg: str) -> None:
         """Log an INFO message (always to file; to the preview if INFO is on)."""

--- a/src/smacc/settings.py
+++ b/src/smacc/settings.py
@@ -9,10 +9,15 @@ reject YAML that wasn't written by it.
 The on-disk shape (a ``.smacc`` file is YAML text with a leading comment header)::
 
     kind: smacc/settings
-    schema_version: 4
+    schema_version: 5
     smacc_version: "0.0.7"
     metadata: {subject: "", session: "", notes: "", created: "..."}
     settings: { ...the panel state from SmaccWindow.gather_settings()... }
+
+The ``settings`` mapping carries, besides each panel's state, a few window-level
+blocks: ``devices`` (role/routing config), ``event_codes`` + ``event_code_safe_max``
+(the marker registry), ``trigger_output`` (the optional hardware-trigger config; see
+:mod:`smacc.triggers`), and ``data_directory``.
 
 Referenced media (cue/noise WAVs) are stored *relative* to the file when they sit
 beside it and *absolute* otherwise, so a study folder is portable as-is; see
@@ -43,9 +48,10 @@ _FILE_HEADER = "# SMACC settings — YAML (.smacc). Edit with care.\n"
 
 # Bump when the serialized layout changes incompatibly. Files written by older
 # (lower) versions are still accepted on load; panels handle field-level
-# back-compat (e.g. a v1 single cue maps into the first multi-slot cue, and a
-# pre-v4 file with no event_codes falls back to the default registry).
-SCHEMA_VERSION = 4
+# back-compat (e.g. a v1 single cue maps into the first multi-slot cue, a pre-v4
+# file with no event_codes falls back to the default registry, and a pre-v5 file
+# with no trigger_output falls back to hardware triggers disabled — LSL only).
+SCHEMA_VERSION = 5
 
 
 def build_payload(settings: dict[str, Any], metadata: dict) -> dict[str, Any]:

--- a/src/smacc/triggers.py
+++ b/src/smacc/triggers.py
@@ -1,0 +1,306 @@
+"""Optional hardware TTL trigger output alongside the LSL marker stream (#28).
+
+SMACC always emits event markers over LSL; this module adds an *opt-in* second
+path that drives a physical trigger, so amplifiers that ingest a TTL pulse (rather
+than a network marker) still see every port code. The byte sent stays inside the
+8-bit port-code contract (:mod:`smacc.events`), so existing EEG marker maps line up.
+
+One transport at a time, selected and configured per study (persisted in the
+``.smacc`` file, edited in the Trigger output dialog):
+
+* ``serial`` — write the code as a single byte to a COM port with `pyserial`. The
+  modern path: a USB-serial trigger box mirrors the received byte onto 8 TTL lines.
+* ``parallel`` — write the byte to an LPT data register through the InpOut32 /
+  inpoutx64 kernel driver (via :mod:`ctypes`). The driver must be installed
+  manually; SMACC never downloads it (see the Triggers docs and the issue history).
+
+Both transports support two pulse behaviors, because rigs differ — pick in config:
+
+* ``pulsed`` — raise ``code`` on the lines, wait ``pulse_ms``, then drop to 0. SMACC
+  times the pulse itself. Use for amps/boxes that expect a brief marker pulse.
+* ``hold`` — write ``code`` once and leave the lines there until the next event.
+  Use for true set-and-hold amps *and* for boxes that pulse on their own fixed
+  width (SMACC just sets the value; the box shapes the pulse).
+
+Every default here is a sane, generalizable starting point — no rig is assumed; all
+of it is editable in the GUI. This module is Qt-free and unit-testable: the GUI
+builds/edits a :class:`TriggerConfig`, and the session opens it via
+:func:`open_trigger` into something satisfying :class:`TriggerOutput`.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, fields
+from typing import Any, Protocol, runtime_checkable
+
+# Defaults: editable per study, so these are only the out-of-the-box starting point.
+DEFAULT_TRANSPORT = "serial"
+DEFAULT_BAUD = 115200
+# The classic LPT1 base address. Real rigs vary (an add-in parallel card maps
+# elsewhere); confirm yours in Device Manager and override it — see the Triggers docs.
+DEFAULT_LPT_ADDRESS = "0x378"
+DEFAULT_MODE = "pulsed"
+DEFAULT_PULSE_MS = 10
+
+TRANSPORTS = ("serial", "parallel")
+MODES = ("pulsed", "hold")
+
+# The idle/"off" value written between and after pulses. The port-code contract
+# reserves 1..255 for events, so 0 is always a safe low state.
+_OFF = 0
+
+
+class TriggerError(Exception):
+    """A hardware trigger transport could not be opened or written to.
+
+    Carries a human-readable, actionable message (missing driver, busy port, …);
+    the window shows it to the operator verbatim.
+    """
+
+
+@runtime_checkable
+class TriggerOutput(Protocol):
+    """A live hardware trigger transport: send a port code, then release it."""
+
+    def send(self, code: int) -> None: ...
+
+    def close(self) -> None: ...
+
+
+@dataclass
+class TriggerConfig:
+    """How (and whether) to mirror each port code onto a hardware trigger line.
+
+    LSL marker output is always on and independent of this; these settings drive the
+    *optional* second path. Persisted as the ``trigger_output`` block of a study.
+    """
+
+    enabled: bool = False
+    transport: str = DEFAULT_TRANSPORT  # one of TRANSPORTS
+    port: str = ""  # serial COM port, e.g. "COM3"
+    baud: int = DEFAULT_BAUD
+    address: str = DEFAULT_LPT_ADDRESS  # parallel-port base address (hex string)
+    mode: str = DEFAULT_MODE  # one of MODES
+    pulse_ms: int = DEFAULT_PULSE_MS
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the plain mapping persisted in a study file."""
+        return {f.name: getattr(self, f.name) for f in fields(self)}
+
+    def summary(self) -> str:
+        """A one-line human description for logs and the dialog (e.g. on a change)."""
+        if not self.enabled:
+            return "disabled (LSL only)"
+        if self.transport == "serial":
+            where = f"{self.port or '(no port)'} @ {self.baud} baud"
+        else:
+            where = f"LPT {self.address}"
+        pulse = f"{self.mode}" + (
+            f" {self.pulse_ms} ms" if self.mode == "pulsed" else ""
+        )
+        return f"{self.transport} — {where}, {pulse}"
+
+
+def _coerce_int(value: object, default: int) -> int:
+    """Best-effort int from a persisted value; ``default`` on anything unparseable."""
+    if isinstance(value, bool):  # bool is an int subclass; never a valid code/baud
+        return default
+    try:
+        return int(value)  # type: ignore[call-overload]  # guarded by except
+    except (TypeError, ValueError):
+        return default
+
+
+def from_dict(data: object) -> TriggerConfig:
+    """Build a :class:`TriggerConfig` from a persisted mapping, coercing each field.
+
+    Mirrors the defensive merge-over-defaults used elsewhere (events/devices): a
+    missing block, an unknown transport/mode, or a malformed value falls back to the
+    default, so a hand-edited or older study never breaks the load.
+    """
+    cfg = TriggerConfig()
+    if not isinstance(data, dict):
+        return cfg
+    cfg.enabled = bool(data.get("enabled", False))
+    if data.get("transport") in TRANSPORTS:
+        cfg.transport = data["transport"]
+    cfg.port = str(data.get("port") or "")
+    cfg.baud = _coerce_int(data.get("baud"), DEFAULT_BAUD)
+    address = data.get("address")
+    cfg.address = str(address) if address else DEFAULT_LPT_ADDRESS
+    if data.get("mode") in MODES:
+        cfg.mode = data["mode"]
+    cfg.pulse_ms = max(1, _coerce_int(data.get("pulse_ms"), DEFAULT_PULSE_MS))
+    return cfg
+
+
+def load(settings: dict) -> TriggerConfig:
+    """Return the trigger config from a study's settings mapping (default if absent)."""
+    return from_dict(settings.get("trigger_output"))
+
+
+def parse_address(address: str | int) -> int:
+    """Parse an LPT base address: a hex string (``"0x378"``), decimal string, or int.
+
+    Hex must carry the ``0x`` prefix; bare digits are read as decimal. Raises
+    :class:`TriggerError` (with guidance) on anything else.
+    """
+    if isinstance(address, bool):
+        raise TriggerError(f"Invalid parallel-port address {address!r}.")
+    if isinstance(address, int):
+        return address
+    text = str(address).strip()
+    try:
+        return int(text, 16) if text.lower().startswith("0x") else int(text, 10)
+    except ValueError as exc:
+        raise TriggerError(
+            f"Invalid parallel-port address {address!r} (use hex like 0x378)."
+        ) from exc
+
+
+class _PulseSender:
+    """Shared pulse/hold logic over a single ``write(value)`` function.
+
+    ``pulsed`` writes ``code`` then 0 after ``pulse_s`` (a marker pulse SMACC times);
+    ``hold`` writes ``code`` once. The sleep is injectable so tests don't actually
+    wait. The rising edge — the write of ``code`` — is what the amplifier timestamps,
+    and it happens first, so the (brief) sleep never costs marker precision.
+    """
+
+    def __init__(
+        self,
+        write: Callable[[int], None],
+        mode: str,
+        pulse_s: float,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._write = write
+        self._mode = mode
+        self._pulse_s = pulse_s
+        self._sleep = sleep
+
+    def send(self, code: int) -> None:
+        self._write(code)
+        if self._mode == "pulsed":
+            self._sleep(self._pulse_s)
+            self._write(_OFF)
+
+
+class SerialTrigger:
+    """Write each port code as one byte to a serial (USB) trigger box."""
+
+    def __init__(self, config: TriggerConfig) -> None:
+        try:
+            import serial  # pyserial; imported lazily so non-serial rigs need no dep
+        except ImportError as exc:  # pragma: no cover - pyserial is a hard dep
+            raise TriggerError(
+                "Serial trigger output needs pyserial, which isn't installed."
+            ) from exc
+        if not config.port:
+            raise TriggerError("No serial port selected for trigger output.")
+        try:
+            # write_timeout caps how long a stuck write blocks the GUI thread, so a
+            # pulled cable can't freeze a live run for long before it's disabled.
+            self._serial = serial.Serial(
+                config.port, config.baud, timeout=0, write_timeout=0.5
+            )
+        except Exception as exc:  # serial.SerialException et al.
+            raise TriggerError(
+                f"Could not open serial port {config.port!r}: {exc}"
+            ) from exc
+        self._sender = _PulseSender(self._write, config.mode, config.pulse_ms / 1000)
+
+    def _write(self, value: int) -> None:
+        self._serial.write(bytes([value & 0xFF]))
+        self._serial.flush()
+
+    def send(self, code: int) -> None:
+        self._sender.send(code)
+
+    def close(self) -> None:
+        try:
+            self._serial.close()
+        except Exception:
+            pass
+
+
+class ParallelTrigger:
+    """Write each port code to an LPT data register via the InpOut32 driver."""
+
+    def __init__(self, config: TriggerConfig) -> None:
+        self._address = parse_address(config.address)
+        self._dll = _load_inpout()
+        self._sender = _PulseSender(self._write, config.mode, config.pulse_ms / 1000)
+        self._write(_OFF)  # start from a known-low state
+
+    def _write(self, value: int) -> None:
+        self._dll.Out32(self._address, value & 0xFF)
+
+    def send(self, code: int) -> None:
+        self._sender.send(code)
+
+    def close(self) -> None:
+        try:
+            self._write(_OFF)
+        except Exception:
+            pass
+
+
+def _load_inpout() -> Any:
+    """Load the InpOut32 / inpoutx64 kernel-driver DLL (Windows only).
+
+    The driver must be installed manually — SMACC never downloads it (see the
+    Triggers docs and the issue history). ``WinDLL`` is fetched via ``getattr`` so
+    this module also type-checks on non-Windows CI, where the attribute is absent.
+    """
+    import ctypes
+
+    win_dll: Any = getattr(ctypes, "WinDLL", None)
+    if win_dll is None:
+        raise TriggerError("Parallel-port output is only available on Windows.")
+    for name in ("inpoutx64.dll", "inpout32.dll"):
+        try:
+            dll = win_dll(name)
+        except OSError:
+            continue
+        dll.Out32.argtypes = [ctypes.c_int16, ctypes.c_int16]
+        dll.Out32.restype = None
+        return dll
+    raise TriggerError(
+        "Parallel-port output needs the InpOut32 driver (inpoutx64.dll), which "
+        "could not be loaded. Install it manually and place inpoutx64.dll on the "
+        "system path — see the Triggers docs. SMACC will not download it."
+    )
+
+
+def open_trigger(config: TriggerConfig) -> TriggerOutput | None:
+    """Open the configured transport, or ``None`` when disabled.
+
+    Raises :class:`TriggerError` (with an actionable message) when an *enabled*
+    transport can't be opened — a missing driver, a busy/absent port, a bad address.
+    """
+    if not config.enabled:
+        return None
+    if config.transport == "serial":
+        return SerialTrigger(config)
+    if config.transport == "parallel":
+        return ParallelTrigger(config)
+    raise TriggerError(f"Unknown trigger transport {config.transport!r}.")
+
+
+def list_serial_ports() -> list[tuple[str, str]]:
+    """Return ``[(device, description), …]`` for attached serial ports (``[]`` on error).
+
+    Used to populate the port dropdown; never raises, so a backend hiccup can't block
+    the dialog.
+    """
+    try:
+        from serial.tools import list_ports
+    except ImportError:  # pragma: no cover - pyserial is a hard dep
+        return []
+    try:
+        return [(p.device, p.description or p.device) for p in list_ports.comports()]
+    except Exception:  # pragma: no cover - defensive against backend quirks
+        return []

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import pytest
 from PyQt6 import QtWidgets
 
-from smacc import dialogs, events
+from smacc import dialogs, events, triggers
 
 # ----- PreferencesDialog -----------------------------------------------------
 
@@ -207,3 +207,65 @@ def test_event_codes_dialog_add_event(qtbot, monkeypatch):
     after = dialog.get_events()
     assert len(after) == before + 1
     assert any(e.label == "New event" for e in after)
+
+
+# ----- TriggerOutputDialog ---------------------------------------------------
+
+
+def test_trigger_output_dialog_round_trips_config(qtbot):
+    cfg = triggers.TriggerConfig(
+        enabled=True, transport="serial", port="COM9", baud=9600, mode="hold"
+    )
+    dialog = dialogs.TriggerOutputDialog(cfg)
+    qtbot.addWidget(dialog)
+    out = dialog.get_config()
+    assert out.enabled is True
+    assert out.transport == "serial"
+    assert out.port == "COM9"  # a port not attached now survives as typed text
+    assert out.baud == 9600
+    assert out.mode == "hold"
+
+
+def test_trigger_output_dialog_reflects_edits(qtbot):
+    dialog = dialogs.TriggerOutputDialog(triggers.TriggerConfig())
+    qtbot.addWidget(dialog)
+    dialog.enabledBox.setChecked(True)
+    dialog._select_data(dialog.transportCombo, "parallel")
+    dialog.addressEdit.setText("0x278")
+    out = dialog.get_config()
+    assert out.enabled is True
+    assert out.transport == "parallel"
+    assert out.address == "0x278"
+
+
+def test_trigger_output_dialog_disabled_greys_config(qtbot):
+    dialog = dialogs.TriggerOutputDialog(triggers.TriggerConfig(enabled=False))
+    qtbot.addWidget(dialog)
+    assert dialog._config_widget.isEnabled() is False
+    dialog.enabledBox.setChecked(True)
+    assert dialog._config_widget.isEnabled() is True
+
+
+def test_trigger_output_dialog_test_button_reports_result(qtbot):
+    calls = []
+
+    def fake_test(config):
+        calls.append(config)
+        return None  # success
+
+    dialog = dialogs.TriggerOutputDialog(
+        triggers.TriggerConfig(enabled=True, port="COM3"), test_callback=fake_test
+    )
+    qtbot.addWidget(dialog)
+    dialog._on_test()
+    assert len(calls) == 1 and calls[0].port == "COM3"
+    assert "✓" in dialog.testResult.text()
+
+
+def test_trigger_output_dialog_test_button_shows_error(qtbot):
+    dialog = dialogs.TriggerOutputDialog(
+        triggers.TriggerConfig(enabled=True), test_callback=lambda cfg: "no such port"
+    )
+    qtbot.addWidget(dialog)
+    dialog._on_test()
+    assert "no such port" in dialog.testResult.text()

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -212,7 +212,19 @@ def test_event_codes_dialog_add_event(qtbot, monkeypatch):
 # ----- TriggerOutputDialog ---------------------------------------------------
 
 
-def test_trigger_output_dialog_round_trips_config(qtbot):
+@pytest.fixture
+def stub_serial_ports(monkeypatch):
+    """Pin the serial-port list so these tests don't depend on the machine's ports.
+
+    Includes a described port (label != device) and a bare one, so the device
+    resolution is exercised regardless of what COM ports the CI runner exposes.
+    """
+    ports = [("COM2", "USB Serial Device"), ("COM5", "COM5")]
+    monkeypatch.setattr(triggers, "list_serial_ports", lambda: ports)
+    return ports
+
+
+def test_trigger_output_dialog_round_trips_config(qtbot, stub_serial_ports):
     cfg = triggers.TriggerConfig(
         enabled=True, transport="serial", port="COM9", baud=9600, mode="hold"
     )
@@ -221,9 +233,23 @@ def test_trigger_output_dialog_round_trips_config(qtbot):
     out = dialog.get_config()
     assert out.enabled is True
     assert out.transport == "serial"
-    assert out.port == "COM9"  # a port not attached now survives as typed text
+    # COM9 isn't attached but other ports are: it must survive as typed text, not
+    # snap to a listed port (regression: editable combo's stale currentData()).
+    assert out.port == "COM9"
     assert out.baud == 9600
     assert out.mode == "hold"
+
+
+def test_trigger_output_dialog_selecting_listed_port_returns_device(
+    qtbot, stub_serial_ports
+):
+    # A listed port is shown with its description ("COM2 — USB Serial Device") but
+    # get_config resolves it back to the bare device name.
+    dialog = dialogs.TriggerOutputDialog(
+        triggers.TriggerConfig(enabled=True, transport="serial", port="COM2")
+    )
+    qtbot.addWidget(dialog)
+    assert dialog.get_config().port == "COM2"
 
 
 def test_trigger_output_dialog_reflects_edits(qtbot):
@@ -246,7 +272,7 @@ def test_trigger_output_dialog_disabled_greys_config(qtbot):
     assert dialog._config_widget.isEnabled() is True
 
 
-def test_trigger_output_dialog_test_button_reports_result(qtbot):
+def test_trigger_output_dialog_test_button_reports_result(qtbot, stub_serial_ports):
     calls = []
 
     def fake_test(config):

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from smacc import winvolume
+from smacc import gui, triggers, winvolume
 from smacc.gui import SmaccWindow
 
 
@@ -97,6 +97,30 @@ def test_apply_settings_lands_values(
     assert got["devices"]["bindings"]["bedroom_out"] == mock_devices["outputs"][0]
     # The bound devices all match advertised hardware, so none are flagged missing.
     assert design_session.missing_devices == []
+
+
+def test_edit_trigger_output_applies_and_persists_config(
+    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+):
+    new_cfg = triggers.TriggerConfig(enabled=True, transport="serial", port="COM4")
+
+    class _StubDialog:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def exec(self):
+            return 1  # accepted
+
+        def get_config(self):
+            return new_cfg
+
+    monkeypatch.setattr(gui, "TriggerOutputDialog", _StubDialog)
+    window = SmaccWindow(design_session)
+    qtbot.addWidget(window)
+    window.edit_trigger_output()
+    assert window.session.trigger_config == new_cfg
+    # The chosen config travels with the rest of the settings.
+    assert window.gather_settings()["trigger_output"]["port"] == "COM4"
 
 
 # ----- theme / lights and owned preferences ----------------------------------

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import replace
 from datetime import datetime
 
-from smacc import events
+from smacc import events, triggers
 from smacc.session import SmaccSession, make_session_dir
 
 
@@ -73,6 +73,26 @@ class _FakeOutlet:
         self.samples.append(sample)
 
 
+class _FakeTrigger:
+    """Stand-in for a hardware trigger transport that records sent codes.
+
+    ``fail`` makes :meth:`send` raise, to exercise the fail-safe in emit_event.
+    """
+
+    def __init__(self, fail=False):
+        self.sent = []
+        self.closed = False
+        self._fail = fail
+
+    def send(self, code):
+        if self._fail:
+            raise OSError("port gone")
+        self.sent.append(code)
+
+    def close(self):
+        self.closed = True
+
+
 def _stub_session():
     """A SmaccSession wired to fakes so emit_event runs without LSL/file/GUI.
 
@@ -86,6 +106,9 @@ def _stub_session():
     sess._event_counts = {}
     sess.recording_start_time = None
     sess.outlet = _FakeOutlet()
+    sess.trigger_out = None  # no hardware transport unless a test sets one
+    sess.design = False
+    sess.trigger_config = triggers.TriggerConfig()
     logger = logging.getLogger("smacc-test-emit")
     logger.handlers.clear()
     logger.setLevel(logging.DEBUG)
@@ -154,6 +177,100 @@ def test_emit_event_unknown_key_warns_without_crashing():
     sess.emit_event("Nonexistent")  # should warn, not raise
     assert sess.outlet.samples == []
     assert any("Unknown event" in m for m, _ in records)
+
+
+# ----- hardware trigger output (#28) ----------------------------------------
+
+
+def test_emit_event_sends_code_to_hardware_transport():
+    sess, _ = _stub_session()
+    sess.trigger_out = _FakeTrigger()
+    sess.emit_event("REMDetected")
+    assert sess.outlet.samples == [["41"]]  # LSL still fires
+    assert sess.trigger_out.sent == [41]  # and the same code goes to hardware
+
+
+def test_emit_event_not_triggered_skips_hardware():
+    sess, _ = _stub_session()
+    sess.trigger_out = _FakeTrigger()
+    sess.events["REMDetected"] = replace(sess.events["REMDetected"], trigger=False)
+    sess.emit_event("REMDetected")
+    assert sess.trigger_out.sent == []  # a non-triggered event drives neither path
+
+
+def test_emit_event_hardware_failure_disables_transport_and_keeps_lsl():
+    sess, records = _stub_session()
+    sess.trigger_out = _FakeTrigger(fail=True)
+    sess.emit_event("REMDetected")
+    assert sess.outlet.samples == [["41"]]  # LSL is unaffected by a hardware fault
+    assert sess.trigger_out is None  # transport dropped after the failure
+    assert any("Hardware trigger failed" in m for m, _ in records)
+    # A later event still logs and pushes LSL without raising.
+    sess.emit_event("LRLRDetected")
+    assert sess.outlet.samples == [["41"], ["45"]]
+
+
+def test_set_trigger_output_disabled_or_design_opens_nothing():
+    sess, _ = _stub_session()
+    assert sess.set_trigger_output(triggers.TriggerConfig(enabled=False)) is None
+    assert sess.trigger_out is None
+    sess.design = True
+    cfg = triggers.TriggerConfig(enabled=True, port="COM3")
+    assert sess.set_trigger_output(cfg) is None  # design mode never opens hardware
+    assert sess.trigger_out is None
+
+
+def test_set_trigger_output_opens_closes_previous_and_logs(monkeypatch):
+    sess, records = _stub_session()
+    old = _FakeTrigger()
+    sess.trigger_out = old
+    new = _FakeTrigger()
+    monkeypatch.setattr(triggers, "open_trigger", lambda cfg: new)
+    cfg = triggers.TriggerConfig(enabled=True, port="COM3")
+    assert sess.set_trigger_output(cfg) is None
+    assert old.closed is True  # the previous transport is released first
+    assert sess.trigger_out is new
+    assert any("Hardware trigger ready" in m for m, _ in records)
+
+
+def test_set_trigger_output_returns_error_message(monkeypatch):
+    sess, _ = _stub_session()
+
+    def boom(cfg):
+        raise triggers.TriggerError("no such port")
+
+    monkeypatch.setattr(triggers, "open_trigger", boom)
+    err = sess.set_trigger_output(triggers.TriggerConfig(enabled=True, port="X"))
+    assert err == "no such port"
+    assert sess.trigger_out is None
+
+
+def test_test_trigger_sends_init_code_and_restores(monkeypatch):
+    sess, _ = _stub_session()
+    opened = []
+
+    def fake_open(cfg):
+        out = _FakeTrigger()
+        opened.append(out)
+        return out
+
+    monkeypatch.setattr(triggers, "open_trigger", fake_open)
+    result = sess.test_trigger(triggers.TriggerConfig(enabled=True, port="COM3"))
+    assert result is None
+    assert opened[0].sent == [100]  # TriggerInitialization's code
+    assert opened[0].closed is True
+    # trigger_config is disabled (the stub default), so nothing is left open.
+    assert sess.trigger_out is None
+
+
+def test_test_trigger_reports_failure(monkeypatch):
+    sess, _ = _stub_session()
+
+    def boom(cfg):
+        raise triggers.TriggerError("driver missing")
+
+    monkeypatch.setattr(triggers, "open_trigger", boom)
+    assert sess.test_trigger(triggers.TriggerConfig(enabled=True)) == "driver missing"
 
 
 # ----- recording-start reference clock (#60) --------------------------------

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -55,7 +55,7 @@ def test_saved_file_is_tagged_yaml(tmp_path):
     assert text.splitlines()[0].startswith("#")  # self-identifying header comment
     payload = yaml.safe_load(text)  # comment is ignored, so it still parses
     assert payload["kind"] == settings.KIND
-    assert payload["schema_version"] == settings.SCHEMA_VERSION == 4
+    assert payload["schema_version"] == settings.SCHEMA_VERSION == 5
     assert payload["smacc_version"] == smacc.__version__
     assert payload["settings"] == {"cue_attack": 0.2}
 

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -1,0 +1,167 @@
+"""Tests for the hardware-trigger config and send logic (#28); no real hardware."""
+
+import pytest
+
+from smacc import triggers
+
+# ----- TriggerConfig serialization ------------------------------------------
+
+
+def test_default_config_is_disabled_lsl_only():
+    cfg = triggers.TriggerConfig()
+    assert cfg.enabled is False
+    assert cfg.transport == "serial"
+    assert cfg.mode == "pulsed"
+    assert "disabled" in cfg.summary()
+
+
+def test_config_round_trips_through_dict():
+    cfg = triggers.TriggerConfig(
+        enabled=True,
+        transport="parallel",
+        port="COM7",
+        baud=9600,
+        address="0x278",
+        mode="hold",
+        pulse_ms=5,
+    )
+    assert triggers.from_dict(cfg.to_dict()) == cfg
+
+
+def test_from_dict_missing_or_garbage_falls_back_to_defaults():
+    assert triggers.from_dict(None) == triggers.TriggerConfig()
+    assert triggers.from_dict("nope") == triggers.TriggerConfig()
+    # Unknown transport/mode and unparseable numbers fall back, never raise.
+    cfg = triggers.from_dict(
+        {"transport": "carrier-pigeon", "mode": "warble", "baud": "fast", "pulse_ms": 0}
+    )
+    assert cfg.transport == triggers.DEFAULT_TRANSPORT
+    assert cfg.mode == triggers.DEFAULT_MODE
+    assert cfg.baud == triggers.DEFAULT_BAUD
+    assert cfg.pulse_ms == 1  # clamped to a minimum of 1 ms
+
+
+def test_load_reads_trigger_output_block():
+    assert triggers.load({}) == triggers.TriggerConfig()  # absent → default
+    cfg = triggers.load({"trigger_output": {"enabled": True, "port": "COM3"}})
+    assert cfg.enabled is True
+    assert cfg.port == "COM3"
+
+
+# ----- parse_address --------------------------------------------------------
+
+
+def test_parse_address_accepts_hex_decimal_and_int():
+    assert triggers.parse_address("0x378") == 0x378
+    assert triggers.parse_address("888") == 888  # bare digits are decimal
+    assert triggers.parse_address(0x278) == 0x278
+
+
+@pytest.mark.parametrize("bad", ["nope", "0xZZ", True])
+def test_parse_address_rejects_garbage(bad):
+    with pytest.raises(triggers.TriggerError):
+        triggers.parse_address(bad)
+
+
+# ----- pulse vs. hold timing ------------------------------------------------
+
+
+def test_pulsed_writes_code_then_zero():
+    writes, waits = [], []
+    sender = triggers._PulseSender(writes.append, "pulsed", 0.01, sleep=waits.append)
+    sender.send(42)
+    assert writes == [42, 0]  # raise the code, then drop the line
+    assert waits == [0.01]  # waited the pulse width between the two writes
+
+
+def test_hold_writes_code_only():
+    writes, waits = [], []
+    sender = triggers._PulseSender(writes.append, "hold", 0.01, sleep=waits.append)
+    sender.send(42)
+    assert writes == [42]  # set and leave it; no drop, no wait
+    assert waits == []
+
+
+# ----- open_trigger routing -------------------------------------------------
+
+
+def test_open_trigger_disabled_returns_none():
+    assert triggers.open_trigger(triggers.TriggerConfig(enabled=False)) is None
+
+
+def test_open_trigger_unknown_transport_raises():
+    cfg = triggers.TriggerConfig(enabled=True)
+    cfg.transport = "telepathy"  # bypasses from_dict's guard, as a hand-edit might
+    with pytest.raises(triggers.TriggerError):
+        triggers.open_trigger(cfg)
+
+
+def test_serial_without_port_raises_clear_error():
+    cfg = triggers.TriggerConfig(enabled=True, transport="serial", port="")
+    with pytest.raises(triggers.TriggerError, match="No serial port"):
+        triggers.open_trigger(cfg)
+
+
+# ----- transport write paths (against fakes, no hardware) -------------------
+
+
+def test_serial_trigger_pulses_a_byte_then_zero(monkeypatch):
+    import serial
+
+    writes = []
+
+    class _FakePort:
+        def __init__(self, port, baud, timeout=0, write_timeout=0.5):
+            self.opened = (port, baud)
+
+        def write(self, data):
+            writes.append(data)
+
+        def flush(self):
+            pass
+
+        def close(self):
+            writes.append("closed")
+
+    monkeypatch.setattr(serial, "Serial", _FakePort)
+    cfg = triggers.TriggerConfig(
+        enabled=True, transport="serial", port="COM3", mode="pulsed", pulse_ms=1
+    )
+    out = triggers.open_trigger(cfg)
+    out.send(42)
+    out.close()
+    assert writes == [bytes([42]), bytes([0]), "closed"]  # raise, drop, release
+
+
+def test_parallel_trigger_holds_a_byte_via_fake_driver(monkeypatch):
+    calls = []
+
+    class _FakeDLL:
+        def Out32(self, address, value):
+            calls.append((address, value))
+
+    monkeypatch.setattr(triggers, "_load_inpout", lambda: _FakeDLL())
+    cfg = triggers.TriggerConfig(
+        enabled=True, transport="parallel", address="0x378", mode="hold"
+    )
+    out = triggers.open_trigger(cfg)  # __init__ writes the address low first
+    out.send(42)  # hold: write the code, no drop
+    out.close()  # returns the line to low
+    assert calls == [(0x378, 0), (0x378, 42), (0x378, 0)]
+
+
+# ----- misc -----------------------------------------------------------------
+
+
+def test_summary_describes_each_transport():
+    serial = triggers.TriggerConfig(enabled=True, transport="serial", port="COM3")
+    assert "COM3" in serial.summary() and "serial" in serial.summary()
+    parallel = triggers.TriggerConfig(
+        enabled=True, transport="parallel", address="0x378"
+    )
+    assert "0x378" in parallel.summary()
+
+
+def test_list_serial_ports_returns_a_list():
+    # No hardware is required; on a port-less CI box this is just empty.
+    assert isinstance(triggers.list_serial_ports(), list)

--- a/uv.lock
+++ b/uv.lock
@@ -1030,6 +1030,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyserial"
+version = "3.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1e/7d/ae3f0a63f41e4d2f6cb66a5b57197850f919f59e558159a4dd3a818f5082/pyserial-3.5.tar.gz", hash = "sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb", size = 159125, upload-time = "2020-11-23T03:59:15.045Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl", hash = "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0", size = 90585, upload-time = "2020-11-23T03:59:13.41Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1299,6 +1308,7 @@ dependencies = [
     { name = "pycaw", marker = "sys_platform == 'win32'" },
     { name = "pylsl" },
     { name = "pyqt6" },
+    { name = "pyserial" },
     { name = "pyyaml" },
     { name = "scipy" },
     { name = "sounddevice" },
@@ -1333,6 +1343,7 @@ requires-dist = [
     { name = "pyinstaller", marker = "extra == 'dev'" },
     { name = "pylsl" },
     { name = "pyqt6" },
+    { name = "pyserial" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-qt", marker = "extra == 'dev'" },


### PR DESCRIPTION
Adds opt-in hardware TTL trigger output beside the always-on LSL marker stream, so amplifiers that read a physical pulse (not a network marker) see every port code again (#28).

## What's in it

- New `smacc.triggers` module — a `TriggerConfig` (transport / port / baud / address / mode / pulse width) plus **serial** (`pyserial`) and **parallel** (`inpoutx64` via `ctypes`) transports, each supporting **pulsed** and **set-and-hold** modes. Qt-free and unit-tested against fakes.
- Fires from the single `SmaccSession.emit_event` path, right beside the LSL push. A hardware fault drops to LSL-only rather than crashing a run.
- **File ▸ Trigger output…** dialog to configure it, with a **Test** button. Config persists in the `.smacc` study file (schema v5; pre-v5 studies default to LSL-only — no behavior change).
- One transport at a time; LSL stays on. No runtime driver download — the parallel path documents a manual InpOut32 install.
- New **Triggers & port codes** docs page (what triggers/port codes are, how to configure each transport, find an LPT address, and install the driver).

Defaults (115200 baud, `0x378`, 10 ms pulse) are sane starting points and fully editable — nothing is hard-coded to one rig.

## Verification

`ruff`, `mypy`, and `pytest` (257 passing, incl. new trigger/dialog/session tests) all green, plus `mkdocs build --strict`. Real TTL output still needs validation on lab hardware — tracked in #84.

Closes #28.