### PR TITLE
feat: multi-slot visual cue board with patterns, loop, and fades

### DIFF
--- a/docs/devices.md
+++ b/docs/devices.md
@@ -8,8 +8,9 @@ devices — roles, the Devices window, and volume — see
 ## BlinkStick
 
 [BlinkStick](https://www.blinkstick.com/) is a USB-controlled RGB LED device.
-SMACC uses it for **visual cues** — lighting up a chosen color for a set duration
-— which is handy for light-based cueing in sleep and lucid-dreaming experiments.
+SMACC uses it for **visual cues** — lighting up a chosen color, steady or
+pulsing/flashing, for a set duration — which is handy for light-based cueing in
+sleep and lucid-dreaming experiments.
 
 ### What you need
 
@@ -24,13 +25,15 @@ SMACC uses it for **visual cues** — lighting up a chosen color for a set durat
 ### Using it in SMACC
 
 1. Plug the BlinkStick into a USB port, then launch SMACC.
-2. Click **Visual stimulation** in the *Tools* column.
+2. Click **Visual cue** in the *Tools* column.
 3. Bind your BlinkStick to the **Bedroom lights** role in the **Devices** window (in
    the *Tools* column). Plug one in after launch and it's detected automatically,
    or choose **File ▸ Refresh devices** (or press `F5`) to rescan.
-4. Pick a **Color** and a **Length** (how long the light stays on, in seconds).
-5. Click **Play** to fire the cue; **Stop** turns the light off before the length
-   runs out. The rest of SMACC stays responsive while the light is on.
+4. Configure a light cue — color, brightness, pattern (steady, or a pulse/flash at
+   a rate in Hz), and length (or **Loop** until stopped) — and add more cues with
+   **+ Add cue** if the protocol needs several.
+5. Click a cue's **Play** to fire it; **Stop** turns the light off early. The rest
+   of SMACC stays responsive while the light is on.
 
 Your chosen device, color, and length are saved in the `.smacc` settings file (see
 [Usage › Settings files](usage.md#settings-files-smacc)), so the visual-cue setup
@@ -38,7 +41,7 @@ travels with the rest of your configuration; the device is reconnected by name o
 the next launch (and flagged if it isn't plugged in).
 
 !!! note
-    If visual stimulation reports that no BlinkStick is set, open the **Devices**
+    If the visual cue window reports that no BlinkStick is set, open the **Devices**
     window and bind one to the **Bedroom lights** role (plug it in first; use
     **File ▸ Refresh devices** or `F5` if it isn't listed). No restart needed.
 

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -14,7 +14,7 @@ guide (creating, editing, sharing). This page is the field reference.
 ```yaml
 # SMACC settings — YAML (.smacc). Edit with care.
 kind: smacc/settings
-schema_version: 1
+schema_version: 2
 smacc_version: "0.0.7"
 metadata:
   subject: "001"
@@ -32,9 +32,11 @@ settings:
   noise_color: white
   noise_source: builtin
   noise_file: ""
-  # --- Visual cue (BlinkStick) -----------------------------------------------
-  blink_color: "#ff0000"
-  blink_length: 1.0
+  # --- Visual cues (BlinkStick) ------------------------------------------------
+  visual_cues:
+    - {name: "Light 1", color: "#ff0000", brightness: 1.0, pattern: steady, rate: 1.0, length: 1.0, loop: false}
+  visual_attack: 0.0
+  visual_release: 0.0
   # --- Survey ----------------------------------------------------------------
   survey_url: ""
   survey_options: {}
@@ -78,7 +80,7 @@ settings:
 | Key | Type | Meaning |
 |---|---|---|
 | `kind` | string | Always `smacc/settings`; a file with a different `kind` is rejected. |
-| `schema_version` | integer | The settings schema version — currently **1**. Only the current version loads. |
+| `schema_version` | integer | The settings schema version — currently **2**. Older versions are upgraded on load (see [Version history](#version-history)). |
 | `smacc_version` | string | The SMACC version that wrote the file (informational). |
 | `metadata` | mapping | Optional run metadata: `subject`, `session`, `notes`, and `created` (ISO timestamp). Blank by default; recorded in the log, not baked into filenames. |
 | `settings` | mapping | The configuration itself (below). |
@@ -99,8 +101,9 @@ Any key may be omitted — each falls back to its default.
 | `noise_color` | string | Selected noise colour (as offered in the Noise panel, e.g. `white`). |
 | `noise_source` | `builtin` \| `file` | Generated noise, or a WAV file. |
 | `noise_file` | path | The noise WAV when `noise_source: file`. |
-| `blink_color` | `#rrggbb` | BlinkStick colour for the visual cue. |
-| `blink_length` | seconds | Visual-cue blink length. |
+| `visual_cues` | list | One entry per light slot: `name` (string), `color` (`#rrggbb`), `brightness` (0–1), `pattern` (`steady` \| `pulse` \| `flash`), `rate` (Hz, the pulse/flash speed), `length` (seconds; ignored while `loop`), `loop` (bool). |
+| `visual_attack` | seconds | Brightness fade-in applied to a starting visual cue. |
+| `visual_release` | seconds | Brightness fade-out applied to a stopping visual cue. |
 | `survey_url` | string | The selected survey URL. |
 | `survey_options` | mapping | Named survey presets: label → URL. |
 | `volume_cap` | 0–1 | Master output safety cap multiplied into every stimulus (`1.0` = no cap). |
@@ -186,3 +189,4 @@ folder stays valid when moved, copied, or zipped.
 | Version | Changes |
 |---|---|
 | 1 | First stable schema. Envelope (`kind` / `schema_version` / `smacc_version` / `metadata` / `settings`); panel state; the `biocals`, `devices`, `event_codes` + `event_code_safe_max`, `trigger_output`, `data_directory`, `preview_levels`, `always_on_top`, and `tool_always_on_top` blocks. |
+| 2 | The single visual cue (`blink_color` / `blink_length`) became the multi-slot `visual_cues` list with the shared `visual_attack` / `visual_release` fades. A v1 file's blink keys load into the first slot. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -188,7 +188,7 @@ summary, export its events to BIDS, or recover its settings.
 ## Settings files (`.smacc`)
 
 A **settings file** captures your reusable setup — cue files, volumes, noise,
-BlinkStick color, survey presets, event codes, the display choices that apply to a
+visual cues, survey presets, event codes, the display choices that apply to a
 session (always-on-top and log-preview levels), and the **data directory** where runs
 are written — in a single portable `.smacc` (plain YAML you can read and edit). The easiest way to build one is the **settings editor** (the launcher's
 **Create settings**, or **Edit…** for an existing one): configure the tools, set the

--- a/src/smacc/assets/default.smacc
+++ b/src/smacc/assets/default.smacc
@@ -1,14 +1,22 @@
 # SMACC settings — YAML (.smacc). Edit with care.
 kind: smacc/settings
-schema_version: 1
+schema_version: 2
 smacc_version: 0.0.7
 metadata:
   subject: ''
   session: ''
   notes: ''
 settings:
-  blink_color: '#ff0000'
-  blink_length: 1.0
+  visual_cues:
+  - name: Light 1
+    color: '#ff0000'
+    brightness: 1.0
+    pattern: steady
+    rate: 1.0
+    length: 1.0
+    loop: false
+  visual_attack: 0.0
+  visual_release: 0.0
   # cues omitted on purpose: the one required cue autofills a random demo on first
   # launch (#65); saving from the app writes the configured cue list back here.
   cue_attack: 0.0

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -195,7 +195,7 @@ class SmaccWindow(ToolWindow):
     PANEL_LABELS = {
         "events": "Event logging",
         "biocals": "Biocals",
-        "visual": "Visual stimulation",
+        "visual": "Visual cue",
         "audio": "Audio cue",
         "noise": "Noise machine",
         "recording": "Dream recording",
@@ -209,7 +209,7 @@ class SmaccWindow(ToolWindow):
         "events": "Log experiment events and send their EEG trigger codes.",
         "biocals": "Run timed biocalibrations, with optional voice instructions "
         "and a full sequence.",
-        "visual": "Flash a BlinkStick LED as a visual cue.",
+        "visual": "Light cues on a BlinkStick: steady, pulse, or flash.",
         "audio": "Play audio cues from a multi-slot cue board.",
         "noise": "Stream continuous background noise (colored noise or a file).",
         "recording": "Record a spoken dream report, monitor input level, open surveys.",

--- a/src/smacc/lights.py
+++ b/src/smacc/lights.py
@@ -42,14 +42,16 @@ class LightEngine:
     :meth:`stop` begins the release fade. :attr:`ended` flips once the envelope
     has reached zero (the duration ran out, or a release finished), so the GUI
     thread can turn the device off and mark the stop. Idle/ended frames are black.
+    ``brightness`` and ``loop`` may be set live (read at the next frame), like
+    ``CueMixer.volume``/``loop``.
     """
 
     def __init__(self) -> None:
         self._color: RGB = (0, 0, 0)
-        self._brightness = 1.0
+        self.brightness = 1.0
         self._pattern = STEADY
         self._rate_hz = 1.0
-        self._loop = False
+        self.loop = False
         self._duration_s = 0.0
         self._attack_s = 0.0
         self._release_s = 0.0
@@ -77,10 +79,10 @@ class LightEngine:
         if pattern not in PATTERNS:
             raise ValueError(f"Unknown light pattern {pattern!r}; one of {PATTERNS}.")
         self._color = color
-        self._brightness = brightness
+        self.brightness = brightness
         self._pattern = pattern
         self._rate_hz = rate_hz
-        self._loop = loop
+        self.loop = loop
         self._duration_s = max(0.0, duration_s)
         self._attack_s = max(0.0, attack_s)
         self._release_s = max(0.0, release_s)
@@ -115,12 +117,12 @@ class LightEngine:
             done = now >= self._stop_t + self._release_s
         else:
             done = (
-                not self._loop and now >= self._t0 + self._duration_s + self._release_s
+                not self.loop and now >= self._t0 + self._duration_s + self._release_s
             )
         if done:
             self._ended = True
             return (0, 0, 0)
-        gain = self._envelope(now) * self._brightness * self._pattern_factor(now)
+        gain = self._envelope(now) * self.brightness * self._pattern_factor(now)
         r, g, b = self._color
         return (_scale(r, gain), _scale(g, gain), _scale(b, gain))
 
@@ -134,7 +136,7 @@ class LightEngine:
         gain = 1.0
         if self._attack_s > 0.0:
             gain = min(1.0, t / self._attack_s)
-        if not self._loop and t > self._duration_s:
+        if not self.loop and t > self._duration_s:
             # Natural release after the ON period (instant when release is 0).
             if self._release_s <= 0.0:
                 return 0.0

--- a/src/smacc/panels/visual.py
+++ b/src/smacc/panels/visual.py
@@ -1,17 +1,24 @@
-"""Visual stimulation window driving a BlinkStick LED device.
+"""Visual cue window: a multi-slot light board (color/pattern/length per slot).
 
-Playback is non-blocking: a ~30 Hz QTimer ticks the pure
-:class:`smacc.lights.LightEngine` and pushes each frame to the resolved backend,
-so the rest of the GUI (markers, intercom, Stop) stays live during a cue — the
-old implementation slept on the GUI thread for the whole blink. Start and stop
-are marked with the ``VisualStarted``/``VisualStopped`` registry events, every
-stop path turns the light off (including app quit), and the color can be picked
-with no device plugged in (the settings editor runs hardware-free).
+The visual sibling of the audio cue board (#86/#87): each slot is one light cue —
+a color at a brightness, shown steady or pulsed/flashed at a rate in Hz — with its
+own length and loop flag, so a protocol that uses several lights (e.g. cue vs.
+sham) can keep them ready and fire any one with a click. Playback is one-at-a-time
+on the BlinkStick resolved from the visual_out role, shaped by a shared brightness
+fade-in/out, and driven by a ~30 Hz QTimer ticking the pure
+:class:`smacc.lights.LightEngine`, so the rest of the GUI stays live throughout.
+Start/stop are marked with the ``VisualStarted``/``VisualStopped`` registry events
+(detail: the slot name), every stop path turns the light off (including app quit),
+and a "sending" swatch mirrors the exact frame on the device — the visual analog
+of the audio board's sending meter. Slots can be added and removed on the fly;
+one is always required.
 """
 
 from __future__ import annotations
 
 import time
+from dataclasses import dataclass, field
+from functools import partial
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
@@ -19,153 +26,488 @@ from .. import lights
 from ..session import SmaccSession
 from .base import ModalityWindow, describe_target, make_section_title
 
+# One light cue is always required; the cap is lower than the audio board's 20
+# because rows are wide and a light protocol rarely needs more than a few variants.
+MIN_LIGHT_SLOTS = 1
+MAX_LIGHT_SLOTS = 10
+# Above this pattern rate the panel shows the photosensitivity/reliability warning.
+RATE_WARN_HZ = 10.0
+# UI ceiling: beyond ~20 Hz a square wave needs more USB updates than the stick's
+# HID timing reliably delivers, so higher settings would just be sold, not shown.
+RATE_MAX_HZ = 20.0
+
+_PATTERN_LABELS = (
+    (lights.STEADY, "Steady"),
+    (lights.PULSE, "Pulse"),
+    (lights.FLASH, "Flash"),
+)
+
+
+def _swatch_pixmap(rgb: lights.RGB, size: int = 22) -> QtGui.QPixmap:
+    """A small color square with a gray border (so black/white still read)."""
+    pixmap = QtGui.QPixmap(size, size)
+    pixmap.fill(QtGui.QColor(*rgb))
+    painter = QtGui.QPainter(pixmap)
+    painter.setPen(QtGui.QColor("#808080"))
+    painter.drawRect(0, 0, size - 1, size - 1)
+    painter.end()
+    return pixmap
+
+
+@dataclass
+class LightSlot:
+    """One light cue: its color plus the row of widgets controlling it.
+
+    Signal handlers bind to the slot *object*, never a row index, so adding or
+    removing rows can't misroute another slot's controls (the audio board's
+    CueSlot approach). ``rgb`` is the cue color; everything else lives in the
+    widgets and is read at play time.
+    """
+
+    nameEdit: QtWidgets.QLineEdit
+    colorButton: QtWidgets.QPushButton
+    brightnessSpinBox: QtWidgets.QDoubleSpinBox
+    patternCombo: QtWidgets.QComboBox
+    rateSpinBox: QtWidgets.QDoubleSpinBox
+    lengthSpinBox: QtWidgets.QDoubleSpinBox
+    loopCheckBox: QtWidgets.QCheckBox
+    playButton: QtWidgets.QPushButton
+    stopButton: QtWidgets.QPushButton
+    removeButton: QtWidgets.QPushButton
+    rgb: lights.RGB = field(default=(255, 0, 0))
+
 
 class VisualWindow(ModalityWindow):
-    """BlinkStick color/length picker with non-blocking play/stop."""
+    """Multi-slot light board with a shared device + fade and per-slot play/stop."""
 
-    TITLE = "Visual stimulation"
-    # ~30 Hz frames: ample for the steady cue here and smooth enough for the
-    # pulse/flash patterns the cue board adds (#86/#87).
+    TITLE = "Visual cue"
+    # ~30 Hz frames: ample headroom for the pulse/flash patterns at allowed rates.
     TICK_MS = 33
 
     def __init__(self, session: SmaccSession, parent: QtWidgets.QWidget | None = None):
         super().__init__(session, parent)
-        # Backend resolved from the visual_out role; the one a playing cue is
-        # bound to is held separately, so re-routing applies from the next Play
-        # (like an audio cue keeping the stream it opened).
+        # Shared brightness fade (attack/release) durations in seconds; 0 == instant.
+        self.visual_attack_s = 0.0
+        self.visual_release_s = 0.0
+        # Backend resolved from the visual_out role; the one a playing cue is bound
+        # to is held separately, so re-routing applies from the next Play (like an
+        # audio cue keeping the stream it opened).
         self._backend: lights.LightBackend | None = None
         self._active_backend: lights.LightBackend | None = None
+        self._active_slot: LightSlot | None = None
         self._engine = lights.LightEngine()
         self._clock = time.monotonic  # injectable for deterministic tests
         self._timer = QtCore.QTimer(self)
         self._timer.setInterval(self.TICK_MS)
         self._timer.timeout.connect(self._tick)
-        self.blink_length_s = 1.0
-        # Default to red: visible out of the box (the old black default made Play
-        # an invisible no-op) and the gentlest color on a dark-adapted sleeper.
-        self.set_blink_color(255, 0, 0)
+        # Populated after the central widget exists so _rebuild_grid has its
+        # header labels and add button to work with.
+        self.slots: list[LightSlot] = []
         self.setCentralWidget(self._build())
-        # The panel's contents are narrow, so without a floor the window opens
-        # too thin to show its "Visual stimulation" titlebar text in full.
-        self.setMinimumWidth(340)
+        self._add_initial_slot()
+
+    # ----- construction ------------------------------------------------------
+
+    def _make_slot(self, name: str) -> LightSlot:
+        """Build one fully-wired light slot and append it to ``self.slots``."""
+        nameEdit = QtWidgets.QLineEdit(name, self)
+        nameEdit.setMaximumWidth(90)
+        colorButton = QtWidgets.QPushButton(self)
+        colorButton.setMaximumWidth(36)
+        colorButton.setStatusTip("Pick this cue's color.")
+        colorButton.setToolTip("Pick this cue's color")
+        brightnessSpinBox = QtWidgets.QDoubleSpinBox(self)
+        brightnessSpinBox.setRange(0, 1)
+        brightnessSpinBox.setSingleStep(0.01)
+        brightnessSpinBox.setMaximumWidth(70)
+        brightnessSpinBox.setStatusTip("Brightness scale for this cue (0–1).")
+        patternCombo = QtWidgets.QComboBox(self)
+        for key, label in _PATTERN_LABELS:
+            patternCombo.addItem(label, key)
+        patternCombo.setStatusTip(
+            "How the light behaves while on: constant, a smooth pulse, or an "
+            "on/off flash at the chosen rate."
+        )
+        rateSpinBox = QtWidgets.QDoubleSpinBox(self)
+        rateSpinBox.setRange(0.1, RATE_MAX_HZ)
+        rateSpinBox.setSingleStep(0.1)
+        rateSpinBox.setSuffix(" Hz")
+        rateSpinBox.setMaximumWidth(85)
+        rateSpinBox.setStatusTip(
+            f"Pulse/flash rate. Above {RATE_WARN_HZ:.0f} Hz: photosensitivity "
+            "risk, and USB timing degrades — see the docs."
+        )
+        rateSpinBox.setEnabled(False)  # steady by default; pattern enables it
+        lengthSpinBox = QtWidgets.QDoubleSpinBox(self)
+        lengthSpinBox.setRange(0, 600)
+        lengthSpinBox.setSingleStep(0.1)
+        lengthSpinBox.setSuffix(" s")
+        lengthSpinBox.setStatusTip(
+            "How long the light stays on, in seconds (ignored while Loop is on)."
+        )
+        loopCheckBox = QtWidgets.QCheckBox(self)
+        loopCheckBox.setStatusTip("Repeat this cue until stopped.")
+        loopCheckBox.setToolTip("Loop until stopped")
+        playButton = QtWidgets.QPushButton("Play", self)
+        stopButton = QtWidgets.QPushButton("Stop", self)
+        removeButton = QtWidgets.QPushButton("✕", self)  # ✕
+        removeButton.setMaximumWidth(28)
+        removeButton.setStatusTip("Remove this cue.")
+        removeButton.setToolTip("Remove this cue")
+        slot = LightSlot(
+            nameEdit,
+            colorButton,
+            brightnessSpinBox,
+            patternCombo,
+            rateSpinBox,
+            lengthSpinBox,
+            loopCheckBox,
+            playButton,
+            stopButton,
+            removeButton,
+        )
+        self.slots.append(slot)  # append before wiring so handlers can resolve it
+        colorButton.clicked.connect(partial(self.pick_slot_color, slot))
+        brightnessSpinBox.valueChanged.connect(
+            partial(self.update_slot_brightness, slot)
+        )
+        patternCombo.currentIndexChanged.connect(
+            partial(self.update_slot_pattern, slot)
+        )
+        rateSpinBox.valueChanged.connect(partial(self.update_slot_rate, slot))
+        loopCheckBox.toggled.connect(partial(self.update_slot_loop, slot))
+        playButton.clicked.connect(partial(self.play_slot, slot))
+        stopButton.clicked.connect(partial(self.stop_slot, slot))
+        removeButton.clicked.connect(partial(self.remove_slot, slot))
+        brightnessSpinBox.setValue(1.0)  # fires update_slot_brightness
+        rateSpinBox.setValue(1.0)
+        lengthSpinBox.setValue(1.0)
+        colorButton.setIcon(QtGui.QIcon(_swatch_pixmap(slot.rgb)))
+        colorButton.setIconSize(QtCore.QSize(22, 22))
+        return slot
+
+    def _add_initial_slot(self) -> None:
+        """Create the single required slot (red/steady: playable out of the box)."""
+        self._make_slot("Light 1")
+        self._rebuild_grid()
 
     def _build(self) -> QtWidgets.QWidget:
-        # The BlinkStick is chosen in the Devices window; show where it resolves.
+        # Shared device (chosen in the Devices window) + fade controls.
         self.deviceLabel = QtWidgets.QLabel(self)
         self.deviceLabel.setStatusTip(
             "Set in the Devices window (Bedroom lights role)."
         )
         self.refresh_device_indicator()
 
-        # Visual color picker: QPushButton signal --> QColorPicker slot
-        colorpickerButton = QtWidgets.QPushButton("Select color", self)
-        colorpickerButton.setStatusTip("Pick the visual stimulus color.")
-        colorpickerButton.clicked.connect(self.pick_color)
-        self.colorpickerButton = colorpickerButton
-        self._update_color_swatch()  # show the current color from the start
-
-        # Cue length selector: QDoubleSpinBox signal --> update params slot
-        lengthSpinBox = QtWidgets.QDoubleSpinBox(self)
-        lengthSpinBox.setStatusTip(
-            "Pick light stimulation length (how long the light will stay on in seconds)."
+        attackSpinBox = QtWidgets.QDoubleSpinBox(self)
+        attackSpinBox.setStatusTip(
+            "Brightness fade-in time for the cue, in seconds (0 = instant)."
         )
-        lengthSpinBox.setMinimum(0)
-        lengthSpinBox.setMaximum(60)
-        lengthSpinBox.setSuffix(" seconds")
-        lengthSpinBox.setSingleStep(0.1)
-        lengthSpinBox.valueChanged.connect(self.handle_length_change)
-        lengthSpinBox.setValue(self.blink_length_s)
-        self.lengthSpinBox = lengthSpinBox
+        attackSpinBox.setRange(0, 60)
+        attackSpinBox.setSingleStep(0.1)
+        attackSpinBox.setSuffix(" seconds")
+        attackSpinBox.valueChanged.connect(self.update_visual_attack)
+        attackSpinBox.setValue(0.0)
+        self.attackSpinBox = attackSpinBox
 
-        playButton = QtWidgets.QPushButton("Play", self)
-        playButton.setStatusTip("Present the visual stimulus.")
-        playButton.clicked.connect(self.play_cue)
-        stopButton = QtWidgets.QPushButton("Stop", self)
-        stopButton.setStatusTip("Turn the light off before its length runs out.")
-        stopButton.clicked.connect(self.stop_cue)
-        buttonRow = QtWidgets.QHBoxLayout()
-        buttonRow.addWidget(playButton)
-        buttonRow.addWidget(stopButton)
+        releaseSpinBox = QtWidgets.QDoubleSpinBox(self)
+        releaseSpinBox.setStatusTip(
+            "Brightness fade-out time when stopping the cue, in seconds (0 = instant)."
+        )
+        releaseSpinBox.setRange(0, 60)
+        releaseSpinBox.setSingleStep(0.1)
+        releaseSpinBox.setSuffix(" seconds")
+        releaseSpinBox.valueChanged.connect(self.update_visual_release)
+        releaseSpinBox.setValue(0.0)
+        self.releaseSpinBox = releaseSpinBox
 
-        # Lit indicator: the operator can't see the bedroom from the control room.
-        self.stateLabel = QtWidgets.QLabel(self)
-        self.stateLabel.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-        self._set_state_off()
+        header = QtWidgets.QFormLayout()
+        header.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        header.addRow("Device:", self.deviceLabel)
+        header.addRow("Fade in:", attackSpinBox)
+        header.addRow("Fade out:", releaseSpinBox)
 
-        layout = QtWidgets.QFormLayout()
-        layout.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
-        layout.addRow(make_section_title("Visual stimulation"))
-        layout.addRow("Device:", self.deviceLabel)
-        layout.addRow("Color:", self.colorpickerButton)
-        layout.addRow("Length:", lengthSpinBox)
-        layout.addRow(buttonRow)
-        layout.addRow(self.stateLabel)
+        # "Now lit" indicator on top of the slot table (mixing-board style).
+        self.nowLitLabel = QtWidgets.QLabel(self)
+        self.nowLitLabel.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self._set_now_off()
+
+        # Light table: a persistent header row, then one rebuildable row per slot,
+        # then an "add" row — the audio board's reparent-don't-delete grid.
+        self._grid = QtWidgets.QGridLayout()
+        self._header_labels = [
+            self._make_header_label(title)
+            for title in (
+                "Name",
+                "Color",
+                "Bright",
+                "Pattern",
+                "Rate",
+                "Length",
+                "Loop",
+                "",
+                "",
+                "",
+            )
+        ]
+        self._addButton = QtWidgets.QPushButton("+ Add cue", self)
+        self._addButton.setStatusTip(
+            f"Add another light cue (up to {MAX_LIGHT_SLOTS})."
+        )
+        self._addButton.setToolTip("Add another light cue")
+        self._addButton.clicked.connect(self.add_slot)
+
+        # Shown whenever any slot's pattern runs faster than RATE_WARN_HZ.
+        self.rateWarningLabel = QtWidgets.QLabel(
+            f"⚠ Rates above {RATE_WARN_HZ:.0f} Hz carry a photosensitivity "
+            "(epilepsy) risk, and USB timing gets unreliable — see the docs.",
+            self,
+        )
+        self.rateWarningLabel.setWordWrap(True)
+        self.rateWarningLabel.setVisible(False)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(make_section_title("Visual cue"))
+        layout.addLayout(header)
+        layout.addWidget(self.nowLitLabel)
+        layout.addLayout(self._grid)
+        layout.addWidget(self.rateWarningLabel)
+        layout.addSpacing(8)
+        layout.addLayout(self._build_monitoring())
+        layout.addStretch(1)
         central = QtWidgets.QWidget()
         central.setLayout(layout)
         return central
 
+    def _make_header_label(self, text: str) -> QtWidgets.QLabel:
+        label = QtWidgets.QLabel(text, self)
+        label.setStyleSheet("font-weight: bold;")
+        return label
+
+    def _build_monitoring(self) -> QtWidgets.QLayout:
+        """The sending swatch: the exact frame on the device right now.
+
+        Like the audio board's "Sending" meter (#37), it confirms emission — that
+        SMACC is driving the light, and with what color — not that the bedroom
+        light itself lit (a BlinkStick has no return channel to check that).
+        """
+        heading = QtWidgets.QLabel("Monitoring", self)
+        heading.setStyleSheet("font-weight: bold;")
+        self.sendingSwatch = QtWidgets.QLabel(self)
+        self.sendingSwatch.setStatusTip(
+            "The exact color SMACC is sending to the light right now — confirms "
+            "emission, not that the bedroom light actually lit."
+        )
+        self._set_swatch((0, 0, 0))
+        form = QtWidgets.QFormLayout()
+        form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        form.addRow("Sending:", self.sendingSwatch)
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(heading)
+        layout.addLayout(form)
+        return layout
+
+    def _rebuild_grid(self) -> None:
+        """Re-lay the light table: header row, one row per slot, then the add row.
+
+        Every widget here is persistent (the header labels, the add button, and
+        each slot's controls), so clearing only reparents them out of the grid —
+        nothing is deleted — and they're re-added in their new positions.
+        """
+        while self._grid.count():
+            self._grid.takeAt(0)  # drop the layout item only; widgets are reused
+        for col, label in enumerate(self._header_labels):
+            self._grid.addWidget(label, 0, col)
+        for row, slot in enumerate(self.slots, start=1):
+            self._grid.addWidget(slot.nameEdit, row, 0)
+            self._grid.addWidget(slot.colorButton, row, 1)
+            self._grid.addWidget(slot.brightnessSpinBox, row, 2)
+            self._grid.addWidget(slot.patternCombo, row, 3)
+            self._grid.addWidget(slot.rateSpinBox, row, 4)
+            self._grid.addWidget(slot.lengthSpinBox, row, 5)
+            self._grid.addWidget(slot.loopCheckBox, row, 6)
+            self._grid.addWidget(slot.playButton, row, 7)
+            self._grid.addWidget(slot.stopButton, row, 8)
+            self._grid.addWidget(slot.removeButton, row, 9)
+            # The lone required slot can't be removed: keep the button in place (so
+            # the column doesn't jump) but disabled.
+            slot.removeButton.setEnabled(len(self.slots) > MIN_LIGHT_SLOTS)
+        self._grid.addWidget(self._addButton, len(self.slots) + 1, 0, 1, 2)
+        self._addButton.setEnabled(len(self.slots) < MAX_LIGHT_SLOTS)
+        self._grid.setColumnStretch(0, 1)
+
+    # ----- add / remove slots ------------------------------------------------
+
+    def add_slot(self) -> None:
+        """Append a new light slot, up to the cap."""
+        if len(self.slots) >= MAX_LIGHT_SLOTS:
+            return
+        slot = self._make_slot(f"Light {len(self.slots) + 1}")
+        self._rebuild_grid()
+        self.adjustSize()
+        self.session.log_interaction(f"Added light cue '{slot.nameEdit.text()}'")
+
+    def remove_slot(self, slot: LightSlot) -> None:
+        """Remove a light slot (never the last one), stopping it first."""
+        if len(self.slots) <= MIN_LIGHT_SLOTS or slot not in self.slots:
+            return
+        name = slot.nameEdit.text()
+        self.slots.remove(slot)
+        self._destroy_slot_widgets(slot)
+        self._rebuild_grid()
+        self._refresh_rate_warning()
+        self.adjustSize()
+        self.session.log_interaction(f"Removed light cue '{name}'")
+
+    def _destroy_slot_widgets(self, slot: LightSlot) -> None:
+        """Tear down a removed slot: darken it if lit, then free its widgets."""
+        if self._active_slot is slot:
+            self._finish(mark=False)  # off without a spurious marker
+        for widget in (
+            slot.nameEdit,
+            slot.colorButton,
+            slot.brightnessSpinBox,
+            slot.patternCombo,
+            slot.rateSpinBox,
+            slot.lengthSpinBox,
+            slot.loopCheckBox,
+            slot.playButton,
+            slot.stopButton,
+            slot.removeButton,
+        ):
+            widget.hide()  # leave no orphan visible before deferred deletion
+            widget.deleteLater()
+
+    def _resize_slots(self, count: int) -> None:
+        """Grow/shrink the slot list to ``count`` (clamped to ``1..MAX``)."""
+        count = max(MIN_LIGHT_SLOTS, min(count, MAX_LIGHT_SLOTS))
+        while len(self.slots) < count:
+            self._make_slot(f"Light {len(self.slots) + 1}")
+        while len(self.slots) > count:
+            self._destroy_slot_widgets(self.slots.pop())
+        self._rebuild_grid()
+
+    # ----- shared device + fade ---------------------------------------------
+
     def refresh_device_indicator(self) -> None:
         """Resolve the BlinkStick from its role and show where the cue routes.
 
-        A cue already playing keeps the backend it started with; the fresh
-        resolution applies from the next Play.
+        A cue already lit keeps the backend it started with; the fresh resolution
+        applies from the next Play.
         """
         serial = self.session.devices.device_for("visual_out")
         self._backend = lights.resolve_blinkstick(serial)
         self.deviceLabel.setText(describe_target(self.session, "visual_out"))
 
-    # ----- color + length ------------------------------------------------------
+    def update_visual_attack(self, value: float) -> None:
+        """Set the shared brightness fade-in (attack) time in seconds."""
+        self.visual_attack_s = value
+        self.session.log_interaction(f"Visual fade-in set to {value:.1f}s")
 
-    def set_blink_color(self, r: int, g: int, b: int) -> None:
-        """Set the cue color from 0-255 RGB components (hex kept for save/load)."""
-        self.blink_rgb: lights.RGB = (r, g, b)
-        self.blink_hexcode = f"#{r:02x}{g:02x}{b:02x}"
-        # Keep the color picker's swatch in sync (once the button exists).
-        if hasattr(self, "colorpickerButton"):
-            self._update_color_swatch()
-        self.session.log_interaction(f"Blink color set to {self.blink_hexcode}")
+    def update_visual_release(self, value: float) -> None:
+        """Set the shared brightness fade-out (release) time in seconds."""
+        self.visual_release_s = value
+        self.session.log_interaction(f"Visual fade-out set to {value:.1f}s")
 
-    def _update_color_swatch(self) -> None:
-        """Show the currently selected blink color on the color picker button."""
-        size = 22
-        pixmap = QtGui.QPixmap(size, size)
-        pixmap.fill(QtGui.QColor(*self.blink_rgb))
-        painter = QtGui.QPainter(pixmap)
-        painter.setPen(QtGui.QColor("#808080"))  # border so black/white read
-        painter.drawRect(0, 0, size - 1, size - 1)
-        painter.end()
-        self.colorpickerButton.setIcon(QtGui.QIcon(pixmap))
-        self.colorpickerButton.setIconSize(QtCore.QSize(size, size))
+    # ----- per-slot controls -------------------------------------------------
 
-    def pick_color(self) -> None:
+    def pick_slot_color(self, slot: LightSlot) -> None:
         # No device needed to choose a color (the settings editor has none).
-        color = QtWidgets.QColorDialog.getColor(QtGui.QColor(self.blink_hexcode), self)
+        current = QtGui.QColor(*slot.rgb)
+        color = QtWidgets.QColorDialog.getColor(current, self)
         if color.isValid():
-            r, g, b, _ = color.getRgb()
-            self.set_blink_color(r, g, b)
+            self._set_slot_color(slot, color.red(), color.green(), color.blue())
 
-    def handle_length_change(self, length: float) -> None:
-        """Takes the blink length in seconds from the spinbox."""
-        self.blink_length_s = length
-        self.session.log_interaction(f"Blink length set to {length:.1f}s")
+    def _set_slot_color(self, slot: LightSlot, r: int, g: int, b: int) -> None:
+        """Set a slot's cue color and its button swatch (applies from next Play)."""
+        slot.rgb = (r, g, b)
+        slot.colorButton.setIcon(QtGui.QIcon(_swatch_pixmap(slot.rgb)))
+        self.session.log_interaction(
+            f"Light cue '{slot.nameEdit.text()}' color set to {_hexcode(slot.rgb)}"
+        )
+
+    def update_slot_brightness(
+        self, slot: LightSlot, value: float | None = None
+    ) -> None:
+        """Set a slot's brightness (0-1) from its spinbox (live if it's lit)."""
+        brightness = slot.brightnessSpinBox.value()
+        if self._active_slot is slot:
+            self._engine.brightness = brightness
+        self.session.log_interaction(
+            f"Light cue '{slot.nameEdit.text()}' brightness set to {brightness:.2f}",
+            debug=True,
+        )
+
+    def update_slot_pattern(self, slot: LightSlot, index: int | None = None) -> None:
+        """A slot's pattern changed: gate its rate control (applies next Play)."""
+        pattern = slot.patternCombo.currentData()
+        slot.rateSpinBox.setEnabled(pattern != lights.STEADY)
+        self._refresh_rate_warning()
+        self.session.log_interaction(
+            f"Light cue '{slot.nameEdit.text()}' pattern set to {pattern}"
+        )
+
+    def update_slot_rate(self, slot: LightSlot, value: float | None = None) -> None:
+        """A slot's pattern rate changed (applies next Play)."""
+        self._refresh_rate_warning()
+        self.session.log_interaction(
+            f"Light cue '{slot.nameEdit.text()}' rate set to "
+            f"{slot.rateSpinBox.value():.1f} Hz",
+            debug=True,
+        )
+
+    def update_slot_loop(self, slot: LightSlot, enabled: bool | None = None) -> None:
+        """Set a slot's loop flag from its checkbox (live if it's lit)."""
+        looping = slot.loopCheckBox.isChecked()
+        if self._active_slot is slot:
+            self._engine.loop = looping
+        self.session.log_interaction(
+            f"Light cue '{slot.nameEdit.text()}' loop {'on' if looping else 'off'}"
+        )
+
+    def _refresh_rate_warning(self) -> None:
+        """Show the photosensitivity note iff any patterned slot runs > the cutoff."""
+        risky = any(
+            slot.patternCombo.currentData() != lights.STEADY
+            and slot.rateSpinBox.value() > RATE_WARN_HZ
+            for slot in self.slots
+        )
+        self.rateWarningLabel.setVisible(risky)
 
     # ----- playback ------------------------------------------------------------
 
-    def play_cue(self) -> None:
-        """Light the cue (non-blocking; re-playing while lit just restarts it)."""
+    def play_slot(self, slot: LightSlot) -> None:
+        """Light one slot (stopping any other lit slot first) with fade-in.
+
+        Re-playing the lit slot just restarts it (no stop marker), like the audio
+        board re-playing its active slot.
+        """
         if self._backend is None:
             self.session.show_error_popup(
-                "Visual stimulation unavailable.",
+                "Visual cue unavailable.",
                 "No BlinkStick is set. Bind one to the Bedroom lights role "
                 "in the Devices window.",
                 parent=self,
             )
             return
+        if self._active_slot is not None:
+            self._finish(mark=self._active_slot is not slot)
         backend = self._backend
         now = self._clock()
-        self._engine.start(now, self.blink_rgb, duration_s=self.blink_length_s)
+        self._engine.start(
+            now,
+            slot.rgb,
+            brightness=slot.brightnessSpinBox.value(),
+            duration_s=slot.lengthSpinBox.value(),
+            loop=slot.loopCheckBox.isChecked(),
+            pattern=slot.patternCombo.currentData(),
+            rate_hz=slot.rateSpinBox.value(),
+            attack_s=self.visual_attack_s,
+            release_s=self.visual_release_s,
+        )
+        first = self._engine.frame(now)
         try:
-            backend.apply(self._engine.frame(now))
+            backend.apply(first)
         except Exception as err:
             self._engine.stop(now)
             self.session.show_error_popup(
@@ -173,18 +515,22 @@ class VisualWindow(ModalityWindow):
             )
             return
         self._active_backend = backend
+        self._active_slot = slot
         self._timer.start()
-        self._set_state_on()
+        self._set_now_lit(slot)
+        self._set_swatch(first)
         # Marked after the first frame is on the device, so the marker trails the
         # photons by microseconds instead of leading them by up to a tick.
-        self.session.emit_event("VisualStarted")
+        self.session.emit_event("VisualStarted", detail=slot.nameEdit.text())
 
-    def stop_cue(self) -> None:
-        """Turn the cue off now (instant; the release fade arrives with #86)."""
-        if not self._timer.isActive():
+    def stop_slot(self, slot: LightSlot) -> None:
+        """Stop a slot (with fade-out) if it is the one currently lit."""
+        if self._active_slot is not slot or not self._timer.isActive():
             return
         self._engine.stop(self._clock())
-        self._tick()  # finalize immediately: off + marker, not a tick later
+        if self._engine.ended:  # instant stop (no release fade)
+            self._tick()  # finalize immediately: off + marker, not a tick later
+        # Otherwise the release fade runs and _tick finalizes it when done.
 
     def _tick(self) -> None:
         """Timer slot: push the current frame, finishing once the cue has ended."""
@@ -193,7 +539,7 @@ class VisualWindow(ModalityWindow):
         if self._engine.ended:
             self._finish(mark=True)
             return
-        assert self._active_backend is not None  # set with the timer in play_cue
+        assert self._active_backend is not None  # set with the timer in play_slot
         try:
             self._active_backend.apply(frame)
         except Exception as err:
@@ -201,9 +547,12 @@ class VisualWindow(ModalityWindow):
             self.session.show_error_popup(
                 "BlinkStick write failed; visual cue stopped.", str(err), parent=self
             )
+            return
+        self._set_swatch(frame)
 
     def _finish(self, mark: bool) -> None:
         """Stop the timer, force the light off (best effort), and mark the stop."""
+        slot = self._active_slot
         self._timer.stop()
         if self._active_backend is not None:
             try:
@@ -211,34 +560,82 @@ class VisualWindow(ModalityWindow):
             except Exception:
                 pass  # unplugged mid-cue; nothing left to turn off
             self._active_backend = None
-        self._set_state_off()
-        if mark:
-            self.session.emit_event("VisualStopped")
+        self._active_slot = None
+        self._set_now_off()
+        self._set_swatch((0, 0, 0))
+        if mark and slot is not None:
+            self.session.emit_event("VisualStopped", detail=slot.nameEdit.text())
 
-    def _set_state_on(self) -> None:
-        self.stateLabel.setText("● lit")
-        self.stateLabel.setStyleSheet("color: red; font-weight: bold;")
+    def _set_now_lit(self, slot: LightSlot) -> None:
+        name = slot.nameEdit.text()
+        looping = slot.loopCheckBox.isChecked()
+        self.nowLitLabel.setText(f"● {name} (looping)" if looping else f"● {name}")
+        self.nowLitLabel.setStyleSheet("color: red; font-weight: bold;")
 
-    def _set_state_off(self) -> None:
-        self.stateLabel.setText("■ off")
-        self.stateLabel.setStyleSheet("")
+    def _set_now_off(self) -> None:
+        self.nowLitLabel.setText("■ off")  # ■
+        self.nowLitLabel.setStyleSheet("")
 
-    # ----- settings state --------------------------------------------------------
+    def _set_swatch(self, rgb: lights.RGB) -> None:
+        self.sendingSwatch.setPixmap(_swatch_pixmap(rgb))
+
+    # ----- settings state ----------------------------------------------------
 
     def gather_state(self) -> dict:
         return {
-            "blink_color": self.blink_hexcode,
-            "blink_length": self.blink_length_s,
+            "visual_cues": [
+                {
+                    "name": slot.nameEdit.text(),
+                    "color": _hexcode(slot.rgb),
+                    "brightness": slot.brightnessSpinBox.value(),
+                    "pattern": slot.patternCombo.currentData(),
+                    "rate": slot.rateSpinBox.value(),
+                    "length": slot.lengthSpinBox.value(),
+                    "loop": slot.loopCheckBox.isChecked(),
+                }
+                for slot in self.slots
+            ],
+            "visual_attack": self.attackSpinBox.value(),
+            "visual_release": self.releaseSpinBox.value(),
         }
 
     def apply_state(self, state: dict) -> None:
-        if hexcode := state.get("blink_color"):
-            qcolor = QtGui.QColor(hexcode)
+        # A v1 file's blink_color/blink_length arrive here already migrated into
+        # a one-slot visual_cues list (see smacc.settings).
+        cues = state.get("visual_cues")
+        if isinstance(cues, list) and cues:
+            self._resize_slots(len(cues))
+            for slot, cue in zip(self.slots, cues, strict=False):
+                if isinstance(cue, dict):
+                    self._apply_cue(slot, cue)
+        if (v := state.get("visual_attack")) is not None:
+            self.attackSpinBox.setValue(float(v))
+        if (v := state.get("visual_release")) is not None:
+            self.releaseSpinBox.setValue(float(v))
+
+    def _apply_cue(self, slot: LightSlot, cue: dict) -> None:
+        if name := cue.get("name"):
+            slot.nameEdit.setText(str(name))
+        if (c := cue.get("color")) is not None:
+            qcolor = QtGui.QColor(str(c))
             if qcolor.isValid():
-                self.set_blink_color(qcolor.red(), qcolor.green(), qcolor.blue())
-        if (length := state.get("blink_length")) is not None:
-            self.lengthSpinBox.setValue(float(length))
+                self._set_slot_color(slot, qcolor.red(), qcolor.green(), qcolor.blue())
+        if (v := cue.get("brightness")) is not None:
+            slot.brightnessSpinBox.setValue(float(v))
+        pattern = cue.get("pattern")
+        if pattern in lights.PATTERNS:
+            slot.patternCombo.setCurrentIndex(slot.patternCombo.findData(pattern))
+        if (v := cue.get("rate")) is not None:
+            slot.rateSpinBox.setValue(float(v))
+        if (v := cue.get("length")) is not None:
+            slot.lengthSpinBox.setValue(float(v))
+        slot.loopCheckBox.setChecked(bool(cue.get("loop", False)))
 
     def cleanup(self) -> None:
         """Stop the cue timer and leave the light off (no marker; app is quitting)."""
         self._finish(mark=False)
+
+
+def _hexcode(rgb: lights.RGB) -> str:
+    r, g, b = rgb
+    return f"#{r:02x}{g:02x}{b:02x}"

--- a/src/smacc/settings.py
+++ b/src/smacc/settings.py
@@ -1,15 +1,15 @@
 """Persist and restore a SMACC study config as a single ``.smacc`` file (YAML).
 
 A study file lets a researcher configure SMACC once (cue sounds, volumes, noise
-color, BlinkStick color/length, survey presets) and reload it each session so the
-setup stays consistent across nights and researchers. It carries optional metadata
+color, visual cues, survey presets) and reload it each session so the setup stays
+consistent across nights and researchers. It carries optional metadata
 (subject/session/notes) and is tagged with a ``kind`` discriminator so SMACC can
 reject YAML that wasn't written by it.
 
 The on-disk shape (a ``.smacc`` file is YAML text with a leading comment header)::
 
     kind: smacc/settings
-    schema_version: 1
+    schema_version: 2
     smacc_version: "0.0.7"
     metadata: {subject: "", session: "", notes: "", created: "..."}
     settings: { ...the panel state from SmaccWindow.gather_settings()... }
@@ -48,13 +48,15 @@ KIND = "smacc/settings"
 # ignores ``#`` comments, so this round-trips cleanly through ``safe_load``).
 _FILE_HEADER = "# SMACC settings — YAML (.smacc). Edit with care.\n"
 
-# v1 is the first stable on-disk schema. Bump this when the layout changes
-# incompatibly — and when you do, add a migration path here plus a row to the
-# version-history table in docs/reference/settings-file.md. A file carrying a
-# higher or otherwise-unknown version is rejected on load. Missing *optional* keys
-# are not a version concern: each panel/sub-block fills its own default, so a
-# partial or hand-edited v1 file still loads.
-SCHEMA_VERSION = 1
+# v1 was the first stable on-disk schema; v2 reshaped the single visual cue
+# (``blink_color``/``blink_length``) into the multi-slot ``visual_cues`` list.
+# Bump this when the layout changes incompatibly — and when you do, extend
+# :func:`_migrate_settings` plus the version-history table in
+# docs/reference/settings-file.md. A file carrying a higher or otherwise-unknown
+# version is rejected on load. Missing *optional* keys are not a version concern:
+# each panel/sub-block fills its own default, so a partial or hand-edited file
+# still loads.
+SCHEMA_VERSION = 2
 
 
 def build_payload(settings: dict[str, Any], metadata: dict) -> dict[str, Any]:
@@ -104,7 +106,7 @@ def parse_settings_mapping(payload: Any) -> tuple[dict, dict]:
     if kind is not None and kind != KIND:
         raise ValueError(f"Not a compatible SMACC settings file (kind={kind!r}).")
     version = payload.get("schema_version")
-    # Only the current schema is accepted; there is no cross-version migration.
+    # Versions 1..current are accepted; older shapes are upgraded on the way in.
     if isinstance(version, bool) or not isinstance(version, int):
         raise ValueError(f"Unsupported settings schema version {version!r}.")
     if not (1 <= version <= SCHEMA_VERSION):
@@ -118,7 +120,27 @@ def parse_settings_mapping(payload: Any) -> tuple[dict, dict]:
     metadata = payload.get("metadata")
     if not isinstance(metadata, dict):
         metadata = {}
-    return settings, metadata
+    return _migrate_settings(settings, version), metadata
+
+
+def _migrate_settings(settings: dict, version: int) -> dict:
+    """Upgrade an older-schema ``settings`` mapping to the current shape, in place.
+
+    v1 -> v2: the single visual cue (``blink_color``/``blink_length``) became the
+    multi-slot ``visual_cues`` list; a v1 file's blink keys load into the first
+    slot (panels only ever see the current shape).
+    """
+    if version < 2:
+        color = settings.pop("blink_color", None)
+        length = settings.pop("blink_length", None)
+        if "visual_cues" not in settings and (color is not None or length is not None):
+            slot: dict[str, Any] = {"name": "Light 1"}
+            if color is not None:
+                slot["color"] = color
+            if length is not None:
+                slot["length"] = length
+            settings["visual_cues"] = [slot]
+    return settings
 
 
 def load_settings(path: str | Path) -> tuple[dict, dict]:

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -39,7 +39,7 @@ def test_window_builds_in_design_mode(
         "data_directory",
         "volume_cap",
         "noise_color",
-        "blink_color",
+        "visual_cues",
         "cues",
     ):
         assert key in state
@@ -93,7 +93,7 @@ def test_apply_settings_lands_values(
     settings = window.gather_settings()
     settings["volume_cap"] = 0.5
     settings["noise_color"] = "brown"
-    settings["blink_color"] = "#abcdef"
+    settings["visual_cues"] = [{"name": "Glow", "color": "#abcdef"}]
     settings["cues"] = [{"name": "Buzz", "file": "", "volume": 0.3, "loop": True}]
     settings["devices"] = {
         "bindings": {
@@ -108,7 +108,8 @@ def test_apply_settings_lands_values(
     got = window.gather_settings()
     assert got["volume_cap"] == pytest.approx(0.5)
     assert got["noise_color"] == "brown"
-    assert got["blink_color"].lower() == "#abcdef"
+    assert got["visual_cues"][0]["name"] == "Glow"
+    assert got["visual_cues"][0]["color"] == "#abcdef"
     assert got["cues"][0]["name"] == "Buzz"
     assert got["devices"]["bindings"]["bedroom_out"] == mock_devices["outputs"][0]
     # The bound devices all match advertised hardware, so none are flagged missing.

--- a/tests/test_lights.py
+++ b/tests/test_lights.py
@@ -183,3 +183,13 @@ def test_resolve_blinkstick_swallows_enumeration_errors(monkeypatch):
     assert lights.resolve_blinkstick("BS123") is None
     monkeypatch.setattr(blinkstick, "find_by_serial", lambda serial: None)
     assert lights.resolve_blinkstick("BS123") is None
+
+
+def test_brightness_and_loop_apply_live():
+    # The board edits these mid-cue (like CueMixer.volume/loop): read per frame.
+    engine = started(duration_s=1.0, loop=True)
+    engine.brightness = 0.5
+    assert engine.frame(50.0) == (100, 50, 25)
+    engine.loop = False  # past duration with loop now off -> done at next frame
+    assert engine.frame(50.1) == (0, 0, 0)
+    assert engine.ended

--- a/tests/test_panels_state.py
+++ b/tests/test_panels_state.py
@@ -84,10 +84,38 @@ def test_recording_panel_round_trips_surveys(qtbot, design_session):
 def test_visual_panel_round_trips(qtbot, design_session):
     panel = VisualWindow(design_session)
     qtbot.addWidget(panel)
-    panel.apply_state({"blink_color": "#123456", "blink_length": 2.5})
+    panel.apply_state(
+        {
+            "visual_cues": [
+                {
+                    "name": "TLR pulse",
+                    "color": "#123456",
+                    "brightness": 0.7,
+                    "pattern": "pulse",
+                    "rate": 2.0,
+                    "length": 2.5,
+                    "loop": True,
+                },
+                {"name": "Sham", "color": "#ffffff"},
+            ],
+            "visual_attack": 0.5,
+            "visual_release": 1.5,
+        }
+    )
     got = panel.gather_state()
-    assert got["blink_color"].lower() == "#123456"
-    assert got["blink_length"] == pytest.approx(2.5)
+    cue, sham = got["visual_cues"]
+    assert cue["name"] == "TLR pulse"
+    assert cue["color"] == "#123456"
+    assert cue["brightness"] == pytest.approx(0.7)
+    assert cue["pattern"] == "pulse"
+    assert cue["rate"] == pytest.approx(2.0)
+    assert cue["length"] == pytest.approx(2.5)
+    assert cue["loop"] is True
+    assert sham["name"] == "Sham"
+    assert sham["color"] == "#ffffff"
+    assert sham["pattern"] == "steady"  # unspecified fields keep their defaults
+    assert got["visual_attack"] == pytest.approx(0.5)
+    assert got["visual_release"] == pytest.approx(1.5)
 
 
 def test_volume_panel_round_trips_cap(qtbot, design_session, monkeypatch):

--- a/tests/test_panels_visual.py
+++ b/tests/test_panels_visual.py
@@ -1,4 +1,4 @@
-"""Tests for the Visual stimulation panel's non-blocking playback.
+"""Tests for the Visual cue board's slots, playback, and live controls.
 
 Headless Qt (offscreen). A fake backend stands in for the BlinkStick and a fake
 clock replaces ``time.monotonic``, so ticks are driven by calling ``_tick()``
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 from PyQt6 import QtGui, QtWidgets
 
-from smacc.panels.visual import VisualWindow
+from smacc import lights
+from smacc.panels.visual import MAX_LIGHT_SLOTS, VisualWindow
 
 
 class _FakeLight:
@@ -35,10 +36,12 @@ class _DeadLight(_FakeLight):
 
 def _spies(panel, monkeypatch):
     """Replace the session's marker + popup sinks with recording lists."""
-    events: list[str] = []
+    events: list[tuple[str, str | None]] = []
     popups: list[str] = []
     monkeypatch.setattr(
-        panel.session, "emit_event", lambda key, detail=None: events.append(key)
+        panel.session,
+        "emit_event",
+        lambda key, detail=None: events.append((key, detail)),
     )
     monkeypatch.setattr(
         panel.session,
@@ -48,8 +51,8 @@ def _spies(panel, monkeypatch):
     return events, popups
 
 
-def _playing_panel(qtbot, design_session, monkeypatch, backend=None):
-    """A panel with a fake clock + backend, plus its event/popup spies."""
+def _board(qtbot, design_session, monkeypatch, backend=None):
+    """A board with a fake clock + backend, plus its event/popup spies."""
     panel = VisualWindow(design_session)
     qtbot.addWidget(panel)
     clock = {"t": 0.0}
@@ -59,11 +62,18 @@ def _playing_panel(qtbot, design_session, monkeypatch, backend=None):
     return panel, clock, events, popups
 
 
-def test_defaults_are_a_visible_red_cue(qtbot, design_session):
+def test_defaults_are_one_playable_red_steady_slot(qtbot, design_session):
     panel = VisualWindow(design_session)
     qtbot.addWidget(panel)
-    assert panel.blink_hexcode == "#ff0000"  # black would make Play invisible
-    assert "off" in panel.stateLabel.text()
+    assert len(panel.slots) == 1
+    slot = panel.slots[0]
+    assert slot.nameEdit.text() == "Light 1"
+    assert slot.rgb == (255, 0, 0)  # black would make Play invisible
+    assert slot.patternCombo.currentData() == lights.STEADY
+    assert not slot.rateSpinBox.isEnabled()  # rate only matters for pulse/flash
+    assert slot.brightnessSpinBox.value() == 1.0
+    assert not slot.removeButton.isEnabled()  # the one required slot stays
+    assert "off" in panel.nowLitLabel.text()
 
 
 def test_play_without_a_device_pops_an_error_and_marks_nothing(
@@ -73,74 +83,133 @@ def test_play_without_a_device_pops_an_error_and_marks_nothing(
     qtbot.addWidget(panel)
     events, popups = _spies(panel, monkeypatch)
     assert panel._backend is None  # the default role has no device bound
-    panel.play_cue()
+    panel.play_slot(panel.slots[0])
     assert popups and not events
     assert not panel._timer.isActive()
 
 
-def test_play_lights_the_first_frame_then_marks_the_start(
+def test_play_lights_the_first_frame_then_marks_with_the_slot_name(
     qtbot, design_session, monkeypatch
 ):
-    panel, clock, events, popups = _playing_panel(qtbot, design_session, monkeypatch)
-    panel.play_cue()
+    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel.play_slot(panel.slots[0])
     backend = panel._active_backend
     assert backend.frames == [(255, 0, 0)]  # frame applied before the marker
-    assert events == ["VisualStarted"]
+    assert events == [("VisualStarted", "Light 1")]
     assert panel._timer.isActive()
-    assert "lit" in panel.stateLabel.text()
+    assert "Light 1" in panel.nowLitLabel.text()
 
 
 def test_cue_ends_on_its_own_with_an_off_and_a_stop_marker(
     qtbot, design_session, monkeypatch
 ):
-    panel, clock, events, popups = _playing_panel(qtbot, design_session, monkeypatch)
-    panel.lengthSpinBox.setValue(2.0)
-    panel.play_cue()
+    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    slot = panel.slots[0]
+    slot.lengthSpinBox.setValue(2.0)
+    panel.play_slot(slot)
     backend = panel._active_backend
     clock["t"] = 1.0
     panel._tick()  # mid-cue: still lit
     assert backend.frames[-1] == (255, 0, 0)
-    assert events == ["VisualStarted"]
     clock["t"] = 2.5
     panel._tick()  # past the length: finished
     assert backend.off_calls == 1
-    assert events == ["VisualStarted", "VisualStopped"]
+    assert events == [("VisualStarted", "Light 1"), ("VisualStopped", "Light 1")]
     assert not panel._timer.isActive()
-    assert "off" in panel.stateLabel.text()
+    assert "off" in panel.nowLitLabel.text()
 
 
-def test_stop_button_turns_off_immediately(qtbot, design_session, monkeypatch):
-    panel, clock, events, popups = _playing_panel(qtbot, design_session, monkeypatch)
-    panel.play_cue()
-    backend = panel._active_backend
-    clock["t"] = 0.2
-    panel.stop_cue()  # finalizes inline, not a tick later
-    assert backend.off_calls == 1
-    assert events == ["VisualStarted", "VisualStopped"]
-    assert not panel._timer.isActive()
-    panel.stop_cue()  # idempotent when nothing is playing
-    assert events == ["VisualStarted", "VisualStopped"]
-
-
-def test_replay_while_lit_restarts_without_a_stop_marker(
+def test_stop_button_turns_off_immediately_without_a_fade(
     qtbot, design_session, monkeypatch
 ):
-    panel, clock, events, popups = _playing_panel(qtbot, design_session, monkeypatch)
-    panel.play_cue()
+    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    slot = panel.slots[0]
+    panel.play_slot(slot)
+    backend = panel._active_backend
+    clock["t"] = 0.2
+    panel.stop_slot(slot)  # finalizes inline, not a tick later
+    assert backend.off_calls == 1
+    assert events[-1] == ("VisualStopped", "Light 1")
+    assert not panel._timer.isActive()
+    panel.stop_slot(slot)  # idempotent when nothing is lit
+    assert len(events) == 2
+
+
+def test_stop_with_a_release_fades_before_the_marker(
+    qtbot, design_session, monkeypatch
+):
+    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel.releaseSpinBox.setValue(1.0)
+    slot = panel.slots[0]
+    slot.lengthSpinBox.setValue(60.0)
+    panel.play_slot(slot)
+    backend = panel._active_backend
+    clock["t"] = 1.0
+    panel.stop_slot(slot)
+    assert panel._timer.isActive()  # release fade still running
+    clock["t"] = 1.5
+    panel._tick()
+    assert backend.frames[-1] == (128, 0, 0)  # half-faded red
+    assert events == [("VisualStarted", "Light 1")]
+    clock["t"] = 2.1
+    panel._tick()  # fade done
+    assert backend.off_calls == 1
+    assert events[-1] == ("VisualStopped", "Light 1")
+
+
+def test_playing_another_slot_stops_the_lit_one_first(
+    qtbot, design_session, monkeypatch
+):
+    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel.add_slot()
+    first, second = panel.slots
+    panel.play_slot(first)
+    panel.play_slot(second)  # one-at-a-time: replaces the lit cue
+    assert events == [
+        ("VisualStarted", "Light 1"),
+        ("VisualStopped", "Light 1"),
+        ("VisualStarted", "Light 2"),
+    ]
+
+
+def test_replay_of_the_lit_slot_restarts_without_a_stop_marker(
+    qtbot, design_session, monkeypatch
+):
+    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    slot = panel.slots[0]
+    panel.play_slot(slot)
     clock["t"] = 0.5
-    panel.play_cue()  # restart, like re-playing the active audio slot
-    assert events == ["VisualStarted", "VisualStarted"]
+    panel.play_slot(slot)
+    assert events == [("VisualStarted", "Light 1"), ("VisualStarted", "Light 1")]
+
+
+def test_brightness_and_loop_edits_apply_to_the_lit_cue(
+    qtbot, design_session, monkeypatch
+):
+    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    slot = panel.slots[0]
+    slot.loopCheckBox.setChecked(True)
+    panel.play_slot(slot)
+    slot.brightnessSpinBox.setValue(0.5)
+    assert panel._engine.brightness == 0.5
+    clock["t"] = 100.0  # looping: far past the 1 s length, still lit
+    panel._tick()
+    assert panel._active_backend.frames[-1] == (128, 0, 0)
+    slot.loopCheckBox.setChecked(False)  # live: the cue now ends
+    clock["t"] = 100.1
+    panel._tick()
+    assert events[-1] == ("VisualStopped", "Light 1")
 
 
 def test_failed_write_mid_cue_stops_marks_and_reports(
     qtbot, design_session, monkeypatch
 ):
-    panel, clock, events, popups = _playing_panel(qtbot, design_session, monkeypatch)
-    panel.play_cue()
+    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel.play_slot(panel.slots[0])
     panel._active_backend = _DeadLight()  # the stick vanishes mid-cue
     clock["t"] = 0.5
     panel._tick()
-    assert events == ["VisualStarted", "VisualStopped"]  # marker before the popup
+    assert events[-1] == ("VisualStopped", "Light 1")  # marker before the popup
     assert popups
     assert not panel._timer.isActive()
 
@@ -148,13 +217,55 @@ def test_failed_write_mid_cue_stops_marks_and_reports(
 def test_cleanup_forces_the_light_off_without_a_marker(
     qtbot, design_session, monkeypatch
 ):
-    panel, clock, events, popups = _playing_panel(qtbot, design_session, monkeypatch)
-    panel.play_cue()
+    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel.play_slot(panel.slots[0])
     backend = panel._active_backend
     panel.cleanup()  # app quit mid-cue
     assert backend.off_calls == 1
-    assert events == ["VisualStarted"]  # no stop marker on quit
+    assert events == [("VisualStarted", "Light 1")]  # no stop marker on quit
     assert not panel._timer.isActive()
+
+
+def test_add_and_remove_slots_respect_the_bounds(qtbot, design_session, monkeypatch):
+    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel.add_slot()
+    assert [s.nameEdit.text() for s in panel.slots] == ["Light 1", "Light 2"]
+    assert all(s.removeButton.isEnabled() for s in panel.slots)
+    panel.remove_slot(panel.slots[1])
+    assert len(panel.slots) == 1
+    panel.remove_slot(panel.slots[0])  # the last slot can't be removed
+    assert len(panel.slots) == 1
+    panel._resize_slots(MAX_LIGHT_SLOTS + 5)  # clamped at the cap
+    assert len(panel.slots) == MAX_LIGHT_SLOTS
+    assert not panel._addButton.isEnabled()
+
+
+def test_removing_the_lit_slot_darkens_without_a_marker(
+    qtbot, design_session, monkeypatch
+):
+    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel.add_slot()
+    second = panel.slots[1]
+    panel.play_slot(second)
+    backend = panel._active_backend
+    panel.remove_slot(second)
+    assert backend.off_calls == 1
+    assert events == [("VisualStarted", "Light 2")]  # no spurious stop marker
+
+
+def test_rate_warning_appears_only_for_fast_patterned_slots(
+    qtbot, design_session, monkeypatch
+):
+    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    slot = panel.slots[0]
+    assert not panel.rateWarningLabel.isVisibleTo(panel)
+    slot.rateSpinBox.setValue(12.0)  # fast, but the pattern is steady
+    assert not panel.rateWarningLabel.isVisibleTo(panel)
+    slot.patternCombo.setCurrentIndex(slot.patternCombo.findData(lights.FLASH))
+    assert slot.rateSpinBox.isEnabled()
+    assert panel.rateWarningLabel.isVisibleTo(panel)
+    slot.rateSpinBox.setValue(5.0)
+    assert not panel.rateWarningLabel.isVisibleTo(panel)
 
 
 def test_color_can_be_picked_with_no_device(qtbot, design_session, monkeypatch):
@@ -165,6 +276,6 @@ def test_color_can_be_picked_with_no_device(qtbot, design_session, monkeypatch):
         QtWidgets.QColorDialog, "getColor", lambda *a, **k: QtGui.QColor("#112233")
     )
     assert panel._backend is None
-    panel.pick_color()
-    assert panel.blink_hexcode == "#112233"
-    assert not popups  # the old panel refused without hardware
+    panel.pick_slot_color(panel.slots[0])
+    assert panel.slots[0].rgb == (0x11, 0x22, 0x33)
+    assert not popups  # choosing a color never needs hardware

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -20,8 +20,19 @@ SAMPLE_SETTINGS = {
     "noise_color": "pink",
     "noise_source": "builtin",
     "noise_file": "",
-    "blink_color": "#ff8800",
-    "blink_length": 2.5,
+    "visual_cues": [
+        {
+            "name": "Light 1",
+            "color": "#ff8800",
+            "brightness": 1.0,
+            "pattern": "steady",
+            "rate": 1.0,
+            "length": 2.5,
+            "loop": False,
+        }
+    ],
+    "visual_attack": 0.0,
+    "visual_release": 0.5,
     "volume_cap": 0.8,
     "devices": {
         "bindings": {
@@ -55,7 +66,7 @@ def test_saved_file_is_tagged_yaml(tmp_path):
     assert text.splitlines()[0].startswith("#")  # self-identifying header comment
     payload = yaml.safe_load(text)  # comment is ignored, so it still parses
     assert payload["kind"] == settings.KIND
-    assert payload["schema_version"] == settings.SCHEMA_VERSION == 1
+    assert payload["schema_version"] == settings.SCHEMA_VERSION == 2
     assert payload["smacc_version"] == smacc.__version__
     assert payload["settings"] == {"cue_attack": 0.2}
 
@@ -181,8 +192,8 @@ def test_load_rejects_unsupported_schema(tmp_path):
 
 
 def test_load_rejects_higher_schema_version(tmp_path):
-    # The v1 reset accepts only the current schema; there is no forward/backward
-    # migration, so any higher version (e.g. a file from a future SMACC) is rejected.
+    # Older versions migrate forward, but there is no *backward* migration, so a
+    # higher version (e.g. a file from a future SMACC) is rejected.
     path = tmp_path / "future.smacc"
     path.write_text(
         yaml.safe_dump(
@@ -285,3 +296,40 @@ def test_resolve_keeps_absolute_and_skips_empty(tmp_path):
     out = settings.resolve_paths(state, tmp_path / "elsewhere")
     assert out["cues"][0]["file"] == str(wav)  # absolute unchanged
     assert out["noise_file"] == ""  # empty untouched
+
+
+def test_v1_blink_keys_migrate_into_the_first_visual_slot():
+    payload = {
+        "kind": settings.KIND,
+        "schema_version": 1,
+        "settings": {
+            "blink_color": "#123456",
+            "blink_length": 2.5,
+            "noise_volume": 0.1,
+        },
+    }
+    state, _ = settings.parse_settings_mapping(payload)
+    assert "blink_color" not in state and "blink_length" not in state
+    assert state["visual_cues"] == [
+        {"name": "Light 1", "color": "#123456", "length": 2.5}
+    ]
+    assert state["noise_volume"] == 0.1  # everything else is untouched
+
+
+def test_v1_without_blink_keys_gains_no_visual_block():
+    payload = {"kind": settings.KIND, "schema_version": 1, "settings": {}}
+    state, _ = settings.parse_settings_mapping(payload)
+    assert "visual_cues" not in state
+
+
+def test_current_version_settings_are_not_migrated():
+    # A stray hand-edited blink key in a v2 file is left alone (panels ignore it)
+    # and never overwrites the real visual_cues block.
+    original = {"blink_color": "#123456", "visual_cues": [{"name": "A"}]}
+    payload = {
+        "kind": settings.KIND,
+        "schema_version": settings.SCHEMA_VERSION,
+        "settings": dict(original),
+    }
+    state, _ = settings.parse_settings_mapping(payload)
+    assert state == original


### PR DESCRIPTION
Rebuilds the Visual cue window as the audio board's visual sibling. Each slot is one light cue — name, color, brightness (0–1), pattern (**steady**, a smooth **pulse**, or an on/off **flash** at a rate in Hz), length, and a **loop** checkbox — so a protocol can keep a cue and a sham (or per-stage variants) ready and fire any one with a click. A shared brightness **fade-in/out** shapes every cue (a long fade-in on a steady cue doubles as dawn simulation), playback stays one-at-a-time, and `VisualStarted`/`VisualStopped` markers now carry the slot name. A **sending swatch** mirrors the exact frame on the device — the visual analog of the audio board's sending meter — and a non-modal ⚠ note appears whenever any pulsed/flashed slot runs above 10 Hz (photosensitivity + USB-timing fidelity; the spinbox caps at 20 Hz, and the docs page coming in the next PR carries the full statement).

Settings schema bumps to **v2**: the single `blink_color`/`blink_length` pair becomes the `visual_cues` list plus `visual_attack`/`visual_release`. A v1 file's blink keys migrate into the first slot centrally in `smacc.settings` (panels only see the current shape), and the reference docs, version-history table, and bundled `default.smacc` are updated in lockstep with the drift guards. The tool is now labeled **Visual cue** (was "Visual stimulation") to match the audio vocabulary.

Engine support: `LightEngine.brightness`/`loop` became live-mutable (read per frame, like `CueMixer.volume`/`loop`) so spinning brightness or unchecking loop acts on the lit cue.

Verified: `pytest` (401, with the board's behavior covered by deterministic fake-clock tests), `ruff`, `ruff format`, `mypy`, `mkdocs build --strict`. Worth a minute on a real BlinkStick: pulse and flash fidelity at a few rates, a loop + live brightness edit, and a fade-out.

Closes #86. Closes #87.