### PR TITLE
feat: drop wasapi suffix from device names and add a refresh button

### DIFF
--- a/src/smacc/devices.py
+++ b/src/smacc/devices.py
@@ -11,7 +11,7 @@ change.
 The config persists in a settings file's ``devices`` block::
 
     devices:
-      bindings: {bedroom_out: "Speakers …, Windows WASAPI", bedroom_mic: "…"}
+      bindings: {bedroom_out: "Speakers (Realtek …)", bedroom_mic: "Microphone …"}
       routing:  {cue_out: bedroom_out, noise_out: bedroom_out, report_in: bedroom_mic}
 
 A pre-roles study (no ``devices`` block) is migrated from its per-panel device
@@ -26,6 +26,27 @@ from dataclasses import dataclass, field
 OUTPUT = "output"
 INPUT = "input"
 VISUAL = "visual"
+
+# SMACC enumerates only WASAPI audio devices, so device names used to carry a
+# redundant ", Windows WASAPI" suffix (the host-API name PortAudio appends). New
+# bindings store the bare name; this constant lets older settings that saved the
+# suffixed form still resolve. See :func:`strip_wasapi_suffix`.
+WASAPI_HOST_API = "Windows WASAPI"
+_WASAPI_SUFFIX = f", {WASAPI_HOST_API}"
+
+
+def strip_wasapi_suffix(device: str) -> str:
+    """Drop a trailing ", Windows WASAPI" from a stored device string.
+
+    Device names are no longer stored with the host-API suffix (SMACC only ever
+    lists WASAPI devices, so it added nothing). Older ``.smacc`` files saved the
+    suffixed form, though, so every place that matches a stored device string
+    normalizes through this first — the bare and suffixed forms then compare equal
+    and an existing binding keeps resolving to the same device.
+    """
+    if device.endswith(_WASAPI_SUFFIX):
+        return device[: -len(_WASAPI_SUFFIX)]
+    return device
 
 
 @dataclass(frozen=True)

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -78,6 +78,9 @@ class SmaccWindow(ToolWindow):
             "volume": VolumeWindow(self.session),
         }
         self.devices_window.changed.connect(self._refresh_device_indicators)
+        # The Devices window's Refresh button runs the same rescan as File ▸ Refresh
+        # devices / F5 (PortAudio re-init + BlinkStick scan), not a duplicate.
+        self.devices_window.refresh_requested.connect(self.refresh_all_devices)
         # Hot-plug doorbell: Qt6's QMediaDevices fires when an audio device is added
         # or removed; that triggers an automatic rescan. Audio I/O stays on
         # sounddevice — QMediaDevices is used only as the "something changed" signal.

--- a/src/smacc/panels/devices.py
+++ b/src/smacc/panels/devices.py
@@ -30,14 +30,20 @@ _NONE_LABEL = "(none)"
 
 
 def wasapi_devices(kind: str) -> list[str]:
-    """Return the WASAPI ``"output"`` or ``"input"`` device strings (best effort)."""
+    """Return the WASAPI ``"output"`` or ``"input"`` device names (best effort).
+
+    Only WASAPI devices are listed, so the bare device name is returned (no
+    ", Windows WASAPI" suffix — it added nothing and is what gets persisted as a
+    role binding). sounddevice still resolves a bare name to the right device, and
+    older settings that stored the suffixed form are normalized on load (see
+    :func:`smacc.devices.strip_wasapi_suffix`).
+    """
     chan_key = "max_output_channels" if kind == devices.OUTPUT else "max_input_channels"
-    host_api_name = "Windows WASAPI"
     try:
         host_api_names = [api["name"] for api in sd.query_hostapis()]
         hostapi = (
-            host_api_names.index(host_api_name)
-            if host_api_name in host_api_names
+            host_api_names.index(devices.WASAPI_HOST_API)
+            if devices.WASAPI_HOST_API in host_api_names
             else None
         )
         out = []
@@ -46,8 +52,7 @@ def wasapi_devices(kind: str) -> list[str]:
                 continue
             if hostapi is not None and device["hostapi"] != hostapi:
                 continue
-            suffix = f", {host_api_name}" if hostapi is not None else ""
-            out.append(f"{device['name']}{suffix}")
+            out.append(device["name"])
         return out
     except Exception:
         return []
@@ -75,6 +80,9 @@ class DevicesWindow(ModalityWindow):
 
     # Fired whenever a binding/route changes, so the window can refresh indicators.
     changed = QtCore.pyqtSignal()
+    # Fired by the Refresh button; the session window runs the same rescan as
+    # File ▸ Refresh devices (PortAudio re-init + a live BlinkStick scan).
+    refresh_requested = QtCore.pyqtSignal()
 
     def __init__(self, session: SmaccSession, parent: QtWidgets.QWidget | None = None):
         super().__init__(session, parent)
@@ -110,9 +118,16 @@ class DevicesWindow(ModalityWindow):
             self._route_combos[target.key] = combo
             routing_form.addRow(f"{target.label}:", combo)
 
+        refresh_button = QtWidgets.QPushButton("Refresh devices", self)
+        refresh_button.setStatusTip(
+            "Rescan for audio devices and BlinkSticks (e.g. after plugging one in)."
+        )
+        refresh_button.setToolTip("Rescan for devices plugged in after launch (F5).")
+        refresh_button.clicked.connect(self.refresh_requested)
+
         hint = QtWidgets.QLabel(
             "Bind each role to a device once, then route each modality to a role. "
-            "Plug a device in after launch? Use File ▸ Refresh devices."
+            "Plugged a device in after launch? Refresh devices (or press F5)."
         )
         hint.setWordWrap(True)
 
@@ -124,6 +139,7 @@ class DevicesWindow(ModalityWindow):
         layout.addWidget(self._subheading("Modalities → roles"))
         layout.addLayout(routing_form)
         layout.addWidget(hint)
+        layout.addWidget(refresh_button)
         layout.addStretch(1)
         central = QtWidgets.QWidget()
         central.setLayout(layout)

--- a/src/smacc/utils.py
+++ b/src/smacc/utils.py
@@ -40,11 +40,19 @@ def index_of_device(candidates: Sequence[str], saved: str | None) -> int | None:
     ``saved`` (no prior selection) returns ``None``, as does a saved device that is
     no longer present (unplugged) — the caller then flags the miss and keeps the
     default.
+
+    Both sides are normalized with :func:`smacc.devices.strip_wasapi_suffix` first,
+    so a binding saved by an older SMACC as ``"Name, Windows WASAPI"`` still matches
+    the bare ``"Name"`` now advertised (and vice versa) — keeping existing ``.smacc``
+    files working without a fuzzy match.
     """
     if not saved:
         return None
+    from . import devices
+
+    target = devices.strip_wasapi_suffix(saved)
     for index, key in enumerate(candidates):
-        if key == saved:
+        if devices.strip_wasapi_suffix(key) == target:
             return index
     return None
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,9 +31,12 @@ from smacc import devices
 from smacc.session import SmaccSession
 
 # Device strings the mock enumeration advertises. Window/settings tests bind roles
-# to these exact strings so a loaded study resolves them (no "missing device" notice).
-FAKE_OUTPUTS = ["Speakers (USB Audio), Windows WASAPI", "Headphones, Windows WASAPI"]
-FAKE_INPUTS = ["Microphone (USB Audio), Windows WASAPI"]
+# to these exact strings so a loaded study resolves them (no "missing device"
+# notice). These are bare names (no ", Windows WASAPI"), matching what
+# ``wasapi_devices`` now returns; backward-compat with the old suffixed form is
+# covered explicitly in the device/util tests.
+FAKE_OUTPUTS = ["Speakers (USB Audio)", "Headphones"]
+FAKE_INPUTS = ["Microphone (USB Audio)"]
 FAKE_BLINKSTICKS = [("BlinkStick Square BS012345", "BS012345")]
 
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -3,6 +3,23 @@
 from smacc import devices
 
 
+def test_strip_wasapi_suffix_drops_trailing_host_api():
+    # Older settings stored the host-API suffix; it normalizes away to the bare name.
+    assert (
+        devices.strip_wasapi_suffix("Speakers (USB Audio), Windows WASAPI")
+        == "Speakers (USB Audio)"
+    )
+
+
+def test_strip_wasapi_suffix_leaves_bare_names_untouched():
+    # New bindings store the bare name already, so stripping is a no-op.
+    assert devices.strip_wasapi_suffix("Speakers (USB Audio)") == "Speakers (USB Audio)"
+    # Only a trailing host-API suffix is removed (not the bare host-API name alone,
+    # nor an interior occurrence).
+    assert devices.strip_wasapi_suffix("Windows WASAPI") == "Windows WASAPI"
+    assert devices.strip_wasapi_suffix("Windows WASAPI mixer") == "Windows WASAPI mixer"
+
+
 def test_default_config_routes_targets_to_their_defaults():
     cfg = devices.default_config()
     assert cfg.role_for("cue_out") == "bedroom_out"

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -55,6 +55,22 @@ def test_window_builds_in_session_mode(
     assert hasattr(window, "lightswitchButton")
 
 
+def test_devices_refresh_button_runs_window_rescan(
+    qtbot, live_session, mock_devices, silence_dialogs, monkeypatch
+):
+    # The Devices window's Refresh button must drive the same rescan as
+    # File ▸ Refresh devices (F5), not a parallel one. Stub the real rescan (it
+    # would re-init PortAudio) on the class so the wired-up connection hits it.
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        SmaccWindow, "refresh_all_devices", lambda self: calls.append(True)
+    )
+    window = SmaccWindow(live_session)
+    qtbot.addWidget(window)
+    window.devices_window.refresh_requested.emit()
+    assert calls == [True]
+
+
 # ----- settings gather/apply contract ----------------------------------------
 
 

--- a/tests/test_panels_devices.py
+++ b/tests/test_panels_devices.py
@@ -8,6 +8,8 @@ set). Edits flow through the combos' ``currentIndexChanged`` signals into
 
 from __future__ import annotations
 
+from PyQt6 import QtWidgets
+
 from smacc.panels.devices import DevicesWindow
 
 
@@ -70,3 +72,27 @@ def test_reload_flags_missing_bound_device(qtbot, design_session, mock_devices):
     # combo falls back to the default entry.
     assert window._role_combos["bedroom_out"].currentIndex() == 0
     assert any("Unplugged speaker" in entry for entry in design_session.missing_devices)
+
+
+def test_reload_resolves_legacy_suffixed_binding(qtbot, design_session, mock_devices):
+    # An older .smacc stored the device with the ", Windows WASAPI" suffix, but
+    # enumeration now advertises the bare name. The binding must still resolve to
+    # that device (no "missing device" notice) for backward compatibility.
+    bare = mock_devices["outputs"][1]
+    design_session.devices.bindings["bedroom_out"] = f"{bare}, Windows WASAPI"
+    window = DevicesWindow(design_session)
+    qtbot.addWidget(window)
+    window.reload_from_config()
+    assert window._role_combos["bedroom_out"].currentText() == bare
+    assert design_session.missing_devices == []
+
+
+def test_refresh_button_emits_refresh_requested(qtbot, design_session, mock_devices):
+    # The in-window Refresh button defers to the session window's rescan via this
+    # signal (rather than duplicating the PortAudio re-init).
+    window = DevicesWindow(design_session)
+    qtbot.addWidget(window)
+    button = window.findChild(QtWidgets.QPushButton)
+    assert button is not None and button.text() == "Refresh devices"
+    with qtbot.waitSignal(window.refresh_requested, timeout=1000):
+        button.click()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,6 +40,28 @@ def test_index_of_device_empty_candidates_is_none():
     assert utils.index_of_device([], "Anything") is None
 
 
+def test_index_of_device_new_bare_name_matches_bare_candidate():
+    # The current world: enumeration advertises bare names and a fresh binding
+    # stored the same bare name, so it resolves directly.
+    candidates = ["Speakers (USB Audio)", "Headphones"]
+    assert utils.index_of_device(candidates, "Headphones") == 1
+
+
+def test_index_of_device_old_suffixed_binding_matches_bare_candidate():
+    # Backward-compat: a binding saved by an older SMACC carries the ", Windows
+    # WASAPI" suffix, but enumeration now lists the bare name. The suffix is
+    # normalized away on both sides, so the old .smacc still resolves.
+    candidates = ["Speakers (USB Audio)", "Headphones"]
+    assert utils.index_of_device(candidates, "Headphones, Windows WASAPI") == 1
+
+
+def test_index_of_device_bare_binding_matches_legacy_suffixed_candidate():
+    # The symmetric case (defensive): even if a candidate still carried the suffix,
+    # a bare saved value would match it.
+    candidates = ["Speakers (USB Audio), Windows WASAPI"]
+    assert utils.index_of_device(candidates, "Speakers (USB Audio)") == 0
+
+
 def test_note_returns_int16_of_expected_length():
     rate = 8000
     duration = 1


### PR DESCRIPTION
Polishes the Devices window (#39 follow-up).

## Task A — drop the redundant ", Windows WASAPI" suffix
SMACC only ever enumerates WASAPI devices, so the host-API suffix added nothing to displayed names. `wasapi_devices()` now returns the **bare** device name, which is what new role bindings display and persist.

**Backward-compat (saved .smacc files preserved):** the stored device string is both the combo display and the persisted identity for role→device bindings, resolved to a real device when opening sounddevice streams. sounddevice already resolves a bare name fine, and the one place SMACC does an *exact* match — `utils.index_of_device` (via `select_saved_device`) — now normalizes **both** sides through the new `devices.strip_wasapi_suffix()`. So an old binding saved as `"Speakers, Windows WASAPI"` still selects the bare `"Speakers"` row (no spurious "device not connected" notice), and a bare value still matches a legacy suffixed candidate. The suffix string lives in one place (`devices.WASAPI_HOST_API`).

## Task B — Refresh button in the Devices window
Added a "Refresh devices" button that emits a new `refresh_requested` signal; `SmaccWindow` wires it to the existing `refresh_all_devices` handler (same rescan as File ▸ Refresh devices / F5 — PortAudio re-init + BlinkStick scan), so no rescan logic is duplicated. The bottom hint is simplified to point at the button (noting F5 also works).

## Tests
- `strip_wasapi_suffix` unit tests; `index_of_device` tests for the new bare name and old suffixed value (both directions).
- DevicesWindow: a legacy-suffixed binding resolves to the bare row with no missing-device flag; the Refresh button emits `refresh_requested`.
- GUI: `refresh_requested` reaches `refresh_all_devices`.
- conftest fake device lists updated to bare names (matching the new enumeration).

Docs note about the WASAPI behavior is intentionally left for a separate docs PR.

Quality gate: `pytest` (266 passed), `ruff check`, `ruff format --check`, `mypy` all green.