### PR TITLE
feat: add cue designer and cue-monitoring meters

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -51,6 +51,10 @@ Two optional routes cover the things you reach for mid-study:
 * **Intercom Listen.** The intercom is two-way: **Talk** sends your voice to the
   participant (and is marked in the EEG record), while **Listen** brings the
   participant's mic to your control-room output.
+* **Room monitor.** A microphone meter in the Audio cue window that confirms a cue is
+  actually audible in the bedroom (see
+  [below](#is-the-cue-reaching-the-bedroom)). It defaults to the **Bedroom mic**, or
+  bind a dedicated, more sensitive **Monitor mic** and route *Room monitor* to it.
 
 ## One audio engine
 
@@ -72,6 +76,36 @@ single source.
 **Hot-plug:** plug a device in after SMACC is already open and it's picked up
 automatically — no restart needed. You can also force a rescan from
 **File ▸ Refresh devices** (or press `F5`).
+
+## Is the cue reaching the bedroom?
+
+A cue you can hear in the control room isn't proof the *participant* heard it — the
+bedroom speaker could be muted, unplugged, or turned down at the hardware. The
+**Audio cue** window's **Monitoring** section shows two meters so you can tell:
+
+* **Sending** — the level SMACC is emitting to the cue output, the moment it plays.
+  It's exact, but it only confirms SMACC is *playing*; it's blind to everything
+  downstream (Windows volume, the speaker's power switch, the cable). Treat it as a
+  diagnostic: if *Sending* is dark, the problem is on SMACC's side (wrong cue, the
+  per-cue volume or the safety cap at zero); if it's lit but the room is silent, the
+  problem is the speaker.
+* **Bedroom** — the level a microphone actually picks up in the room. This is the
+  objective check: it only moves when sound really happens in the bedroom. Tick the
+  box beside it to start monitoring. Because a faint cue can sit close to a cheap
+  mic's noise floor, the meter also shows the **rise above the room's resting level**
+  (the `+N` next to the reading), so even a small bump stands out.
+
+!!! tip "A dedicated monitor mic"
+    The *Bedroom* meter listens on the **Room monitor** route, which defaults to your
+    bedroom mic. For the most reliable check — especially for the very quiet cues a
+    study often starts at — bind a separate, sensitive **Monitor mic** in the Devices
+    window and route *Room monitor* to it. That keeps verification independent of the
+    (often cheaper, voice-activated) dream-report mic.
+
+!!! warning "A quiet mic isn't proof of silence"
+    A cheap or voice-activated mic may not register a very faint cue even when it is
+    playing, so a dark *Bedroom* meter is a prompt to check — not proof the cue
+    failed. Read it together with *Sending*.
 
 ## Volume you can see
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -23,6 +23,9 @@ into a session. From here you:
 - **Create settings** — build a new `.smacc` in the **settings editor**: configure
   the tools (cues, noise, visual, event codes, surveys), choose a data directory,
   and save it anywhere. Use **Edit…** to reopen an existing one.
+- **Design cues** — open the standalone **Cue designer** to build a simple tone cue
+  and export it as a WAV into a study's `cues/` folder, ready to use from the Audio
+  cue board (see [Designing a cue](#designing-a-cue)).
 - **Analyze** — open a past session (a `.log`, a session folder, or a
   zipped session) to see a summary (events, duration, subject/session, dream
   reports), export its events to a BIDS `events.tsv`, or recover its settings to a
@@ -42,6 +45,25 @@ Place sound files where your settings expect them — by default the data direct
 `demo-*` cues there so there is always something to test with. You start with one
 cue — prefilled with a random demo — and use **+ Add cue** and each row's **✕** to
 add or remove cues to match a protocol (one minimum, up to 20).
+
+### Designing a cue
+
+No sound file ready? Open **Design cues** from the launcher to build a simple cue
+inside SMACC — no external audio editor needed. Lay out a sequence of **tone** and
+**silence** segments (each tone has a frequency, duration, and level, with an
+optional bell-like **decay**), add an optional whole-cue fade in/out, **Preview** it
+on your default output, then **Export WAV…** into your study's `cues/` folder. The
+exported file then appears in the Audio cue board like any other cue. The designer is
+a standalone tool: it plays on the default device and ignores the session's device
+routing and volume safety cap.
+
+### Is the cue reaching the bedroom?
+
+The Audio cue window has a **Monitoring** section — a *Sending* meter (what SMACC is
+emitting) beside a *Bedroom* meter (what a mic actually picks up in the room) — so you
+can confirm a cue is audible to the participant, not just leaving SMACC. See
+[Audio &amp; routing](audio.md#is-the-cue-reaching-the-bedroom) for how to read them
+and how to set up a dedicated monitor mic.
 
 ## Dream reports
 

--- a/src/smacc/audio.py
+++ b/src/smacc/audio.py
@@ -36,6 +36,46 @@ def dbfs_to_meter(db: float, floor_db: float = METER_FLOOR_DBFS) -> int:
     return int(min(100.0, max(0.0, percent)))
 
 
+class AmbientBaseline:
+    """A slowly-adapting noise-floor estimate, so a *rise* above the room's resting
+    level is readable even when the absolute level is low (#37).
+
+    Fed the input level in dBFS each refresh, the floor drops instantly to a quieter
+    level but creeps back up only slowly. The headline :meth:`update` return — the
+    rise (level minus floor) — then jumps when a cue lifts the mic above the room
+    noise, which is the sensitivity a cheap mic on a faint cue otherwise lacks. The
+    floor adapts to a *sustained* sound over a few seconds, so this favors short
+    cues; a long looping cue still reads on the absolute level meter beside it.
+    """
+
+    def __init__(
+        self, creep_db_per_update: float = 0.15, floor_db: float = FLOOR_DBFS
+    ) -> None:
+        self._initial = floor_db
+        self._creep = creep_db_per_update
+        self._floor = floor_db
+        self._seen = False
+
+    @property
+    def floor(self) -> float:
+        """The current noise-floor estimate, in dBFS."""
+        return self._floor
+
+    def update(self, level_db: float) -> float:
+        """Fold in a new level (dBFS); return the rise above the floor (``>= 0``)."""
+        if not self._seen or level_db < self._floor:
+            self._floor = level_db
+            self._seen = True
+        else:
+            self._floor = min(level_db, self._floor + self._creep)
+        return max(0.0, level_db - self._floor)
+
+    def reset(self) -> None:
+        """Forget the learned floor (e.g. when the meter's device changes)."""
+        self._floor = self._initial
+        self._seen = False
+
+
 class CueMixer:
     """One-at-a-time cue playback engine for the audio callback (no Qt, no I/O).
 

--- a/src/smacc/cuedesigner.py
+++ b/src/smacc/cuedesigner.py
@@ -1,0 +1,414 @@
+"""The Cue designer: build a simple tone cue and export it as a WAV (#77).
+
+Reached from the launcher's **Design cues** button — a standalone tool (like
+Analyze), not a session panel, since authoring a cue is a design-time task with no
+markers, devices, or run folder. You lay out a short sequence of **tone** and
+**silence** segments (the simple beeps/chimes a cueing study actually uses, 1-30 s),
+preview it on the default output, and export a PCM-16 WAV. Exported into a study's
+``cues`` folder, the file is immediately pickable from the Audio cue board.
+
+The DSP lives in :mod:`smacc.synth`; this window is just the editor around it.
+Preview reuses :class:`smacc.audio.CueMixer` so playback matches the cue board's
+fade/finish behavior, but with no volume cap or routing — the designer runs
+independently of any session (see #77). WAV-only: a design isn't persisted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+
+import numpy as np
+import sounddevice as sd
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from . import audio, synth
+from .panels.base import make_section_title
+from .paths import LOGO_PATH
+from .toolwindow import ToolWindow
+
+# One segment is always required; the cap keeps the grid and a previewed buffer
+# manageable (a 30 s cue rarely needs more than a handful of segments).
+MIN_SEGMENTS = 1
+MAX_SEGMENTS = 64
+# WAV files are written at a fixed, device-independent rate; the cue board
+# resamples to whatever output device it plays on. Preview uses the device rate.
+EXPORT_RATE = synth.DEFAULT_RATE
+
+_TONE = "Tone"
+_SILENCE = "Silence"
+
+
+@dataclass
+class SegmentRow:
+    """One row of the segment table: its type plus the widgets controlling it.
+
+    Handlers bind to the row *object*, never an index, so adding/removing rows can't
+    misroute another row's controls (the same discipline the cue board uses).
+    """
+
+    typeCombo: QtWidgets.QComboBox
+    freqSpin: QtWidgets.QDoubleSpinBox
+    durationSpin: QtWidgets.QDoubleSpinBox
+    levelSpin: QtWidgets.QDoubleSpinBox
+    decayCheck: QtWidgets.QCheckBox
+    removeButton: QtWidgets.QPushButton
+
+    def is_tone(self) -> bool:
+        return self.typeCombo.currentText() == _TONE
+
+    def to_segment(self) -> synth.Segment:
+        """Build the pure-DSP segment this row describes."""
+        duration = self.durationSpin.value()
+        if self.is_tone():
+            return synth.ToneSegment(
+                freq=self.freqSpin.value(),
+                duration=duration,
+                level=self.levelSpin.value(),
+                decay=self.decayCheck.isChecked(),
+            )
+        return synth.SilenceSegment(duration=duration)
+
+
+class CueDesignerWindow(ToolWindow):
+    """Lay out tone/silence segments, preview them, and export a WAV cue."""
+
+    def __init__(self, cues_dir: str | Path | None = None) -> None:
+        super().__init__()
+        # Default directory for the export dialog (a study's cues folder when known).
+        self._cues_dir = Path(cues_dir) if cues_dir is not None else None
+        # The active preview (mixer + its output stream), or None when stopped. A
+        # GUI-thread timer polls the mixer so a finished preview resets the UI.
+        self._preview: tuple[audio.CueMixer, sd.OutputStream] | None = None
+        self._timer = QtCore.QTimer(self)
+        self._timer.setInterval(30)  # ~33 Hz: finish detection, not playback
+        self._timer.timeout.connect(self._poll_preview)
+        self.rows: list[SegmentRow] = []
+        self.setWindowTitle("SMACC — Cue designer")
+        if LOGO_PATH.is_file():
+            self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
+        self._build()
+        self._add_row()  # start with the one required segment (a tone)
+        self.show()  # the launcher hides itself and relies on the tool showing itself
+
+    # ----- construction ------------------------------------------------------
+
+    def _build(self) -> None:
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+        layout.setContentsMargins(16, 12, 16, 12)
+        layout.setSpacing(10)
+        layout.addWidget(make_section_title("Cue designer"))
+
+        intro = QtWidgets.QLabel(
+            "Build a short cue from tone and silence segments, preview it, then "
+            "export a WAV into your study's cues folder.",
+            self,
+        )
+        intro.setWordWrap(True)
+        layout.addWidget(intro)
+
+        # Name (seeds the export filename) + master shaping shared by the whole cue.
+        self.nameEdit = QtWidgets.QLineEdit("cue", self)
+        self.nameEdit.setStatusTip("Name for the exported cue file.")
+
+        self.fadeInSpin = self._seconds_spin("Whole-cue fade-in (0 = none).")
+        self.fadeOutSpin = self._seconds_spin("Whole-cue fade-out (0 = none).")
+        self.normalizeCheck = QtWidgets.QCheckBox("Normalize", self)
+        self.normalizeCheck.setStatusTip(
+            "Scale the cue up to a consistent peak level before fading."
+        )
+
+        header = QtWidgets.QFormLayout()
+        header.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        header.addRow("Name:", self.nameEdit)
+        header.addRow("Fade in:", self.fadeInSpin)
+        header.addRow("Fade out:", self.fadeOutSpin)
+        header.addRow("", self.normalizeCheck)
+        layout.addLayout(header)
+
+        # Segment table: a persistent header row, then one rebuildable row per
+        # segment, then the add row. Header labels and the add button are built once
+        # and reused, so a rebuild only reparents widgets (never deletes them).
+        self._grid = QtWidgets.QGridLayout()
+        self._header_labels = [
+            self._header_label(text)
+            for text in ("Type", "Freq", "Duration", "Level", "Decay", "")
+        ]
+        self._addButton = QtWidgets.QPushButton("+ Add segment", self)
+        self._addButton.setStatusTip(f"Add another segment (up to {MAX_SEGMENTS}).")
+        self._addButton.clicked.connect(self.add_segment)
+        layout.addLayout(self._grid)
+
+        self.durationLabel = QtWidgets.QLabel(self)
+        self.durationLabel.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        layout.addWidget(self.durationLabel)
+
+        # Transport: preview on the default output, stop, and the now-playing line.
+        self.previewButton = QtWidgets.QPushButton("Preview", self)
+        self.previewButton.setStatusTip("Play the cue on the default output device.")
+        self.previewButton.clicked.connect(self.preview)
+        self.stopButton = QtWidgets.QPushButton("Stop", self)
+        self.stopButton.setStatusTip("Stop the preview.")
+        self.stopButton.clicked.connect(self.stop_preview)
+        transport = QtWidgets.QHBoxLayout()
+        transport.addWidget(self.previewButton)
+        transport.addWidget(self.stopButton)
+        layout.addLayout(transport)
+
+        self.statusLabel = QtWidgets.QLabel("■ stopped", self)
+        self.statusLabel.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(self.statusLabel)
+
+        self.exportButton = QtWidgets.QPushButton("Export WAV…", self)
+        self.exportButton.setStatusTip("Render the cue and save it as a WAV file.")
+        self.exportButton.clicked.connect(self.export)
+        layout.addWidget(self.exportButton)
+
+        layout.addStretch(1)
+        self.statusBar()
+        self.setCentralWidget(central)
+        self.resize(560, 520)
+
+    def _seconds_spin(self, tip: str) -> QtWidgets.QDoubleSpinBox:
+        spin = QtWidgets.QDoubleSpinBox(self)
+        spin.setRange(0, 10)
+        spin.setSingleStep(0.1)
+        spin.setSuffix(" s")
+        spin.setStatusTip(tip)
+        return spin
+
+    def _header_label(self, text: str) -> QtWidgets.QLabel:
+        label = QtWidgets.QLabel(text, self)
+        label.setStyleSheet("font-weight: bold;")
+        return label
+
+    # ----- segment rows ------------------------------------------------------
+
+    def _make_row(self) -> SegmentRow:
+        """Build one fully-wired segment row and append it to ``self.rows``."""
+        typeCombo = QtWidgets.QComboBox(self)
+        typeCombo.addItems([_TONE, _SILENCE])
+        typeCombo.setStatusTip("Tone (a sine beep) or a gap of silence.")
+
+        freqSpin = QtWidgets.QDoubleSpinBox(self)
+        freqSpin.setRange(20, 20000)
+        freqSpin.setDecimals(0)
+        freqSpin.setSingleStep(10)
+        freqSpin.setValue(440)
+        freqSpin.setSuffix(" Hz")
+        freqSpin.setStatusTip("Tone frequency in hertz.")
+
+        durationSpin = QtWidgets.QDoubleSpinBox(self)
+        durationSpin.setRange(0.01, 60)
+        durationSpin.setDecimals(2)
+        durationSpin.setSingleStep(0.1)
+        durationSpin.setValue(1.0)
+        durationSpin.setSuffix(" s")
+        durationSpin.setStatusTip("Segment length in seconds.")
+
+        levelSpin = QtWidgets.QDoubleSpinBox(self)
+        levelSpin.setRange(0, 1)
+        levelSpin.setDecimals(2)
+        levelSpin.setSingleStep(0.05)
+        levelSpin.setValue(0.5)
+        levelSpin.setStatusTip("Tone level (0-1, software gain at or below unity).")
+
+        decayCheck = QtWidgets.QCheckBox(self)
+        decayCheck.setStatusTip("Apply a bell-like exponential decay across the tone.")
+        decayCheck.setToolTip("Bell-like decay")
+
+        removeButton = QtWidgets.QPushButton("✕", self)
+        removeButton.setMaximumWidth(28)
+        removeButton.setStatusTip("Remove this segment.")
+        removeButton.setToolTip("Remove this segment")
+
+        row = SegmentRow(
+            typeCombo, freqSpin, durationSpin, levelSpin, decayCheck, removeButton
+        )
+        self.rows.append(row)  # append before wiring so handlers can resolve it
+        typeCombo.currentTextChanged.connect(partial(self._on_type_changed, row))
+        durationSpin.valueChanged.connect(self._refresh_duration_label)
+        removeButton.clicked.connect(partial(self.remove_segment, row))
+        self._sync_row_enabled(row)
+        return row
+
+    def _on_type_changed(self, row: SegmentRow, _text: str) -> None:
+        self._sync_row_enabled(row)
+
+    def _sync_row_enabled(self, row: SegmentRow) -> None:
+        """Enable the tone-only controls only when the row is a tone."""
+        tone = row.is_tone()
+        row.freqSpin.setEnabled(tone)
+        row.levelSpin.setEnabled(tone)
+        row.decayCheck.setEnabled(tone)
+
+    def _add_row(self) -> None:
+        self._make_row()
+        self._rebuild_grid()
+        self._refresh_duration_label()
+
+    def add_segment(self) -> None:
+        """Append a new segment row, up to the cap."""
+        if len(self.rows) >= MAX_SEGMENTS:
+            return
+        self._add_row()
+        self.adjustSize()
+
+    def remove_segment(self, row: SegmentRow) -> None:
+        """Remove a segment row (never the last one)."""
+        if len(self.rows) <= MIN_SEGMENTS or row not in self.rows:
+            return
+        self.rows.remove(row)
+        for widget in (
+            row.typeCombo,
+            row.freqSpin,
+            row.durationSpin,
+            row.levelSpin,
+            row.decayCheck,
+            row.removeButton,
+        ):
+            widget.hide()
+            widget.deleteLater()
+        self._rebuild_grid()
+        self._refresh_duration_label()
+        self.adjustSize()
+
+    def _rebuild_grid(self) -> None:
+        """Re-lay the segment table: header row, one row per segment, then add row."""
+        while self._grid.count():
+            self._grid.takeAt(0)  # drop the layout item only; widgets are reused
+        for col, label in enumerate(self._header_labels):
+            self._grid.addWidget(label, 0, col)
+        for r, row in enumerate(self.rows, start=1):
+            self._grid.addWidget(row.typeCombo, r, 0)
+            self._grid.addWidget(row.freqSpin, r, 1)
+            self._grid.addWidget(row.durationSpin, r, 2)
+            self._grid.addWidget(row.levelSpin, r, 3)
+            self._grid.addWidget(row.decayCheck, r, 4)
+            self._grid.addWidget(row.removeButton, r, 5)
+            # The lone required row can't be removed: keep the button (so the column
+            # doesn't jump) but disabled.
+            row.removeButton.setEnabled(len(self.rows) > MIN_SEGMENTS)
+        self._grid.addWidget(self._addButton, len(self.rows) + 1, 0, 1, 2)
+        self._addButton.setEnabled(len(self.rows) < MAX_SEGMENTS)
+
+    def _refresh_duration_label(self) -> None:
+        total = synth.total_duration([row.to_segment() for row in self.rows])
+        self.durationLabel.setText(f"Total length: {total:.2f} s")
+
+    # ----- render / preview / export -----------------------------------------
+
+    def _segments(self) -> list[synth.Segment]:
+        return [row.to_segment() for row in self.rows]
+
+    def _render(self, rate: int) -> np.ndarray:
+        return synth.render_sequence(
+            self._segments(),
+            rate=rate,
+            fade_in=self.fadeInSpin.value(),
+            fade_out=self.fadeOutSpin.value(),
+            normalize=self.normalizeCheck.isChecked(),
+        )
+
+    def _device_rate(self) -> int:
+        """Best output sample rate for the default device (fallback to the export rate)."""
+        try:
+            return int(sd.query_devices(None, "output")["default_samplerate"])
+        except Exception:
+            return EXPORT_RATE
+
+    def preview(self) -> None:
+        """Render the cue and play it once on the default output device."""
+        self.stop_preview()
+        rate = self._device_rate()
+        buffer = self._render(rate)
+        if not np.any(buffer):  # empty, all-silence, or zero-level
+            self._warn("Nothing to preview.", "Add a tone segment first.")
+            return
+        mixer = audio.CueMixer()
+        mixer.start(buffer, loop=False)
+        try:
+            stream = sd.OutputStream(
+                channels=1,
+                samplerate=rate,
+                callback=partial(self._render_callback, mixer),
+            )
+            stream.start()
+        except Exception as err:  # PortAudio / no device
+            self._warn("Could not start preview.", str(err))
+            return
+        self._preview = (mixer, stream)
+        self._timer.start()
+        self._set_playing(True)
+
+    def _render_callback(self, mixer, outdata, frames, time, status) -> None:
+        """sounddevice callback (audio thread): render one preview block (no cap)."""
+        outdata[:, 0] = mixer.render(frames)
+
+    def _poll_preview(self) -> None:
+        """GUI-thread timer: reset once the previewed cue has finished."""
+        if self._preview is not None and self._preview[0].ended:
+            self.stop_preview()
+
+    def stop_preview(self) -> None:
+        """Stop and tear down the preview stream, if any."""
+        self._timer.stop()
+        if self._preview is not None:
+            _, stream = self._preview
+            stream.abort()
+            stream.close()
+            self._preview = None
+        self._set_playing(False)
+
+    def _set_playing(self, playing: bool) -> None:
+        if playing:
+            self.statusLabel.setText("▶ previewing")
+            self.statusLabel.setStyleSheet("color: red; font-weight: bold;")
+        else:
+            self.statusLabel.setText("■ stopped")
+            self.statusLabel.setStyleSheet("")
+
+    def export(self) -> None:
+        """Render at the fixed export rate and save the cue as a WAV file."""
+        buffer = self._render(EXPORT_RATE)
+        if not np.any(buffer):  # empty, all-silence, or zero-level
+            self._warn("Nothing to export.", "Add a tone segment first.")
+            return
+        name = self.nameEdit.text().strip() or "cue"
+        start_dir = self._cues_dir if self._cues_dir is not None else Path.home()
+        default = str(start_dir / f"{name}.wav")
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Export cue (WAV)", default, "WAV audio (*.wav)"
+        )
+        if not path:
+            return
+        try:
+            Path(path).parent.mkdir(parents=True, exist_ok=True)
+            synth.export_wav(path, buffer, EXPORT_RATE)
+        except Exception as err:  # write / encode failure
+            self._warn("Could not export the cue.", str(err))
+            return
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.showMessage(f"Saved {Path(path).name}", 5000)
+        QtWidgets.QMessageBox.information(self, "Cue designer", f"Saved cue to\n{path}")
+
+    # ----- helpers / lifecycle ----------------------------------------------
+
+    def _warn(self, short: str, detail: str | None = None) -> None:
+        box = QtWidgets.QMessageBox(self)
+        box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+        box.setWindowTitle("Cue designer")
+        box.setText(short)
+        if detail is not None:
+            box.setInformativeText(detail)
+        box.exec()
+
+    def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+        """Stop any preview and hand control back to the launcher."""
+        self.stop_preview()
+        if event is not None:
+            event.accept()
+        self.closed.emit()

--- a/src/smacc/devices.py
+++ b/src/smacc/devices.py
@@ -38,11 +38,14 @@ class Role:
 
 
 # The fixed role set. Two outputs and one mic cover the issue's rig; BlinkStick is
-# its own (visual) role. Kept small on purpose — extra roles can be added later.
+# its own (visual) role. The monitor mic (#37) is a second, optional input so a lab
+# can place a dedicated, sensitive mic for verifying cues without disturbing the
+# (often cheaper) dream-report mic. Kept small on purpose — more can be added later.
 ROLES: tuple[Role, ...] = (
     Role("bedroom_out", "Bedroom output", OUTPUT),
     Role("control_out", "Control-room output", OUTPUT),
     Role("bedroom_mic", "Bedroom mic", INPUT),
+    Role("monitor_mic", "Monitor mic", INPUT),
     Role("blinkstick", "BlinkStick", VISUAL),
 )
 
@@ -67,6 +70,9 @@ TARGETS: tuple[Target, ...] = (
     Target("intercom_talk", "Intercom → participant", OUTPUT, "bedroom_out"),
     Target("intercom_listen", "Intercom ← participant", OUTPUT, "", optional=True),
     Target("report_in", "Dream-report mic", INPUT, "bedroom_mic"),
+    # The room monitor (#37) defaults to the bedroom mic so the cue meter works out
+    # of the box; route it to the dedicated monitor mic for a more sensitive check.
+    Target("monitor_in", "Room monitor", INPUT, "bedroom_mic", optional=True),
     Target("visual_out", "Visual (BlinkStick)", VISUAL, "blinkstick"),
 )
 

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -21,6 +21,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 from . import preferences, settings
 from .analyze import AnalyzeWindow
 from .config import VERSION
+from .cuedesigner import CueDesignerWindow
 from .dialogs import PreferencesDialog
 from .gui import SmaccWindow
 from .paths import DEFAULT_DATA_DIR, DEFAULT_SETTINGS_PATH, LOGO_PATH, preferences_path
@@ -98,8 +99,15 @@ class LauncherWindow(QtWidgets.QMainWindow):
         layout.addLayout(self._build_settings_row())
         layout.addLayout(self._build_action_row())
 
-        # Analyzing a past session is a separate, post-hoc task.
+        # Standalone tools that don't act on the selected settings: design a cue
+        # WAV, or analyze a past session. Each opens from here and returns on close.
         layout.addSpacing(8)
+        designButton = QtWidgets.QPushButton("Design cues", self)
+        designButton.setMinimumHeight(40)
+        designButton.setStatusTip("Create a tone cue and export it as a WAV file.")
+        designButton.clicked.connect(self.design_cues)
+        layout.addWidget(designButton)
+
         analyzeButton = QtWidgets.QPushButton("Analyze", self)
         analyzeButton.setMinimumHeight(40)
         analyzeButton.setStatusTip(
@@ -288,6 +296,10 @@ class LauncherWindow(QtWidgets.QMainWindow):
         """Open the editor on the current settings file."""
         session = SmaccSession(self._data_dir(), design=True)
         self._open_tool(SmaccWindow(session, settings_path=self._settings_path))
+
+    def design_cues(self) -> None:
+        """Open the standalone Cue designer (exports WAVs to a study's cues folder)."""
+        self._open_tool(CueDesignerWindow(self._data_dir() / "cues"))
 
     def analyze_session(self) -> None:
         """Open the analyze window over the current settings' data directory."""

--- a/src/smacc/panels/audio.py
+++ b/src/smacc/panels/audio.py
@@ -24,6 +24,7 @@ from .. import audio, utils
 from ..session import SmaccSession
 from ..utils import pick_random_demo_cue
 from .base import ModalityWindow, describe_target, make_section_title
+from .meter import InputLevelMeter, LevelMeter
 
 # One cue is always required; the upper bound is generous (a session typically
 # uses 2-5) but capped so the grid and playback stay manageable (#65).
@@ -85,6 +86,14 @@ class AudioCueWindow(ModalityWindow):
         self._cue_timer = QtCore.QTimer(self)
         self._cue_timer.setInterval(30)  # ~33 Hz: finish detection, not playback
         self._cue_timer.timeout.connect(self._poll_cue)
+        # Monitoring meters (#37), built before _build(): the latter calls
+        # refresh_device_indicator(), which touches the room-monitor widgets. The
+        # output "sending" meter is fed the level of each block the cue callback emits.
+        self._out_level_db = audio.FLOOR_DBFS
+        self.outMeter = LevelMeter(self)
+        self.roomMeter = InputLevelMeter(self)
+        self.monitorCheckBox = QtWidgets.QCheckBox(self)
+        self.monitorDeviceLabel = QtWidgets.QLabel(self)
         # Populated after the central widget exists so _rebuild_grid has its
         # header labels and add button to work with.
         self.slots: list[CueSlot] = []
@@ -203,6 +212,8 @@ class AudioCueWindow(ModalityWindow):
         layout.addLayout(header)
         layout.addWidget(self.nowPlayingLabel)
         layout.addLayout(self._grid)
+        layout.addSpacing(8)
+        layout.addLayout(self._build_monitoring())
         layout.addStretch(1)
         central = QtWidgets.QWidget()
         central.setLayout(layout)
@@ -296,10 +307,12 @@ class AudioCueWindow(ModalityWindow):
         if self.session.devices.role_for("cue_monitor"):
             text += f"   •   monitor: {describe_target(self.session, 'cue_monitor')}"
         self.deviceLabel.setText(text)
+        self.monitorDeviceLabel.setText(describe_target(self.session, "monitor_in"))
+        self._restart_room_monitor_if_active()
 
     def is_streaming(self) -> bool:
-        """True while a cue is playing (any open output stream)."""
-        return bool(self._outputs)
+        """True while a cue is playing or the room monitor mic is open."""
+        return bool(self._outputs) or self.roomMeter.is_active()
 
     def _device_samplerate(self, device: str | None) -> int:
         """Best output sample rate for ``device`` (WASAPI opens only at its own)."""
@@ -453,9 +466,12 @@ class AudioCueWindow(ModalityWindow):
             self.session.logger.warning(f"Audio output status: {status}")
         # The master safety cap is the single final gain stage (read live).
         outdata[:, 0] = mixer.render(frames) * self.session.volume_cap
+        # Stash the level actually sent (post-cap) for the "sending" meter (#37).
+        self._out_level_db = audio.rms_dbfs(outdata[:, 0])
 
     def _poll_cue(self) -> None:
-        """GUI-thread timer: finalize once the cue (its primary output) has ended."""
+        """GUI-thread timer: drive the output meter, then finalize once the cue ends."""
+        self.outMeter.show_level(self._out_level_db)
         if (
             self._active_slot is not None
             and self._outputs
@@ -473,6 +489,8 @@ class AudioCueWindow(ModalityWindow):
         self._outputs = []
         self._active_slot = None
         self._set_now_playing_stopped()
+        self.outMeter.clear_level()
+        self._out_level_db = audio.FLOOR_DBFS
         if mark and slot is not None:
             self.session.emit_event("CueStopped", detail=slot.nameEdit.text())
 
@@ -487,6 +505,69 @@ class AudioCueWindow(ModalityWindow):
     def _set_now_playing_stopped(self) -> None:
         self.nowPlayingLabel.setText("■ stopped")  # ■
         self.nowPlayingLabel.setStyleSheet("")
+
+    # ----- monitoring (#37) --------------------------------------------------
+
+    def _build_monitoring(self) -> QtWidgets.QLayout:
+        """Build the monitoring block: an output 'sending' meter + a bedroom-mic meter.
+
+        'Sending' shows the level SMACC emits — a deterministic diagnostic, but blind
+        to a muted or unplugged speaker. 'Bedroom' is the objective acoustic check: a
+        mic in the room, the only thing that confirms the cue was actually audible.
+        Its mic is the Room-monitor route (a dedicated mic, or the bedroom mic).
+        """
+        heading = QtWidgets.QLabel("Monitoring", self)
+        heading.setStyleSheet("font-weight: bold;")
+
+        self.outMeter.setStatusTip(
+            "Level SMACC is sending to the cue output — confirms emission, not that "
+            "the bedroom speaker actually sounded."
+        )
+        self.monitorCheckBox.setStatusTip(
+            "Open the bedroom monitor mic to confirm the cue is audible in the room "
+            "(set its device in the Devices window)."
+        )
+        self.monitorCheckBox.setToolTip("Listen on the bedroom monitor mic")
+        self.monitorCheckBox.toggled.connect(self.toggle_room_monitor)
+        self.monitorDeviceLabel.setStatusTip(
+            "Set in the Devices window (Room monitor → role)."
+        )
+
+        roomRow = QtWidgets.QHBoxLayout()
+        roomRow.addWidget(self.monitorCheckBox)
+        roomRow.addWidget(self.roomMeter)
+
+        form = QtWidgets.QFormLayout()
+        form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        form.addRow("Sending:", self.outMeter)
+        form.addRow("Bedroom:", roomRow)
+        form.addRow("Monitor mic:", self.monitorDeviceLabel)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(heading)
+        layout.addLayout(form)
+        return layout
+
+    def toggle_room_monitor(self, enabled: bool) -> None:
+        """Start/stop the bedroom monitor-mic meter (the objective acoustic check)."""
+        self.session.log_interaction(f"Cue room monitor {'on' if enabled else 'off'}")
+        if enabled:
+            device = self.session.devices.device_for("monitor_in") or None
+            try:
+                self.roomMeter.start(device)
+            except Exception as exc:  # PortAudio errors, no device, busy, etc.
+                self.session.show_error_popup(
+                    "Could not open the room monitor.", str(exc), parent=self
+                )
+                self.monitorCheckBox.setChecked(False)
+        else:
+            self.roomMeter.stop()
+
+    def _restart_room_monitor_if_active(self) -> None:
+        """Re-open the room monitor on the current device if it's running."""
+        if self.roomMeter.is_active():
+            self.toggle_room_monitor(False)
+            self.toggle_room_monitor(True)
 
     # ----- settings state ----------------------------------------------------
 
@@ -543,3 +624,4 @@ class AudioCueWindow(ModalityWindow):
             out.stream.abort()
             out.stream.close()
         self._outputs = []
+        self.roomMeter.stop()

--- a/src/smacc/panels/meter.py
+++ b/src/smacc/panels/meter.py
@@ -1,0 +1,107 @@
+"""Reusable level meters shared by the recorder and the cue monitor (#37).
+
+Two small widgets, both rendering a dBFS bar:
+
+* :class:`LevelMeter` displays a level you feed it from outside — the cue panel's
+  output "sending" meter pushes the block it emits here, so it never owns a stream.
+* :class:`InputLevelMeter` drives itself from a sounddevice input stream and tracks
+  a rolling ambient baseline, so a faint cue's *rise* above the room noise shows
+  even when the absolute level is low.
+
+The absolute level is always the bar (it can't collapse to zero on a sustained
+sound); the baseline only adds a "+N dB above floor" readout in the text.
+"""
+
+from __future__ import annotations
+
+import sounddevice as sd
+from PyQt6 import QtCore, QtWidgets
+
+from .. import audio
+
+
+class LevelMeter(QtWidgets.QProgressBar):
+    """A dBFS level bar fed from outside (no stream of its own).
+
+    Used for the cue panel's output "sending" meter: the audio callback measures the
+    block it emits and pushes it here via :meth:`show_level`. This confirms SMACC is
+    *emitting* a cue — a diagnostic, not proof the bedroom speaker actually sounded
+    (only a mic can confirm that; see :class:`InputLevelMeter`).
+    """
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setRange(0, 100)
+        self.setValue(0)
+        self.setTextVisible(True)
+        self.setFormat("")
+
+    def show_level(self, db: float) -> None:
+        """Render ``db`` dBFS onto the bar (value + text)."""
+        self.setValue(audio.dbfs_to_meter(db))
+        self.setFormat(f"{db:.0f} dBFS")
+
+    def clear_level(self) -> None:
+        """Reset the bar to empty (e.g. when playback stops)."""
+        self.setValue(0)
+        self.setFormat("")
+
+
+class InputLevelMeter(LevelMeter):
+    """A level meter that drives itself from a sounddevice input stream.
+
+    Owns the :class:`sounddevice.InputStream` and a ~20 Hz refresh timer; the audio
+    callback stashes the latest level and the timer renders it. A rolling
+    :class:`smacc.audio.AmbientBaseline` adds a "+N dB above floor" readout so a
+    cue that lifts a cheap mic only a little above the room noise is still visible.
+
+    The stream is the panel's, so a panel that embeds this must report it from
+    ``is_streaming()`` (a device rescan re-inits PortAudio and would cut it).
+    """
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._stream: sd.InputStream | None = None
+        self._level_db = audio.FLOOR_DBFS
+        self._baseline = audio.AmbientBaseline()
+        self._timer = QtCore.QTimer(self)
+        self._timer.setInterval(50)  # ~20 Hz display refresh
+        self._timer.timeout.connect(self._refresh)
+
+    def is_active(self) -> bool:
+        """True while the input stream is open."""
+        return self._stream is not None
+
+    def start(self, device: str | None) -> None:
+        """Open the input stream on ``device`` (raises on a PortAudio error).
+
+        The caller surfaces any error (and reverts its toggle); this leaves the meter
+        stopped on failure. A fresh start forgets the previous room's baseline.
+        """
+        self.stop()
+        self._baseline.reset()
+        self._level_db = audio.FLOOR_DBFS
+        stream = sd.InputStream(channels=1, device=device, callback=self._capture)
+        stream.start()
+        self._stream = stream
+        self._timer.start()
+
+    def stop(self) -> None:
+        """Close the input stream and clear the bar (safe to call when stopped)."""
+        self._timer.stop()
+        if self._stream is not None:
+            self._stream.abort()
+            self._stream.close()
+            self._stream = None
+        self.clear_level()
+
+    def _capture(self, indata, frames, time, status) -> None:
+        """sounddevice callback (audio thread): stash the latest input level."""
+        self._level_db = audio.rms_dbfs(indata)
+
+    def _refresh(self) -> None:
+        """GUI-thread timer: render absolute level + the rise above the room floor."""
+        db = self._level_db
+        rise = self._baseline.update(db)
+        self.setValue(audio.dbfs_to_meter(db))
+        self.setFormat(f"{db:.0f} dBFS  (+{rise:.0f})")

--- a/src/smacc/panels/recording.py
+++ b/src/smacc/panels/recording.py
@@ -8,12 +8,12 @@ import sounddevice as sd
 import soundfile as sf
 from PyQt6 import QtCore, QtWidgets
 
-from .. import audio
 from ..config import SURVEY_OPTIONS
 from ..dialogs import ManageSurveysDialog
 from ..session import SmaccSession
 from ..utils import format_elapsed
 from .base import ModalityWindow, describe_target, make_section_title
+from .meter import InputLevelMeter
 
 
 class RecordingWindow(ModalityWindow):
@@ -31,7 +31,9 @@ class RecordingWindow(ModalityWindow):
         super().__init__(session, parent)
         self.n_report_counter = 0  # cumulative counter for determining filenames
         self.init_recorder()
-        self.init_level_meter()
+        # Built before _build(): refresh_device_indicator() (called inside _build)
+        # restarts the meter, so the widget must already exist.
+        self.levelMeter = InputLevelMeter(self)
         self.setCentralWidget(self._build())
 
     def _build(self) -> QtWidgets.QWidget:
@@ -65,16 +67,9 @@ class RecordingWindow(ModalityWindow):
         monitorCheckBox.toggled.connect(self.toggle_level_monitor)
         self.monitorCheckBox = monitorCheckBox
 
-        levelMeterBar = QtWidgets.QProgressBar(self)
-        levelMeterBar.setRange(0, 100)
-        levelMeterBar.setValue(0)
-        levelMeterBar.setTextVisible(True)
-        levelMeterBar.setFormat("")
-        self.levelMeterBar = levelMeterBar
-
         levelLayout = QtWidgets.QHBoxLayout()
         levelLayout.addWidget(monitorCheckBox)
-        levelLayout.addWidget(levelMeterBar)
+        levelLayout.addWidget(self.levelMeter)
 
         # Survey selector: editable dropdown of named presets (or a typed-in URL).
         surveyComboBox = QtWidgets.QComboBox(self)
@@ -127,7 +122,7 @@ class RecordingWindow(ModalityWindow):
 
     def is_streaming(self) -> bool:
         """True while the level meter is open or a dream report is recording."""
-        return self.meter_stream is not None or self._record_stream is not None
+        return self.levelMeter.is_active() or self._record_stream is not None
 
     def start_or_stop_recording(self):
         """Start or stop a dream report (the button's checked state is the intent)."""
@@ -227,19 +222,11 @@ class RecordingWindow(ModalityWindow):
             self.recordingIndicatorLabel.setText("■ idle")
             self.recordingIndicatorLabel.setStyleSheet("")
 
-    # ----- input level meter (#25) ------------------------------------------
-
-    def init_level_meter(self) -> None:
-        """Set up the input level meter stream and its refresh timer."""
-        self.meter_stream: sd.InputStream | None = None
-        self._input_level_db = audio.FLOOR_DBFS
-        self.meter_timer = QtCore.QTimer(self)
-        self.meter_timer.setInterval(50)  # ~20 Hz display refresh
-        self.meter_timer.timeout.connect(self.update_level_meter)
+    # ----- input level meter (#25, shared widget #37) -----------------------
 
     def _restart_meter_if_monitoring(self) -> None:
         """Re-open the level meter on the current device if it's running."""
-        if self.meter_stream is not None:
+        if self.levelMeter.is_active():
             self.toggle_level_monitor(False)
             self.toggle_level_monitor(True)
 
@@ -248,38 +235,14 @@ class RecordingWindow(ModalityWindow):
         self.session.log_interaction(f"Input level meter {'on' if enabled else 'off'}")
         if enabled:
             try:
-                self.meter_stream = sd.InputStream(
-                    channels=1,
-                    device=self._selected_input_device(),
-                    callback=self._meter_callback,
-                )
-                self.meter_stream.start()
+                self.levelMeter.start(self._selected_input_device())
             except Exception as exc:  # PortAudio errors, no device, etc.
                 self.session.show_error_popup(
                     "Could not open input for monitoring.", str(exc), parent=self
                 )
                 self.monitorCheckBox.setChecked(False)
-                self.meter_stream = None
-                return
-            self.meter_timer.start()
         else:
-            self.meter_timer.stop()
-            if self.meter_stream is not None:
-                self.meter_stream.abort()
-                self.meter_stream.close()
-                self.meter_stream = None
-            self.levelMeterBar.setValue(0)
-            self.levelMeterBar.setFormat("")
-
-    def _meter_callback(self, indata, frames, time, status) -> None:
-        """sounddevice callback (audio thread): stash the latest input level."""
-        self._input_level_db = audio.rms_dbfs(indata)
-
-    def update_level_meter(self) -> None:
-        """GUI-thread timer: render the latest level onto the meter bar."""
-        db = self._input_level_db
-        self.levelMeterBar.setValue(audio.dbfs_to_meter(db))
-        self.levelMeterBar.setFormat(f"{db:.0f} dBFS")
+            self.levelMeter.stop()
 
     # ----- survey + settings state ------------------------------------------
 
@@ -348,9 +311,5 @@ class RecordingWindow(ModalityWindow):
         self._apply_survey_state(state)
 
     def cleanup(self) -> None:
-        self.meter_timer.stop()
-        if self.meter_stream is not None:
-            self.meter_stream.abort()
-            self.meter_stream.close()
-            self.meter_stream = None
+        self.levelMeter.stop()
         self._teardown_recording()

--- a/src/smacc/synth.py
+++ b/src/smacc/synth.py
@@ -1,0 +1,151 @@
+"""Tone synthesis for the Cue designer (#77): build a cue from simple segments.
+
+Pure, hardware-free DSP — no Qt, no streams — so it is unit-testable on its own. The
+Cue designer (:mod:`smacc.cuedesigner`) assembles a list of **segments** (a pure
+tone or a gap of silence), renders them into one mono float32 buffer in ``[-1, 1]``,
+and exports a PCM-16 WAV that drops straight into a study's ``cues`` folder.
+
+This is deliberately kept separate from the demo-cue synthesis in
+:mod:`smacc.utils` (``note``/``_demo_*``), which is frozen to match the committed
+demo WAV assets. The model here is intentionally simple — a monophonic sequence of
+tones and silences with a per-tone decay and a master fade — not a full ADSR
+synthesizer (see #33, closed in favor of this).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import soundfile as sf
+
+# A generated cue's default sample rate (CD quality); the designer may override it.
+DEFAULT_RATE = 44100
+# Shortest fade applied to every tone's edges so a hard sine edge — or the seam
+# between two segments — doesn't click. In seconds.
+EDGE_FADE_S = 0.005
+# Peak magnitude a normalized cue is scaled to (leaves a sliver of headroom).
+NORMALIZE_PEAK = 0.97
+
+
+@dataclass
+class ToneSegment:
+    """A pure sine tone: ``freq`` Hz for ``duration`` s at ``level`` (0-1).
+
+    ``decay`` applies a bell-like exponential fall across the tone; a short
+    anti-click fade is always applied at both edges regardless.
+    """
+
+    freq: float
+    duration: float
+    level: float = 1.0
+    decay: bool = False
+
+
+@dataclass
+class SilenceSegment:
+    """A gap of silence lasting ``duration`` seconds."""
+
+    duration: float
+
+
+Segment = ToneSegment | SilenceSegment
+
+
+def _edge_fade(env: np.ndarray, rate: int) -> None:
+    """Multiply a short linear ramp into both ends of ``env`` in place (anti-click)."""
+    n = env.shape[0]
+    fade_n = min(int(EDGE_FADE_S * rate), n // 2)
+    if fade_n > 0:
+        ramp = np.linspace(0.0, 1.0, fade_n)
+        env[:fade_n] *= ramp
+        env[-fade_n:] *= ramp[::-1]
+
+
+def _render_tone(seg: ToneSegment, rate: int) -> np.ndarray:
+    """Render one tone segment to mono float32 (empty for a non-positive duration)."""
+    n = max(0, int(round(seg.duration * rate)))
+    if n == 0:
+        return np.zeros(0, dtype=np.float32)
+    t = np.arange(n, dtype=np.float64) / rate
+    wave = np.sin(2.0 * np.pi * seg.freq * t) * seg.level
+    env = np.ones(n, dtype=np.float64)
+    if seg.decay:
+        env *= np.exp(-3.0 * np.linspace(0.0, 1.0, n))
+    _edge_fade(env, rate)
+    return (wave * env).astype(np.float32)
+
+
+def render_segment(seg: Segment, rate: int) -> np.ndarray:
+    """Render a single segment (tone or silence) to a mono float32 buffer."""
+    if isinstance(seg, ToneSegment):
+        return _render_tone(seg, rate)
+    if isinstance(seg, SilenceSegment):
+        return np.zeros(max(0, int(round(seg.duration * rate))), dtype=np.float32)
+    raise TypeError(f"unknown segment type: {type(seg).__name__}")
+
+
+def _normalize_peak(samples: np.ndarray, peak: float = NORMALIZE_PEAK) -> np.ndarray:
+    """Scale ``samples`` so their largest magnitude is ``peak`` (silence unchanged)."""
+    largest = float(np.max(np.abs(samples))) if samples.size else 0.0
+    if largest > 0:
+        return (samples * (peak / largest)).astype(np.float32)
+    return samples
+
+
+def _master_fades(
+    samples: np.ndarray, rate: int, fade_in: float, fade_out: float
+) -> None:
+    """Apply whole-cue fade-in/out ramps to ``samples`` in place (seconds)."""
+    n = samples.shape[0]
+    if n == 0:
+        return
+    fi = min(int(round(fade_in * rate)), n)
+    if fi > 0:
+        samples[:fi] *= np.linspace(0.0, 1.0, fi, dtype=np.float32)
+    fo = min(int(round(fade_out * rate)), n)
+    if fo > 0:
+        samples[-fo:] *= np.linspace(1.0, 0.0, fo, dtype=np.float32)
+
+
+def render_sequence(
+    segments: list[Segment],
+    *,
+    rate: int = DEFAULT_RATE,
+    fade_in: float = 0.0,
+    fade_out: float = 0.0,
+    normalize: bool = False,
+) -> np.ndarray:
+    """Render ``segments`` end-to-end into one mono float32 cue in ``[-1, 1]``.
+
+    Segments are concatenated in order. ``normalize`` scales the whole cue to a
+    fixed peak first; the master ``fade_in``/``fade_out`` ramps (seconds) are then
+    applied over the start/end of the result. An empty list yields an empty buffer.
+    """
+    if rate <= 0:
+        raise ValueError("sample rate must be positive")
+    parts = [render_segment(seg, rate) for seg in segments]
+    out = (
+        np.concatenate(parts).astype(np.float32)
+        if parts
+        else np.zeros(0, dtype=np.float32)
+    )
+    if normalize:
+        out = _normalize_peak(out)
+    out = np.ascontiguousarray(out, dtype=np.float32)  # writable for the in-place fades
+    _master_fades(out, rate, fade_in, fade_out)
+    np.clip(out, -1.0, 1.0, out=out)
+    return out
+
+
+def total_duration(segments: list[Segment]) -> float:
+    """Total length of ``segments`` in seconds (negative durations count as zero)."""
+    return float(sum(max(0.0, seg.duration) for seg in segments))
+
+
+def export_wav(
+    path: str | Path, samples: np.ndarray, rate: int, *, subtype: str = "PCM_16"
+) -> None:
+    """Write ``samples`` (mono float32 in ``[-1, 1]``) to ``path`` as a WAV."""
+    sf.write(str(path), samples, int(rate), subtype=subtype)

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -58,6 +58,45 @@ def test_meter_mapping_endpoints_and_clamp():
     assert audio.dbfs_to_meter(0.0) == 100
     assert audio.dbfs_to_meter(audio.METER_FLOOR_DBFS) == 0
     assert audio.dbfs_to_meter(-1000.0) == 0  # clamped
+
+
+def test_ambient_baseline_tracks_a_quiet_floor():
+    base = audio.AmbientBaseline()
+    for _ in range(50):
+        base.update(-70.0)  # steady quiet room
+    assert base.floor == pytest.approx(-70.0, abs=0.5)
+
+
+def test_ambient_baseline_reports_rise_for_a_cue_above_the_floor():
+    base = audio.AmbientBaseline()
+    for _ in range(50):
+        base.update(-70.0)  # settle the floor at the room noise
+    rise = base.update(-40.0)  # a cue lifts the level 30 dB
+    assert rise == pytest.approx(30.0, abs=1.0)
+
+
+def test_ambient_baseline_drops_instantly_to_a_quieter_level():
+    base = audio.AmbientBaseline()
+    base.update(-40.0)
+    base.update(-80.0)  # quieter than the floor -> snaps down immediately
+    assert base.floor == pytest.approx(-80.0, abs=0.01)
+
+
+def test_ambient_baseline_floor_creeps_up_under_sustained_sound():
+    base = audio.AmbientBaseline(creep_db_per_update=0.15)
+    base.update(-70.0)  # floor starts low
+    for _ in range(100):  # a sustained louder sound
+        base.update(-40.0)
+    # The floor adapts upward toward the sustained level (so the rise shrinks).
+    assert base.floor > -70.0
+    assert base.update(-40.0) < 30.0
+
+
+def test_ambient_baseline_reset_forgets_the_floor():
+    base = audio.AmbientBaseline()
+    base.update(-30.0)
+    base.reset()
+    assert base.floor == audio.FLOOR_DBFS
     assert audio.dbfs_to_meter(50.0) == 100  # clamped
     midpoint = audio.METER_FLOOR_DBFS / 2
     assert audio.dbfs_to_meter(midpoint) == 50

--- a/tests/test_cuedesigner.py
+++ b/tests/test_cuedesigner.py
@@ -1,0 +1,149 @@
+"""Tests for the Cue designer window (#77).
+
+Headless Qt (offscreen, via conftest). Preview would open a sounddevice stream, so
+the one preview test stubs ``sd.OutputStream``/``sd.query_devices``; everything else
+exercises the pure row model and the file export (no hardware).
+"""
+
+from __future__ import annotations
+
+from scipy.io.wavfile import read
+
+from smacc import cuedesigner, synth
+from smacc.cuedesigner import (
+    EXPORT_RATE,
+    MAX_SEGMENTS,
+    MIN_SEGMENTS,
+    CueDesignerWindow,
+)
+
+
+def test_starts_with_one_required_tone_row(qtbot):
+    win = CueDesignerWindow()
+    qtbot.addWidget(win)
+    assert len(win.rows) == MIN_SEGMENTS
+    assert win.rows[0].is_tone()
+    assert not win.rows[0].removeButton.isEnabled()  # the lone row can't be removed
+
+
+def test_add_and_remove_segments(qtbot):
+    win = CueDesignerWindow()
+    qtbot.addWidget(win)
+    win.add_segment()
+    assert len(win.rows) == 2
+    assert win.rows[0].removeButton.isEnabled()  # now removable
+    win.remove_segment(win.rows[1])
+    assert len(win.rows) == 1
+    assert not win.rows[0].removeButton.isEnabled()
+
+
+def test_add_segment_respects_cap(qtbot):
+    win = CueDesignerWindow()
+    qtbot.addWidget(win)
+    for _ in range(MAX_SEGMENTS + 5):
+        win.add_segment()
+    assert len(win.rows) == MAX_SEGMENTS
+
+
+def test_silence_row_disables_tone_controls(qtbot):
+    win = CueDesignerWindow()
+    qtbot.addWidget(win)
+    row = win.rows[0]
+    row.typeCombo.setCurrentText("Silence")
+    assert not row.freqSpin.isEnabled()
+    assert not row.levelSpin.isEnabled()
+    assert not row.decayCheck.isEnabled()
+    assert isinstance(row.to_segment(), synth.SilenceSegment)
+
+
+def test_tone_row_builds_tone_segment(qtbot):
+    win = CueDesignerWindow()
+    qtbot.addWidget(win)
+    row = win.rows[0]
+    row.freqSpin.setValue(523)
+    row.durationSpin.setValue(0.5)
+    row.levelSpin.setValue(0.3)
+    seg = row.to_segment()
+    assert isinstance(seg, synth.ToneSegment)
+    assert seg.freq == 523
+    assert seg.duration == 0.5
+    assert seg.level == 0.3
+
+
+def test_duration_label_tracks_segments(qtbot):
+    win = CueDesignerWindow()
+    qtbot.addWidget(win)
+    win.rows[0].durationSpin.setValue(2.0)
+    win.add_segment()
+    win.rows[1].durationSpin.setValue(0.5)
+    assert "2.50 s" in win.durationLabel.text()
+
+
+def test_export_writes_a_wav(qtbot, tmp_path, monkeypatch):
+    win = CueDesignerWindow(cues_dir=tmp_path)
+    qtbot.addWidget(win)
+    out = tmp_path / "mycue.wav"
+    monkeypatch.setattr(
+        cuedesigner.QtWidgets.QFileDialog,
+        "getSaveFileName",
+        lambda *a, **k: (str(out), ""),
+    )
+    monkeypatch.setattr(
+        cuedesigner.QtWidgets.QMessageBox, "information", lambda *a, **k: None
+    )
+    win.export()
+    assert out.is_file()
+    rate, data = read(out)
+    assert rate == EXPORT_RATE
+    assert data.shape[0] > 0
+
+
+def test_export_warns_and_skips_when_silent(qtbot, tmp_path, monkeypatch):
+    win = CueDesignerWindow(cues_dir=tmp_path)
+    qtbot.addWidget(win)
+    win.rows[0].typeCombo.setCurrentText("Silence")  # no tones -> silent render
+    warned: list = []
+    saved: list = []
+    monkeypatch.setattr(win, "_warn", lambda *a, **k: warned.append(a))
+
+    def fake_save(*a, **k):
+        saved.append(True)
+        return ("", "")
+
+    monkeypatch.setattr(cuedesigner.QtWidgets.QFileDialog, "getSaveFileName", fake_save)
+    win.export()
+    assert warned  # warned the user
+    assert not saved  # returned before opening the save dialog
+
+
+def test_preview_opens_then_stop_closes_stream(qtbot, monkeypatch):
+    win = CueDesignerWindow()
+    qtbot.addWidget(win)
+
+    class FakeStream:
+        instances: list = []
+
+        def __init__(self, *a, **k):
+            self.aborted = False
+            self.closed = False
+            FakeStream.instances.append(self)
+
+        def start(self):
+            pass
+
+        def abort(self):
+            self.aborted = True
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(cuedesigner.sd, "OutputStream", FakeStream)
+    monkeypatch.setattr(
+        cuedesigner.sd, "query_devices", lambda *a, **k: {"default_samplerate": 44100}
+    )
+    win.preview()
+    assert win._preview is not None
+    win.stop_preview()
+    assert win._preview is None
+    assert FakeStream.instances[0].aborted
+    assert FakeStream.instances[0].closed

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -31,6 +31,31 @@ def test_device_for_is_empty_when_role_unbound_or_off():
     assert cfg.device_for("cue_monitor") == ""  # optional route still off
 
 
+def test_room_monitor_defaults_to_the_bedroom_mic():
+    # Out of the box the room monitor (#37) shares the bedroom mic, so the cue
+    # meter works without binding a separate device.
+    cfg = devices.default_config()
+    assert cfg.role_for("monitor_in") == "bedroom_mic"
+    cfg.bindings["bedroom_mic"] = "Mic, Windows WASAPI"
+    assert cfg.device_for("monitor_in") == "Mic, Windows WASAPI"
+
+
+def test_room_monitor_can_use_a_dedicated_monitor_mic():
+    cfg = devices.default_config()
+    cfg.bindings["bedroom_mic"] = "Cheap Mic, Windows WASAPI"
+    cfg.bindings["monitor_mic"] = "Measurement Mic, Windows WASAPI"
+    cfg.routing["monitor_in"] = "monitor_mic"
+    assert cfg.device_for("monitor_in") == "Measurement Mic, Windows WASAPI"
+    assert cfg.device_for("report_in") == "Cheap Mic, Windows WASAPI"  # unaffected
+
+
+def test_room_monitor_route_can_be_turned_off():
+    cfg = devices.default_config()
+    cfg.bindings["bedroom_mic"] = "Mic, Windows WASAPI"
+    cfg.routing["monitor_in"] = ""  # optional route set to none
+    assert cfg.device_for("monitor_in") == ""
+
+
 def test_routing_override_enables_a_monitor():
     cfg = devices.default_config()
     cfg.bindings["control_out"] = "Headphones, Windows WASAPI"

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from smacc import launcher
-from smacc.launcher import resolve_initial_settings
+from smacc.cuedesigner import CueDesignerWindow
+from smacc.launcher import LauncherWindow, resolve_initial_settings
 
 
 def test_resolve_initial_settings_prefers_last_used(tmp_path):
@@ -26,3 +27,17 @@ def test_resolve_initial_settings_none_when_nothing_available(tmp_path, monkeypa
         resolve_initial_settings({"last_settings": str(tmp_path / "gone.smacc")})
         is None
     )
+
+
+def test_design_cues_button_opens_the_cue_designer(qtbot, tmp_path, monkeypatch):
+    # Point preferences at a temp file so building the launcher can't touch real prefs.
+    monkeypatch.setattr(launcher, "preferences_path", tmp_path / "preferences.yaml")
+    win = LauncherWindow(settings_path=None)
+    qtbot.addWidget(win)
+    win.show()
+    win.design_cues()
+    assert isinstance(win._tool, CueDesignerWindow)
+    assert win._tool.isVisible()  # the tool shows itself
+    assert not win.isVisible()  # and the launcher hides until it closes
+    win._tool.close()  # returns control to the launcher (it reappears)
+    assert win.isVisible()

--- a/tests/test_panels_audio.py
+++ b/tests/test_panels_audio.py
@@ -1,0 +1,72 @@
+"""Tests for the Audio cue panel's monitoring additions (#37).
+
+Headless Qt (offscreen). The room-monitor meter would open a sounddevice input
+stream, so those tests stub ``sd.InputStream`` via the meter module.
+"""
+
+from __future__ import annotations
+
+from smacc.panels import meter
+from smacc.panels.audio import AudioCueWindow
+
+
+class _FakeInput:
+    """Stand-in for sd.InputStream that records its lifecycle calls."""
+
+    def __init__(self, *args, **kwargs):
+        self.aborted = False
+        self.closed = False
+
+    def start(self):
+        pass
+
+    def abort(self):
+        self.aborted = True
+
+    def close(self):
+        self.closed = True
+
+
+def test_monitor_device_label_shows_the_room_monitor_route(qtbot, design_session):
+    panel = AudioCueWindow(design_session)
+    qtbot.addWidget(panel)
+    # monitor_in defaults to the bedroom-mic role (unbound -> system default).
+    assert "Bedroom mic" in panel.monitorDeviceLabel.text()
+
+
+def test_output_meter_reflects_the_sent_level(qtbot, design_session):
+    panel = AudioCueWindow(design_session)
+    qtbot.addWidget(panel)
+    assert panel.outMeter.value() == 0  # nothing playing yet
+    panel._out_level_db = -6.0  # as if the cue callback measured a block
+    panel._poll_cue()  # the GUI-thread tick that drives the meter
+    assert panel.outMeter.value() > 0
+
+
+def test_room_monitor_toggle_opens_and_closes_and_gates_streaming(
+    qtbot, design_session, monkeypatch
+):
+    monkeypatch.setattr(meter.sd, "InputStream", _FakeInput)
+    panel = AudioCueWindow(design_session)
+    qtbot.addWidget(panel)
+    assert not panel.is_streaming()
+    panel.monitorCheckBox.setChecked(True)  # -> toggle_room_monitor(True)
+    assert panel.roomMeter.is_active()
+    assert panel.is_streaming()  # the open input stream gates device rescans
+    panel.monitorCheckBox.setChecked(False)
+    assert not panel.roomMeter.is_active()
+    assert not panel.is_streaming()
+
+
+def test_room_monitor_start_failure_reverts_the_checkbox(
+    qtbot, design_session, monkeypatch, silence_dialogs
+):
+    def boom(*args, **kwargs):
+        raise RuntimeError("no mic")
+
+    monkeypatch.setattr(meter.sd, "InputStream", boom)
+    panel = AudioCueWindow(design_session)
+    qtbot.addWidget(panel)
+    panel.monitorCheckBox.setChecked(True)
+    assert not panel.monitorCheckBox.isChecked()  # reverted on failure
+    assert not panel.roomMeter.is_active()

--- a/tests/test_panels_meter.py
+++ b/tests/test_panels_meter.py
@@ -1,0 +1,83 @@
+"""Tests for the reusable level meters (#37).
+
+Headless Qt (offscreen). ``InputLevelMeter`` would open a sounddevice input stream,
+so those tests stub ``sd.InputStream`` and drive the callback/refresh by hand.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from smacc.panels import meter
+from smacc.panels.meter import InputLevelMeter, LevelMeter
+
+
+def test_level_meter_shows_and_clears(qtbot):
+    m = LevelMeter()
+    qtbot.addWidget(m)
+    m.show_level(0.0)  # full scale -> top of the bar
+    assert m.value() == 100
+    assert "dBFS" in m.format()
+    m.clear_level()
+    assert m.value() == 0
+    assert m.format() == ""
+
+
+class _FakeInput:
+    """Stand-in for sd.InputStream that records its lifecycle calls."""
+
+    last: _FakeInput | None = None
+
+    def __init__(self, *args, **kwargs):
+        self.started = False
+        self.aborted = False
+        self.closed = False
+        _FakeInput.last = self
+
+    def start(self):
+        self.started = True
+
+    def abort(self):
+        self.aborted = True
+
+    def close(self):
+        self.closed = True
+
+
+def test_input_meter_start_then_stop(qtbot, monkeypatch):
+    monkeypatch.setattr(meter.sd, "InputStream", _FakeInput)
+    m = InputLevelMeter()
+    qtbot.addWidget(m)
+    assert not m.is_active()
+    m.start("Mic, Windows WASAPI")
+    assert m.is_active()
+    assert _FakeInput.last is not None and _FakeInput.last.started
+    m.stop()
+    assert not m.is_active()
+    assert _FakeInput.last.aborted and _FakeInput.last.closed
+
+
+def test_input_meter_start_propagates_errors(qtbot, monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("no device")
+
+    monkeypatch.setattr(meter.sd, "InputStream", boom)
+    m = InputLevelMeter()
+    qtbot.addWidget(m)
+    with pytest.raises(RuntimeError):
+        m.start(None)
+    assert not m.is_active()  # left cleanly stopped for the caller to handle
+
+
+def test_input_meter_refresh_renders_level_and_rise(qtbot, monkeypatch):
+    monkeypatch.setattr(meter.sd, "InputStream", _FakeInput)
+    m = InputLevelMeter()
+    qtbot.addWidget(m)
+    m.start(None)
+    # Simulate the audio callback delivering a block, then a display refresh.
+    m._capture(np.full((256, 1), 0.5, dtype=np.float32), 256, None, None)
+    m._refresh()
+    assert m.value() > 0
+    assert "dBFS" in m.format()
+    m.stop()

--- a/tests/test_synth.py
+++ b/tests/test_synth.py
@@ -1,0 +1,140 @@
+"""Tests for the pure tone-synthesis core in :mod:`smacc.synth` (#77)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from scipy.io.wavfile import read
+
+from smacc import synth
+
+
+def test_tone_segment_has_expected_length_and_range():
+    rate = 8000
+    samples = synth.render_segment(synth.ToneSegment(freq=440, duration=1.0), rate)
+    assert samples.dtype == np.float32
+    assert samples.shape == (rate,)
+    assert np.all(np.isfinite(samples))
+    assert np.max(np.abs(samples)) <= 1.0
+
+
+def test_tone_dominant_frequency_matches_request():
+    rate = 8000
+    freq = 500.0
+    samples = synth.render_segment(synth.ToneSegment(freq=freq, duration=1.0), rate)
+    spectrum = np.abs(np.fft.rfft(samples))
+    peak_hz = np.fft.rfftfreq(samples.shape[0], 1.0 / rate)[int(np.argmax(spectrum))]
+    assert peak_hz == pytest.approx(freq, abs=2.0)
+
+
+def test_tone_level_scales_amplitude():
+    rate = 8000
+    quiet = synth.render_segment(synth.ToneSegment(440, 0.5, level=0.25), rate)
+    loud = synth.render_segment(synth.ToneSegment(440, 0.5, level=1.0), rate)
+    assert np.max(np.abs(loud)) > np.max(np.abs(quiet))
+    assert np.max(np.abs(quiet)) == pytest.approx(0.25, abs=0.02)
+
+
+def test_tone_edges_fade_to_avoid_clicks():
+    rate = 44100
+    samples = synth.render_segment(synth.ToneSegment(440, 0.5), rate)
+    assert abs(samples[0]) < 1e-3  # ramps up from ~0
+    assert abs(samples[-1]) < 1e-3  # and back down to ~0
+
+
+def test_decay_makes_the_tail_quieter_than_the_onset():
+    rate = 8000
+    plain = synth.render_segment(synth.ToneSegment(440, 1.0), rate)
+    decayed = synth.render_segment(synth.ToneSegment(440, 1.0, decay=True), rate)
+    head = slice(rate // 10, rate // 5)  # past the onset fade
+    tail = slice(-rate // 5, -rate // 10)
+    assert np.max(np.abs(decayed[tail])) < np.max(np.abs(decayed[head]))
+    # A plain tone holds its level across the same window.
+    assert np.max(np.abs(plain[tail])) == pytest.approx(
+        np.max(np.abs(plain[head])), abs=0.02
+    )
+
+
+def test_silence_segment_is_zeros_of_expected_length():
+    rate = 8000
+    samples = synth.render_segment(synth.SilenceSegment(duration=0.5), rate)
+    assert samples.shape == (rate // 2,)
+    assert np.all(samples == 0)
+
+
+def test_zero_or_negative_duration_renders_empty():
+    assert synth.render_segment(synth.ToneSegment(440, 0.0), 8000).shape == (0,)
+    assert synth.render_segment(synth.SilenceSegment(-1.0), 8000).shape == (0,)
+
+
+def test_sequence_concatenates_in_order():
+    rate = 8000
+    segments = [
+        synth.ToneSegment(440, 0.25),
+        synth.SilenceSegment(0.25),
+        synth.ToneSegment(880, 0.25),
+    ]
+    out = synth.render_sequence(segments, rate=rate)
+    assert out.dtype == np.float32
+    assert out.shape == (rate * 3 // 4,)
+    mid = slice(rate // 4, rate // 2)  # the silence segment in the middle
+    assert np.all(out[mid] == 0)
+
+
+def test_empty_sequence_is_empty_buffer():
+    out = synth.render_sequence([], rate=8000)
+    assert out.shape == (0,)
+    assert out.dtype == np.float32
+
+
+def test_normalize_scales_peak_with_headroom():
+    rate = 8000
+    out = synth.render_sequence(
+        [synth.ToneSegment(440, 0.5, level=0.1)], rate=rate, normalize=True
+    )
+    assert np.max(np.abs(out)) == pytest.approx(synth.NORMALIZE_PEAK, abs=0.02)
+
+
+def test_master_fades_ramp_the_whole_cue():
+    rate = 8000
+    out = synth.render_sequence(
+        [synth.ToneSegment(440, 1.0)], rate=rate, fade_in=0.2, fade_out=0.2
+    )
+    assert abs(out[0]) < 1e-3
+    assert abs(out[-1]) < 1e-3
+    # The quarter-second mark is mid-fade-in, so quieter than the sustained middle.
+    assert np.max(np.abs(out[: rate // 5])) < np.max(np.abs(out[rate // 2 :]))
+
+
+def test_output_is_clipped_into_range():
+    rate = 8000
+    # Two stacked-level tones can't exceed 1.0 individually, but force a clip check
+    # by requesting an over-unity level and confirming the result still bounds.
+    out = synth.render_sequence([synth.ToneSegment(440, 0.5, level=4.0)], rate=rate)
+    assert np.max(np.abs(out)) <= 1.0
+
+
+def test_total_duration_sums_segments_and_ignores_negatives():
+    segments = [
+        synth.ToneSegment(440, 1.0),
+        synth.SilenceSegment(0.5),
+        synth.SilenceSegment(-2.0),  # clamped to 0
+    ]
+    assert synth.total_duration(segments) == pytest.approx(1.5)
+
+
+def test_export_wav_writes_a_readable_pcm16_file(tmp_path):
+    rate = 8000
+    out = synth.render_sequence([synth.ToneSegment(440, 0.5)], rate=rate)
+    path = tmp_path / "cue.wav"
+    synth.export_wav(path, out, rate)
+    assert path.is_file()
+    read_rate, data = read(path)
+    assert read_rate == rate
+    assert data.dtype == np.int16
+    assert data.shape[0] == out.shape[0]
+
+
+def test_render_sequence_rejects_bad_rate():
+    with pytest.raises(ValueError):
+        synth.render_sequence([synth.ToneSegment(440, 0.5)], rate=0)


### PR DESCRIPTION
Implements all open `audio cues` issues.

**Cue designer (#77, subsumes #33).** A standalone launcher tool (**Design cues**) that builds a cue from a simple sequence of tone/silence segments — per-tone bell decay, whole-cue fade, optional normalize — previews it on the default output, and exports a PCM-16 WAV into a study's `cues/` folder (where the Audio cue board picks it up). Pure, tested DSP in `synth.py`. #33's full attack/sustain/decay window is intentionally dropped in favor of this simpler model — the lab uses "super simple" tones.

**Cue monitoring (#37).** A **Monitoring** section in the Audio cue panel:

- **Sending** — the level SMACC emits to the cue output (post-cap). Deterministic, but blind to everything downstream, so it's a *diagnostic*, not proof the speaker sounded.
- **Bedroom** — a mic meter, the objective acoustic check. It shows the absolute level plus the **rise above the room's resting noise floor** (`+N`), so a faint cue on a cheap mic still registers.

Adds an optional `monitor_mic` role + `monitor_in` route so a lab can use a dedicated, sensitive monitor mic separate from the (often cheap) dream-report mic; it defaults to the bedroom mic so it works out of the box. The dream recorder's level meter is refactored onto the shared `InputLevelMeter` widget.

Friture/spectral analysis was declined as overkill (per the issue). The automatic "cue sent but not detected" cross-check verdict is deferred to #89.

**Testing:** 299 tests pass; `ruff` + `mypy` clean. Hardware-dependent behavior — real mic dBFS, a faint cue showing on *Sending* but maybe not *Bedroom*, and cue-out + monitor-in + recorder streams coexisting — still needs validation on the rig.

Closes #77
Closes #33
Closes #37
