### PR TITLE
feat: tune and document stimulus presentation latency

### DIFF
--- a/docs/latency.md
+++ b/docs/latency.md
@@ -1,0 +1,146 @@
+# Latency
+
+How long is it from clicking **Play** (or firing a cue) to the participant
+actually hearing the sound or seeing the light — and how well does the event
+marker line up with it? This page answers that, shows how to measure it on your own
+rig, and explains what SMACC does to keep markers honest.
+
+!!! note "The short version"
+    For the dream-engineering work SMACC is built for — cueing for lucidity or memory
+    reactivation — **absolute latency is rarely critical**. A cue landing 20 ms early
+    or late doesn't change whether it reaches REM. What matters is that the **marker
+    lines up with the stimulus in the EEG**, and there a *constant* offset is harmless
+    (you can correct it after the fact) while **jitter** — random variation — is not.
+    SMACC therefore optimises for *predictable* timing, not minimal latency.
+
+## What contributes
+
+From the click to the sound, in order:
+
+| Stage | Typical | Notes |
+|---|---|---|
+| Click → handler | < 1 ms | Qt event dispatch. |
+| Decode + resample | a few ms | The cue is decoded when loaded; only the resample runs at play time. |
+| Open the output stream | tens of ms | A fresh WASAPI stream is opened per cue (see [#105](https://github.com/remrama/smacc/issues/105)). Affects *click→sound*, not the marker. |
+| **Output buffer** | **~3–25 ms** | The stream's buffer: sound reaches the DAC about one buffer after it starts. **This is the marker↔sound gap.** |
+| DAC → speaker → air | ~1–5 ms | Hardware + ~3 ms per metre of air. |
+
+The two that matter are separate axes with separate fixes:
+
+- **Marker → sound** (the science): the **output buffer**. SMACC corrects for this
+  (below), and it's what a per-rig measurement pins down.
+- **Click → sound** (operator feel): dominated by the per-play **stream open**. Not a
+  marker-alignment problem; tracked separately in
+  [#105](https://github.com/remrama/smacc/issues/105).
+
+## The marker marks the software event, not the photons
+
+By default an event marker is timestamped when SMACC *fires* it — which is **before**
+the sound leaves the speaker (by one output buffer) or, for a light, around when the
+device write completes. To keep the marker aligned with the stimulus:
+
+- **Audio cue / noise.** SMACC stamps the marker (its LSL timestamp **and** the
+  canonical log line) at the *estimated onset* — the moment it fires **plus the
+  stream's reported output latency** — so the marker tracks the sound rather than
+  SMACC's buffer, and stays put when you change the latency setting. The raw
+  software-trigger instant is kept on a `DEBUG` line in the log for audit.
+- **Visual cue.** The first frame is written to the device **synchronously**, and the
+  marker fires right after, so it trails the photons by microseconds (BlinkStick)
+  rather than leading them.
+
+!!! warning "This is an estimate, not a measurement"
+    The correction uses the latency PortAudio *reports*. The residual — fade-in ramp,
+    DAC, speaker, the Hue bridge — is small and roughly constant, but only a recording
+    of the actual onset pins it down. If you need sample-accurate alignment, measure
+    your rig (below) and apply the leftover offset; that per-session capability is
+    tracked in [#104](https://github.com/remrama/smacc/issues/104).
+
+## Measured: a typical Windows rig
+
+Run the bundled probe from the project (it needs no special hardware for this part):
+
+```sh
+uv run tools/measure_latency.py
+```
+
+On a stock laptop (Realtek WASAPI shared-mode output) it reports:
+
+```text
+Device:       Speakers (Realtek(R) Audio)
+Sample rate:  48000 Hz
+Reported:     low   3.0 ms   high  10.0 ms
+Negotiated [ low]:  22.0 ms   (SMACC stamps the marker this far ahead of the stream start)
+Negotiated [high]:  22.0 ms   (SMACC stamps the marker this far ahead of the stream start)
+```
+
+Two things to take from this:
+
+1. The **negotiated** latency (~22 ms) is what you actually get — *not* the smaller
+   "reported" figure. SMACC corrects the cue marker by this negotiated value.
+2. On **shared-mode WASAPI**, the engine rounds up to its own period, so **Low and
+   High come out the same** here. The Low setting only helps on devices/drivers whose
+   buffer it can actually shrink; true low latency needs WASAPI *exclusive* mode,
+   which SMACC doesn't use today. **Don't assume Low helps — measure it.**
+
+## The Low / High setting
+
+The Volume window has an **Output latency** choice, saved in the `.smacc`
+([`output_latency`](reference/settings-file.md)):
+
+- **High** (default) — PortAudio's robust buffer. Fewer underruns; the safe choice
+  for an overnight looping cue, where a glitch in a sleeper's ear is worse than 20 ms.
+- **Low** — asks for a smaller buffer. Trims the marker↔sound gap *where the device
+  allows it* (often no change on shared-mode WASAPI). It applies to the next cue or
+  noise played, not the one currently sounding.
+
+Because the marker is corrected by the *negotiated* latency, switching High/Low never
+silently shifts your markers — the correction tracks the setting.
+
+## Visual cues: BlinkStick vs Hue
+
+Light latency depends entirely on the backend:
+
+- **BlinkStick** — a USB-HID write, a few milliseconds. Fast enough that the marker
+  effectively coincides with the light.
+- **Philips Hue** — each command is an HTTP call to the bridge (~100 ms) plus the
+  bridge→bulb hop, and the bridge rate-limits, so Hue is unsuitable for tight timing
+  or flashing (SMACC refuses `flash` on Hue for this reason). Fine for slow ambient
+  cues; don't time-lock analyses to a Hue marker without measuring it.
+
+## Measure it on your own rig
+
+The numbers above are specific to one machine — **don't quote them for a different
+rig**. To characterise yours:
+
+- **Round-trip, on the bench.** Couple the output back to an input (a loopback cable,
+  or a microphone at the speaker) and run:
+
+    ```sh
+    uv run tools/measure_latency.py --loopback --repeats 30
+    ```
+
+    It plays tone bursts, hears them back, and reports the distribution. Watch the
+    **jitter** (the spread), not just the mean.
+
+- **Against the EEG, per session (authoritative).** Record the real stimulus onset on
+  a spare amplifier channel — a microphone for the cue, a photodiode for the light —
+  alongside the LSL portcode. The difference between the portcode and the recorded
+  onset, across the night, is the true distribution, and it can be visualised in the
+  Analyze tool. This needs a spare channel and is tracked in
+  [#104](https://github.com/remrama/smacc/issues/104).
+
+!!! note "Why the log can't give you this"
+    You might hope to read latency straight from the log, since it records both the
+    raw trigger time (`DEBUG`) and the corrected onset (`INFO`). But their difference
+    is just the latency SMACC *added* — a constant, not a measurement. A real
+    distribution needs an independent observation of the stimulus, i.e. the methods
+    above.
+
+## If you want it lower
+
+In rough order of effort: prefer **short, sharp-onset cues** (a long fade-in is its
+own latency); try the **Low** setting and measure whether your device honours it;
+keep the machine unloaded at night. A persistent pre-warmed stream
+([#105](https://github.com/remrama/smacc/issues/105)) and WASAPI exclusive mode would
+cut more, but neither is a SMACC goal today — for lucidity and TMR cueing, predictable
+beats fast.

--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -32,6 +32,23 @@ just `"{label}"` when it does not. The code-to-event map is the study's
 [`event_codes`](settings-file.md#event_codes) registry; see the
 [default code catalog](../triggers.md#default-event-codes).
 
+### Stimulus marker timing
+
+Most markers are stamped when SMACC fires them. **Audio cue and noise** markers are
+the exception: their timestamp — in the log line *and* the LSL stream — is the
+*estimated onset* (the fire time plus the output stream's reported latency), so the
+marker lines up with the sound rather than SMACC's buffer (see
+[Latency](../latency.md)). The raw software-trigger instant rides alongside on a
+`DEBUG` line:
+
+```text
+2026-06-09 22:18:30.858, DEBUG, Cue started: Piano cue: software trigger at 22:18:30.858, marker advanced +22.0 ms to estimated onset (output latency)
+2026-06-09 22:18:30.880, INFO, Cue started: Piano cue - portcode 60
+```
+
+That `DEBUG` line is deliberately **not** a `" - portcode N"` line, so the
+[BIDS export](bids-export.md) counts the event once, at its onset.
+
 ## Embedded settings blocks
 
 The log carries the **complete settings the run used**, so a session stays

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -45,8 +45,9 @@ settings:
     voice_volume: 0.5
     rows:
       - {biocal: eyes_open, sequence: true, voice: true, duration: 30}
-  # --- Output safety cap -----------------------------------------------------
+  # --- Output cap + latency --------------------------------------------------
   volume_cap: 1.0
+  output_latency: high
   # --- Device roles + routing ------------------------------------------------
   devices:
     bindings: {}
@@ -111,6 +112,7 @@ Any key may be omitted — each falls back to its default.
 | `survey_url` | string | The selected survey URL. |
 | `survey_options` | mapping | Named survey presets: label → URL. |
 | `volume_cap` | 0–1 | Master output safety cap multiplied into every stimulus (`1.0` = no cap). |
+| `output_latency` | `high` \| `low` | Output buffer for the cue + noise streams: `high` is robust (default), `low` trims marker-to-sound delay where the device allows it (often unchanged on shared-mode WASAPI). See [Latency](../latency.md). |
 
 ### `biocals`
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
   - Installation: installation.md
   - Usage: usage.md
   - Audio & routing: audio.md
+  - Latency: latency.md
   - Devices: devices.md
   - Triggers & port codes: triggers.md
   - Reference:

--- a/src/smacc/panels/audio.py
+++ b/src/smacc/panels/audio.py
@@ -413,7 +413,13 @@ class AudioCueWindow(ModalityWindow):
         self._active_slot = slot
         self._cue_timer.start()
         self._set_now_playing(slot)
-        self.session.emit_event("CueStarted", detail=slot.nameEdit.text())
+        # Mark the cue at its estimated onset: the sound reaches the speaker about one
+        # output buffer after the stream starts, so pass that reported buffer latency.
+        self.session.emit_event(
+            "CueStarted",
+            detail=slot.nameEdit.text(),
+            onset_offset=float(primary.stream.latency),
+        )
 
     def _open_output(
         self, slot: CueSlot, device: str | None, *, optional: bool = False
@@ -437,6 +443,7 @@ class AudioCueWindow(ModalityWindow):
                 channels=1,
                 samplerate=rate,
                 device=device,
+                latency=self.session.output_latency,
                 callback=partial(self._render_output, mixer),
             )
             stream.start()

--- a/src/smacc/panels/noise.py
+++ b/src/smacc/panels/noise.py
@@ -234,7 +234,10 @@ class NoiseWindow(ModalityWindow):
         already_playing = self.noise_stream is not None
         self.play_noise()
         if not already_playing and self.noise_stream is not None:
-            self.session.emit_event("NoiseStarted")
+            # Mark at the estimated onset (about one output buffer after start).
+            self.session.emit_event(
+                "NoiseStarted", onset_offset=float(self.noise_stream.latency)
+            )
 
     def on_stop_noise_clicked(self, _checked: bool = False) -> None:
         """User pressed Stop: stop the noise and mark it (NoiseStopped)."""
@@ -264,6 +267,7 @@ class NoiseWindow(ModalityWindow):
                 samplerate=rate,
                 callback=self._noise_callback,
                 device=device,
+                latency=self.session.output_latency,
             )
             stream.start()
         except Exception as err:

--- a/src/smacc/panels/volume.py
+++ b/src/smacc/panels/volume.py
@@ -17,7 +17,7 @@ from .base import ModalityWindow, make_section_title
 
 
 class VolumeWindow(ModalityWindow):
-    """Set the master output cap and view the (read-only) Windows volume stages."""
+    """Set the master output cap + latency mode, and view the Windows volume stages."""
 
     TITLE = "Volume"
 
@@ -39,6 +39,19 @@ class VolumeWindow(ModalityWindow):
         capSpinBox.valueChanged.connect(self.set_cap)
         self.capSpinBox = capSpinBox
 
+        latencyCombo = QtWidgets.QComboBox(self)
+        latencyCombo.addItem("High — robust (default)", "high")
+        latencyCombo.addItem("Low — less delay", "low")
+        latencyCombo.setStatusTip(
+            "Output buffer for cue + noise: High is robust (fewer glitches); Low "
+            "trims marker-to-sound delay but risks underruns. Applies to the next "
+            "cue/noise played. Rarely critical for lucidity cueing — see the docs."
+        )
+        index = latencyCombo.findData(self.session.output_latency)
+        latencyCombo.setCurrentIndex(index if index >= 0 else 0)
+        latencyCombo.currentIndexChanged.connect(self.set_output_latency)
+        self.latencyCombo = latencyCombo
+
         self.endpointLabel = QtWidgets.QLabel(self)
         self.appLabel = QtWidgets.QLabel(self)
         refreshButton = QtWidgets.QPushButton("Refresh levels", self)
@@ -48,6 +61,7 @@ class VolumeWindow(ModalityWindow):
         form = QtWidgets.QFormLayout()
         form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         form.addRow("Output safety cap:", capSpinBox)
+        form.addRow("Output latency:", self.latencyCombo)
         form.addRow("System output volume:", self.endpointLabel)
         form.addRow("SMACC app volume:", self.appLabel)
 
@@ -75,6 +89,12 @@ class VolumeWindow(ModalityWindow):
             f"Output safety cap set to {value:.2f}", debug=True
         )
 
+    def set_output_latency(self, _index: int = 0) -> None:
+        """Apply the output latency mode (used the next time a stimulus stream opens)."""
+        mode = self.latencyCombo.currentData()
+        self.session.output_latency = mode
+        self.session.log_interaction(f"Output latency set to {mode}")
+
     def refresh_levels(self) -> None:
         """Re-read the Windows endpoint + app volumes (best-effort)."""
         endpoint = winvolume.endpoint_volume()
@@ -94,8 +114,15 @@ class VolumeWindow(ModalityWindow):
         return f"{round(scalar * 100)}%" if scalar is not None else "unavailable"
 
     def gather_state(self) -> dict:
-        return {"volume_cap": self.capSpinBox.value()}
+        return {
+            "volume_cap": self.capSpinBox.value(),
+            "output_latency": self.latencyCombo.currentData(),
+        }
 
     def apply_state(self, state: dict) -> None:
         if (v := state.get("volume_cap")) is not None:
             self.capSpinBox.setValue(float(v))  # fires set_cap -> session.volume_cap
+        if (lat := state.get("output_latency")) in ("high", "low"):
+            index = self.latencyCombo.findData(lat)
+            if index >= 0:
+                self.latencyCombo.setCurrentIndex(index)  # fires set_output_latency

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -14,7 +14,7 @@ import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 
-from pylsl import StreamInfo, StreamOutlet
+from pylsl import StreamInfo, StreamOutlet, local_clock
 from PyQt6 import QtWidgets
 
 from . import bids, devices, events, hue, settings, triggers
@@ -107,6 +107,12 @@ class SmaccSession:
         # calibrated rig can't blast a sleeping participant. 1.0 == no cap. Edited in
         # the Volume window; read live by the audio threads.
         self.volume_cap = 1.0
+        # Output stream latency mode for the stimulus streams (cue + noise): "high"
+        # (PortAudio's robust default — larger buffer, fewer glitches) or "low"
+        # (smaller buffer, less marker-to-sound delay, more underrun risk). Edited in
+        # the Volume window, persisted in the study, read when a stimulus stream opens.
+        # Stimulus latency is rarely critical for lucidity cueing (see docs/latency).
+        self.output_latency = "high"
         # Soft interaction logs (volume/color/device/…) are gated off until the
         # main window finishes startup, so construction and study loads don't
         # spam the log; the window flips this on afterwards.
@@ -224,7 +230,9 @@ class SmaccSession:
         self.info = StreamInfo("MyMarkerStream", "Markers", 1, 0, "string", stream_id)
         self.outlet = StreamOutlet(self.info)
 
-    def emit_event(self, key: str, detail: str | None = None) -> None:
+    def emit_event(
+        self, key: str, detail: str | None = None, *, onset_offset: float = 0.0
+    ) -> None:
         """Route a registry event: send its marker (if triggered) and log it.
 
         ``detail`` appends a free-text suffix to the log label (e.g. a cue name).
@@ -232,6 +240,15 @@ class SmaccSession:
         the level filter) controls whether it also shows in the live preview. An
         ``increment`` event advances its code on each firing (by the per-key firing
         count), so each occurrence is individually findable in the trigger channel.
+
+        ``onset_offset`` (seconds) shifts the marker forward to the stimulus's
+        estimated physical onset. An audio cue is heard about one output buffer
+        after SMACC starts the stream, so the cue/noise panels pass that buffer
+        latency: the LSL timestamp and the INFO log line are then stamped at the
+        onset (so the marker — and the BIDS export derived from the log — tracks the
+        sound, not SMACC's buffer), while the raw software-trigger instant is kept on
+        a DEBUG line. Most events fire at ``0.0`` (marker == trigger instant); see
+        docs/latency for why this matters (and why it usually doesn't, for lucidity).
         """
         event = self.events.get(key)
         if event is None:
@@ -249,9 +266,14 @@ class SmaccSession:
         line = f"{label} - portcode {code}" if event.trigger else label
         # In design mode there is no outlet, so triggers are logged but not sent.
         # LSL and the hardware line are written back-to-back (before any pulse-down
-        # sleep) so both edges land as close together as possible.
+        # sleep) so both edges land as close together as possible. LSL is stamped at
+        # the estimated onset (now + onset_offset) so it lines up with the stimulus;
+        # the hardware TTL just fires its edge now (LSL is the timed path SMACC owns).
         if event.trigger and self.outlet is not None:
-            self.outlet.push_sample([str(code)])
+            if onset_offset > 0.0:
+                self.outlet.push_sample([str(code)], local_clock() + onset_offset)
+            else:
+                self.outlet.push_sample([str(code)])
         if event.trigger and self.trigger_out is not None:
             try:
                 self.trigger_out.send(code)
@@ -269,7 +291,50 @@ class SmaccSession:
                 self.trigger_out = None
         # Every event is written to the log file; the preview flag (+ level filter)
         # gates whether it also appears in the live log viewer.
-        self.logger.info(line, extra={"smacc_preview": event.preview})
+        if onset_offset > 0.0:
+            # Stamp the marker at its onset, and keep the raw trigger instant (and the
+            # correction applied) on a DEBUG line for audit. That DEBUG line is
+            # deliberately not a "… - portcode N" line, so the BIDS parser counts the
+            # event exactly once, at its onset.
+            raw = datetime.now()
+            self.logger.debug(
+                f"{label}: software trigger at {raw:%H:%M:%S.%f}, marker advanced "
+                f"+{onset_offset * 1000:.1f} ms to estimated onset (output latency)"
+            )
+            self._log_marker(
+                line,
+                when=raw + timedelta(seconds=onset_offset),
+                level=logging.INFO,
+                preview=event.preview,
+            )
+        else:
+            self.logger.info(line, extra={"smacc_preview": event.preview})
+
+    def _log_marker(
+        self, line: str, *, when: datetime, level: int, preview: bool
+    ) -> None:
+        """Log ``line`` stamped at ``when`` rather than at the call instant.
+
+        Records a stimulus marker at its estimated physical onset so the log — and
+        the BIDS events derived from it — line up with the stimulus, not with the
+        moment SMACC fired. Routes through the same handlers as a normal log call,
+        including the live-preview gate (``smacc_preview``).
+        """
+        record = self.logger.makeRecord(
+            self.logger.name,
+            level,
+            "(smacc)",
+            0,
+            line,
+            (),
+            None,
+            extra={"smacc_preview": preview},
+        )
+        # The formatter reads created (H:M:S) and msecs (.mmm) separately, so set both.
+        ct = when.timestamp()
+        record.created = ct
+        record.msecs = (ct - int(ct)) * 1000
+        self.logger.handle(record)
 
     def mark_recording_start(self) -> None:
         """Stamp the recording-start reference clock and emit its marker (#60).

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -16,6 +16,24 @@ def test_log_to_events_extracts_only_portcode_lines():
     assert [e["trial_type"] for e in events] == ["Lights off", "Note [saw a light]"]
 
 
+def test_onset_corrected_cue_counts_once_at_the_info_line():
+    # A cue/noise marker is logged twice: a DEBUG line keeping the raw software-trigger
+    # instant, and the canonical INFO "- portcode N" line stamped at the estimated
+    # onset. Only the INFO line is a portcode line, so BIDS counts the cue once — and
+    # at its onset (the INFO timestamp), not the raw trigger instant.
+    log = (
+        "2026-06-05 22:00:00.000, INFO, Opened SMACC v0.0.7\n"
+        "2026-06-05 22:00:09.978, DEBUG, Cue started: Piano: software trigger at "
+        "22:00:09.978, marker advanced +22.0 ms to estimated onset (output latency)\n"
+        "2026-06-05 22:00:10.000, INFO, Cue started: Piano - portcode 60\n"
+    )
+    events = bids.log_to_events(log)
+    assert len(events) == 1
+    assert events[0]["value"] == 60
+    assert events[0]["trial_type"] == "Cue started: Piano"
+    assert events[0]["onset"] == 10.0  # the corrected INFO time, not the raw 9.978
+
+
 def test_onset_is_relative_to_first_log_entry():
     events = bids.log_to_events(SAMPLE_LOG)
     # First event is 5.5s after the "Opened SMACC" line at 22:00:00.000.

--- a/tests/test_panels_state.py
+++ b/tests/test_panels_state.py
@@ -125,10 +125,15 @@ def test_volume_panel_round_trips_cap(qtbot, design_session, monkeypatch):
     monkeypatch.setattr(winvolume, "app_volume", lambda: None)
     panel = VolumeWindow(design_session)
     qtbot.addWidget(panel)
-    panel.apply_state({"volume_cap": 0.50})
-    assert panel.gather_state() == {"volume_cap": pytest.approx(0.50)}
-    # apply_state also drives the live session cap (read by the audio callbacks).
+    panel.apply_state({"volume_cap": 0.50, "output_latency": "low"})
+    assert panel.gather_state() == {
+        "volume_cap": pytest.approx(0.50),
+        "output_latency": "low",
+    }
+    # apply_state also drives the live session state: the cap (read by the audio
+    # callbacks) and the latency mode (read when a stimulus stream opens).
     assert design_session.volume_cap == pytest.approx(0.50)
+    assert design_session.output_latency == "low"
 
 
 def test_biocals_panel_round_trips_stack(qtbot, design_session):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -64,13 +64,15 @@ def test_design_logger_does_not_accumulate_handlers(tmp_path):
 
 
 class _FakeOutlet:
-    """Stand-in for the LSL outlet that records pushed marker samples."""
+    """Stand-in for the LSL outlet that records pushed marker samples + timestamps."""
 
     def __init__(self):
         self.samples = []
+        self.timestamps = []
 
-    def push_sample(self, sample):
+    def push_sample(self, sample, timestamp=None):
         self.samples.append(sample)
+        self.timestamps.append(timestamp)
 
 
 class _FakeTrigger:
@@ -154,7 +156,28 @@ def test_emit_event_detail_suffix():
     sess, records = _stub_session()
     sess.emit_event("CueStarted", detail="Cue 1")
     assert sess.outlet.samples == [["60"]]
+    assert sess.outlet.timestamps == [None]  # no offset -> default "now" timestamp
     assert records == [("Cue started: Cue 1 - portcode 60", True)]
+
+
+def test_emit_event_onset_offset_marks_at_estimated_onset():
+    # A stimulus marker with an onset offset (the output buffer latency) is stamped
+    # at the estimated onset, and the raw software-trigger instant is kept separately.
+    sess, records = _stub_session()
+    sess.emit_event("CueStarted", detail="Cue 1", onset_offset=0.02)
+    # The LSL marker carries the code with an explicit timestamp (not the "now"
+    # sentinel), so it lands at the estimated sound onset.
+    assert sess.outlet.samples == [["60"]]
+    assert sess.outlet.timestamps[0] is not None
+    # The canonical portcode line is still logged verbatim (INFO) — it is what the
+    # BIDS parser reads, and it carries the onset timestamp in the log.
+    assert ("Cue started: Cue 1 - portcode 60", True) in records
+    # The raw trigger instant + the correction ride a separate line, deliberately not
+    # a "- portcode N" line, so BIDS counts the event exactly once (at its onset).
+    raw_lines = [m for m, _ in records if "software trigger at" in m]
+    assert len(raw_lines) == 1
+    assert "+20.0 ms" in raw_lines[0]
+    assert "portcode 60" not in raw_lines[0]
 
 
 def test_emit_event_dream_increment_auto_counts():

--- a/tools/measure_latency.py
+++ b/tools/measure_latency.py
@@ -1,0 +1,146 @@
+"""Measure SMACC's audio output latency on this machine (issue #10).
+
+Two questions, two modes:
+
+* ``--report`` (default): what latency does the WASAPI output negotiate at SMACC's
+  High vs Low setting? Opens a brief stream each way and prints the latency PortAudio
+  reports — the same number SMACC adds to a cue/noise marker (its ``onset_offset``).
+  Needs no special hardware: it only queries the device and opens a silent stream.
+
+* ``--loopback``: how long from "play" to the sound actually arriving? Plays a short
+  tone burst on the output while recording the input, and cross-correlates each burst
+  to estimate the round-trip delay. This needs the output coupled to the input — a
+  loopback cable, or a microphone in front of the speaker (then the number also
+  includes the room). It is the *spread* across bursts, not the mean, that bounds
+  marker jitter; a constant offset is correctable, jitter is not.
+
+Run from the project so the deps (sounddevice/numpy) resolve::
+
+    uv run tools/measure_latency.py
+    uv run tools/measure_latency.py --loopback --repeats 30
+
+Numbers are specific to THIS machine + device + load; don't quote them for another
+rig. The authoritative per-rig figure comes from a recorded onset channel — see
+docs/latency.md and issue #104.
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+
+import numpy as np
+import sounddevice as sd
+
+WASAPI = "Windows WASAPI"
+
+
+def wasapi_default_output() -> int | None:
+    """The default WASAPI output device index (the host API SMACC uses), or None."""
+    for api in sd.query_hostapis():
+        if api["name"] == WASAPI:
+            dev = api["default_output_device"]
+            return dev if dev is not None and dev >= 0 else None
+    return None
+
+
+def report(device: int | None) -> None:
+    """Print the device's reported and negotiated output latency at low vs high."""
+    dev = device if device is not None else wasapi_default_output()
+    if dev is None:
+        print("No WASAPI output device found (SMACC enumerates WASAPI only).")
+        return
+    info = sd.query_devices(dev, "output")
+    rate = int(info["default_samplerate"])
+    print(f"Device:       {info['name']}")
+    print(f"Sample rate:  {rate} Hz")
+    print(
+        f"Reported:     low {info['default_low_output_latency'] * 1000:5.1f} ms"
+        f"   high {info['default_high_output_latency'] * 1000:5.1f} ms"
+    )
+    for mode in ("low", "high"):
+        try:
+            stream = sd.OutputStream(
+                device=dev, channels=1, samplerate=rate, latency=mode
+            )
+            stream.start()
+            negotiated = float(stream.latency) * 1000
+            stream.stop()
+            stream.close()
+            print(
+                f"Negotiated [{mode:>4}]: {negotiated:5.1f} ms"
+                "   (SMACC stamps the marker this far ahead of the stream start)"
+            )
+        except Exception as exc:  # noqa: BLE001 - report and continue to the other mode
+            print(f"Negotiated [{mode:>4}]: could not open a stream: {exc}")
+
+
+def loopback(
+    device: int | None, repeats: int, mode: str, gap_s: float = 0.4
+) -> None:
+    """Estimate round-trip latency by playing tone bursts and hearing them back."""
+    out_dev = device if device is not None else wasapi_default_output()
+    if out_dev is None:
+        print("No WASAPI output device found.")
+        return
+    rate = int(sd.query_devices(out_dev, "output")["default_samplerate"])
+    click_n = int(rate * 0.005)  # 5 ms burst
+    t = np.arange(click_n) / rate
+    burst = (0.5 * np.sin(2 * np.pi * 2000 * t) * np.hanning(click_n)).astype(
+        np.float32
+    )
+    trial = np.concatenate([burst, np.zeros(int(rate * gap_s), dtype=np.float32)])
+    signal = np.tile(trial, repeats).reshape(-1, 1)
+    print(
+        f"Playing {repeats} bursts (couple output->input first: loopback cable or a "
+        f"mic at the speaker)..."
+    )
+    rec = sd.playrec(signal, samplerate=rate, channels=1, latency=mode)
+    sd.wait()
+    rec = rec[:, 0]
+    trial_n = len(trial)
+    delays_ms = []
+    for k in range(repeats):
+        seg = rec[k * trial_n : (k + 1) * trial_n]
+        if len(seg) < click_n:
+            break
+        corr = np.correlate(seg, burst, mode="valid")
+        lag = int(np.argmax(np.abs(corr)))
+        delays_ms.append(lag / rate * 1000)
+    if not delays_ms:
+        print("No bursts recovered — is the output actually reaching the input?")
+        return
+    mean = statistics.mean(delays_ms)
+    jitter = statistics.pstdev(delays_ms)
+    print(f"Round-trip over {len(delays_ms)} bursts [{mode}]:")
+    print(f"  mean {mean:.1f} ms   jitter (sd) {jitter:.1f} ms")
+    print(f"  min  {min(delays_ms):.1f} ms   max {max(delays_ms):.1f} ms")
+    print("Round-trip includes output + input latency (+ the room, if via a mic).")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--loopback",
+        action="store_true",
+        help="measure round-trip latency (needs output coupled to input)",
+    )
+    parser.add_argument(
+        "--device", type=int, default=None, help="output device index (default: WASAPI)"
+    )
+    parser.add_argument("--repeats", type=int, default=20, help="loopback burst count")
+    parser.add_argument(
+        "--latency",
+        choices=("low", "high"),
+        default="high",
+        help="latency mode for the loopback run (default: high, SMACC's default)",
+    )
+    args = parser.parse_args()
+    if args.loopback:
+        loopback(args.device, args.repeats, args.latency)
+    else:
+        report(args.device)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/measure_latency.py
+++ b/tools/measure_latency.py
@@ -75,9 +75,7 @@ def report(device: int | None) -> None:
             print(f"Negotiated [{mode:>4}]: could not open a stream: {exc}")
 
 
-def loopback(
-    device: int | None, repeats: int, mode: str, gap_s: float = 0.4
-) -> None:
+def loopback(device: int | None, repeats: int, mode: str, gap_s: float = 0.4) -> None:
     """Estimate round-trip latency by playing tone bursts and hearing them back."""
     out_dev = device if device is not None else wasapi_default_output()
     if out_dev is None:


### PR DESCRIPTION
Reframes #10 ("how bad is latency?") as a measured, documented answer plus a modest tuning knob. Latency is rarely critical for lucidity cueing, but markers should still line up with the stimulus.

- **Setting:** a High/Low output-latency choice (Volume window, saved as `output_latency`), applied to the cue + noise streams. Default High (robust). Additive — no schema bump.
- **Marker timing:** cue/noise markers (the LSL timestamp and the canonical `- portcode` log line) are stamped at the estimated sound onset — fire time plus the stream's reported output latency — so BIDS onsets and XDF markers track the sound, not SMACC's buffer. The raw software-trigger instant is kept on a DEBUG line.
- **Docs:** new Latency page (in the nav) plus session-log and settings-file notes. Honest finding: on shared-mode WASAPI the *negotiated* latency (~22 ms on a test Realtek device) is what you actually get, and Low often equals High without exclusive mode.
- **Tool:** `tools/measure_latency.py` (`uv run`) reports negotiated latency and, with `--loopback`, round-trip.

Visual needed no code change — #103 already marks after the first synchronous light frame; the page documents the BlinkStick-vs-Hue split.

Verified: 431 tests + ruff + mypy green; bench `--report` run on a Realtek WASAPI device; marker and BIDS behaviour covered by new unit + regression tests.

Per-session on-rig measurement (+ an Analyze histogram) and a persistent pre-warmed stream are split to #104 and #105.

Closes #10.