### PR TITLE
fix: non-blocking visual cue playback with stop and offset marker

### DIFF
--- a/docs/devices.md
+++ b/docs/devices.md
@@ -29,7 +29,8 @@ SMACC uses it for **visual cues** — lighting up a chosen color for a set durat
    the *Tools* column). Plug one in after launch and it's detected automatically,
    or choose **File ▸ Refresh devices** (or press `F5`) to rescan.
 4. Pick a **Color** and a **Length** (how long the light stays on, in seconds).
-5. Click **Play BlinkStick** to fire the cue.
+5. Click **Play** to fire the cue; **Stop** turns the light off before the length
+   runs out. The rest of SMACC stays responsive while the light is on.
 
 Your chosen device, color, and length are saved in the `.smacc` settings file (see
 [Usage › Settings files](usage.md#settings-files-smacc)), so the visual-cue setup

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -33,7 +33,7 @@ settings:
   noise_source: builtin
   noise_file: ""
   # --- Visual cue (BlinkStick) -----------------------------------------------
-  blink_color: "#000000"
+  blink_color: "#ff0000"
   blink_length: 1.0
   # --- Survey ----------------------------------------------------------------
   survey_url: ""

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -47,8 +47,9 @@ study can retune any code in the **Event codes** editor; the change travels in i
 | 63 | Noise stopped | `NoiseStopped` | |
 | 64 | Intercom started | `IntercomStarted` | |
 | 65 | Intercom stopped | `IntercomStopped` | |
-| 66 | Visual stimulation | `VisualStarted` | |
+| 66 | Visual started | `VisualStarted` | |
 | 67 | Survey opened | `SurveyOpened` | |
+| 68 | Visual stopped | `VisualStopped` | the light is actually off (pairs with 66) |
 | 100 | SMACC initialized | `TriggerInitialization` | startup connection test; not a stimulus marker |
 | 105 | Biocal sequence started | `BiocalSequenceStarted` | brackets a played biocal sequence |
 | 106 | Biocal sequence stopped | `BiocalSequenceStopped` | completed or aborted |

--- a/src/smacc/assets/default.smacc
+++ b/src/smacc/assets/default.smacc
@@ -7,7 +7,7 @@ metadata:
   session: ''
   notes: ''
 settings:
-  blink_color: '#000000'
+  blink_color: '#ff0000'
   blink_length: 1.0
   # cues omitted on purpose: the one required cue autofills a random demo on first
   # launch (#65); saving from the app writes the configured cue list back here.
@@ -112,6 +112,11 @@ settings:
     increment: false
   - key: VisualStarted
     code: 66
+    trigger: true
+    preview: true
+    increment: false
+  - key: VisualStopped
+    code: 68
     trigger: true
     preview: true
     increment: false

--- a/src/smacc/events.py
+++ b/src/smacc/events.py
@@ -196,7 +196,9 @@ def default_events() -> list[EventDef]:
         EventDef("NoiseStopped", "Noise stopped", 63),
         EventDef("IntercomStarted", "Intercom started", 64),
         EventDef("IntercomStopped", "Intercom stopped", 65),
-        EventDef("VisualStarted", "Visual stimulation", 66),
+        EventDef("VisualStarted", "Visual started", 66),
+        # The stop pairs with 66 at the next free code (67 predates it).
+        EventDef("VisualStopped", "Visual stopped", 68),
         EventDef("SurveyOpened", "Survey opened", 67),
         # --- Biocals: run from the Biocals window (#78) -------------------------
         *_biocal_events(),

--- a/src/smacc/lights.py
+++ b/src/smacc/lights.py
@@ -1,0 +1,204 @@
+"""Visual cue engine and light-device backends.
+
+The engine is the lights analog of audio's :class:`smacc.audio.CueMixer`: a pure
+state machine (no Qt, no I/O) that renders the RGB frame a cue should show at any
+caller-supplied clock instant. The GUI panel ticks it from a QTimer and pushes each
+frame to a :class:`LightBackend`; tests drive it with hand-picked timestamps, so
+patterns and envelopes are verifiable without hardware.
+
+A cue is a *color* at a *brightness*, shaped by a *pattern* — ``steady``, a smooth
+``pulse``, or an on/off ``flash`` at a rate in Hz — inside a linear attack/release
+envelope (the visual counterpart of the audio board's fade-in/out). A non-looping
+cue holds its pattern for ``duration_s`` and then releases on its own; a looping
+cue runs until :meth:`LightEngine.stop`. Time is always passed in (a monotonic
+timestamp), never read here, and pattern phase is computed from elapsed time — not
+accumulated per tick — so a late or missed GUI tick can't drift the stimulus.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Protocol
+
+RGB = tuple[int, int, int]
+
+# Cue patterns: constant light, a raised-cosine "breathing" pulse (starts dark,
+# peaks mid-cycle, so onset is gentle), and a 50%-duty on/off flash.
+STEADY = "steady"
+PULSE = "pulse"
+FLASH = "flash"
+PATTERNS = (STEADY, PULSE, FLASH)
+
+
+def _scale(component: int, gain: float) -> int:
+    """One 0-255 color component scaled by ``gain``, rounded and clamped."""
+    return max(0, min(255, round(component * gain)))
+
+
+class LightEngine:
+    """One-at-a-time visual cue renderer (the CueMixer of lights).
+
+    :meth:`start` arms a cue; :meth:`frame` returns the RGB to show *now*;
+    :meth:`stop` begins the release fade. :attr:`ended` flips once the envelope
+    has reached zero (the duration ran out, or a release finished), so the GUI
+    thread can turn the device off and mark the stop. Idle/ended frames are black.
+    """
+
+    def __init__(self) -> None:
+        self._color: RGB = (0, 0, 0)
+        self._brightness = 1.0
+        self._pattern = STEADY
+        self._rate_hz = 1.0
+        self._loop = False
+        self._duration_s = 0.0
+        self._attack_s = 0.0
+        self._release_s = 0.0
+        self._t0 = 0.0
+        # Manual-stop release: the time it began and the gain it started from
+        # (a stop mid-attack releases from the part-way gain, like CueMixer).
+        self._stop_t: float | None = None
+        self._stop_gain = 0.0
+        self._ended = True
+
+    def start(
+        self,
+        now: float,
+        color: RGB,
+        *,
+        brightness: float = 1.0,
+        duration_s: float,
+        loop: bool = False,
+        pattern: str = STEADY,
+        rate_hz: float = 1.0,
+        attack_s: float = 0.0,
+        release_s: float = 0.0,
+    ) -> None:
+        """Arm a cue starting at ``now`` (restarts any cue already playing)."""
+        if pattern not in PATTERNS:
+            raise ValueError(f"Unknown light pattern {pattern!r}; one of {PATTERNS}.")
+        self._color = color
+        self._brightness = brightness
+        self._pattern = pattern
+        self._rate_hz = rate_hz
+        self._loop = loop
+        self._duration_s = max(0.0, duration_s)
+        self._attack_s = max(0.0, attack_s)
+        self._release_s = max(0.0, release_s)
+        self._t0 = now
+        self._stop_t = None
+        self._stop_gain = 0.0
+        # A zero-length non-looping cue is over before its first frame.
+        self._ended = self._duration_s <= 0.0 and not loop
+
+    def stop(self, now: float) -> None:
+        """Begin the release fade (end immediately when the release is 0)."""
+        if self._ended or self._stop_t is not None:
+            return
+        if self._release_s <= 0.0:
+            self._ended = True
+            return
+        self._stop_gain = self._envelope(now)
+        self._stop_t = now
+        if self._stop_gain <= 0.0:
+            self._ended = True
+
+    @property
+    def ended(self) -> bool:
+        """True once the cue has finished (duration ran out, or a release hit 0)."""
+        return self._ended
+
+    def frame(self, now: float) -> RGB:
+        """Return the RGB to show at ``now`` (black when idle/ended)."""
+        if self._ended:
+            return (0, 0, 0)
+        if self._stop_t is not None:
+            done = now >= self._stop_t + self._release_s
+        else:
+            done = (
+                not self._loop and now >= self._t0 + self._duration_s + self._release_s
+            )
+        if done:
+            self._ended = True
+            return (0, 0, 0)
+        gain = self._envelope(now) * self._brightness * self._pattern_factor(now)
+        r, g, b = self._color
+        return (_scale(r, gain), _scale(g, gain), _scale(b, gain))
+
+    def _envelope(self, now: float) -> float:
+        """The attack/release gain in [0, 1] at ``now``."""
+        if self._stop_t is not None:
+            # Manual release: from the captured gain down to 0 over release_s.
+            faded = 1.0 - (now - self._stop_t) / self._release_s
+            return max(0.0, self._stop_gain * faded)
+        t = now - self._t0
+        gain = 1.0
+        if self._attack_s > 0.0:
+            gain = min(1.0, t / self._attack_s)
+        if not self._loop and t > self._duration_s:
+            # Natural release after the ON period (instant when release is 0).
+            if self._release_s <= 0.0:
+                return 0.0
+            gain = min(gain, max(0.0, 1.0 - (t - self._duration_s) / self._release_s))
+        return max(0.0, gain)
+
+    def _pattern_factor(self, now: float) -> float:
+        """The pattern's brightness factor in [0, 1] at ``now``."""
+        if self._pattern == STEADY or self._rate_hz <= 0.0:
+            return 1.0
+        phase = ((now - self._t0) * self._rate_hz) % 1.0
+        if self._pattern == FLASH:
+            return 1.0 if phase < 0.5 else 0.0
+        return 0.5 * (1.0 - math.cos(math.tau * phase))  # PULSE: raised cosine
+
+
+class LightBackend(Protocol):
+    """A light device that can show one color (all its LEDs together)."""
+
+    def apply(self, rgb: RGB) -> None:
+        """Show ``rgb`` now."""
+        ...
+
+    def off(self) -> None:
+        """Turn the light fully off."""
+        ...
+
+
+# Every BlinkStick variant SMACC drives exposes up to 32 LEDs on channel 0; the
+# whole strip gets one color (#11 documents per-LED color as a non-goal).
+BLINKSTICK_LED_COUNT = 32
+
+
+class BlinkStickBackend:
+    """Drives one BlinkStick: the same color on all its LEDs.
+
+    ``set_led_data`` expects G,R,B-ordered triplets, one per LED.
+    """
+
+    def __init__(self, device) -> None:
+        self._device = device
+
+    def apply(self, rgb: RGB) -> None:
+        r, g, b = rgb
+        self._device.set_led_data(channel=0, data=[g, r, b] * BLINKSTICK_LED_COUNT)
+
+    def off(self) -> None:
+        self.apply((0, 0, 0))
+
+
+def resolve_blinkstick(serial: str) -> BlinkStickBackend | None:
+    """Wrap the connected BlinkStick with ``serial`` (None when blank/missing).
+
+    The blinkstick import is local: the package is Windows-only and touches USB,
+    so the engine half of this module stays importable (and testable) anywhere.
+    A USB enumeration hiccup resolves to None rather than raising — the panel
+    treats that the same as no device bound.
+    """
+    if not serial:
+        return None
+    from blinkstick import blinkstick
+
+    try:
+        device = blinkstick.find_by_serial(serial)
+    except Exception:
+        return None
+    return BlinkStickBackend(device) if device is not None else None

--- a/src/smacc/panels/visual.py
+++ b/src/smacc/panels/visual.py
@@ -1,24 +1,49 @@
-"""Visual stimulation window driving a BlinkStick LED device."""
+"""Visual stimulation window driving a BlinkStick LED device.
+
+Playback is non-blocking: a ~30 Hz QTimer ticks the pure
+:class:`smacc.lights.LightEngine` and pushes each frame to the resolved backend,
+so the rest of the GUI (markers, intercom, Stop) stays live during a cue — the
+old implementation slept on the GUI thread for the whole blink. Start and stop
+are marked with the ``VisualStarted``/``VisualStopped`` registry events, every
+stop path turns the light off (including app quit), and the color can be picked
+with no device plugged in (the settings editor runs hardware-free).
+"""
 
 from __future__ import annotations
 
-from blinkstick import blinkstick
+import time
+
 from PyQt6 import QtCore, QtGui, QtWidgets
 
+from .. import lights
 from ..session import SmaccSession
 from .base import ModalityWindow, describe_target, make_section_title
 
 
 class VisualWindow(ModalityWindow):
-    """BlinkStick color/length picker and trigger."""
+    """BlinkStick color/length picker with non-blocking play/stop."""
 
     TITLE = "Visual stimulation"
+    # ~30 Hz frames: ample for the steady cue here and smooth enough for the
+    # pulse/flash patterns the cue board adds (#86/#87).
+    TICK_MS = 33
 
     def __init__(self, session: SmaccSession, parent: QtWidgets.QWidget | None = None):
         super().__init__(session, parent)
-        self.bstick = None  # selected device; None until one is found/selected
-        self.bstick_blink_freq = 1.0
-        self.set_blink_color(0, 0, 0)  # default color: black/off
+        # Backend resolved from the visual_out role; the one a playing cue is
+        # bound to is held separately, so re-routing applies from the next Play
+        # (like an audio cue keeping the stream it opened).
+        self._backend: lights.LightBackend | None = None
+        self._active_backend: lights.LightBackend | None = None
+        self._engine = lights.LightEngine()
+        self._clock = time.monotonic  # injectable for deterministic tests
+        self._timer = QtCore.QTimer(self)
+        self._timer.setInterval(self.TICK_MS)
+        self._timer.timeout.connect(self._tick)
+        self.blink_length_s = 1.0
+        # Default to red: visible out of the box (the old black default made Play
+        # an invisible no-op) and the gentlest color on a dark-adapted sleeper.
+        self.set_blink_color(255, 0, 0)
         self.setCentralWidget(self._build())
         # The panel's contents are narrow, so without a floor the window opens
         # too thin to show its "Visual stimulation" titlebar text in full.
@@ -28,14 +53,9 @@ class VisualWindow(ModalityWindow):
         # The BlinkStick is chosen in the Devices window; show where it resolves.
         self.deviceLabel = QtWidgets.QLabel(self)
         self.deviceLabel.setStatusTip(
-            "Set in the Devices window (Visual → BlinkStick)."
+            "Set in the Devices window (Bedroom lights role)."
         )
         self.refresh_device_indicator()
-
-        # Visual play button: QPushButton signal --> visual_stim slot
-        blinkButton = QtWidgets.QPushButton("Play BlinkStick", self)
-        blinkButton.setStatusTip("Present visual stimulus.")
-        blinkButton.clicked.connect(self.stimulate_visual)
 
         # Visual color picker: QPushButton signal --> QColorPicker slot
         colorpickerButton = QtWidgets.QPushButton("Select color", self)
@@ -44,55 +64,72 @@ class VisualWindow(ModalityWindow):
         self.colorpickerButton = colorpickerButton
         self._update_color_swatch()  # show the current color from the start
 
-        # Visual frequency selector: QDoubleSpinBox signal --> update params slot
-        freqSpinBox = QtWidgets.QDoubleSpinBox(self)
-        freqSpinBox.setStatusTip(
+        # Cue length selector: QDoubleSpinBox signal --> update params slot
+        lengthSpinBox = QtWidgets.QDoubleSpinBox(self)
+        lengthSpinBox.setStatusTip(
             "Pick light stimulation length (how long the light will stay on in seconds)."
         )
-        freqSpinBox.setMinimum(0)
-        freqSpinBox.setMaximum(60)
-        freqSpinBox.setSuffix(" seconds")
-        freqSpinBox.setSingleStep(0.1)
-        freqSpinBox.valueChanged.connect(self.handle_freq_change)
-        freqSpinBox.setValue(self.bstick_blink_freq)
-        self.freqSpinBox = freqSpinBox
+        lengthSpinBox.setMinimum(0)
+        lengthSpinBox.setMaximum(60)
+        lengthSpinBox.setSuffix(" seconds")
+        lengthSpinBox.setSingleStep(0.1)
+        lengthSpinBox.valueChanged.connect(self.handle_length_change)
+        lengthSpinBox.setValue(self.blink_length_s)
+        self.lengthSpinBox = lengthSpinBox
+
+        playButton = QtWidgets.QPushButton("Play", self)
+        playButton.setStatusTip("Present the visual stimulus.")
+        playButton.clicked.connect(self.play_cue)
+        stopButton = QtWidgets.QPushButton("Stop", self)
+        stopButton.setStatusTip("Turn the light off before its length runs out.")
+        stopButton.clicked.connect(self.stop_cue)
+        buttonRow = QtWidgets.QHBoxLayout()
+        buttonRow.addWidget(playButton)
+        buttonRow.addWidget(stopButton)
+
+        # Lit indicator: the operator can't see the bedroom from the control room.
+        self.stateLabel = QtWidgets.QLabel(self)
+        self.stateLabel.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self._set_state_off()
 
         layout = QtWidgets.QFormLayout()
         layout.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         layout.addRow(make_section_title("Visual stimulation"))
         layout.addRow("Device:", self.deviceLabel)
-        layout.addRow("Color:", colorpickerButton)
-        layout.addRow("Length:", freqSpinBox)
-        layout.addRow(blinkButton)
+        layout.addRow("Color:", self.colorpickerButton)
+        layout.addRow("Length:", lengthSpinBox)
+        layout.addRow(buttonRow)
+        layout.addRow(self.stateLabel)
         central = QtWidgets.QWidget()
         central.setLayout(layout)
         return central
 
     def refresh_device_indicator(self) -> None:
-        """Resolve the BlinkStick from its role and show where the cue routes."""
+        """Resolve the BlinkStick from its role and show where the cue routes.
+
+        A cue already playing keeps the backend it started with; the fresh
+        resolution applies from the next Play.
+        """
         serial = self.session.devices.device_for("visual_out")
-        self.bstick = blinkstick.find_by_serial(serial) if serial else None
+        self._backend = lights.resolve_blinkstick(serial)
         self.deviceLabel.setText(describe_target(self.session, "visual_out"))
 
-    def set_blink_color(self, r: int, g: int, b: int) -> None:
-        """Set the BlinkStick color from 0-255 RGB components.
+    # ----- color + length ------------------------------------------------------
 
-        Stores the hex code (for settings save/load) and precomputes the LED data.
-        blinkstick.set_led_data expects G/R swapped: 3 values per LED, 32 LEDs.
-        """
-        self.bstick_rgb = (r, g, b, 255)
-        self.bstick_hexcode = f"#{r:02x}{g:02x}{b:02x}"
-        self.bstick_led_data = [g, r, b] * 32
+    def set_blink_color(self, r: int, g: int, b: int) -> None:
+        """Set the cue color from 0-255 RGB components (hex kept for save/load)."""
+        self.blink_rgb: lights.RGB = (r, g, b)
+        self.blink_hexcode = f"#{r:02x}{g:02x}{b:02x}"
         # Keep the color picker's swatch in sync (once the button exists).
         if hasattr(self, "colorpickerButton"):
             self._update_color_swatch()
-        self.session.log_interaction(f"Blink color set to {self.bstick_hexcode}")
+        self.session.log_interaction(f"Blink color set to {self.blink_hexcode}")
 
     def _update_color_swatch(self) -> None:
         """Show the currently selected blink color on the color picker button."""
         size = 22
         pixmap = QtGui.QPixmap(size, size)
-        pixmap.fill(QtGui.QColor(*self.bstick_rgb))
+        pixmap.fill(QtGui.QColor(*self.blink_rgb))
         painter = QtGui.QPainter(pixmap)
         painter.setPen(QtGui.QColor("#808080"))  # border so black/white read
         painter.drawRect(0, 0, size - 1, size - 1)
@@ -100,47 +137,98 @@ class VisualWindow(ModalityWindow):
         self.colorpickerButton.setIcon(QtGui.QIcon(pixmap))
         self.colorpickerButton.setIconSize(QtCore.QSize(size, size))
 
-    def _ensure_blinkstick(self) -> bool:
-        """Return True if a BlinkStick device is selected, else show one error popup."""
-        if self.bstick is not None:
-            return True
-        self.session.show_error_popup(
-            "Visual stimulation unavailable.",
-            "No BlinkStick is set. Bind one in the Devices window "
-            "(Roles → BlinkStick).",
-            parent=self,
-        )
-        return False
-
-    def pick_color(self):
-        if not self._ensure_blinkstick():
-            return
-        color = QtWidgets.QColorDialog.getColor(QtGui.QColor(self.bstick_hexcode), self)
+    def pick_color(self) -> None:
+        # No device needed to choose a color (the settings editor has none).
+        color = QtWidgets.QColorDialog.getColor(QtGui.QColor(self.blink_hexcode), self)
         if color.isValid():
             r, g, b, _ = color.getRgb()
             self.set_blink_color(r, g, b)
 
-    def handle_freq_change(self, freq: float) -> None:
+    def handle_length_change(self, length: float) -> None:
         """Takes the blink length in seconds from the spinbox."""
-        self.bstick_blink_freq = freq
-        self.session.log_interaction(f"Blink length set to {freq:.1f}s")
+        self.blink_length_s = length
+        self.session.log_interaction(f"Blink length set to {length:.1f}s")
 
-    def stimulate_visual(self):
-        if not self._ensure_blinkstick():
+    # ----- playback ------------------------------------------------------------
+
+    def play_cue(self) -> None:
+        """Light the cue (non-blocking; re-playing while lit just restarts it)."""
+        if self._backend is None:
+            self.session.show_error_popup(
+                "Visual stimulation unavailable.",
+                "No BlinkStick is set. Bind one to the Bedroom lights role "
+                "in the Devices window.",
+                parent=self,
+            )
             return
-        from time import sleep
-
-        black = [0, 0, 0] * 32
-        freq = self.bstick_blink_freq
+        backend = self._backend
+        now = self._clock()
+        self._engine.start(now, self.blink_rgb, duration_s=self.blink_length_s)
+        try:
+            backend.apply(self._engine.frame(now))
+        except Exception as err:
+            self._engine.stop(now)
+            self.session.show_error_popup(
+                "Could not light the BlinkStick.", str(err), parent=self
+            )
+            return
+        self._active_backend = backend
+        self._timer.start()
+        self._set_state_on()
+        # Marked after the first frame is on the device, so the marker trails the
+        # photons by microseconds instead of leading them by up to a tick.
         self.session.emit_event("VisualStarted")
-        self.bstick.set_led_data(channel=0, data=self.bstick_led_data)
-        sleep(freq)
-        self.bstick.set_led_data(channel=0, data=black)
+
+    def stop_cue(self) -> None:
+        """Turn the cue off now (instant; the release fade arrives with #86)."""
+        if not self._timer.isActive():
+            return
+        self._engine.stop(self._clock())
+        self._tick()  # finalize immediately: off + marker, not a tick later
+
+    def _tick(self) -> None:
+        """Timer slot: push the current frame, finishing once the cue has ended."""
+        now = self._clock()
+        frame = self._engine.frame(now)
+        if self._engine.ended:
+            self._finish(mark=True)
+            return
+        assert self._active_backend is not None  # set with the timer in play_cue
+        try:
+            self._active_backend.apply(frame)
+        except Exception as err:
+            self._finish(mark=True)  # the stimulus is over, whatever the LEDs say
+            self.session.show_error_popup(
+                "BlinkStick write failed; visual cue stopped.", str(err), parent=self
+            )
+
+    def _finish(self, mark: bool) -> None:
+        """Stop the timer, force the light off (best effort), and mark the stop."""
+        self._timer.stop()
+        if self._active_backend is not None:
+            try:
+                self._active_backend.off()
+            except Exception:
+                pass  # unplugged mid-cue; nothing left to turn off
+            self._active_backend = None
+        self._set_state_off()
+        if mark:
+            self.session.emit_event("VisualStopped")
+
+    def _set_state_on(self) -> None:
+        self.stateLabel.setText("● lit")
+        self.stateLabel.setStyleSheet("color: red; font-weight: bold;")
+
+    def _set_state_off(self) -> None:
+        self.stateLabel.setText("■ off")
+        self.stateLabel.setStyleSheet("")
+
+    # ----- settings state --------------------------------------------------------
 
     def gather_state(self) -> dict:
         return {
-            "blink_color": self.bstick_hexcode,
-            "blink_length": self.bstick_blink_freq,
+            "blink_color": self.blink_hexcode,
+            "blink_length": self.blink_length_s,
         }
 
     def apply_state(self, state: dict) -> None:
@@ -149,4 +237,8 @@ class VisualWindow(ModalityWindow):
             if qcolor.isValid():
                 self.set_blink_color(qcolor.red(), qcolor.green(), qcolor.blue())
         if (length := state.get("blink_length")) is not None:
-            self.freqSpinBox.setValue(float(length))
+            self.lengthSpinBox.setValue(float(length))
+
+    def cleanup(self) -> None:
+        """Stop the cue timer and leave the light off (no marker; app is quitting)."""
+        self._finish(mark=False)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -227,3 +227,23 @@ def test_biocal_events_merge_into_older_studies():
     merged = {e.key: e for e in events.merge_event_codes(older)}
     assert "BiocalEyesOpen" in merged
     assert merged["BiocalEyesOpen"].code == 110
+
+
+def test_visual_pair_brackets_the_stimulus():
+    # Looping/long visual cues need an offset marker for EEG alignment, so the
+    # registry pairs VisualStarted with a VisualStopped at the next free code
+    # (68: SurveyOpened took 67 before the pair existed).
+    registry = {e.key: e for e in events.default_events()}
+    assert registry["VisualStarted"].label == "Visual started"
+    assert registry["VisualStarted"].code == 66
+    stop = registry["VisualStopped"]
+    assert stop.code == 68
+    assert stop.category == "control"
+    assert stop.trigger and stop.preview and not stop.increment
+
+
+def test_visual_stopped_merges_into_older_studies():
+    # A study saved before the pair existed gains the stop event on load.
+    older = [{"key": "VisualStarted", "code": 66}]
+    merged = {e.key: e for e in events.merge_event_codes(older)}
+    assert merged["VisualStopped"].code == 68

--- a/tests/test_lights.py
+++ b/tests/test_lights.py
@@ -1,0 +1,185 @@
+"""Tests for the pure visual-cue engine and light backends (no Qt, no hardware).
+
+The engine never reads a clock — every call takes a timestamp — so envelopes,
+patterns, and end conditions are checked here with hand-picked instants.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from smacc import lights
+
+RED = (200, 100, 50)  # asymmetric components so channel mixups can't hide
+
+
+def started(now: float = 0.0, **kwargs) -> lights.LightEngine:
+    engine = lights.LightEngine()
+    kwargs.setdefault("duration_s", 10.0)
+    engine.start(now, RED, **kwargs)
+    return engine
+
+
+# ----- envelope + duration -----------------------------------------------------
+
+
+def test_steady_frame_is_the_full_color_within_duration():
+    engine = started(duration_s=2.0)
+    assert engine.frame(1.0) == RED
+    assert not engine.ended
+
+
+def test_non_looping_cue_ends_at_duration_without_release():
+    engine = started(duration_s=2.0)
+    assert engine.frame(2.0) == (0, 0, 0)
+    assert engine.ended
+
+
+def test_zero_duration_cue_is_over_before_its_first_frame():
+    engine = started(duration_s=0.0)
+    assert engine.ended
+    assert engine.frame(0.0) == (0, 0, 0)
+
+
+def test_idle_engine_renders_black():
+    engine = lights.LightEngine()
+    assert engine.ended
+    assert engine.frame(123.0) == (0, 0, 0)
+
+
+def test_attack_ramps_the_gain_linearly():
+    engine = started(attack_s=1.0)
+    assert engine.frame(0.5) == (100, 50, 25)  # half-way up the ramp
+    assert engine.frame(1.0) == RED  # ramp done
+
+
+def test_duration_end_runs_the_release_fade():
+    engine = started(duration_s=1.0, release_s=1.0)
+    assert engine.frame(1.5) == (100, 50, 25)  # half-way down
+    assert not engine.ended
+    assert engine.frame(2.0) == (0, 0, 0)
+    assert engine.ended
+
+
+def test_manual_stop_releases_from_the_current_gain():
+    # Stopped half-way through the attack: the release starts from gain 0.5 and
+    # still spends the full release time getting to zero (CueMixer semantics).
+    engine = started(attack_s=1.0, release_s=1.0)
+    engine.stop(0.5)
+    assert engine.frame(1.0) == (
+        50,
+        25,
+        12,
+    )  # 0.5 gain * 0.5 released (12.5 rounds even)
+    assert not engine.ended
+    assert engine.frame(1.5) == (0, 0, 0)
+    assert engine.ended
+
+
+def test_manual_stop_is_instant_without_a_release():
+    engine = started()
+    engine.stop(1.0)
+    assert engine.ended
+    assert engine.frame(1.0) == (0, 0, 0)
+
+
+def test_loop_ignores_duration_until_stopped():
+    engine = started(duration_s=1.0, loop=True)
+    assert engine.frame(100.0) == RED
+    assert not engine.ended
+    engine.stop(100.5)
+    assert engine.ended
+
+
+def test_restart_replaces_a_playing_cue():
+    engine = started(duration_s=1.0)
+    engine.start(5.0, RED, duration_s=2.0)
+    assert engine.frame(6.5) == RED  # timed from the new start
+    assert not engine.ended
+
+
+# ----- patterns ------------------------------------------------------------------
+
+
+def test_pulse_is_a_raised_cosine_starting_dark():
+    engine = started(pattern=lights.PULSE, rate_hz=1.0)
+    assert engine.frame(0.0) == (0, 0, 0)  # trough: dark but not ended
+    assert not engine.ended
+    assert engine.frame(0.25) == (100, 50, 25)  # half brightness
+    assert engine.frame(0.5) == RED  # peak
+    assert engine.frame(1.0) == (0, 0, 0)  # next trough
+
+
+def test_flash_is_a_half_duty_square_wave():
+    engine = started(pattern=lights.FLASH, rate_hz=2.0)  # 0.5 s cycle
+    assert engine.frame(0.1) == RED  # first half-cycle: on
+    assert engine.frame(0.3) == (0, 0, 0)  # second half-cycle: off
+    assert not engine.ended
+    assert engine.frame(0.6) == RED  # next cycle
+
+
+def test_zero_rate_degrades_to_steady():
+    engine = started(pattern=lights.FLASH, rate_hz=0.0)
+    assert engine.frame(0.3) == RED
+
+
+def test_unknown_pattern_is_rejected():
+    engine = lights.LightEngine()
+    with pytest.raises(ValueError):
+        engine.start(0.0, RED, duration_s=1.0, pattern="strobe")
+
+
+def test_brightness_scales_the_color():
+    engine = started(brightness=0.5)
+    assert engine.frame(1.0) == (100, 50, 25)
+
+
+# ----- backends -------------------------------------------------------------------
+
+
+class _StubStick:
+    """Records set_led_data calls like a blinkstick.BlinkStick would take them."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, list[int]]] = []
+
+    def set_led_data(self, channel: int, data: list[int]) -> None:
+        self.calls.append((channel, data))
+
+
+def test_blinkstick_backend_sends_grb_triplets_for_every_led():
+    stick = _StubStick()
+    backend = lights.BlinkStickBackend(stick)
+    backend.apply((1, 2, 3))
+    channel, data = stick.calls[-1]
+    assert channel == 0
+    assert data == [2, 1, 3] * lights.BLINKSTICK_LED_COUNT  # G,R,B order
+    backend.off()
+    assert stick.calls[-1][1] == [0, 0, 0] * lights.BLINKSTICK_LED_COUNT
+
+
+def test_resolve_blinkstick_blank_serial_is_none():
+    assert lights.resolve_blinkstick("") is None
+
+
+def test_resolve_blinkstick_wraps_a_found_device(monkeypatch):
+    from blinkstick import blinkstick
+
+    stick = _StubStick()
+    monkeypatch.setattr(blinkstick, "find_by_serial", lambda serial: stick)
+    backend = lights.resolve_blinkstick("BS123")
+    assert backend is not None
+    backend.apply((9, 8, 7))
+    assert stick.calls  # the wrapped device got the frame
+
+
+def test_resolve_blinkstick_swallows_enumeration_errors(monkeypatch):
+    from blinkstick import blinkstick
+
+    def boom(serial):
+        raise OSError("usb went away")
+
+    monkeypatch.setattr(blinkstick, "find_by_serial", boom)
+    assert lights.resolve_blinkstick("BS123") is None
+    monkeypatch.setattr(blinkstick, "find_by_serial", lambda serial: None)
+    assert lights.resolve_blinkstick("BS123") is None

--- a/tests/test_panels_visual.py
+++ b/tests/test_panels_visual.py
@@ -1,0 +1,170 @@
+"""Tests for the Visual stimulation panel's non-blocking playback.
+
+Headless Qt (offscreen). A fake backend stands in for the BlinkStick and a fake
+clock replaces ``time.monotonic``, so ticks are driven by calling ``_tick()``
+directly — fully deterministic, no real-timer waits.
+"""
+
+from __future__ import annotations
+
+from PyQt6 import QtGui, QtWidgets
+
+from smacc.panels.visual import VisualWindow
+
+
+class _FakeLight:
+    """LightBackend stand-in recording every frame and off() call."""
+
+    def __init__(self) -> None:
+        self.frames: list[tuple[int, int, int]] = []
+        self.off_calls = 0
+
+    def apply(self, rgb) -> None:
+        self.frames.append(rgb)
+
+    def off(self) -> None:
+        self.off_calls += 1
+
+
+class _DeadLight(_FakeLight):
+    """A backend whose writes fail (the stick was unplugged mid-cue)."""
+
+    def apply(self, rgb) -> None:
+        raise OSError("usb gone")
+
+
+def _spies(panel, monkeypatch):
+    """Replace the session's marker + popup sinks with recording lists."""
+    events: list[str] = []
+    popups: list[str] = []
+    monkeypatch.setattr(
+        panel.session, "emit_event", lambda key, detail=None: events.append(key)
+    )
+    monkeypatch.setattr(
+        panel.session,
+        "show_error_popup",
+        lambda short, long=None, parent=None: popups.append(short),
+    )
+    return events, popups
+
+
+def _playing_panel(qtbot, design_session, monkeypatch, backend=None):
+    """A panel with a fake clock + backend, plus its event/popup spies."""
+    panel = VisualWindow(design_session)
+    qtbot.addWidget(panel)
+    clock = {"t": 0.0}
+    panel._clock = lambda: clock["t"]
+    panel._backend = backend if backend is not None else _FakeLight()
+    events, popups = _spies(panel, monkeypatch)
+    return panel, clock, events, popups
+
+
+def test_defaults_are_a_visible_red_cue(qtbot, design_session):
+    panel = VisualWindow(design_session)
+    qtbot.addWidget(panel)
+    assert panel.blink_hexcode == "#ff0000"  # black would make Play invisible
+    assert "off" in panel.stateLabel.text()
+
+
+def test_play_without_a_device_pops_an_error_and_marks_nothing(
+    qtbot, design_session, monkeypatch
+):
+    panel = VisualWindow(design_session)
+    qtbot.addWidget(panel)
+    events, popups = _spies(panel, monkeypatch)
+    assert panel._backend is None  # the default role has no device bound
+    panel.play_cue()
+    assert popups and not events
+    assert not panel._timer.isActive()
+
+
+def test_play_lights_the_first_frame_then_marks_the_start(
+    qtbot, design_session, monkeypatch
+):
+    panel, clock, events, popups = _playing_panel(qtbot, design_session, monkeypatch)
+    panel.play_cue()
+    backend = panel._active_backend
+    assert backend.frames == [(255, 0, 0)]  # frame applied before the marker
+    assert events == ["VisualStarted"]
+    assert panel._timer.isActive()
+    assert "lit" in panel.stateLabel.text()
+
+
+def test_cue_ends_on_its_own_with_an_off_and_a_stop_marker(
+    qtbot, design_session, monkeypatch
+):
+    panel, clock, events, popups = _playing_panel(qtbot, design_session, monkeypatch)
+    panel.lengthSpinBox.setValue(2.0)
+    panel.play_cue()
+    backend = panel._active_backend
+    clock["t"] = 1.0
+    panel._tick()  # mid-cue: still lit
+    assert backend.frames[-1] == (255, 0, 0)
+    assert events == ["VisualStarted"]
+    clock["t"] = 2.5
+    panel._tick()  # past the length: finished
+    assert backend.off_calls == 1
+    assert events == ["VisualStarted", "VisualStopped"]
+    assert not panel._timer.isActive()
+    assert "off" in panel.stateLabel.text()
+
+
+def test_stop_button_turns_off_immediately(qtbot, design_session, monkeypatch):
+    panel, clock, events, popups = _playing_panel(qtbot, design_session, monkeypatch)
+    panel.play_cue()
+    backend = panel._active_backend
+    clock["t"] = 0.2
+    panel.stop_cue()  # finalizes inline, not a tick later
+    assert backend.off_calls == 1
+    assert events == ["VisualStarted", "VisualStopped"]
+    assert not panel._timer.isActive()
+    panel.stop_cue()  # idempotent when nothing is playing
+    assert events == ["VisualStarted", "VisualStopped"]
+
+
+def test_replay_while_lit_restarts_without_a_stop_marker(
+    qtbot, design_session, monkeypatch
+):
+    panel, clock, events, popups = _playing_panel(qtbot, design_session, monkeypatch)
+    panel.play_cue()
+    clock["t"] = 0.5
+    panel.play_cue()  # restart, like re-playing the active audio slot
+    assert events == ["VisualStarted", "VisualStarted"]
+
+
+def test_failed_write_mid_cue_stops_marks_and_reports(
+    qtbot, design_session, monkeypatch
+):
+    panel, clock, events, popups = _playing_panel(qtbot, design_session, monkeypatch)
+    panel.play_cue()
+    panel._active_backend = _DeadLight()  # the stick vanishes mid-cue
+    clock["t"] = 0.5
+    panel._tick()
+    assert events == ["VisualStarted", "VisualStopped"]  # marker before the popup
+    assert popups
+    assert not panel._timer.isActive()
+
+
+def test_cleanup_forces_the_light_off_without_a_marker(
+    qtbot, design_session, monkeypatch
+):
+    panel, clock, events, popups = _playing_panel(qtbot, design_session, monkeypatch)
+    panel.play_cue()
+    backend = panel._active_backend
+    panel.cleanup()  # app quit mid-cue
+    assert backend.off_calls == 1
+    assert events == ["VisualStarted"]  # no stop marker on quit
+    assert not panel._timer.isActive()
+
+
+def test_color_can_be_picked_with_no_device(qtbot, design_session, monkeypatch):
+    panel = VisualWindow(design_session)
+    qtbot.addWidget(panel)
+    events, popups = _spies(panel, monkeypatch)
+    monkeypatch.setattr(
+        QtWidgets.QColorDialog, "getColor", lambda *a, **k: QtGui.QColor("#112233")
+    )
+    assert panel._backend is None
+    panel.pick_color()
+    assert panel.blink_hexcode == "#112233"
+    assert not popups  # the old panel refused without hardware


### PR DESCRIPTION
Playing a visual cue slept on the GUI thread for the whole blink (up to 60 s) — no markers, no intercom, no way to stop, exactly when an operator might need them. Groundwork for the #86/#87 cue board.

- New pure `smacc.lights` module (the CueMixer of lights): a `LightEngine` that renders RGB frames from caller-supplied monotonic timestamps — steady/pulse/flash patterns with an attack/release envelope, all unit-tested without hardware — plus a `LightBackend` protocol and the BlinkStick backend. The panel ticks it from a ~30 Hz QTimer, so the app stays live during a cue.
- **Stop** button, and a `VisualStopped` marker (code 68, next free) emitted when the light is actually off, so cue offset is recoverable from the EEG; `VisualStarted` relabeled "Visual started" to pair. Every stop path — natural end, Stop, failed USB write, app quit — forces the light off (a quit mid-cue used to leave the LEDs lit).
- Default color is red instead of black (Play was an invisible no-op out of the box), and the color picker no longer requires a plugged-in device (the settings editor runs hardware-free).
- Docs kept in lockstep per the #101 drift guards: triggers catalog, settings-file example, bundled `default.smacc`, and the BlinkStick walkthrough.

Settings keys are unchanged (`blink_color`/`blink_length`); the multi-slot board, fades, and loop UI follow in the #86/#87 PR.

Verified: `pytest` (391, incl. new `test_lights.py` + `test_panels_visual.py`), `ruff`, `ruff format`, `mypy`. Needs a quick check on a real BlinkStick: play/stop/replay, unplug mid-cue, F5 rescan.