### PR TITLE
feat: add philips hue backend for visual cues

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -15,8 +15,8 @@ Instead of picking a device separately in every window, SMACC has one **Devices
 window** (in the *Tools* column) where you do two things:
 
 1. **Bind each _role_ to a device, once.** The roles are the physical endpoints of a
-   rig: **Bedroom speakers**, **Control-room speakers**, **Bedroom mic**, and
-   **Bedroom lights**.
+   rig: **Bedroom speakers**, **Control-room speakers**, **Bedroom mic**, plus the
+   light devices (**BlinkStick**, **Philips Hue**).
 2. **Route each modality to a role.** The cue, noise, intercom, and dream-report
    recorder each point at a role.
 

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -26,7 +26,7 @@ sleep and lucid-dreaming experiments.
 
 1. Plug the BlinkStick into a USB port, then launch SMACC.
 2. Click **Visual cue** in the *Tools* column.
-3. Bind your BlinkStick to the **Bedroom lights** role in the **Devices** window (in
+3. Bind your BlinkStick to the **BlinkStick** role in the **Devices** window (in
    the *Tools* column). Plug one in after launch and it's detected automatically,
    or choose **File ▸ Refresh devices** (or press `F5`) to rescan.
 4. Configure a light cue — color, brightness, pattern (steady, or a pulse/flash at
@@ -41,12 +41,29 @@ travels with the rest of your configuration; the device is reconnected by name o
 the next launch (and flagged if it isn't plugged in).
 
 !!! note
-    If the visual cue window reports that no BlinkStick is set, open the **Devices**
-    window and bind one to the **Bedroom lights** role (plug it in first; use
+    If the visual cue window reports that no light is set, open the **Devices**
+    window and bind one to the **BlinkStick** role (plug it in first; use
     **File ▸ Refresh devices** or `F5` if it isn't listed). No restart needed.
 
-## More devices
+## Philips Hue
 
-Support for additional hardware is planned — for example a
-[Philips Hue](https://github.com/remrama/smacc/issues/53) bridge for ambient room
-lighting. This page will grow as devices are added.
+A [Philips Hue](https://www.philips-hue.com/) bridge is the room-scale alternative
+to the BlinkStick: the visual cue drives an ordinary Hue bulb (or a whole group)
+over the local network. Setup is once per bridge:
+
+1. In the **Devices** window, click **Set up Philips Hue…**.
+2. Click **Find bridge** (or type the bridge's IP — the Hue app shows it under
+   bridge settings).
+3. Press the round **link button** on the bridge itself, then click **Pair**
+   within 30 seconds. **Test** lists the bridge's lights to confirm.
+4. Bind a light or group to the **Philips Hue** role, and route **Present visual
+   cue** to **Philips Hue**.
+
+The bridge IP and pairing key are stored in the study's `.smacc` (the key is a
+local-network credential — treat the file accordingly). Two constraints to know:
+every command is an HTTP round-trip, so a Hue cue's onset lags its marker by tens
+of milliseconds (time-locked protocols should keep the BlinkStick), and the
+bridge's rate limits rule out the **flash** pattern — SMACC refuses it on Hue
+rather than degrade it silently. Steady cues and slow pulses work well. A full
+comparison of the two devices is coming with the visual-cues docs page
+([#53](https://github.com/remrama/smacc/issues/53)).

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -68,6 +68,10 @@ settings:
     address: "0x378"
     mode: pulsed
     pulse_ms: 10
+  # --- Philips Hue bridge (visual cues) ---------------------------------------
+  hue:
+    bridge_ip: ""
+    app_key: ""
   # --- Data directory + interface --------------------------------------------
   data_directory: data
   preview_levels: [INFO, WARNING, ERROR, CRITICAL]
@@ -157,7 +161,7 @@ and [Devices](../devices.md)).
 
 | Key | Type | Meaning |
 |---|---|---|
-| `bindings` | mapping | Role key → device name. Roles: `bedroom_out`, `control_out`, `bedroom_mic`, `monitor_mic`, `blinkstick`. |
+| `bindings` | mapping | Role key → device key. Roles: `bedroom_out`, `control_out`, `bedroom_mic`, `monitor_mic`, `blinkstick` (a stick's serial), `hue` (a bridge target like `light:3` or `group:1`). |
 | `routing` | mapping | Target key → role key (`""` = off). Targets: `cue_out`, `cue_monitor`, `noise_out`, `intercom_talk`, `intercom_listen`, `report_in`, `monitor_in`, `visual_out`. |
 
 A missing `devices` block loads the defaults (each target on its default role, with
@@ -177,6 +181,18 @@ Optional hardware TTL trigger output, mirrored alongside the always-on LSL strea
 | `address` | string | Parallel-port base address as hex, e.g. `0x378`. |
 | `mode` | `pulsed` \| `hold` | Pulse the code then drop, or set-and-hold until the next event. |
 | `pulse_ms` | integer | Pulse width in ms when `mode: pulsed` (default 10). |
+
+### `hue`
+
+The Philips Hue bridge used for visual cues (see [Devices › Philips Hue](../devices.md#philips-hue)),
+paired once in the Devices window. Like the device bindings, this is rig state
+that travels with the study — note that `app_key` is the bridge credential minted
+by pairing, stored in plain text.
+
+| Field | Type | Meaning |
+|---|---|---|
+| `bridge_ip` | string | The bridge's IP on the rig's network. |
+| `app_key` | string | The app key minted by press-button pairing (blank = not set up). |
 
 ## Paths and portability
 

--- a/src/smacc/devices.py
+++ b/src/smacc/devices.py
@@ -58,16 +58,19 @@ class Role:
     kind: str
 
 
-# The fixed role set. Two outputs and one mic cover the issue's rig; BlinkStick is
-# its own (visual) role. The monitor mic (#37) is a second, optional input so a lab
-# can place a dedicated, sensitive mic for verifying cues without disturbing the
-# (often cheaper) dream-report mic. Kept small on purpose — more can be added later.
+# The fixed role set. Two outputs and one mic cover the issue's rig; the two light
+# technologies are separate visual roles (#53: a BlinkStick binds one USB stick, a
+# Hue binds one bridge light/group — the visual cue routes to whichever is in use).
+# The monitor mic (#37) is a second, optional input so a lab can place a dedicated,
+# sensitive mic for verifying cues without disturbing the (often cheaper)
+# dream-report mic. Kept small on purpose — more can be added later.
 ROLES: tuple[Role, ...] = (
     Role("bedroom_out", "Bedroom speakers", OUTPUT),
     Role("control_out", "Control-room speakers", OUTPUT),
     Role("bedroom_mic", "Bedroom mic", INPUT),
     Role("monitor_mic", "Monitor mic", INPUT),
-    Role("blinkstick", "Bedroom lights", VISUAL),
+    Role("blinkstick", "BlinkStick", VISUAL),
+    Role("hue", "Philips Hue", VISUAL),
 )
 
 

--- a/src/smacc/dialogs.py
+++ b/src/smacc/dialogs.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from . import events, triggers
+from . import events, hue, triggers
 from .utils import normalize_survey_url
 
 
@@ -727,4 +727,139 @@ class TriggerOutputDialog(QtWidgets.QDialog):
             address=self.addressEdit.text().strip() or triggers.DEFAULT_LPT_ADDRESS,
             mode=self.modeCombo.currentData(),
             pulse_ms=self.pulseSpin.value(),
+        )
+
+
+class HueBridgeDialog(QtWidgets.QDialog):
+    """Find and pair with a Philips Hue bridge (#53).
+
+    The flow mirrors the Hue app's: find the bridge's IP (auto-discovery, or type
+    it in), press the bridge's round link button, then Pair — the bridge mints the
+    app key SMACC stores. A Test button lists the bridge's lights/groups inline so
+    the rig can be verified before relying on it. The dialog edits a copy; the
+    caller reads :meth:`get_config` only when accepted.
+    """
+
+    def __init__(self, config: hue.HueConfig, parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Philips Hue bridge")
+        self.setWindowFlags(
+            self.windowFlags() ^ QtCore.Qt.WindowType.WindowContextHelpButtonHint
+        )
+        self._app_key = config.app_key
+
+        hint = QtWidgets.QLabel(
+            "Pair once per bridge: find its IP, press the round link button on "
+            "the bridge itself, then click Pair within 30 seconds. The pairing "
+            "key is stored in the study's .smacc file."
+        )
+        hint.setWordWrap(True)
+
+        self.ipEdit = QtWidgets.QLineEdit(config.bridge_ip, self)
+        self.ipEdit.setPlaceholderText("e.g. 192.168.1.23")
+        self.ipEdit.setStatusTip("The bridge's IP on this network.")
+        self.ipEdit.textChanged.connect(self._refresh_status)
+        discoverButton = QtWidgets.QPushButton("Find bridge", self)
+        discoverButton.setStatusTip(
+            "Ask Philips' discovery service for bridges on this network."
+        )
+        discoverButton.clicked.connect(self._discover)
+        ipRow = QtWidgets.QHBoxLayout()
+        ipRow.addWidget(self.ipEdit)
+        ipRow.addWidget(discoverButton)
+
+        pairButton = QtWidgets.QPushButton("Pair", self)
+        pairButton.setStatusTip(
+            "Mint an app key (press the bridge's link button first)."
+        )
+        pairButton.clicked.connect(self._pair)
+        testButton = QtWidgets.QPushButton("Test", self)
+        testButton.setStatusTip(
+            "List the bridge's lights and groups with the current key."
+        )
+        testButton.clicked.connect(self._test)
+        actionRow = QtWidgets.QHBoxLayout()
+        actionRow.addWidget(pairButton)
+        actionRow.addWidget(testButton)
+
+        self.statusLabel = QtWidgets.QLabel(self)
+        self.statusLabel.setWordWrap(True)
+        self._refresh_status()
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+
+        form = QtWidgets.QFormLayout()
+        form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        form.addRow("Bridge IP:", ipRow)
+        form.addRow(actionRow)
+        form.addRow(self.statusLabel)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(hint)
+        layout.addLayout(form)
+        layout.addWidget(buttons)
+        self.setLayout(layout)
+
+    # ----- actions (each is one user-initiated, short-timeout bridge call) ----
+
+    def _discover(self) -> None:
+        found = hue.discover()
+        if found:
+            self.ipEdit.setText(found[0])
+            extra = f" (+{len(found) - 1} more)" if len(found) > 1 else ""
+            self._set_status(f"Found a bridge at {found[0]}{extra}.")
+        else:
+            self._set_status(
+                "No bridge found. Enter its IP by hand (the Hue app shows it "
+                "under bridge settings)."
+            )
+
+    def _pair(self) -> None:
+        ip = self.ipEdit.text().strip()
+        if not ip:
+            self._set_status("Enter the bridge IP first.")
+            return
+        try:
+            self._app_key = hue.pair(ip)
+        except hue.HueError as err:
+            self._set_status(str(err))
+            return
+        self._set_status("Paired ✓ — now Test, then OK.")
+
+    def _test(self) -> None:
+        cfg = self.get_config()
+        if not cfg.configured:
+            self._set_status("Pair with the bridge first.")
+            return
+        try:
+            found = hue.targets(cfg)
+        except hue.HueError as err:
+            self._set_status(str(err))
+            return
+        n_lights = sum(1 for _, key in found if key.startswith("light:"))
+        n_groups = len(found) - n_lights
+        self._set_status(
+            f"Bridge OK: {n_lights} light(s), {n_groups} group(s). Bind one to "
+            "the Philips Hue role after closing this dialog."
+        )
+
+    def _set_status(self, text: str) -> None:
+        self.statusLabel.setText(text)
+
+    def _refresh_status(self) -> None:
+        """The resting status line: paired or not, for the current IP."""
+        if self._app_key:
+            self._set_status("Paired ✓")
+        else:
+            self._set_status("Not paired yet.")
+
+    def get_config(self) -> hue.HueConfig:
+        """The edited config (read by the caller when the dialog is accepted)."""
+        return hue.HueConfig(
+            bridge_ip=self.ipEdit.text().strip(), app_key=self._app_key
         )

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -15,6 +15,7 @@ from smacc import (
     bids,
     biocals,
     devices,
+    hue,
     preferences,
     settings,
     triggers,
@@ -660,6 +661,9 @@ class SmaccWindow(ToolWindow):
         state["event_code_safe_max"] = self.session.event_code_safe_max
         # Optional hardware-trigger config (transport/port/mode/…), also window-level.
         state["trigger_output"] = self.session.trigger_config.to_dict()
+        # Philips Hue bridge config (#53): rig state that travels with the study,
+        # like the device bindings. The app key is a local-network credential.
+        state["hue"] = self.session.hue_config.to_dict()
         # The data directory (where runs are written) travels with the settings;
         # the editor can repoint it, so read the window's copy, not the session's.
         state["data_directory"] = str(self.data_dir)
@@ -711,6 +715,10 @@ class SmaccWindow(ToolWindow):
             # Open the transport now so a bad port/driver is reported at load.
             self.session.trigger_config = triggers.load(state)
             trigger_error = self.session.set_trigger_output(self.session.trigger_config)
+            # Hue bridge config before the Devices reload: the Hue role's dropdown
+            # enumerates from the (newly loaded) bridge, so a bound light matches.
+            self.session.hue_config = hue.load(state)
+            self.devices_window.refresh_device_lists()
             self._rebuild_events_panel()  # a loaded study may add/remove buttons
             self.devices_window.reload_from_config()  # sync widgets + flag missing
             self._refresh_device_indicators()
@@ -837,10 +845,11 @@ class SmaccWindow(ToolWindow):
     def refresh_all_devices(self) -> None:
         """Rescan for devices plugged in after launch (File ▸ Refresh devices, F5).
 
-        BlinkSticks are a live USB scan, so they are always rescanned. PortAudio
-        caches its device list at initialization, so audio devices are only picked
-        up by re-initializing it — which invalidates open streams, so that is done
-        only while nothing is playing, recording, or monitoring.
+        BlinkSticks are a live USB scan and Hue lights a live bridge query, so both
+        are always rescanned. PortAudio caches its device list at initialization,
+        so audio devices are only picked up by re-initializing it — which
+        invalidates open streams, so that is done only while nothing is playing,
+        recording, or monitoring.
         """
         was_logging = self.session.log_interactions
         self.session.log_interactions = False  # don't spam logs as lists repopulate
@@ -860,9 +869,9 @@ class SmaccWindow(ToolWindow):
         if audio_active:
             self.session.show_info_popup(
                 "Audio devices not fully rescanned.",
-                "BlinkSticks were rescanned. To rescan audio devices too, stop "
-                "playback, recording, and the level meter, then choose Refresh "
-                "devices again.",
+                "BlinkSticks and Hue lights were rescanned. To rescan audio "
+                "devices too, stop playback, recording, and the level meter, "
+                "then choose Refresh devices again.",
                 parent=self,
             )
         else:

--- a/src/smacc/hue.py
+++ b/src/smacc/hue.py
@@ -1,0 +1,261 @@
+"""Philips Hue bridge client and visual-cue backend (#53).
+
+A Hue bridge is the second visual-cue device next to the BlinkStick: room-scale
+light through ordinary bulbs, reached over the local network instead of USB. This
+module is the whole integration — a tiny V1 REST client built on stdlib
+``urllib`` (every bridge generation speaks V1; no new dependency, no async
+machinery), the press-button pairing flow, light/group enumeration for the
+Devices window, and the :class:`HueBackend` the visual cue board drives.
+
+The trade-offs a study must know (documented on the docs site): each command is
+an HTTP round-trip (~50–150 ms), so a Hue cue's photon onset lags its marker by
+tens of milliseconds with jitter, and the bridge rate-limits to roughly 10
+commands/s per light (~1/s per group) — fine for steady cues and slow pulses
+(``transitiontime`` smooths the steps), far too slow for a square-wave flash, so
+the board refuses flash on Hue rather than degrade it silently. Time-locked
+protocols should keep the BlinkStick.
+
+Config (bridge IP + the app key minted by pairing) persists in the ``hue`` block
+of a study's ``.smacc`` — like device bindings, it is rig state that travels with
+the study. The app key is a local-network credential; treat the file accordingly.
+
+Qt-free and unit-testable: HTTP goes through one seam (:func:`_http_json`) that
+tests stub.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import urllib.request
+from dataclasses import dataclass, fields
+from typing import Any
+
+# One knob for every bridge call: long enough for a sleepy bridge, short enough
+# that a wrong IP fails while the operator is still looking at the dialog.
+HTTP_TIMEOUT_S = 2.0
+# Philips' cloud discovery endpoint: returns the bridges seen on this LAN.
+DISCOVERY_URL = "https://discovery.meethue.com/"
+
+
+class HueError(Exception):
+    """A bridge call failed; carries an actionable, human-readable message."""
+
+
+@dataclass
+class HueConfig:
+    """How to reach the bridge: its IP and the app key minted by pairing.
+
+    Persisted as the ``hue`` block of a study file (the ``trigger_output``
+    precedent). Empty fields mean "not set up".
+    """
+
+    bridge_ip: str = ""
+    app_key: str = ""
+
+    @property
+    def configured(self) -> bool:
+        return bool(self.bridge_ip and self.app_key)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to the plain mapping persisted in a study file."""
+        return {f.name: getattr(self, f.name) for f in fields(self)}
+
+
+def from_dict(data: object) -> HueConfig:
+    """Build a :class:`HueConfig` from a persisted mapping (defaults on junk)."""
+    cfg = HueConfig()
+    if not isinstance(data, dict):
+        return cfg
+    cfg.bridge_ip = str(data.get("bridge_ip") or "")
+    cfg.app_key = str(data.get("app_key") or "")
+    return cfg
+
+
+def load(settings: dict) -> HueConfig:
+    """Return the Hue config from a study's settings mapping (default if absent)."""
+    return from_dict(settings.get("hue"))
+
+
+# ----- HTTP (the one seam tests stub) -----------------------------------------
+
+
+def _http_json(method: str, url: str, payload: dict | None = None) -> Any:
+    """One bridge/discovery round-trip: JSON in, parsed JSON out.
+
+    Raises :class:`HueError` with the underlying reason on any transport problem
+    (unreachable IP, timeout, bad JSON), so callers only handle one error type.
+    """
+    body = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(url, data=body, method=method)
+    request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_S) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except HueError:
+        raise
+    except Exception as exc:
+        raise HueError(f"Could not reach the bridge: {exc}") from exc
+
+
+def _first_error(reply: Any) -> dict | None:
+    """The first ``error`` object in a bridge reply list, if any."""
+    if isinstance(reply, list):
+        for item in reply:
+            if isinstance(item, dict) and isinstance(item.get("error"), dict):
+                return item["error"]
+    return None
+
+
+# ----- discovery + pairing ------------------------------------------------------
+
+
+def discover() -> list[str]:
+    """Bridge IPs on this LAN via Philips' discovery endpoint (best effort)."""
+    try:
+        reply = _http_json("GET", DISCOVERY_URL)
+    except HueError:
+        return []
+    if not isinstance(reply, list):
+        return []
+    return [
+        item["internalipaddress"]
+        for item in reply
+        if isinstance(item, dict) and item.get("internalipaddress")
+    ]
+
+
+def pair(bridge_ip: str) -> str:
+    """Mint an app key on the bridge (the operator presses its link button first).
+
+    Returns the key. Raises :class:`HueError` with press-the-button guidance when
+    the button wasn't pressed (bridge error type 101), or with the bridge's own
+    message for anything else.
+    """
+    devicetype = f"smacc#{socket.gethostname()[:19] or 'host'}"
+    reply = _http_json("POST", f"http://{bridge_ip}/api", {"devicetype": devicetype})
+    error = _first_error(reply)
+    if error is not None:
+        if error.get("type") == 101:
+            raise HueError(
+                "Press the round link button on the bridge, then pair again "
+                "within 30 seconds."
+            )
+        raise HueError(str(error.get("description") or "Pairing failed."))
+    if isinstance(reply, list):
+        for item in reply:
+            if isinstance(item, dict) and isinstance(item.get("success"), dict):
+                key = item["success"].get("username")
+                if key:
+                    return str(key)
+    raise HueError("Unexpected reply from the bridge while pairing.")
+
+
+# ----- enumeration ----------------------------------------------------------------
+
+
+def targets(cfg: HueConfig) -> list[tuple[str, str]]:
+    """``(label, key)`` for each light and group on the bridge.
+
+    Keys are stable ``light:<id>`` / ``group:<id>`` strings — what a Devices-window
+    binding persists. Raises :class:`HueError` when the bridge can't be read.
+    """
+    if not cfg.configured:
+        return []
+    base = f"http://{cfg.bridge_ip}/api/{cfg.app_key}"
+    out: list[tuple[str, str]] = []
+    for kind, path in (("light", "lights"), ("group", "groups")):
+        reply = _http_json("GET", f"{base}/{path}")
+        error = _first_error(reply)
+        if error is not None:
+            raise HueError(str(error.get("description") or f"Could not list {path}."))
+        if not isinstance(reply, dict):
+            continue
+        for ident in sorted(reply, key=lambda i: (len(i), i)):
+            item = reply[ident]
+            name = item.get("name") if isinstance(item, dict) else None
+            label = f"{name or kind.title()} ({kind} {ident})"
+            out.append((label, f"{kind}:{ident}"))
+    return out
+
+
+# ----- color ------------------------------------------------------------------------
+
+
+def rgb_to_xy_bri(rgb: tuple[int, int, int]) -> tuple[float, float, int]:
+    """Map an 8-bit RGB to Hue's ``xy`` chromaticity + ``bri`` (Philips' formula).
+
+    Inverse-gamma sRGB to linear, Philips' wide-gamut D65 matrix to XYZ, then
+    chromaticity. ``bri`` carries the value component (the engine already shaped
+    brightness/envelope into the RGB), clamped to the bridge's 1..254.
+    """
+    r, g, b = (component / 255.0 for component in rgb)
+
+    def linear(channel: float) -> float:
+        if channel > 0.04045:
+            return ((channel + 0.055) / 1.055) ** 2.4
+        return channel / 12.92
+
+    lr, lg, lb = linear(r), linear(g), linear(b)
+    x_comp = lr * 0.664511 + lg * 0.154324 + lb * 0.162028
+    y_comp = lr * 0.283881 + lg * 0.668433 + lb * 0.047685
+    z_comp = lr * 0.000088 + lg * 0.072310 + lb * 0.986039
+    total = x_comp + y_comp + z_comp
+    if total <= 0.0:
+        x, y = 0.3127, 0.3290  # D65 white point; bri 0 means the caller turns off
+    else:
+        x, y = x_comp / total, y_comp / total
+    bri = max(1, min(254, round(max(r, g, b) * 254)))
+    return (round(x, 4), round(y, 4), bri)
+
+
+# ----- the visual-cue backend ---------------------------------------------------------
+
+
+class HueBackend:
+    """Drives one Hue light or group as a visual-cue target.
+
+    Satisfies the :class:`smacc.lights.LightBackend` protocol. Each ``apply`` is
+    one HTTP PUT with a 100 ms ``transitiontime``, which smooths the steps a slow
+    pulse arrives in; a black frame turns the light off. ``supports_flash`` is
+    False — the bridge's rate limits can't honor a square wave, and the board
+    refuses rather than degrade the stimulus silently.
+    """
+
+    supports_flash = False
+
+    def __init__(self, cfg: HueConfig, target_key: str) -> None:
+        kind, _, ident = target_key.partition(":")
+        base = f"http://{cfg.bridge_ip}/api/{cfg.app_key}"
+        if kind == "group":
+            self._url = f"{base}/groups/{ident}/action"
+        else:
+            self._url = f"{base}/lights/{ident}/state"
+
+    def _put(self, state: dict) -> None:
+        reply = _http_json("PUT", self._url, state)
+        error = _first_error(reply)
+        if error is not None:
+            raise HueError(str(error.get("description") or "The bridge refused."))
+
+    def apply(self, rgb: tuple[int, int, int]) -> None:
+        if rgb == (0, 0, 0):
+            self._put({"on": False, "transitiontime": 1})
+            return
+        x, y, bri = rgb_to_xy_bri(rgb)
+        self._put({"on": True, "bri": bri, "xy": [x, y], "transitiontime": 1})
+
+    def off(self) -> None:
+        self._put({"on": False, "transitiontime": 0})
+
+
+def resolve_backend(cfg: HueConfig, target_key: str) -> HueBackend | None:
+    """Wrap the bound light/group (None when the bridge or binding isn't set).
+
+    Construction is offline on purpose — resolution runs on every Devices-window
+    change, so a probe here would block the GUI; an unreachable bridge surfaces
+    at the first write instead.
+    """
+    if not cfg.configured or not target_key:
+        return None
+    return HueBackend(cfg, target_key)

--- a/src/smacc/lights.py
+++ b/src/smacc/lights.py
@@ -18,6 +18,7 @@ accumulated per tick — so a late or missed GUI tick can't drift the stimulus.
 from __future__ import annotations
 
 import math
+import threading
 from typing import Protocol
 
 RGB = tuple[int, int, int]
@@ -173,8 +174,11 @@ BLINKSTICK_LED_COUNT = 32
 class BlinkStickBackend:
     """Drives one BlinkStick: the same color on all its LEDs.
 
-    ``set_led_data`` expects G,R,B-ordered triplets, one per LED.
+    ``set_led_data`` expects G,R,B-ordered triplets, one per LED. USB-HID writes
+    are fast enough for square-wave flashing, hence ``supports_flash``.
     """
+
+    supports_flash = True
 
     def __init__(self, device) -> None:
         self._device = device
@@ -204,3 +208,63 @@ def resolve_blinkstick(serial: str) -> BlinkStickBackend | None:
     except Exception:
         return None
     return BlinkStickBackend(device) if device is not None else None
+
+
+class FrameWriter:
+    """Applies frames to a backend from its own thread (latest-frame-wins).
+
+    A slow backend (the Hue bridge's ~100 ms HTTP writes) must not run on the GUI
+    thread at the cue tick rate. The GUI submits the newest frame; the worker
+    applies frames as fast as the backend absorbs them, always skipping to the
+    latest (stale frames are dropped, never queued) and skipping duplicates — a
+    steady cue costs one write, not thirty a second. The first write error stops
+    the worker and is kept in :attr:`error` for the GUI to poll; :meth:`stop`
+    joins the thread so the caller can then turn the light off in a known state.
+
+    ``applied`` seeds the duplicate filter with a frame the caller already wrote
+    synchronously (the cue's first frame, applied before its start marker).
+    """
+
+    def __init__(self, backend: LightBackend, applied: RGB | None = None) -> None:
+        self._backend = backend
+        self._cond = threading.Condition()
+        self._latest: RGB | None = None
+        self._applied = applied
+        self._stopping = False
+        self.error: str | None = None
+        self._thread = threading.Thread(
+            target=self._run, name="smacc-light-writer", daemon=True
+        )
+        self._thread.start()
+
+    def submit(self, rgb: RGB) -> None:
+        """Deposit the newest frame (the worker writes it when the device is free)."""
+        with self._cond:
+            self._latest = rgb
+            self._cond.notify()
+
+    def stop(self, timeout: float = 2.0) -> None:
+        """Stop the worker and wait for any in-flight write to finish."""
+        with self._cond:
+            self._stopping = True
+            self._cond.notify()
+        self._thread.join(timeout)
+
+    def _run(self) -> None:
+        while True:
+            with self._cond:
+                while not self._stopping and (
+                    self._latest is None or self._latest == self._applied
+                ):
+                    self._cond.wait()
+                if self._stopping:
+                    return
+                frame = self._latest
+            assert frame is not None  # the wait loop only exits with a fresh frame
+            try:
+                self._backend.apply(frame)  # outside the lock: possibly slow I/O
+            except Exception as exc:
+                self.error = str(exc) or type(exc).__name__
+                return
+            with self._cond:
+                self._applied = frame

--- a/src/smacc/panels/devices.py
+++ b/src/smacc/panels/devices.py
@@ -16,7 +16,8 @@ import sounddevice as sd
 from blinkstick import blinkstick
 from PyQt6 import QtCore, QtWidgets
 
-from .. import devices
+from .. import devices, hue
+from ..dialogs import HueBridgeDialog
 from ..session import SmaccSession
 from .base import (
     ModalityWindow,
@@ -73,6 +74,18 @@ def blinkstick_devices() -> list[tuple[str, str]]:
         return []
 
 
+def hue_devices(cfg: hue.HueConfig) -> list[tuple[str, str]]:
+    """Return ``(label, key)`` for each Hue light/group (best effort).
+
+    Empty when the bridge isn't set up or can't be reached — the combo then only
+    offers "(none)", and the Set up button is the path forward.
+    """
+    try:
+        return hue.targets(cfg)
+    except hue.HueError:
+        return []
+
+
 class DevicesWindow(ModalityWindow):
     """Bind devices to roles and route modalities to roles (edits session.devices)."""
 
@@ -120,10 +133,22 @@ class DevicesWindow(ModalityWindow):
 
         refresh_button = QtWidgets.QPushButton("Refresh devices", self)
         refresh_button.setStatusTip(
-            "Rescan for audio devices and BlinkSticks (e.g. after plugging one in)."
+            "Rescan for audio devices, BlinkSticks, and Hue lights (e.g. after "
+            "plugging one in)."
         )
         refresh_button.setToolTip("Rescan for devices plugged in after launch (F5).")
         refresh_button.clicked.connect(self.refresh_requested)
+
+        hue_button = QtWidgets.QPushButton("Set up Philips Hue…", self)
+        hue_button.setStatusTip(
+            "Pair with a Hue bridge so its lights can serve as the visual cue (#53)."
+        )
+        hue_button.setToolTip("Find and pair with a Philips Hue bridge")
+        hue_button.clicked.connect(self.setup_hue_bridge)
+
+        buttons = QtWidgets.QHBoxLayout()
+        buttons.addWidget(refresh_button)
+        buttons.addWidget(hue_button)
 
         hint = QtWidgets.QLabel(
             "Bind each role to a device once, then route each modality to a role. "
@@ -139,7 +164,7 @@ class DevicesWindow(ModalityWindow):
         layout.addWidget(self._subheading("Modalities → roles"))
         layout.addLayout(routing_form)
         layout.addWidget(hint)
-        layout.addWidget(refresh_button)
+        layout.addLayout(buttons)
         layout.addStretch(1)
         central = QtWidgets.QWidget()
         central.setLayout(layout)
@@ -159,7 +184,11 @@ class DevicesWindow(ModalityWindow):
             previous = current_device_key(combo)
             combo.blockSignals(True)
             combo.clear()
-            if role.kind == devices.VISUAL:
+            if role.key == "hue":
+                combo.addItem(_NONE_LABEL, "")
+                for label, key in hue_devices(self.session.hue_config):
+                    combo.addItem(label, key)
+            elif role.kind == devices.VISUAL:
                 combo.addItem(_NONE_LABEL, "")
                 for label, serial in blinkstick_devices():
                     combo.addItem(label, serial)
@@ -225,3 +254,13 @@ class DevicesWindow(ModalityWindow):
     def refresh_device_lists(self) -> None:
         """Re-enumerate the role device dropdowns (the File ▸ Refresh devices hook)."""
         self._populate_role_combos()
+
+    def setup_hue_bridge(self) -> None:
+        """Open the Hue pairing dialog; on accept, store the config and re-list."""
+        dialog = HueBridgeDialog(self.session.hue_config, parent=self)
+        if not dialog.exec():
+            return
+        self.session.hue_config = dialog.get_config()
+        self.session.log_interaction("Philips Hue bridge configured")
+        self._populate_role_combos()  # the Hue role now lists the bridge's lights
+        self.changed.emit()

--- a/src/smacc/panels/visual.py
+++ b/src/smacc/panels/visual.py
@@ -4,9 +4,12 @@ The visual sibling of the audio cue board (#86/#87): each slot is one light cue 
 a color at a brightness, shown steady or pulsed/flashed at a rate in Hz — with its
 own length and loop flag, so a protocol that uses several lights (e.g. cue vs.
 sham) can keep them ready and fire any one with a click. Playback is one-at-a-time
-on the BlinkStick resolved from the visual_out role, shaped by a shared brightness
-fade-in/out, and driven by a ~30 Hz QTimer ticking the pure
+on the device the visual_out route resolves to — a BlinkStick over USB, or a
+Philips Hue light/group over the bridge (#53) — shaped by a shared brightness
+fade-in/out and driven by a ~30 Hz QTimer ticking the pure
 :class:`smacc.lights.LightEngine`, so the rest of the GUI stays live throughout.
+Device writes run on a :class:`smacc.lights.FrameWriter` thread (a Hue write is an
+HTTP round-trip), and flash is refused on backends that can't honor it.
 Start/stop are marked with the ``VisualStarted``/``VisualStopped`` registry events
 (detail: the slot name), every stop path turns the light off (including app quit),
 and a "sending" swatch mirrors the exact frame on the device — the visual analog
@@ -22,7 +25,7 @@ from functools import partial
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from .. import lights
+from .. import hue, lights
 from ..session import SmaccSession
 from .base import ModalityWindow, describe_target, make_section_title
 
@@ -95,6 +98,9 @@ class VisualWindow(ModalityWindow):
         self._backend: lights.LightBackend | None = None
         self._active_backend: lights.LightBackend | None = None
         self._active_slot: LightSlot | None = None
+        # Frames go to the device through a writer thread: a Hue write is an HTTP
+        # round-trip (~100 ms), far too slow for the GUI thread at the tick rate.
+        self._writer: lights.FrameWriter | None = None
         self._engine = lights.LightEngine()
         self._clock = time.monotonic  # injectable for deterministic tests
         self._timer = QtCore.QTimer(self)
@@ -195,7 +201,7 @@ class VisualWindow(ModalityWindow):
         # Shared device (chosen in the Devices window) + fade controls.
         self.deviceLabel = QtWidgets.QLabel(self)
         self.deviceLabel.setStatusTip(
-            "Set in the Devices window (Bedroom lights role)."
+            "Set in the Devices window (BlinkStick or Philips Hue role)."
         )
         self.refresh_device_indicator()
 
@@ -390,13 +396,17 @@ class VisualWindow(ModalityWindow):
     # ----- shared device + fade ---------------------------------------------
 
     def refresh_device_indicator(self) -> None:
-        """Resolve the BlinkStick from its role and show where the cue routes.
+        """Resolve the light backend from the routed role (BlinkStick or Hue).
 
         A cue already lit keeps the backend it started with; the fresh resolution
         applies from the next Play.
         """
-        serial = self.session.devices.device_for("visual_out")
-        self._backend = lights.resolve_blinkstick(serial)
+        role = self.session.devices.role_for("visual_out")
+        binding = self.session.devices.device_for("visual_out")
+        if role == "hue":
+            self._backend = hue.resolve_backend(self.session.hue_config, binding)
+        else:
+            self._backend = lights.resolve_blinkstick(binding)
         self.deviceLabel.setText(describe_target(self.session, "visual_out"))
 
     def update_visual_attack(self, value: float) -> None:
@@ -485,14 +495,27 @@ class VisualWindow(ModalityWindow):
         if self._backend is None:
             self.session.show_error_popup(
                 "Visual cue unavailable.",
-                "No BlinkStick is set. Bind one to the Bedroom lights role "
-                "in the Devices window.",
+                "No light is set. In the Devices window, bind a BlinkStick "
+                "(or pair a Philips Hue) and route the visual cue to it.",
+                parent=self,
+            )
+            return
+        backend = self._backend
+        # Refuse flash on a backend that can't honor it (the Hue bridge's rate
+        # limits) rather than degrade the stimulus silently — and refuse before
+        # touching whatever cue is currently lit.
+        if slot.patternCombo.currentData() == lights.FLASH and not getattr(
+            backend, "supports_flash", True
+        ):
+            self.session.show_error_popup(
+                "Flash isn't available on the Philips Hue.",
+                "The bridge rate-limits commands, far below a square wave. Use "
+                "pulse or steady, or route the visual cue to a BlinkStick.",
                 parent=self,
             )
             return
         if self._active_slot is not None:
             self._finish(mark=self._active_slot is not slot)
-        backend = self._backend
         now = self._clock()
         self._engine.start(
             now,
@@ -511,17 +534,25 @@ class VisualWindow(ModalityWindow):
         except Exception as err:
             self._engine.stop(now)
             self.session.show_error_popup(
-                "Could not light the BlinkStick.", str(err), parent=self
+                "Could not light the visual cue.", str(err), parent=self
             )
             return
         self._active_backend = backend
         self._active_slot = slot
+        # Later frames go through the writer thread; it skips duplicates (the
+        # first frame seeds that filter) and always jumps to the newest frame, so
+        # a slow backend lags a little but never queues stale light.
+        self._writer = self._make_writer(backend, first)
         self._timer.start()
         self._set_now_lit(slot)
         self._set_swatch(first)
         # Marked after the first frame is on the device, so the marker trails the
         # photons by microseconds instead of leading them by up to a tick.
         self.session.emit_event("VisualStarted", detail=slot.nameEdit.text())
+
+    def _make_writer(self, backend: lights.LightBackend, first: lights.RGB):
+        """Build the cue's frame writer (a seam: tests inject a synchronous fake)."""
+        return lights.FrameWriter(backend, applied=first)
 
     def stop_slot(self, slot: LightSlot) -> None:
         """Stop a slot (with fade-out) if it is the one currently lit."""
@@ -533,27 +564,33 @@ class VisualWindow(ModalityWindow):
         # Otherwise the release fade runs and _tick finalizes it when done.
 
     def _tick(self) -> None:
-        """Timer slot: push the current frame, finishing once the cue has ended."""
+        """Timer slot: submit the current frame, finishing once the cue has ended."""
         now = self._clock()
         frame = self._engine.frame(now)
         if self._engine.ended:
             self._finish(mark=True)
             return
-        assert self._active_backend is not None  # set with the timer in play_slot
-        try:
-            self._active_backend.apply(frame)
-        except Exception as err:
-            self._finish(mark=True)  # the stimulus is over, whatever the LEDs say
+        writer = self._writer
+        assert writer is not None  # created with the timer in play_slot
+        if writer.error is not None:  # a device write failed on the writer thread
+            error = writer.error
+            self._finish(mark=True)  # the stimulus is over, whatever the light says
             self.session.show_error_popup(
-                "BlinkStick write failed; visual cue stopped.", str(err), parent=self
+                "Light write failed; visual cue stopped.", error, parent=self
             )
             return
+        writer.submit(frame)
         self._set_swatch(frame)
 
     def _finish(self, mark: bool) -> None:
         """Stop the timer, force the light off (best effort), and mark the stop."""
         slot = self._active_slot
         self._timer.stop()
+        if self._writer is not None:
+            # Join the writer before the off, so a slow in-flight frame can't land
+            # after it and leave the light stuck on.
+            self._writer.stop()
+            self._writer = None
         if self._active_backend is not None:
             try:
                 self._active_backend.off()

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from pylsl import StreamInfo, StreamOutlet
 from PyQt6 import QtWidgets
 
-from . import bids, devices, events, settings, triggers
+from . import bids, devices, events, hue, settings, triggers
 from .config import VERSION
 
 
@@ -81,6 +81,10 @@ class SmaccSession:
         # both LSL and this transport from the single emit_event path.
         self.trigger_config = triggers.TriggerConfig()
         self.trigger_out: triggers.TriggerOutput | None = None
+        # Philips Hue bridge config (#53): rig state like the device bindings,
+        # persisted in the study's ``hue`` block and edited in the Devices window.
+        # Stateless REST — nothing to open; the visual panel resolves from it.
+        self.hue_config = hue.HueConfig()
         # The live event-marker registry (codes + routing flags), keyed by event
         # key. Defaults here; a loaded study overrides them via set_event_codes().
         self.events = {e.key: e for e in events.default_events()}

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -117,3 +117,15 @@ def test_load_defaults_when_no_devices_block():
     cfg = devices.load({"cue_device": "Spk"})
     assert cfg.role_for("cue_out") == "bedroom_out"  # default role
     assert cfg.bindings == {}  # nothing bound; the stray key is ignored
+
+
+def test_both_light_technologies_are_visual_roles():
+    # #53: separate BlinkStick and Philips Hue selectors — two roles of the
+    # VISUAL kind, with the visual cue routed to whichever is in use.
+    roles = devices.ROLES_BY_KEY
+    assert roles["blinkstick"].kind == devices.VISUAL
+    assert roles["hue"].kind == devices.VISUAL
+    cfg = devices.from_dict(
+        {"bindings": {"hue": "light:3"}, "routing": {"visual_out": "hue"}}
+    )
+    assert cfg.device_for("visual_out") == "light:3"

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -266,3 +266,20 @@ def test_tool_window_geometry_persists_and_restores(
     assert second.panels["volume"].y() == 234
     second._teardown_panels()
     second.session.close()
+
+
+def test_hue_config_round_trips_through_settings(
+    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+):
+    from smacc import hue
+
+    # The post-load device re-enumeration must not hit the network.
+    monkeypatch.setattr(hue, "targets", lambda cfg: [])
+    window = SmaccWindow(design_session)
+    qtbot.addWidget(window)
+    state = window.gather_settings()
+    assert state["hue"] == {"bridge_ip": "", "app_key": ""}
+    state["hue"] = {"bridge_ip": "192.168.1.50", "app_key": "k"}
+    window.apply_settings(state)
+    assert window.gather_settings()["hue"]["bridge_ip"] == "192.168.1.50"
+    assert design_session.hue_config.configured

--- a/tests/test_hue.py
+++ b/tests/test_hue.py
@@ -1,0 +1,183 @@
+"""Tests for the Philips Hue client and visual-cue backend (no network).
+
+Every bridge call goes through the one ``hue._http_json`` seam; these tests stub
+it with canned replies (or transport failures) and assert the client's behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from smacc import hue
+
+CFG = hue.HueConfig(bridge_ip="192.168.1.50", app_key="testkey")
+
+
+def _stub_http(monkeypatch, handler):
+    """Route hue._http_json through ``handler(method, url, payload)``."""
+    calls: list[tuple[str, str, dict | None]] = []
+
+    def fake(method, url, payload=None):
+        calls.append((method, url, payload))
+        return handler(method, url, payload)
+
+    monkeypatch.setattr(hue, "_http_json", fake)
+    return calls
+
+
+# ----- config ---------------------------------------------------------------
+
+
+def test_config_round_trips_and_tolerates_junk():
+    assert hue.from_dict(CFG.to_dict()) == CFG
+    assert hue.from_dict(None) == hue.HueConfig()
+    assert hue.from_dict({"bridge_ip": 5, "app_key": None}) == hue.HueConfig("5", "")
+    assert hue.load({"hue": CFG.to_dict()}) == CFG
+    assert hue.load({}) == hue.HueConfig()
+
+
+def test_configured_requires_both_fields():
+    assert CFG.configured
+    assert not hue.HueConfig(bridge_ip="1.2.3.4").configured
+    assert not hue.HueConfig(app_key="k").configured
+
+
+# ----- discovery + pairing ----------------------------------------------------
+
+
+def test_discover_returns_bridge_ips(monkeypatch):
+    _stub_http(
+        monkeypatch,
+        lambda *a: [{"id": "abc", "internalipaddress": "10.0.0.7"}, {"id": "x"}],
+    )
+    assert hue.discover() == ["10.0.0.7"]
+
+
+def test_discover_swallows_transport_errors(monkeypatch):
+    def boom(*a):
+        raise hue.HueError("down")
+
+    _stub_http(monkeypatch, boom)
+    assert hue.discover() == []
+
+
+def test_pair_returns_the_minted_key(monkeypatch):
+    calls = _stub_http(monkeypatch, lambda *a: [{"success": {"username": "newkey"}}])
+    assert hue.pair("10.0.0.7") == "newkey"
+    method, url, payload = calls[0]
+    assert (method, url) == ("POST", "http://10.0.0.7/api")
+    assert payload is not None and payload["devicetype"].startswith("smacc#")
+
+
+def test_pair_guides_when_link_button_not_pressed(monkeypatch):
+    _stub_http(
+        monkeypatch,
+        lambda *a: [{"error": {"type": 101, "description": "link button not pressed"}}],
+    )
+    with pytest.raises(hue.HueError, match="link button"):
+        hue.pair("10.0.0.7")
+
+
+def test_pair_surfaces_other_bridge_errors(monkeypatch):
+    _stub_http(monkeypatch, lambda *a: [{"error": {"type": 7, "description": "nope"}}])
+    with pytest.raises(hue.HueError, match="nope"):
+        hue.pair("10.0.0.7")
+
+
+# ----- enumeration ---------------------------------------------------------------
+
+
+def test_targets_lists_lights_then_groups(monkeypatch):
+    def handler(method, url, payload):
+        if url.endswith("/lights"):
+            return {"1": {"name": "Bed lamp"}, "10": {"name": "Ceiling"}}
+        return {"1": {"name": "Bedroom"}}
+
+    _stub_http(monkeypatch, handler)
+    assert hue.targets(CFG) == [
+        ("Bed lamp (light 1)", "light:1"),
+        ("Ceiling (light 10)", "light:10"),
+        ("Bedroom (group 1)", "group:1"),
+    ]
+
+
+def test_targets_without_config_is_empty_and_offline(monkeypatch):
+    calls = _stub_http(monkeypatch, lambda *a: pytest.fail("should not call"))
+    assert hue.targets(hue.HueConfig()) == []
+    assert calls == []
+
+
+def test_targets_surfaces_bridge_errors(monkeypatch):
+    _stub_http(
+        monkeypatch,
+        lambda *a: [{"error": {"type": 1, "description": "unauthorized user"}}],
+    )
+    with pytest.raises(hue.HueError, match="unauthorized"):
+        hue.targets(CFG)
+
+
+# ----- color mapping -------------------------------------------------------------
+
+
+def test_rgb_to_xy_bri_hits_the_philips_primaries():
+    x, y, bri = hue.rgb_to_xy_bri((255, 0, 0))
+    assert (x, y) == (pytest.approx(0.7006, abs=1e-3), pytest.approx(0.2993, abs=1e-3))
+    assert bri == 254
+    x, y, bri = hue.rgb_to_xy_bri((255, 255, 255))
+    assert (x, y) == (pytest.approx(0.3227, abs=1e-3), pytest.approx(0.3290, abs=1e-3))
+    assert bri == 254
+
+
+def test_rgb_to_xy_bri_scales_bri_with_the_value_component():
+    _, _, bri = hue.rgb_to_xy_bri((128, 0, 0))
+    assert bri == round(128 / 255 * 254)
+    _, _, bri = hue.rgb_to_xy_bri((1, 0, 0))
+    assert bri == 1  # clamped to the bridge's floor
+
+
+# ----- backend ----------------------------------------------------------------------
+
+
+def test_backend_apply_puts_color_state_to_a_light(monkeypatch):
+    calls = _stub_http(monkeypatch, lambda *a: [{"success": {}}])
+    backend = hue.HueBackend(CFG, "light:3")
+    backend.apply((255, 0, 0))
+    method, url, payload = calls[0]
+    assert method == "PUT"
+    assert url == "http://192.168.1.50/api/testkey/lights/3/state"
+    assert payload is not None
+    assert payload["on"] is True
+    assert payload["bri"] == 254
+    assert payload["transitiontime"] == 1
+    assert payload["xy"] == [
+        pytest.approx(0.7006, abs=1e-3),
+        pytest.approx(0.2993, abs=1e-3),
+    ]
+
+
+def test_backend_black_frame_and_off_turn_the_light_off(monkeypatch):
+    calls = _stub_http(monkeypatch, lambda *a: [{"success": {}}])
+    backend = hue.HueBackend(CFG, "group:2")
+    backend.apply((0, 0, 0))
+    backend.off()
+    (_, url1, p1), (_, url2, p2) = calls
+    assert url1 == url2 == "http://192.168.1.50/api/testkey/groups/2/action"
+    assert p1 == {"on": False, "transitiontime": 1}
+    assert p2 == {"on": False, "transitiontime": 0}
+
+
+def test_backend_raises_on_bridge_refusal(monkeypatch):
+    _stub_http(monkeypatch, lambda *a: [{"error": {"description": "resource down"}}])
+    backend = hue.HueBackend(CFG, "light:1")
+    with pytest.raises(hue.HueError, match="resource down"):
+        backend.apply((10, 10, 10))
+
+
+def test_backend_declares_no_flash_support():
+    assert hue.HueBackend(CFG, "light:1").supports_flash is False
+
+
+def test_resolve_backend_requires_config_and_binding():
+    assert hue.resolve_backend(hue.HueConfig(), "light:1") is None
+    assert hue.resolve_backend(CFG, "") is None
+    assert isinstance(hue.resolve_backend(CFG, "light:1"), hue.HueBackend)

--- a/tests/test_lights.py
+++ b/tests/test_lights.py
@@ -193,3 +193,73 @@ def test_brightness_and_loop_apply_live():
     engine.loop = False  # past duration with loop now off -> done at next frame
     assert engine.frame(50.1) == (0, 0, 0)
     assert engine.ended
+
+
+# ----- FrameWriter ---------------------------------------------------------------
+
+
+class _RecordingBackend:
+    def __init__(self) -> None:
+        self.frames: list[tuple[int, int, int]] = []
+
+    def apply(self, rgb) -> None:
+        self.frames.append(rgb)
+
+    def off(self) -> None:
+        self.frames.append((0, 0, 0))
+
+
+class _FailingBackend(_RecordingBackend):
+    def apply(self, rgb) -> None:
+        raise OSError("bridge unreachable")
+
+
+def _wait_for(predicate, timeout: float = 2.0) -> bool:
+    import time
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return False
+
+
+def test_frame_writer_applies_the_submitted_frame():
+    backend = _RecordingBackend()
+    writer = lights.FrameWriter(backend)
+    writer.submit((1, 2, 3))
+    assert _wait_for(lambda: backend.frames)
+    writer.stop()
+    assert backend.frames == [(1, 2, 3)]
+    assert writer.error is None
+
+
+def test_frame_writer_skips_duplicate_frames():
+    # A steady cue submits the same frame every tick; only changes cost a write.
+    backend = _RecordingBackend()
+    writer = lights.FrameWriter(backend)
+    writer.submit((9, 9, 9))
+    assert _wait_for(lambda: backend.frames)
+    writer.submit((9, 9, 9))
+    writer.submit((9, 9, 9))
+    writer.stop()
+    assert backend.frames == [(9, 9, 9)]
+
+
+def test_frame_writer_seeded_first_frame_is_not_rewritten():
+    # play_slot applies the first frame synchronously, then seeds the writer with
+    # it — resubmitting that frame must not hit the device a second time.
+    backend = _RecordingBackend()
+    writer = lights.FrameWriter(backend, applied=(5, 5, 5))
+    writer.submit((5, 5, 5))
+    writer.stop()
+    assert backend.frames == []
+
+
+def test_frame_writer_captures_the_first_error_and_stops():
+    writer = lights.FrameWriter(_FailingBackend())
+    writer.submit((1, 1, 1))
+    assert _wait_for(lambda: writer.error is not None)
+    writer.stop()  # already exited; join returns immediately
+    assert "bridge unreachable" in (writer.error or "")

--- a/tests/test_panels_base.py
+++ b/tests/test_panels_base.py
@@ -38,7 +38,7 @@ def test_describe_target_unbound_audio_reads_system_default(design_session):
 
 def test_describe_target_unbound_visual_reads_not_set(design_session):
     session = _session_with(design_session, {})
-    assert base.describe_target(session, "visual_out") == "Bedroom lights (not set)"
+    assert base.describe_target(session, "visual_out") == "BlinkStick (not set)"
 
 
 def test_describe_target_off_route_reads_off(design_session):

--- a/tests/test_panels_devices.py
+++ b/tests/test_panels_devices.py
@@ -96,3 +96,28 @@ def test_refresh_button_emits_refresh_requested(qtbot, design_session, mock_devi
     assert button is not None and button.text() == "Refresh devices"
     with qtbot.waitSignal(window.refresh_requested, timeout=1000):
         button.click()
+
+
+def test_hue_role_combo_lists_bridge_targets(
+    qtbot, design_session, mock_devices, monkeypatch
+):
+    from smacc import hue
+
+    design_session.hue_config = hue.HueConfig("192.168.1.50", "key")
+    monkeypatch.setattr(hue, "targets", lambda cfg: [("Bed lamp (light 1)", "light:1")])
+    window = DevicesWindow(design_session)
+    qtbot.addWidget(window)
+    combo = window._role_combos["hue"]
+    assert [combo.itemText(i) for i in range(combo.count())] == [
+        "(none)",
+        "Bed lamp (light 1)",
+    ]
+    combo.setCurrentIndex(1)  # bind the lamp
+    assert design_session.devices.bindings["hue"] == "light:1"
+
+
+def test_hue_role_combo_is_empty_without_a_bridge(qtbot, design_session, mock_devices):
+    window = DevicesWindow(design_session)
+    qtbot.addWidget(window)
+    combo = window._role_combos["hue"]
+    assert [combo.itemText(i) for i in range(combo.count())] == ["(none)"]

--- a/tests/test_panels_visual.py
+++ b/tests/test_panels_visual.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from PyQt6 import QtGui, QtWidgets
 
-from smacc import lights
+from smacc import hue, lights
 from smacc.panels.visual import MAX_LIGHT_SLOTS, VisualWindow
 
 
@@ -34,6 +34,23 @@ class _DeadLight(_FakeLight):
         raise OSError("usb gone")
 
 
+class _SyncWriter:
+    """FrameWriter stand-in: applies on submit, no thread — deterministic tests."""
+
+    def __init__(self, backend, applied=None) -> None:
+        self._backend = backend
+        self.error: str | None = None
+
+    def submit(self, rgb) -> None:
+        try:
+            self._backend.apply(rgb)
+        except Exception as exc:  # mirror the real writer's error capture
+            self.error = str(exc)
+
+    def stop(self, timeout: float = 2.0) -> None:
+        pass
+
+
 def _spies(panel, monkeypatch):
     """Replace the session's marker + popup sinks with recording lists."""
     events: list[tuple[str, str | None]] = []
@@ -52,12 +69,13 @@ def _spies(panel, monkeypatch):
 
 
 def _board(qtbot, design_session, monkeypatch, backend=None):
-    """A board with a fake clock + backend, plus its event/popup spies."""
+    """A board with a fake clock + backend + sync writer, plus its spies."""
     panel = VisualWindow(design_session)
     qtbot.addWidget(panel)
     clock = {"t": 0.0}
     panel._clock = lambda: clock["t"]
     panel._backend = backend if backend is not None else _FakeLight()
+    panel._make_writer = _SyncWriter  # no writer thread: frames apply inline
     events, popups = _spies(panel, monkeypatch)
     return panel, clock, events, popups
 
@@ -206,11 +224,24 @@ def test_failed_write_mid_cue_stops_marks_and_reports(
 ):
     panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
     panel.play_slot(panel.slots[0])
-    panel._active_backend = _DeadLight()  # the stick vanishes mid-cue
+    # The device vanishes mid-cue: the writer captures the failure on its thread
+    # and the next tick polls it.
+    panel._writer.error = "usb gone"
     clock["t"] = 0.5
     panel._tick()
     assert events[-1] == ("VisualStopped", "Light 1")  # marker before the popup
     assert popups
+    assert not panel._timer.isActive()
+
+
+def test_failed_first_frame_reports_without_markers(qtbot, design_session, monkeypatch):
+    # The first frame is applied synchronously, so an unreachable device is
+    # reported at the click and no start marker fires for a cue that never lit.
+    panel, clock, events, popups = _board(
+        qtbot, design_session, monkeypatch, backend=_DeadLight()
+    )
+    panel.play_slot(panel.slots[0])
+    assert popups and not events
     assert not panel._timer.isActive()
 
 
@@ -279,3 +310,33 @@ def test_color_can_be_picked_with_no_device(qtbot, design_session, monkeypatch):
     panel.pick_slot_color(panel.slots[0])
     assert panel.slots[0].rgb == (0x11, 0x22, 0x33)
     assert not popups  # choosing a color never needs hardware
+
+
+def test_visual_route_to_hue_resolves_a_hue_backend(qtbot, design_session):
+    design_session.hue_config = hue.HueConfig("192.168.1.50", "key")
+    design_session.devices.bindings["hue"] = "light:1"
+    design_session.devices.routing["visual_out"] = "hue"
+    panel = VisualWindow(design_session)
+    qtbot.addWidget(panel)
+    assert isinstance(panel._backend, hue.HueBackend)
+    assert "Philips Hue" in panel.deviceLabel.text()
+
+
+def test_flash_is_refused_on_a_backend_without_flash_support(
+    qtbot, design_session, monkeypatch
+):
+    class _NoFlashLight(_FakeLight):
+        supports_flash = False
+
+    panel, clock, events, popups = _board(
+        qtbot, design_session, monkeypatch, backend=_NoFlashLight()
+    )
+    panel.add_slot()
+    steady, flashy = panel.slots
+    flashy.patternCombo.setCurrentIndex(flashy.patternCombo.findData(lights.FLASH))
+    panel.play_slot(steady)  # steady is fine on any backend
+    panel.play_slot(flashy)  # refused — and must not kill the lit steady cue
+    assert popups
+    assert events == [("VisualStarted", "Light 1")]
+    assert panel._active_slot is steady
+    assert panel._timer.isActive()


### PR DESCRIPTION
Adds the Philips Hue bridge as the second visual-cue device — room-scale light through ordinary bulbs, next to the BlinkStick's USB stick.

- **New `smacc.hue`**: a minimal V1 REST client on stdlib `urllib` (no new dependency; every bridge generation speaks V1) — cloud discovery, press-button pairing, light/group enumeration, Philips' RGB→xy conversion, and a `HueBackend` satisfying the `LightBackend` protocol. All bridge traffic goes through one stubbable seam, so the client is fully unit-tested offline.
- **Two visual roles** (per the separate-selectors plan in #53): the `blinkstick` role is relabeled **BlinkStick** (key unchanged — old bindings survive) and a **Philips Hue** role binds one bridge light or group (`light:3` / `group:1`). "Present visual cue" routes to either. **Set up Philips Hue…** in the Devices window runs the find → press-button → pair → test flow; the bridge IP + app key persist in a new window-level `hue` block (the `trigger_output` precedent — rig state that travels with the study; the docs note the key is a plaintext local-network credential).
- **Writer thread**: device frames now go through a `FrameWriter` (latest-frame-wins, duplicate-skipping) so a Hue write's ~100 ms HTTP round-trip never runs on the GUI thread at tick rate — a steady cue costs one write, a slow pulse paces itself to the bridge, and write errors surface on the next tick. The cue's *first* frame stays synchronous, so the `VisualStarted` marker still trails the photons and an unreachable device is reported at the click.
- **Capability honesty**: flash is refused on Hue with an explanatory popup (bridge rate limits can't honor a square wave) instead of degrading the stimulus silently; the devices docs carry the latency caveat (time-locked protocols should keep the BlinkStick).

Verified: `pytest` (429 — new `test_hue.py`, `FrameWriter` thread tests, panel/devices/gui integration), `ruff`, `ruff format`, `mypy`, `mkdocs build --strict`. Needs validation on a real bridge: the pairing flow end-to-end, a measured command→photon latency number for the docs, light-vs-group pacing, and an overnight steady/pulse soak.

Closes #53.