### PR TITLE
chore: trim log-preview noise and capture windows volume

### DIFF
--- a/src/smacc/__main__.py
+++ b/src/smacc/__main__.py
@@ -1,6 +1,7 @@
 """Run the app."""
 
 import logging
+import os
 import sys
 import threading
 import traceback
@@ -25,6 +26,25 @@ from .utils import seed_default_settings, seed_demo_cues
 
 # Study-file extensions SMACC will open when launched with a file (or double-click).
 _STUDY_SUFFIXES = {".smacc", ".yaml", ".yml"}
+
+# Qt logging-category rule that mutes one harmless line QMediaDevices prints on
+# startup ("qt.multimedia.ffmpeg: Using Qt multimedia with FFmpeg version ...").
+_FFMPEG_QUIET_RULE = "qt.multimedia.ffmpeg=false"
+
+
+def _quiet_qt_multimedia_logging() -> None:
+    """Mute the noisy Qt-multimedia FFmpeg banner via QT_LOGGING_RULES.
+
+    Must run before QApplication is created (Qt reads the env var at startup). An
+    existing QT_LOGGING_RULES is preserved — the rule is appended, not clobbered —
+    so a developer's own rules still apply.
+    """
+    existing = os.environ.get("QT_LOGGING_RULES", "")
+    if _FFMPEG_QUIET_RULE in existing:
+        return
+    os.environ["QT_LOGGING_RULES"] = (
+        f"{existing};{_FFMPEG_QUIET_RULE}" if existing else _FFMPEG_QUIET_RULE
+    )
 
 
 def pick_settings_path(args: list[str]) -> str | None:
@@ -103,6 +123,7 @@ def main() -> None:
     folders and logs are created only when a session starts, not the instant the app
     launches.
     """
+    _quiet_qt_multimedia_logging()  # before QApplication: Qt reads the rule at startup
     app = QApplication(sys.argv)
     _install_excepthook()
     # Fusion honors the full QPalette consistently across platforms, which the

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -562,7 +562,7 @@ class SmaccWindow(ToolWindow):
         self.setWindowFlag(QtCore.Qt.WindowType.WindowStaysOnTopHint, enabled)
         # Re-applying window flags hides the window on some platforms; re-show it.
         self.show()
-        self.session.log_info_msg(
+        self.session.log_debug_msg(
             f"Always-on-top {'enabled' if enabled else 'disabled'}"
         )
 
@@ -704,7 +704,7 @@ class SmaccWindow(ToolWindow):
             return
         finally:
             self.session.log_interactions = was_logging
-        self.session.log_info_msg("Devices changed; lists rescanned")
+        self.session.log_debug_msg("Devices changed; lists rescanned")
 
     def _notify_missing_devices(self) -> None:
         """Surface, once, any saved devices that weren't connected when settings loaded.

--- a/src/smacc/panels/audio.py
+++ b/src/smacc/panels/audio.py
@@ -362,7 +362,7 @@ class AudioCueWindow(ModalityWindow):
             for out in self._outputs:
                 out.mixer.volume = vol
         self.session.log_interaction(
-            f"Cue '{slot.nameEdit.text()}' volume set to {vol:.2f}"
+            f"Cue '{slot.nameEdit.text()}' volume set to {vol:.2f}", debug=True
         )
 
     def update_slot_loop(self, slot: CueSlot, enabled: bool | None = None) -> None:

--- a/src/smacc/panels/noise.py
+++ b/src/smacc/panels/noise.py
@@ -290,7 +290,7 @@ class NoiseWindow(ModalityWindow):
     def update_noise_volume(self, value: float) -> None:
         """Catch the noise volume spinbox signal (value is a 0-1 float)."""
         self.noise_stream_volume = value
-        self.session.log_interaction(f"Noise volume set to {value:.2f}")
+        self.session.log_interaction(f"Noise volume set to {value:.2f}", debug=True)
 
     def gather_state(self) -> dict:
         return {

--- a/src/smacc/panels/volume.py
+++ b/src/smacc/panels/volume.py
@@ -71,12 +71,23 @@ class VolumeWindow(ModalityWindow):
     def set_cap(self, value: float) -> None:
         """Apply the master output cap (read live by the cue/noise audio callbacks)."""
         self.session.volume_cap = float(value)
-        self.session.log_interaction(f"Output safety cap set to {value:.2f}")
+        self.session.log_interaction(
+            f"Output safety cap set to {value:.2f}", debug=True
+        )
 
     def refresh_levels(self) -> None:
         """Re-read the Windows endpoint + app volumes (best-effort)."""
-        self.endpointLabel.setText(self._format_level(winvolume.endpoint_volume()))
-        self.appLabel.setText(self._format_level(winvolume.app_volume()))
+        endpoint = winvolume.endpoint_volume()
+        app = winvolume.app_volume()
+        self.endpointLabel.setText(self._format_level(endpoint))
+        self.appLabel.setText(self._format_level(app))
+        # Record the OS-side volumes on each actual read (not on slider drags), so a
+        # run's cue levels stay reproducible from the log alone.
+        self.session.log_info_msg(
+            "Windows output volume: "
+            f"endpoint {self._format_level(endpoint)}, "
+            f"SMACC mixer {self._format_level(app)}"
+        )
 
     @staticmethod
     def _format_level(scalar: float | None) -> str:

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -362,6 +362,15 @@ class SmaccSession:
         """Log an INFO message (always to file; to the preview if INFO is on)."""
         self.logger.info(msg)
 
+    def log_debug_msg(self, msg: str) -> None:
+        """Log a DEBUG message (always to file; hidden from the preview by default).
+
+        For routine, high-frequency lines that belong in the log file for the
+        record but would only clutter the live preview (whose default level gate
+        starts at INFO).
+        """
+        self.logger.debug(msg)
+
     def note_missing_device(self, label: str, name: str) -> None:
         """Record that a saved ``label`` device ``name`` wasn't found on load.
 
@@ -372,15 +381,22 @@ class SmaccSession:
         self.missing_devices.append(f"{label}: {name}")
         self.logger.warning(f"Saved {label.lower()} not connected: {name}")
 
-    def log_interaction(self, msg: str) -> None:
+    def log_interaction(self, msg: str, *, debug: bool = False) -> None:
         """Log a soft interaction (volume/color/device/…) once the session is live.
 
         Gated by ``log_interactions`` so the programmatic widget setup that runs
         during construction or a study load doesn't spam the log; the main window
         flips the gate on after startup. These lines never carry a portcode.
+
+        ``debug=True`` logs at DEBUG instead of INFO, for high-frequency lines
+        (e.g. live volume edits) that should still hit the file but stay out of
+        the live preview, whose default level gate starts at INFO.
         """
         if self.log_interactions:
-            self.log_info_msg(msg)
+            if debug:
+                self.log_debug_msg(msg)
+            else:
+                self.log_info_msg(msg)
 
     def show_info_popup(self, short_msg, long_msg=None, parent=None) -> None:
         """Record an info line and show an information dialog (parented if given)."""

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -1,6 +1,12 @@
 """Tests for launch-with-a-file argument picking (no GUI required)."""
 
-from smacc.__main__ import pick_settings_path
+import os
+
+from smacc.__main__ import (
+    _FFMPEG_QUIET_RULE,
+    _quiet_qt_multimedia_logging,
+    pick_settings_path,
+)
 
 
 def test_no_positional_returns_none():
@@ -23,3 +29,26 @@ def test_ignores_flags_and_other_files():
 
 def test_last_study_file_wins():
     assert pick_settings_path(["SMACC.exe", "a.smacc", "b.smacc"]) == "b.smacc"
+
+
+# ----- Qt-multimedia logging rule (quiet the FFmpeg startup banner) ----------
+
+
+def test_quiet_qt_multimedia_sets_rule_when_unset(monkeypatch):
+    monkeypatch.delenv("QT_LOGGING_RULES", raising=False)
+    _quiet_qt_multimedia_logging()
+    assert os.environ["QT_LOGGING_RULES"] == _FFMPEG_QUIET_RULE
+
+
+def test_quiet_qt_multimedia_appends_to_existing_rules(monkeypatch):
+    monkeypatch.setenv("QT_LOGGING_RULES", "qt.qpa.*=true")
+    _quiet_qt_multimedia_logging()
+    # The developer's existing rule is preserved; ours is appended after it.
+    assert os.environ["QT_LOGGING_RULES"] == f"qt.qpa.*=true;{_FFMPEG_QUIET_RULE}"
+
+
+def test_quiet_qt_multimedia_is_idempotent(monkeypatch):
+    monkeypatch.setenv("QT_LOGGING_RULES", _FFMPEG_QUIET_RULE)
+    _quiet_qt_multimedia_logging()
+    # Already present -> not duplicated.
+    assert os.environ["QT_LOGGING_RULES"] == _FFMPEG_QUIET_RULE

--- a/tests/test_panels_state.py
+++ b/tests/test_panels_state.py
@@ -10,6 +10,8 @@ empty contribution.
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 
 from smacc import winvolume
@@ -98,6 +100,61 @@ def test_volume_panel_round_trips_cap(qtbot, design_session, monkeypatch):
     assert panel.gather_state() == {"volume_cap": pytest.approx(0.50)}
     # apply_state also drives the live session cap (read by the audio callbacks).
     assert design_session.volume_cap == pytest.approx(0.50)
+
+
+def _capture_session_log(session) -> list[logging.LogRecord]:
+    """Attach a recording handler to a session's logger and return its record list.
+
+    The session logger sets ``propagate=False`` (and design mode only has a
+    NullHandler), so pytest's ``caplog`` — which captures on the root logger —
+    never sees these records; capture on the logger directly instead.
+    """
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    session.logger.addHandler(_Capture())
+    return records
+
+
+def test_volume_panel_logs_windows_levels_on_refresh(
+    qtbot, design_session, monkeypatch
+):
+    # Each actual read of the Windows volumes is logged at INFO for reproducibility.
+    monkeypatch.setattr(winvolume, "endpoint_volume", lambda: 0.85)
+    monkeypatch.setattr(winvolume, "app_volume", lambda: 0.50)
+    panel = VolumeWindow(design_session)  # constructor calls refresh_levels() once
+    qtbot.addWidget(panel)
+    records = _capture_session_log(design_session)
+    panel.refresh_levels()
+    windows_lines = [
+        r for r in records if r.getMessage().startswith("Windows output volume:")
+    ]
+    assert windows_lines, "a refresh should log the read Windows volumes"
+    record = windows_lines[-1]
+    assert record.levelno == logging.INFO
+    assert "endpoint 85%" in record.getMessage()
+    assert "SMACC mixer 50%" in record.getMessage()
+
+
+def test_volume_panel_refresh_reports_unavailable_levels(
+    qtbot, design_session, monkeypatch
+):
+    # When the COM read fails (non-Windows / no endpoint), the log says so rather
+    # than crashing on a None percentage.
+    monkeypatch.setattr(winvolume, "endpoint_volume", lambda: None)
+    monkeypatch.setattr(winvolume, "app_volume", lambda: None)
+    panel = VolumeWindow(design_session)
+    qtbot.addWidget(panel)
+    records = _capture_session_log(design_session)
+    panel.refresh_levels()
+    messages = [r.getMessage() for r in records]
+    assert (
+        "Windows output volume: endpoint unavailable, SMACC mixer unavailable"
+        in messages
+    )
 
 
 # ----- stateless panels (their config lives at window/session level) ---------

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -290,3 +290,57 @@ def test_mark_recording_start_stamps_clock_and_emits_marker():
     # The marker routes through emit_event: triggered with code 51 and logged.
     assert sess.outlet.samples == [["51"]]
     assert records == [("Start recording - portcode 51", True)]
+
+
+# ----- log levels: preview-noise demotion (DEBUG vs INFO) --------------------
+
+
+def _level_capturing_session():
+    """A bare session whose logger records ``(levelno, message)`` per line.
+
+    Only the logging helpers are exercised, so the rest of the session can stay
+    unconfigured aside from the interaction gate (set per-test).
+    """
+    sess = SmaccSession.__new__(SmaccSession)
+    logger = logging.getLogger("smacc-test-levels")
+    logger.handlers.clear()
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    records: list[tuple[int, str]] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            records.append((record.levelno, record.getMessage()))
+
+    logger.addHandler(_Capture())
+    sess.logger = logger
+    return sess, records
+
+
+def test_log_debug_msg_logs_at_debug_level():
+    sess, records = _level_capturing_session()
+    sess.log_debug_msg("quiet line")
+    assert records == [(logging.DEBUG, "quiet line")]
+
+
+def test_log_interaction_defaults_to_info():
+    sess, records = _level_capturing_session()
+    sess.log_interactions = True
+    sess.log_interaction("an interaction")
+    assert records == [(logging.INFO, "an interaction")]
+
+
+def test_log_interaction_debug_demotes_to_debug():
+    sess, records = _level_capturing_session()
+    sess.log_interactions = True
+    sess.log_interaction("a noisy interaction", debug=True)
+    # Demoted lines still get logged (and so reach the file), just at DEBUG, so
+    # the INFO-gated live preview leaves them out.
+    assert records == [(logging.DEBUG, "a noisy interaction")]
+
+
+def test_log_interaction_debug_still_respects_the_gate():
+    sess, records = _level_capturing_session()
+    sess.log_interactions = False  # programmatic setup / study load
+    sess.log_interaction("a noisy interaction", debug=True)
+    assert records == []  # gated off entirely, regardless of level


### PR DESCRIPTION
## What
Reduce log-preview noise, capture the Windows system output volume for reproducibility, and silence a harmless Qt startup line.

- Demote five high-frequency lines from INFO to DEBUG so they still hit the log file but stay out of the live preview (whose default gate starts at INFO): cue volume, noise volume, output safety cap, the hot-plug auto-rescan (`Devices changed; lists rescanned`), and the always-on-top toggle. The deliberate manual `Refreshed devices` (F5/menu) stays at INFO.
- On each actual Volume-panel refresh (not on slider drags), log the OS-side output volumes at INFO: `Windows output volume: endpoint X%, SMACC mixer Y%` (or `unavailable` when the COM read fails), so a run's cue levels are reproducible from the log alone.
- Silence `qt.multimedia.ffmpeg: Using Qt multimedia with FFmpeg version ...` by setting `QT_LOGGING_RULES=qt.multimedia.ffmpeg=false` before `QApplication` is created. An existing `QT_LOGGING_RULES` is appended to, never clobbered.

## How
- New `SmaccSession.log_debug_msg`; `log_interaction` gains a `debug=` flag (default INFO) so gated interaction lines can be demoted while keeping the `log_interactions` gate.
- `_quiet_qt_multimedia_logging()` in `__main__.py`, called at the top of `main()`.

## Verified
`uv run --extra dev pytest` (267 passed, +9 new), `ruff check`, `ruff format --check`, and `mypy` all green. New tests cover the DEBUG demotion + gate behavior, the Volume-refresh INFO log (available and unavailable cases), and the QT_LOGGING_RULES append/no-clobber/idempotency logic.