### PR TITLE
docs: document SMACC file schemas and reset them to a stable v1

### DIFF
--- a/docs/reference/bids-export.md
+++ b/docs/reference/bids-export.md
@@ -1,0 +1,48 @@
+# BIDS export (`events.tsv` + sidecar)
+
+SMACC can convert a session [log](session-log.md) into a
+[BIDS](https://bids.neuroimaging.io/) events file — a tab-separated `events.tsv` plus
+a JSON sidecar describing its columns. Export one from **Analyze**, or from a live
+session's exporters. Only event-marker lines (`" - portcode N"`) become rows.
+
+## `events.tsv`
+
+Tab-separated, one header row plus one row per marker:
+
+```text
+onset	duration	trial_type	value
+5.5	n/a	Lights off	47
+283.9	n/a	Dream report started	201
+```
+
+| Column | Type | Meaning |
+|---|---|---|
+| `onset` | seconds | Time from the **first** parseable log line (the onset origin). |
+| `duration` | seconds or `n/a` | `n/a` for instantaneous markers (all SMACC markers are instantaneous). |
+| `trial_type` | string | The event label, exactly as logged. |
+| `value` | integer | The event's port code (1–255). |
+
+## JSON sidecar
+
+Written alongside as `<name>.json`, describing each column. `value` points back to the
+log's [`event_codes`](settings-file.md#event_codes) block for the full code-to-event
+map of that session:
+
+```json
+{
+  "onset": {
+    "Description": "Event onset relative to the first log entry.",
+    "Units": "second"
+  },
+  "duration": {
+    "Description": "Event duration; 'n/a' for instantaneous markers.",
+    "Units": "second"
+  },
+  "trial_type": {
+    "Description": "Event label as logged by SMACC."
+  },
+  "value": {
+    "Description": "SMACC event-marker port code. The full code-to-event map for the session is recorded in its .log settings block (under event_codes)."
+  }
+}
+```

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,0 +1,33 @@
+# File formats
+
+SMACC reads and writes a handful of files. This section is the **reference** for
+each one — its on-disk shape, every field, and how it is versioned — as distinct
+from the task-oriented [Usage](../usage.md) guide.
+
+| File | What it is | Format | Version |
+|---|---|---|---|
+| [`.smacc` settings](settings-file.md) | A portable study configuration | YAML | `schema_version: 1` |
+| [`preferences.yaml`](preferences-file.md) | Per-machine operator preferences | YAML | `schema_version: 1` |
+| [Session `.log`](session-log.md) | The per-run record (events + settings) | Text | — |
+| [BIDS export](bids-export.md) | `events.tsv` + JSON sidecar | TSV / JSON | follows BIDS |
+
+## Where each file lives
+
+- The **SMACC directory** (`$SMACC_DIRECTORY`, else `~/SMACC`) holds `preferences.yaml`,
+  the seeded `default.smacc`, and the default data directory.
+- A **`.smacc`** can live anywhere; it names the **data directory** its runs are
+  written to.
+- Each **run** gets its own timestamped folder (`smacc-YYYYmmdd-HHMMSS/`) under that
+  data directory, holding the session `.log`, any dream-report audio, and exports.
+
+## Stability promise
+
+`.smacc` and `preferences.yaml` each carry an integer `schema_version`, currently
+**1** — the first stable release schema. SMACC loads only the current version; it
+does **not** migrate older or unknown versions. Missing *optional* keys are always
+tolerated (each falls back to a default), so a partial or hand-edited file still
+loads.
+
+The format will not change incompatibly without **bumping `schema_version`** and
+adding a row to that file's version-history table. The `kind` discriminator
+(`smacc/settings`, `smacc/preferences`) lets SMACC reject files that aren't its own.

--- a/docs/reference/preferences-file.md
+++ b/docs/reference/preferences-file.md
@@ -1,0 +1,54 @@
+# Preferences file (`preferences.yaml`)
+
+`preferences.yaml` holds **per-machine operator preferences** — where each window was
+last placed and the launcher's recent-files list. It is the machine layer, kept
+separate from a portable [`.smacc` study](settings-file.md) (which a researcher shares
+between rigs) and from a per-run [session log](session-log.md).
+
+It lives in the SMACC directory (`$SMACC_DIRECTORY`, else `~/SMACC/preferences.yaml`),
+is loaded at startup, and is written on quit. It must never break the app: a missing
+or corrupt file falls back to the built-in defaults, and saving swallows errors.
+
+## Example
+
+```yaml
+kind: smacc/preferences
+schema_version: 1
+preferences:
+  windows:
+    launcher: {x: 100, y: 100, w: 340, h: 360}
+    main: {x: 120, y: 80, w: 900, h: 700}
+  association_prompted: true
+  recent_settings:
+    - C:\Users\you\SMACC\peter.smacc
+    - C:\Users\you\SMACC\paul.smacc
+  last_settings: C:\Users\you\SMACC\peter.smacc
+```
+
+## Fields
+
+| Key | Type | Meaning |
+|---|---|---|
+| `kind` | string | Always `smacc/preferences`; a file with a different `kind` is ignored (defaults are used). |
+| `schema_version` | integer | The preferences schema version (currently **1**). |
+| `preferences` | mapping | The preferences themselves (below). |
+
+### `preferences`
+
+| Key | Type | Meaning |
+|---|---|---|
+| `windows` | mapping | Per-window geometry, keyed by a stable window id → `{x, y, w, h}`. Ids include `launcher`, `main` (the session window), the analyze window, and each tool window. An absent/`null` `x`/`y` means "no saved position — open at a default". |
+| `association_prompted` | boolean | Whether the first-run "associate `.smacc` files (Windows)?" prompt has already been shown. |
+| `recent_settings` | list of paths | Recently opened `.smacc` files, most-recent first, de-duplicated and capped at 8. |
+| `last_settings` | path or `null` | The last `.smacc` opened, so the launcher can preselect it. |
+
+!!! note "Partial files are fine"
+    Loading merges a file's keys over the defaults, so a file missing some keys still
+    yields every key. There is no cross-version migration; only `schema_version: 1`
+    is current.
+
+## Version history
+
+| Version | Changes |
+|---|---|
+| 1 | First stable schema: `windows`, `association_prompted`, `recent_settings`, `last_settings`. |

--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -1,0 +1,61 @@
+# Session log (`.log`)
+
+Every live run writes one plain-text log to its own timestamped folder
+(`smacc-YYYYmmdd-HHMMSS/`) under the study's data directory. It is the session's
+record: every event marker, the soft interactions (volume / colour / device changes),
+and two embedded snapshots of the full settings the run used. The study *designer*
+(which records nothing) writes no log.
+
+## Line format
+
+Each line is three comma-separated fields:
+
+```text
+YYYY-MM-DD HH:MM:SS.mmm, LEVEL, message
+```
+
+- **timestamp** — local wall-clock, millisecond precision.
+- **LEVEL** — a Python logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or
+  `CRITICAL`. The file records every level; the live on-screen preview shows only a
+  configurable subset.
+- **message** — the log text. An **event-marker** line ends in `" - portcode N"`:
+
+```text
+2026-06-09 22:14:01.003, INFO, Opened SMACC v0.0.7
+2026-06-09 22:14:05.221, INFO, Lights off - portcode 47
+2026-06-09 22:18:30.880, INFO, Dream report started - portcode 201
+2026-06-09 22:19:02.114, INFO, Cue volume set to 0.40
+```
+
+A marker line is `"{label} - portcode {code}"` when the event drives a trigger, or
+just `"{label}"` when it does not. The code-to-event map is the study's
+[`event_codes`](settings-file.md#event_codes) registry; see the
+[default code catalog](../triggers.md#default-event-codes).
+
+## Embedded settings blocks
+
+The log carries the **complete settings the run used**, so a session stays
+self-documenting even if the study file later changes. The block is the same payload
+as a [`.smacc` file](settings-file.md), but every line is prefixed with `#` and
+fenced by sentinels, so log parsers skip it entirely:
+
+```text
+# --8<-- smacc/settings initial
+# kind: smacc/settings
+# schema_version: 1
+# smacc_version: 0.0.7
+# metadata:
+#   subject: '001'
+#   ...
+# settings:
+#   ...
+# --8<-- end smacc/settings initial
+```
+
+Two snapshots are written: **`initial`** (at startup) and **`final`** (appended at
+quit). The `final` block may be absent if a session crashed before quitting. Analyze
+can recover a `.smacc` from either block.
+
+!!! note "No separate version"
+    The log itself isn't versioned; its embedded blocks carry the
+    [settings `schema_version`](settings-file.md#version-history).

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -1,0 +1,168 @@
+# Settings file (`.smacc`)
+
+A `.smacc` file is a **portable study configuration**: it lets a researcher set
+SMACC up once — cue sounds and volumes, noise, the visual cue, surveys, event codes,
+device routing, optional hardware triggers — and reload it each session so the setup
+stays consistent across nights and researchers. It is plain YAML you can read and
+edit. The user-facing extension is `.smacc`, but the `kind` stays `smacc/settings`.
+
+See [Usage › Settings files](../usage.md#settings-files-smacc) for the task-level
+guide (creating, editing, sharing). This page is the field reference.
+
+## On-disk shape
+
+```yaml
+# SMACC settings — YAML (.smacc). Edit with care.
+kind: smacc/settings
+schema_version: 1
+smacc_version: "0.0.7"
+metadata:
+  subject: "001"
+  session: "1"
+  notes: ""
+  created: "2026-06-09T22:14:00"
+settings:
+  # --- Audio cues ------------------------------------------------------------
+  cues:
+    - {name: "Piano cue", file: "cues/piano.wav", volume: 0.4, loop: false}
+  cue_attack: 0.0
+  cue_release: 0.0
+  # --- Background noise ------------------------------------------------------
+  noise_volume: 0.2
+  noise_color: white
+  noise_source: builtin
+  noise_file: ""
+  # --- Visual cue (BlinkStick) -----------------------------------------------
+  blink_color: "#000000"
+  blink_length: 1.0
+  # --- Survey ----------------------------------------------------------------
+  survey_url: ""
+  survey_options: {}
+  # --- Output safety cap -----------------------------------------------------
+  volume_cap: 1.0
+  # --- Device roles + routing ------------------------------------------------
+  devices:
+    bindings: {}
+    routing:
+      cue_out: bedroom_out
+      noise_out: bedroom_out
+      report_in: bedroom_mic
+      visual_out: blinkstick
+  # --- Event-marker registry -------------------------------------------------
+  event_codes:
+    - {key: REMDetected, code: 41, trigger: true, preview: true, increment: false}
+  event_code_safe_max: 255
+  # --- Optional hardware trigger output --------------------------------------
+  trigger_output:
+    enabled: false
+    transport: serial
+    port: ""
+    baud: 115200
+    address: "0x378"
+    mode: pulsed
+    pulse_ms: 10
+  # --- Data directory + interface --------------------------------------------
+  data_directory: data
+  preview_levels: [INFO, WARNING, ERROR, CRITICAL]
+  always_on_top: false
+  tool_always_on_top: {}
+```
+
+## Envelope
+
+| Key | Type | Meaning |
+|---|---|---|
+| `kind` | string | Always `smacc/settings`; a file with a different `kind` is rejected. |
+| `schema_version` | integer | The settings schema version — currently **1**. Only the current version loads. |
+| `smacc_version` | string | The SMACC version that wrote the file (informational). |
+| `metadata` | mapping | Optional run metadata: `subject`, `session`, `notes`, and `created` (ISO timestamp). Blank by default; recorded in the log, not baked into filenames. |
+| `settings` | mapping | The configuration itself (below). |
+
+## `settings`
+
+Every panel contributes its own keys; a few window-level blocks travel alongside.
+Any key may be omitted — each falls back to its default.
+
+### Audio, noise, visual, survey, volume
+
+| Key | Type | Meaning |
+|---|---|---|
+| `cues` | list | One entry per cue slot: `name` (string), `file` (WAV path), `volume` (0–1), `loop` (bool). |
+| `cue_attack` | seconds | Fade-in applied to a starting cue. |
+| `cue_release` | seconds | Fade-out applied to a stopping cue. |
+| `noise_volume` | 0–1 | Background-noise level. |
+| `noise_color` | string | Selected noise colour (as offered in the Noise panel, e.g. `white`). |
+| `noise_source` | `builtin` \| `file` | Generated noise, or a WAV file. |
+| `noise_file` | path | The noise WAV when `noise_source: file`. |
+| `blink_color` | `#rrggbb` | BlinkStick colour for the visual cue. |
+| `blink_length` | seconds | Visual-cue blink length. |
+| `survey_url` | string | The selected survey URL. |
+| `survey_options` | mapping | Named survey presets: label → URL. |
+| `volume_cap` | 0–1 | Master output safety cap multiplied into every stimulus (`1.0` = no cap). |
+
+### Window-level
+
+| Key | Type | Meaning |
+|---|---|---|
+| `data_directory` | path | Where this study's runs are written (relative to the `.smacc`, or absolute). |
+| `preview_levels` | list | Log levels shown in the live preview, e.g. `[INFO, WARNING, ERROR, CRITICAL]`. |
+| `always_on_top` | boolean | Whether the main session window floats on top. |
+| `tool_always_on_top` | mapping | Per-tool always-on-top, keyed by panel key. |
+
+### `event_codes`
+
+The editable event-marker registry: a list of overrides applied over the
+[built-in registry](../triggers.md#default-event-codes). A study that omits it uses
+the built-ins; one that overrides a few codes keeps the rest.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `key` | string | Stable event id (e.g. `REMDetected`). |
+| `code` | integer | Port code, 1–255. |
+| `trigger` | boolean | Whether the event pushes a marker. |
+| `preview` | boolean | Whether it shows in the live preview (the file always records it). |
+| `increment` | boolean | Whether successive firings advance the code (e.g. dream reports). |
+
+A built-in entry persists only those fields. A **custom** event also carries
+`label`, `category`, `tooltip`, and `builtin: false` so it can be reconstructed on
+load. `event_code_safe_max` (integer, default 255) sets the soft upper-bound warning.
+
+### `devices`
+
+Role → device bindings plus target → role routing (see [Audio & routing](../audio.md)
+and [Devices](../devices.md)).
+
+| Key | Type | Meaning |
+|---|---|---|
+| `bindings` | mapping | Role key → device name. Roles: `bedroom_out`, `control_out`, `bedroom_mic`, `monitor_mic`, `blinkstick`. |
+| `routing` | mapping | Target key → role key (`""` = off). Targets: `cue_out`, `cue_monitor`, `noise_out`, `intercom_talk`, `intercom_listen`, `report_in`, `monitor_in`, `visual_out`. |
+
+A missing `devices` block loads the defaults (each target on its default role, with
+no devices bound).
+
+### `trigger_output`
+
+Optional hardware TTL trigger output, mirrored alongside the always-on LSL stream
+(see [Triggers & port codes](../triggers.md)).
+
+| Field | Type | Meaning |
+|---|---|---|
+| `enabled` | boolean | Whether the hardware path is on (LSL is always on regardless). |
+| `transport` | `serial` \| `parallel` | USB trigger box, or parallel (LPT) port. |
+| `port` | string | Serial COM port, e.g. `COM3`. |
+| `baud` | integer | Serial baud rate (default 115200). |
+| `address` | string | Parallel-port base address as hex, e.g. `0x378`. |
+| `mode` | `pulsed` \| `hold` | Pulse the code then drop, or set-and-hold until the next event. |
+| `pulse_ms` | integer | Pulse width in ms when `mode: pulsed` (default 10). |
+
+## Paths and portability
+
+Cue/noise WAVs and `data_directory` are stored **relative** to the `.smacc` when they
+sit beside it (POSIX separators) and **absolute** otherwise, so a self-contained study
+folder stays valid when moved, copied, or zipped.
+
+## Version history
+
+| Version | Changes |
+|---|---|
+| 1 | First stable schema. Envelope (`kind` / `schema_version` / `smacc_version` / `metadata` / `settings`); panel state; the `devices`, `event_codes` + `event_code_safe_max`, `trigger_output`, `data_directory`, `preview_levels`, `always_on_top`, and `tool_always_on_top` blocks. |

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -20,6 +20,42 @@ bits), and the amplifier reads them as one byte. SMACC keeps every code inside 1
 for this reason. See [Configuring codes](usage.md#configuring-codes) for how to view
 and edit which event sends which code.
 
+## Default event codes
+
+These are SMACC's built-in event markers and their default port codes — the
+out-of-the-box [`event_codes`](reference/settings-file.md#event_codes) registry. A
+study can retune any code in the **Event codes** editor; the change travels in its
+[`.smacc`](reference/settings-file.md) and is written into every session log.
+
+<!-- BEGIN auto:event-codes (kept in lockstep with smacc.events.default_events by tests/test_docs_schema.py) -->
+| Code | Event | Key | Notes |
+|------|-------|-----|-------|
+| 41 | REM detected | `REMDetected` | |
+| 42 | Tech in room | `TechInRoom` | |
+| 43 | TLR training start | `TLRTrainingStart` | |
+| 44 | TLR training end | `TLRTrainingEnd` | |
+| 45 | LRLR detected | `LRLRDetected` | lucid left-right-left-right signal |
+| 46 | Sleep onset | `SleepOnset` | |
+| 47 | Lights off | `LightsOff` | |
+| 48 | Lights on | `LightsOn` | |
+| 49 | Clapper | `Clapper` | sync marker |
+| 50 | Note | `Note` | |
+| 51 | Start recording | `RecordingStarted` | sets the reference clock for dream-report timestamps |
+| 60 | Cue started | `CueStarted` | |
+| 61 | Cue stopped | `CueStopped` | |
+| 62 | Noise started | `NoiseStarted` | |
+| 63 | Noise stopped | `NoiseStopped` | |
+| 64 | Intercom started | `IntercomStarted` | |
+| 65 | Intercom stopped | `IntercomStopped` | |
+| 66 | Visual stimulation | `VisualStarted` | |
+| 67 | Survey opened | `SurveyOpened` | |
+| 100 | SMACC initialized | `TriggerInitialization` | startup connection test; not a stimulus marker |
+| 200 | Dream report stopped | `DreamReportStopped` | |
+| 201 | Dream report started | `DreamReportStarted` | increments per report (201, 202, …) |
+<!-- END auto:event-codes -->
+
+Codes are integers in **1–255** and must be unique among triggered events.
+
 ## How SMACC sends triggers
 
 SMACC always emits markers over **LSL** (Lab Streaming Layer), a network marker

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -145,7 +145,9 @@ session (always-on-top and log-preview levels), and the **data directory** where
 are written — in a single portable `.smacc` (plain YAML you can read and edit). The easiest way to build one is the **settings editor** (the launcher's
 **Create settings**, or **Edit…** for an existing one): configure the tools, set the
 data directory, and save. SMACC ships a `default.smacc` in your SMACC directory as a
-working example you can copy.
+working example you can copy. For the exact on-disk format — every field, the
+sub-blocks, and the schema version — see the
+[`.smacc` reference](reference/settings-file.md).
 
 You can keep settings files anywhere — for instance one per participant
 (`peter.smacc`, `paul.smacc`, …), each pointing at whatever data directory you like

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,4 +50,10 @@ nav:
   - Audio & routing: audio.md
   - Devices: devices.md
   - Triggers & port codes: triggers.md
+  - Reference:
+    - File formats: reference/index.md
+    - Settings file (.smacc): reference/settings-file.md
+    - Preferences file: reference/preferences-file.md
+    - Session log: reference/session-log.md
+    - BIDS export: reference/bids-export.md
   - Contributing: contributing.md

--- a/src/smacc/assets/default.smacc
+++ b/src/smacc/assets/default.smacc
@@ -1,6 +1,6 @@
 # SMACC settings — YAML (.smacc). Edit with care.
 kind: smacc/settings
-schema_version: 4
+schema_version: 1
 smacc_version: 0.0.7
 metadata:
   subject: ''

--- a/src/smacc/devices.py
+++ b/src/smacc/devices.py
@@ -14,8 +14,8 @@ The config persists in a settings file's ``devices`` block::
       bindings: {bedroom_out: "Speakers (Realtek …)", bedroom_mic: "Microphone …"}
       routing:  {cue_out: bedroom_out, noise_out: bedroom_out, report_in: bedroom_mic}
 
-A pre-roles study (no ``devices`` block) is migrated from its per-panel device
-keys; see :func:`migrate_legacy`.
+A settings dict with no ``devices`` block loads the default config (each target on
+its default role, with no devices bound yet).
 """
 
 from __future__ import annotations
@@ -159,40 +159,10 @@ def from_dict(data: object) -> DeviceConfig:
     return cfg
 
 
-# Pre-roles studies stored one device per panel; map each onto a role. Outputs all
-# seed the bedroom output (cue/noise/intercom usually shared one speaker), so the
-# first non-empty one wins; the control-room output starts unbound.
-_LEGACY_DEVICE_KEYS: tuple[tuple[str, str], ...] = (
-    ("cue_device", "bedroom_out"),
-    ("noise_device", "bedroom_out"),
-    ("intercom_output_device", "bedroom_out"),
-    ("recording_device", "bedroom_mic"),
-    ("blink_device", "blinkstick"),
-)
-
-
-def migrate_legacy(settings: dict) -> DeviceConfig:
-    """Seed a DeviceConfig from a pre-roles study's per-panel device keys.
-
-    Best-effort: the old keys are per-modality, not per-role, so the first
-    non-empty output device becomes the bedroom output, the recorder's mic becomes
-    the bedroom mic, and the BlinkStick its own role. Anything can be re-pointed in
-    the Devices panel afterward.
-    """
-    cfg = default_config()
-    for legacy_key, role_key in _LEGACY_DEVICE_KEYS:
-        device = settings.get(legacy_key)
-        if isinstance(device, str) and device and role_key not in cfg.bindings:
-            cfg.bindings[role_key] = device
-    return cfg
-
-
 def load(settings: dict) -> DeviceConfig:
-    """Build the device config for a loaded settings dict.
+    """Build the device config from a settings dict's ``devices`` block.
 
-    Uses the ``devices`` block when present, else migrates the legacy per-panel
-    device keys so an older study keeps its routing on first load.
+    A missing block yields the default config (each target on its default role, with
+    no devices bound); :func:`from_dict` tolerates a malformed block the same way.
     """
-    if isinstance(settings.get("devices"), dict):
-        return from_dict(settings["devices"])
-    return migrate_legacy(settings)
+    return from_dict(settings.get("devices"))

--- a/src/smacc/events.py
+++ b/src/smacc/events.py
@@ -234,10 +234,9 @@ def merge_event_codes(loaded: Any) -> list[EventDef]:
     """Return the default registry with saved overrides + custom events applied.
 
     Mirrors the merge-over-DEFAULTS approach in :mod:`smacc.preferences`: a study
-    with no ``event_codes`` (older schema) yields the full defaults; a study that
-    overrides only a few built-in codes keeps the rest; saved custom events
-    (``builtin: false``) are appended after the built-ins. Default ordering is
-    preserved.
+    with no ``event_codes`` yields the full defaults; a study that overrides only a
+    few built-in codes keeps the rest; saved custom events (``builtin: false``) are
+    appended after the built-ins. Default ordering is preserved.
     """
     defaults = {e.key: e for e in default_events()}
     custom: list[EventDef] = []

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -648,9 +648,9 @@ class SmaccWindow(ToolWindow):
         # The data directory (where runs are written) travels with the settings;
         # the editor can repoint it, so read the window's copy, not the session's.
         state["data_directory"] = str(self.data_dir)
-        # Interface choices that used to live in preferences.yaml now travel with the
-        # study (schema v6): the live-preview levels and the main window's
-        # always-on-top, plus a per-tool always-on-top map keyed by panel key.
+        # Interface choices that travel with the study: the live-preview levels and
+        # the main window's always-on-top, plus a per-tool always-on-top map keyed by
+        # panel key.
         state["preview_levels"] = self._gather_preview_levels()
         state["always_on_top"] = self._always_on_top_action.isChecked()
         state["tool_always_on_top"] = {
@@ -681,26 +681,26 @@ class SmaccWindow(ToolWindow):
         was_logging = self.session.log_interactions
         self.session.log_interactions = False
         self.session.missing_devices = []  # filled by the Devices reload below
-        # Device roles/routing first, so panels resolve correctly (migrates old files).
+        # Device roles/routing first, so panels resolve their device against them.
         self.session.devices = devices.load(state)
         trigger_error: str | None = None
         try:
             for panel in self.panels.values():
                 panel.apply_state(state)
-            # Apply the study's event-code registry (or defaults for a pre-v4
-            # study with no event_codes) to the live session.
+            # Apply the study's event-code registry (or the defaults when it omits
+            # event_codes) to the live session.
             self.session.set_event_codes(
                 state.get("event_codes"), state.get("event_code_safe_max")
             )
-            # Optional hardware-trigger config (disabled for a pre-v5 study). Open
-            # the transport now so a bad port/driver is reported at load, not mid-run.
+            # Optional hardware-trigger config (disabled when the study omits it).
+            # Open the transport now so a bad port/driver is reported at load.
             self.session.trigger_config = triggers.load(state)
             trigger_error = self.session.set_trigger_output(self.session.trigger_config)
             self._rebuild_events_panel()  # a loaded study may add/remove buttons
             self.devices_window.reload_from_config()  # sync widgets + flag missing
             self._refresh_device_indicators()
-            # Interface choices carried by the study (schema v6): preview levels and
-            # per-window always-on-top. A pre-v6 study omits these; defaults apply.
+            # Interface choices carried by the study: preview levels and per-window
+            # always-on-top. A study may omit these; the interface defaults apply.
             self._apply_preview_levels(state)
             self._apply_always_on_top_settings(state)
         finally:
@@ -712,8 +712,8 @@ class SmaccWindow(ToolWindow):
     def _apply_preview_levels(self, state: dict) -> None:
         """Sync the live-preview level boxes from a loaded study's ``preview_levels``.
 
-        Absent (a pre-v6 study) leaves the current selection — which the window seeded
-        to the default set — untouched, so older files load with sensible defaults.
+        Absent (the study omits the key) leaves the current selection — which the
+        window seeded to the default set — untouched, so the defaults apply.
         The value is also remembered so the editor (which has no preview pane) can
         round-trip it on save instead of clobbering it.
         """
@@ -731,9 +731,9 @@ class SmaccWindow(ToolWindow):
     def _apply_always_on_top_settings(self, state: dict) -> None:
         """Apply the main window's + each tool window's always-on-top from a study.
 
-        The main window's flag is the moved ``always_on_top`` scalar; the tools read
-        a ``tool_always_on_top`` map keyed by panel key. Both default to off for a
-        pre-v6 study (or any key the file omits).
+        The main window's flag is the ``always_on_top`` scalar; the tools read a
+        ``tool_always_on_top`` map keyed by panel key. Both default to off for any
+        key the study omits.
         """
         main = bool(state.get("always_on_top", False))
         self._always_on_top_action.blockSignals(True)

--- a/src/smacc/panels/audio.py
+++ b/src/smacc/panels/audio.py
@@ -592,17 +592,6 @@ class AudioCueWindow(ModalityWindow):
             self._resize_slots(len(cues))
             for slot, cue in zip(self.slots, cues, strict=False):
                 self._apply_cue(slot, cue)
-        elif state.get("cue_file") is not None or state.get("cue_volume") is not None:
-            # Back-compat: a v1 single cue maps into the first slot.
-            self._resize_slots(1)
-            self._apply_cue(
-                self.slots[0],
-                {
-                    "file": state.get("cue_file", ""),
-                    "volume": state.get("cue_volume"),
-                    "loop": state.get("cue_loop"),
-                },
-            )
         if (v := state.get("cue_attack")) is not None:
             self.attackSpinBox.setValue(float(v))
         if (v := state.get("cue_release")) is not None:

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -10,8 +10,7 @@ errors.
 
 Window geometry is a *per-window* map (:data:`DEFAULTS` ``windows``) keyed by a
 stable id (``"launcher"``, ``"main"``, the analyze window, each tool window), so
-every window reopens where it was last left. A legacy single ``window`` block (the
-old session-window-only geometry) is migrated into ``windows["main"]`` on load.
+every window reopens where it was last left.
 """
 
 from __future__ import annotations
@@ -26,8 +25,8 @@ import yaml
 KIND = "smacc/preferences"
 SCHEMA_VERSION = 1
 
-# The stable id under which the old single-window geometry block is migrated into
-# the per-window ``windows`` map (the main session window's geometry).
+# The stable id of the main session window's geometry within the per-window
+# ``windows`` map.
 MAIN_WINDOW_ID = "main"
 
 # Operator/machine preferences and their out-of-the-box values. Loading merges a
@@ -56,8 +55,8 @@ def load_preferences(path: str | Path) -> dict[str, Any]:
     """Return preferences merged over the defaults; never raises.
 
     A missing, unreadable, unparseable, or non-preferences file yields a full copy
-    of :data:`DEFAULTS`. A valid file's keys are merged on top, so a file written
-    by an older schema still provides every key.
+    of :data:`DEFAULTS`. A valid file's keys are merged on top, so a partial file
+    still provides every key.
     """
     prefs = default_preferences()
     try:
@@ -72,25 +71,7 @@ def load_preferences(path: str | Path) -> dict[str, Any]:
         for key in prefs:
             if key in stored:
                 prefs[key] = stored[key]
-        _migrate_legacy_window(prefs, stored)
     return prefs
-
-
-def _migrate_legacy_window(prefs: dict[str, Any], stored: dict[str, Any]) -> None:
-    """Fold a legacy single ``window`` block into ``windows[MAIN_WINDOW_ID]``.
-
-    Older preference files stored only the session window's geometry under a flat
-    ``window`` key. Map it onto the main window's entry in the per-window ``windows``
-    map so an upgrading operator keeps their saved main-window position. An explicit
-    ``windows`` entry already in the file wins (it is the newer shape).
-    """
-    legacy = stored.get("window")
-    windows = prefs.get("windows")
-    if not isinstance(windows, dict):
-        windows = {}
-        prefs["windows"] = windows
-    if isinstance(legacy, dict) and MAIN_WINDOW_ID not in windows:
-        windows[MAIN_WINDOW_ID] = legacy
 
 
 def save_preferences(path: str | Path, prefs: dict[str, Any]) -> None:

--- a/src/smacc/settings.py
+++ b/src/smacc/settings.py
@@ -9,7 +9,7 @@ reject YAML that wasn't written by it.
 The on-disk shape (a ``.smacc`` file is YAML text with a leading comment header)::
 
     kind: smacc/settings
-    schema_version: 6
+    schema_version: 1
     smacc_version: "0.0.7"
     metadata: {subject: "", session: "", notes: "", created: "..."}
     settings: { ...the panel state from SmaccWindow.gather_settings()... }
@@ -17,9 +17,9 @@ The on-disk shape (a ``.smacc`` file is YAML text with a leading comment header)
 The ``settings`` mapping carries, besides each panel's state, a few window-level
 blocks: ``devices`` (role/routing config), ``event_codes`` + ``event_code_safe_max``
 (the marker registry), ``trigger_output`` (the optional hardware-trigger config; see
-:mod:`smacc.triggers`), ``data_directory``, and (since v6) the interface choices that
-used to live in ``preferences.yaml``: ``preview_levels`` (the live-log levels),
-``always_on_top`` (the main window's), and ``tool_always_on_top`` (a per-tool map).
+:mod:`smacc.triggers`), ``data_directory``, and the interface choices ``preview_levels``
+(the live-log levels), ``always_on_top`` (the main window's), and ``tool_always_on_top``
+(a per-tool map).
 
 Referenced media (cue/noise WAVs) are stored *relative* to the file when they sit
 beside it and *absolute* otherwise, so a study folder is portable as-is; see
@@ -48,14 +48,13 @@ KIND = "smacc/settings"
 # ignores ``#`` comments, so this round-trips cleanly through ``safe_load``).
 _FILE_HEADER = "# SMACC settings — YAML (.smacc). Edit with care.\n"
 
-# Bump when the serialized layout changes incompatibly. Files written by older
-# (lower) versions are still accepted on load; panels handle field-level
-# back-compat (e.g. a v1 single cue maps into the first multi-slot cue, a pre-v4
-# file with no event_codes falls back to the default registry, a pre-v5 file with
-# no trigger_output falls back to hardware triggers disabled — LSL only, and a
-# pre-v6 file with no preview_levels/always_on_top falls back to the interface
-# defaults: the INFO+ preview levels and always-on-top off).
-SCHEMA_VERSION = 6
+# v1 is the first stable on-disk schema. Bump this when the layout changes
+# incompatibly — and when you do, add a migration path here plus a row to the
+# version-history table in docs/reference/settings-file.md. A file carrying a
+# higher or otherwise-unknown version is rejected on load. Missing *optional* keys
+# are not a version concern: each panel/sub-block fills its own default, so a
+# partial or hand-edited v1 file still loads.
+SCHEMA_VERSION = 1
 
 
 def build_payload(settings: dict[str, Any], metadata: dict) -> dict[str, Any]:
@@ -105,7 +104,7 @@ def parse_settings_mapping(payload: Any) -> tuple[dict, dict]:
     if kind is not None and kind != KIND:
         raise ValueError(f"Not a compatible SMACC settings file (kind={kind!r}).")
     version = payload.get("schema_version")
-    # Accept any known (current-or-older) version; panels migrate field shapes.
+    # Only the current schema is accepted; there is no cross-version migration.
     if isinstance(version, bool) or not isinstance(version, int):
         raise ValueError(f"Unsupported settings schema version {version!r}.")
     if not (1 <= version <= SCHEMA_VERSION):

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -120,7 +120,7 @@ def test_write_events_json_sidecar(tmp_path):
 
 # ----- embedded settings block ----------------------------------------------
 
-PAYLOAD = {"kind": "smacc/settings", "schema_version": 3, "settings": {"v": 0.1}}
+PAYLOAD = {"kind": "smacc/settings", "schema_version": 1, "settings": {"v": 0.1}}
 
 
 def test_settings_block_is_ignored_by_event_parsing():
@@ -137,8 +137,8 @@ def test_settings_block_is_ignored_by_event_parsing():
 
 
 def test_extract_settings_initial_and_final():
-    initial = {"kind": "smacc/settings", "schema_version": 3, "settings": {"v": 0.1}}
-    final = {"kind": "smacc/settings", "schema_version": 3, "settings": {"v": 0.9}}
+    initial = {"kind": "smacc/settings", "schema_version": 1, "settings": {"v": 0.1}}
+    final = {"kind": "smacc/settings", "schema_version": 1, "settings": {"v": 0.9}}
     log = (
         bids.format_settings_block(initial, "initial")
         + SAMPLE_LOG

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -106,34 +106,14 @@ def test_from_dict_handles_non_mapping():
     assert cfg.role_for("cue_out") == "bedroom_out"  # falls back to defaults
 
 
-def test_migrate_legacy_maps_panel_keys_to_roles():
-    cfg = devices.migrate_legacy(
-        {
-            "cue_device": "Spk, Windows WASAPI",
-            "noise_device": "Other, Windows WASAPI",  # ignored: bedroom_out already set
-            "recording_device": "Mic, Windows WASAPI",
-            "blink_device": "BS012345",
-        }
-    )
-    assert cfg.bindings["bedroom_out"] == "Spk, Windows WASAPI"  # first output wins
-    assert cfg.bindings["bedroom_mic"] == "Mic, Windows WASAPI"
-    assert cfg.bindings["blinkstick"] == "BS012345"
-    assert "control_out" not in cfg.bindings  # new role starts unbound
-    assert cfg.device_for("noise_out") == "Spk, Windows WASAPI"  # shares bedroom_out
+def test_load_reads_devices_block():
+    settings = {"devices": {"bindings": {"bedroom_out": "Spk"}, "routing": {}}}
+    assert devices.load(settings).device_for("cue_out") == "Spk"
 
 
-def test_migrate_legacy_falls_back_to_noise_when_no_cue_device():
-    cfg = devices.migrate_legacy({"noise_device": "N, Windows WASAPI"})
-    assert cfg.bindings["bedroom_out"] == "N, Windows WASAPI"
-
-
-def test_load_prefers_devices_block_over_legacy():
-    settings = {
-        "devices": {"bindings": {"bedroom_out": "New"}, "routing": {}},
-        "cue_device": "Old",  # legacy key ignored when a devices block is present
-    }
-    assert devices.load(settings).device_for("cue_out") == "New"
-
-
-def test_load_migrates_when_no_devices_block():
-    assert devices.load({"cue_device": "Spk"}).device_for("cue_out") == "Spk"
+def test_load_defaults_when_no_devices_block():
+    # No devices block -> the default config (each target on its default role, with no
+    # devices bound). Per-panel device keys are no longer migrated.
+    cfg = devices.load({"cue_device": "Spk"})
+    assert cfg.role_for("cue_out") == "bedroom_out"  # default role
+    assert cfg.bindings == {}  # nothing bound; the stray key is ignored

--- a/tests/test_docs_schema.py
+++ b/tests/test_docs_schema.py
@@ -1,0 +1,112 @@
+"""Guard that the docs reference stays in lockstep with the code.
+
+These tests fail when the documentation drifts from the schemas/registry it
+describes: the embedded ``.smacc`` / ``preferences.yaml`` examples must still load,
+the documented schema versions and ``kind`` strings must match the code constants,
+and the default event-code catalog on the Triggers page must match
+``smacc.events.default_events()``. This is what makes the reference pages a contract
+rather than prose that can quietly fall out of date.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+from smacc import bids, events, preferences, settings
+
+DOCS = Path(__file__).resolve().parents[1] / "docs"
+REFERENCE = DOCS / "reference"
+
+
+def _read(name: str) -> str:
+    return (DOCS / name).read_text(encoding="utf-8")
+
+
+def _fenced(text: str, lang: str) -> list[str]:
+    """Return the bodies of all ```<lang> fenced code blocks in ``text``."""
+    return re.findall(rf"```{lang}\n(.*?)```", text, re.DOTALL)
+
+
+def _yaml_payloads() -> list[dict]:
+    """Every YAML mapping embedded in the reference pages."""
+    payloads: list[dict] = []
+    for md in REFERENCE.glob("*.md"):
+        for block in _fenced(md.read_text(encoding="utf-8"), "yaml"):
+            data = yaml.safe_load(block)
+            if isinstance(data, dict):
+                payloads.append(data)
+    return payloads
+
+
+def test_settings_example_loads_at_current_version(tmp_path):
+    examples = [p for p in _yaml_payloads() if p.get("kind") == settings.KIND]
+    assert examples, "no smacc/settings example found in docs/reference"
+    for i, payload in enumerate(examples):
+        assert payload["schema_version"] == settings.SCHEMA_VERSION
+        path = tmp_path / f"example_{i}.smacc"
+        path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+        settings.load_settings(path)  # must round-trip through the real loader
+
+
+def test_preferences_example_loads_at_current_version(tmp_path):
+    examples = [p for p in _yaml_payloads() if p.get("kind") == preferences.KIND]
+    assert examples, "no smacc/preferences example found in docs/reference"
+    for i, payload in enumerate(examples):
+        assert payload["schema_version"] == preferences.SCHEMA_VERSION
+        path = tmp_path / f"example_{i}.yaml"
+        path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+        loaded = preferences.load_preferences(path)
+        # The example must be recognized, not silently fall back to defaults.
+        assert loaded["last_settings"] == payload["preferences"]["last_settings"]
+
+
+def test_documented_versions_match_constants():
+    settings_doc = _read("reference/settings-file.md")
+    assert settings.KIND in settings_doc
+    assert f"schema_version: {settings.SCHEMA_VERSION}" in settings_doc
+    prefs_doc = _read("reference/preferences-file.md")
+    assert preferences.KIND in prefs_doc
+    assert f"schema_version: {preferences.SCHEMA_VERSION}" in prefs_doc
+
+
+def _catalog_rows() -> dict[int, tuple[str, str]]:
+    """Parse the Triggers page's fenced event-code table -> {code: (label, key)}."""
+    text = _read("triggers.md")
+    block = re.search(
+        r"<!-- BEGIN auto:event-codes.*?-->(.*?)<!-- END auto:event-codes -->",
+        text,
+        re.DOTALL,
+    )
+    assert block, "event-code catalog sentinels not found in docs/triggers.md"
+    rows: dict[int, tuple[str, str]] = {}
+    for line in block.group(1).splitlines():
+        if not line.strip().startswith("|"):
+            continue
+        cells = [c.strip().strip("`") for c in line.strip().strip("|").split("|")]
+        if len(cells) < 3 or not cells[0].isdigit():
+            continue  # header / separator / non-data row
+        rows[int(cells[0])] = (cells[1], cells[2])
+    return rows
+
+
+def test_event_code_catalog_matches_registry():
+    documented = _catalog_rows()
+    expected = {e.code: (e.label, e.key) for e in events.default_events()}
+    assert documented == expected
+
+
+def test_inline_code_examples_match_registry():
+    # Numbers cited in prose must stay true to the registry.
+    by_key = {e.key: e.code for e in events.default_events()}
+    assert by_key["REMDetected"] == 41  # "every 41 is an observed REM onset"
+    assert by_key["DreamReportStarted"] == 201  # "201, 202, 203, ..."
+
+
+def test_bids_sidecar_example_matches_code():
+    blocks = _fenced(_read("reference/bids-export.md"), "json")
+    assert blocks, "no JSON sidecar example in docs/reference/bids-export.md"
+    assert json.loads(blocks[0]) == bids.events_sidecar()

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -160,7 +160,7 @@ def test_set_lights_toggles_state_and_label(
     assert "ON" in window.lightswitchButton.text()
 
 
-# ----- interface choices now carried by the .smacc settings (schema v6) -------
+# ----- interface choices carried by the .smacc settings -----------------------
 
 
 def test_gather_settings_includes_interface_choices(
@@ -169,7 +169,7 @@ def test_gather_settings_includes_interface_choices(
     window = SmaccWindow(live_session)
     qtbot.addWidget(window)
     state = window.gather_settings()
-    # Moved out of preferences.yaml and into the portable settings file.
+    # Carried in the portable settings file so they travel with the study.
     assert isinstance(state["preview_levels"], list)
     assert state["always_on_top"] is False  # main window, default off
     # A per-tool always-on-top map keyed by panel key (default all off).
@@ -180,7 +180,7 @@ def test_gather_settings_includes_interface_choices(
 def test_default_interface_choices_when_settings_omit_them(
     qtbot, live_session, mock_devices, silence_dialogs
 ):
-    # A pre-v6 study has no preview_levels/always_on_top; defaults must stand.
+    # A study that omits preview_levels/always_on_top; the defaults must stand.
     window = SmaccWindow(live_session)
     qtbot.addWidget(window)
     state = window.gather_settings()

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -51,33 +51,6 @@ def test_round_trip(tmp_path):
     assert preferences.load_preferences(path) == custom
 
 
-def test_legacy_window_migrates_into_main_entry(tmp_path):
-    # A pre-per-window-map file stored only the session window under a flat ``window``.
-    path = tmp_path / "preferences.yaml"
-    preferences.save_preferences(path, {"window": {"x": 5, "y": 6, "w": 700, "h": 500}})
-    prefs = preferences.load_preferences(path)
-    assert prefs["windows"][preferences.MAIN_WINDOW_ID] == {
-        "x": 5,
-        "y": 6,
-        "w": 700,
-        "h": 500,
-    }
-
-
-def test_explicit_windows_entry_wins_over_legacy_window(tmp_path):
-    # If both the new map and the legacy key are present, the newer map is kept.
-    path = tmp_path / "preferences.yaml"
-    preferences.save_preferences(
-        path,
-        {
-            "window": {"x": 5, "y": 6, "w": 700, "h": 500},
-            "windows": {"main": {"x": 1, "y": 2, "w": 100, "h": 200}},
-        },
-    )
-    prefs = preferences.load_preferences(path)
-    assert prefs["windows"]["main"] == {"x": 1, "y": 2, "w": 100, "h": 200}
-
-
 def test_save_to_unwritable_path_does_not_raise(tmp_path):
     # A directory can't be written as a file; save must swallow the error.
     preferences.save_preferences(tmp_path, {"last_settings": "/x"})  # no exception

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -55,7 +55,7 @@ def test_saved_file_is_tagged_yaml(tmp_path):
     assert text.splitlines()[0].startswith("#")  # self-identifying header comment
     payload = yaml.safe_load(text)  # comment is ignored, so it still parses
     assert payload["kind"] == settings.KIND
-    assert payload["schema_version"] == settings.SCHEMA_VERSION == 6
+    assert payload["schema_version"] == settings.SCHEMA_VERSION == 1
     assert payload["smacc_version"] == smacc.__version__
     assert payload["settings"] == {"cue_attack": 0.2}
 
@@ -104,12 +104,15 @@ def test_load_data_directory_reads_file(tmp_path):
 
 
 def test_bundled_default_settings_is_valid_and_complete():
+    from smacc import events
     from smacc.paths import BUNDLED_DEFAULT_SETTINGS
 
     assert BUNDLED_DEFAULT_SETTINGS.is_file()  # shipped example/default
     state, _ = settings.load_settings(BUNDLED_DEFAULT_SETTINGS)
     assert state["data_directory"] == "data"
-    assert state["event_codes"]  # carries the default event registry as an example
+    # It carries the default event registry as an example; keep it in lockstep with
+    # the code so the shipped example can't drift from the built-in codes.
+    assert state["event_codes"] == events.events_to_list(events.default_events())
 
 
 def test_load_rejects_legacy_state_key(tmp_path):
@@ -131,15 +134,15 @@ def test_load_accepts_current_schema(tmp_path):
     assert state == {"cue_attack": 1.0}
 
 
-def test_load_accepts_older_schema_without_event_codes(tmp_path):
-    # A pre-v4 study (no event_codes) must still load; the GUI fills the default
-    # registry on apply via events.merge_event_codes.
-    path = tmp_path / "old.smacc"
+def test_load_accepts_settings_without_event_codes(tmp_path):
+    # A study may omit event_codes; it must still load (the GUI fills the default
+    # registry on apply via events.merge_event_codes).
+    path = tmp_path / "partial.smacc"
     path.write_text(
         yaml.safe_dump(
             {
                 "kind": settings.KIND,
-                "schema_version": 3,
+                "schema_version": settings.SCHEMA_VERSION,
                 "settings": {"cue_attack": 0.5},
             }
         ),
@@ -149,15 +152,15 @@ def test_load_accepts_older_schema_without_event_codes(tmp_path):
     assert state == {"cue_attack": 0.5}
 
 
-def test_load_accepts_older_schema_without_interface_keys(tmp_path):
-    # A pre-v6 study has no preview_levels/always_on_top/tool_always_on_top; it must
-    # still load (the GUI applies the interface defaults on apply_settings).
-    path = tmp_path / "old.smacc"
+def test_load_accepts_settings_without_interface_keys(tmp_path):
+    # A study may omit preview_levels/always_on_top/tool_always_on_top; it must still
+    # load (the GUI applies the interface defaults on apply_settings).
+    path = tmp_path / "partial.smacc"
     path.write_text(
         yaml.safe_dump(
             {
                 "kind": settings.KIND,
-                "schema_version": 5,
+                "schema_version": settings.SCHEMA_VERSION,
                 "settings": {"cue_attack": 0.5},
             }
         ),
@@ -177,6 +180,24 @@ def test_load_rejects_unsupported_schema(tmp_path):
         settings.load_settings(path)
 
 
+def test_load_rejects_higher_schema_version(tmp_path):
+    # The v1 reset accepts only the current schema; there is no forward/backward
+    # migration, so any higher version (e.g. a file from a future SMACC) is rejected.
+    path = tmp_path / "future.smacc"
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "kind": settings.KIND,
+                "schema_version": settings.SCHEMA_VERSION + 1,
+                "settings": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="schema version"):
+        settings.load_settings(path)
+
+
 def test_load_rejects_nonpositive_schema(tmp_path):
     path = tmp_path / "settings.yaml"
     path.write_text(
@@ -189,7 +210,7 @@ def test_load_rejects_nonpositive_schema(tmp_path):
 def test_load_rejects_wrong_kind(tmp_path):
     path = tmp_path / "settings.yaml"
     path.write_text(
-        yaml.safe_dump({"kind": "something/else", "schema_version": 3, "settings": {}}),
+        yaml.safe_dump({"kind": "something/else", "schema_version": 1, "settings": {}}),
         encoding="utf-8",
     )
     with pytest.raises(ValueError, match="compatible"):
@@ -198,7 +219,7 @@ def test_load_rejects_wrong_kind(tmp_path):
 
 def test_load_rejects_missing_settings(tmp_path):
     path = tmp_path / "settings.yaml"
-    path.write_text(yaml.safe_dump({"schema_version": 3}), encoding="utf-8")
+    path.write_text(yaml.safe_dump({"schema_version": 1}), encoding="utf-8")
     with pytest.raises(ValueError, match="settings"):
         settings.load_settings(path)
 


### PR DESCRIPTION
Resets `.smacc` and `preferences.yaml` to `schema_version: 1` — with no users yet, the dead cross-version migration paths are removed rather than carried (kept all within-v1 defensive defaulting). Adds a versioned **Reference** docs section documenting all four file formats (`.smacc`, `preferences.yaml`, session `.log`, BIDS export), plus a CI drift-guard (`tests/test_docs_schema.py`) so the docs can't diverge from the code or the event-code registry.

Machine-readable JSON Schema is split out to #99.

Verified: `pytest` (332), `ruff`, `mypy`, and `mkdocs build --strict` all pass.

Closes #88.
