### PR TITLE
Add spin value restoration helper

### DIFF
--- a/src/smacc/__init__.py
+++ b/src/smacc/__init__.py
@@ -1,4 +1,4 @@
 """SMACC: Sleep Manipulation And Communication Clickything."""
 
 __author__ = "Remington Mallett <mallett.remy@gmail.com>"
-__version__ = "0.0.7"
+__version__ = "0.0.8"

--- a/src/smacc/bids.py
+++ b/src/smacc/bids.py
@@ -8,6 +8,7 @@ no GUI — directly unit-testable.
 
 from __future__ import annotations
 
+import csv
 import json
 import re
 from datetime import datetime
@@ -74,9 +75,10 @@ def log_to_events(log_text: str) -> list[dict[str, Any]]:
 
 def write_events_tsv(events: list[dict[str, Any]], path: str | Path) -> None:
     """Write event rows to ``path`` as a BIDS tab-separated values file."""
-    lines = ["\t".join(EVENT_COLUMNS)]
-    lines += ["\t".join(str(ev[col]) for col in EVENT_COLUMNS) for ev in events]
-    Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+    with Path(path).open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.writer(stream, delimiter="\t", lineterminator="\n")
+        writer.writerow(EVENT_COLUMNS)
+        writer.writerows([str(ev[col]) for col in EVENT_COLUMNS] for ev in events)
 
 
 def events_sidecar() -> dict[str, Any]:

--- a/src/smacc/panels/audio.py
+++ b/src/smacc/panels/audio.py
@@ -23,7 +23,12 @@ from PyQt6 import QtCore, QtWidgets
 from .. import audio, utils
 from ..session import SmaccSession
 from ..utils import pick_random_demo_cue
-from .base import ModalityWindow, describe_target, make_section_title
+from .base import (
+    ModalityWindow,
+    describe_target,
+    make_section_title,
+    restore_spin_value,
+)
 from .meter import InputLevelMeter, LevelMeter
 
 # One cue is always required; the upper bound is generous (a session typically
@@ -600,9 +605,9 @@ class AudioCueWindow(ModalityWindow):
             for slot, cue in zip(self.slots, cues, strict=False):
                 self._apply_cue(slot, cue)
         if (v := state.get("cue_attack")) is not None:
-            self.attackSpinBox.setValue(float(v))
+            restore_spin_value(self.attackSpinBox, v)
         if (v := state.get("cue_release")) is not None:
-            self.releaseSpinBox.setValue(float(v))
+            restore_spin_value(self.releaseSpinBox, v)
 
     @staticmethod
     def _apply_cue(slot: CueSlot, cue: dict) -> None:
@@ -611,7 +616,7 @@ class AudioCueWindow(ModalityWindow):
         if (f := cue.get("file")) is not None:
             slot.fileEdit.setText(str(f))  # textChanged -> update_slot_source decodes
         if (v := cue.get("volume")) is not None:
-            slot.volumeSpinBox.setValue(float(v))
+            restore_spin_value(slot.volumeSpinBox, v)
         slot.loopCheckBox.setChecked(bool(cue.get("loop", False)))
 
     def cleanup(self) -> None:

--- a/src/smacc/panels/base.py
+++ b/src/smacc/panels/base.py
@@ -77,6 +77,19 @@ def make_section_title(text: str) -> QtWidgets.QLabel:
     return label
 
 
+def restore_spin_value(spin: QtWidgets.QDoubleSpinBox, value: object) -> bool:
+    """Best-effort restore of a persisted numeric spinbox value.
+
+    Hand-edited studies should not crash a load because one optional scalar is
+    malformed. Returning False lets callers keep the widget's current/default value.
+    """
+    try:
+        spin.setValue(float(value))  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
 class ModalityWindow(QtWidgets.QMainWindow):
     """Base class for a single modality's window.
 

--- a/src/smacc/panels/noise.py
+++ b/src/smacc/panels/noise.py
@@ -12,7 +12,12 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import utils
 from ..session import SmaccSession
-from .base import ModalityWindow, describe_target, make_section_title
+from .base import (
+    ModalityWindow,
+    describe_target,
+    make_section_title,
+    restore_spin_value,
+)
 
 NOISE_RATE = 44100
 # Seconds of colored noise pre-generated per Play and then looped. A single
@@ -306,7 +311,7 @@ class NoiseWindow(ModalityWindow):
 
     def apply_state(self, state: dict) -> None:
         if (v := state.get("noise_volume")) is not None:
-            self.noisevolumeSpinBox.setValue(float(v))
+            restore_spin_value(self.noisevolumeSpinBox, v)
         if color := state.get("noise_color"):
             idx = self.available_noisecolors_dropdown.findText(color)
             if idx >= 0:

--- a/src/smacc/panels/visual.py
+++ b/src/smacc/panels/visual.py
@@ -27,7 +27,12 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import hue, lights
 from ..session import SmaccSession
-from .base import ModalityWindow, describe_target, make_section_title
+from .base import (
+    ModalityWindow,
+    describe_target,
+    make_section_title,
+    restore_spin_value,
+)
 
 # One light cue is always required; the cap is lower than the audio board's 20
 # because rows are wide and a light protocol rarely needs more than a few variants.
@@ -646,9 +651,9 @@ class VisualWindow(ModalityWindow):
                 if isinstance(cue, dict):
                     self._apply_cue(slot, cue)
         if (v := state.get("visual_attack")) is not None:
-            self.attackSpinBox.setValue(float(v))
+            restore_spin_value(self.attackSpinBox, v)
         if (v := state.get("visual_release")) is not None:
-            self.releaseSpinBox.setValue(float(v))
+            restore_spin_value(self.releaseSpinBox, v)
 
     def _apply_cue(self, slot: LightSlot, cue: dict) -> None:
         if name := cue.get("name"):
@@ -658,14 +663,14 @@ class VisualWindow(ModalityWindow):
             if qcolor.isValid():
                 self._set_slot_color(slot, qcolor.red(), qcolor.green(), qcolor.blue())
         if (v := cue.get("brightness")) is not None:
-            slot.brightnessSpinBox.setValue(float(v))
+            restore_spin_value(slot.brightnessSpinBox, v)
         pattern = cue.get("pattern")
         if pattern in lights.PATTERNS:
             slot.patternCombo.setCurrentIndex(slot.patternCombo.findData(pattern))
         if (v := cue.get("rate")) is not None:
-            slot.rateSpinBox.setValue(float(v))
+            restore_spin_value(slot.rateSpinBox, v)
         if (v := cue.get("length")) is not None:
-            slot.lengthSpinBox.setValue(float(v))
+            restore_spin_value(slot.lengthSpinBox, v)
         slot.loopCheckBox.setChecked(bool(cue.get("loop", False)))
 
     def cleanup(self) -> None:

--- a/src/smacc/panels/volume.py
+++ b/src/smacc/panels/volume.py
@@ -13,7 +13,7 @@ from PyQt6 import QtCore, QtWidgets
 
 from .. import winvolume
 from ..session import SmaccSession
-from .base import ModalityWindow, make_section_title
+from .base import ModalityWindow, make_section_title, restore_spin_value
 
 
 class VolumeWindow(ModalityWindow):
@@ -121,7 +121,7 @@ class VolumeWindow(ModalityWindow):
 
     def apply_state(self, state: dict) -> None:
         if (v := state.get("volume_cap")) is not None:
-            self.capSpinBox.setValue(float(v))  # fires set_cap -> session.volume_cap
+            restore_spin_value(self.capSpinBox, v)  # fires set_cap on success
         if (lat := state.get("output_latency")) in ("high", "low"):
             index = self.latencyCombo.findData(lat)
             if index >= 0:

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -1,5 +1,7 @@
 """Tests for the BIDS events exporter (no GUI required)."""
 
+import csv
+
 from smacc import bids, settings
 
 SAMPLE_LOG = """2026-06-05 22:00:00.000, INFO, Opened SMACC v0.0.7
@@ -125,6 +127,25 @@ def test_write_events_tsv_round_trip(tmp_path):
     assert lines[0] == "onset\tduration\ttrial_type\tvalue"
     assert lines[1].split("\t") == ["5.5", "n/a", "Lights off", "47"]
     assert len(lines) == 3  # header + 2 events
+
+
+def test_write_events_tsv_quotes_user_text(tmp_path):
+    path = tmp_path / "events.tsv"
+    events = [
+        {
+            "onset": 1.25,
+            "duration": "n/a",
+            "trial_type": "Note: tab\tand newline\ninside",
+            "value": 50,
+        }
+    ]
+    bids.write_events_tsv(events, path)
+    with path.open(encoding="utf-8", newline="") as stream:
+        rows = list(csv.reader(stream, delimiter="\t"))
+    assert rows == [
+        bids.EVENT_COLUMNS,
+        ["1.25", "n/a", "Note: tab\tand newline\ninside", "50"],
+    ]
 
 
 def test_write_events_json_sidecar(tmp_path):

--- a/tests/test_panels_state.py
+++ b/tests/test_panels_state.py
@@ -51,6 +51,23 @@ def test_audio_panel_round_trips_cues_and_envelope(qtbot, design_session):
     assert got["cues"][1]["loop"] is False
 
 
+def test_audio_panel_ignores_malformed_numeric_settings(qtbot, design_session):
+    panel = AudioCueWindow(design_session)
+    qtbot.addWidget(panel)
+    before = panel.gather_state()
+    panel.apply_state(
+        {
+            "cues": [{"name": "Bad numbers", "file": "", "volume": "loud"}],
+            "cue_attack": "fast",
+            "cue_release": object(),
+        }
+    )
+    got = panel.gather_state()
+    assert got["cue_attack"] == before["cue_attack"]
+    assert got["cue_release"] == before["cue_release"]
+    assert got["cues"][0]["volume"] == before["cues"][0]["volume"]
+
+
 def test_noise_panel_round_trips(qtbot, design_session):
     panel = NoiseWindow(design_session)
     qtbot.addWidget(panel)
@@ -66,6 +83,14 @@ def test_noise_panel_round_trips(qtbot, design_session):
     assert got["noise_color"] == "pink"
     assert got["noise_source"] == "file"
     assert got["noise_file"] == "loop.wav"
+
+
+def test_noise_panel_ignores_malformed_numeric_settings(qtbot, design_session):
+    panel = NoiseWindow(design_session)
+    qtbot.addWidget(panel)
+    before = panel.gather_state()["noise_volume"]
+    panel.apply_state({"noise_volume": "loud"})
+    assert panel.gather_state()["noise_volume"] == before
 
 
 def test_recording_panel_round_trips_surveys(qtbot, design_session):
@@ -118,6 +143,34 @@ def test_visual_panel_round_trips(qtbot, design_session):
     assert got["visual_release"] == pytest.approx(1.5)
 
 
+def test_visual_panel_ignores_malformed_numeric_settings(qtbot, design_session):
+    panel = VisualWindow(design_session)
+    qtbot.addWidget(panel)
+    before = panel.gather_state()
+    panel.apply_state(
+        {
+            "visual_cues": [
+                {
+                    "name": "Bad numbers",
+                    "brightness": "bright",
+                    "rate": object(),
+                    "length": "long",
+                }
+            ],
+            "visual_attack": "fast",
+            "visual_release": "slow",
+        }
+    )
+    got = panel.gather_state()
+    assert got["visual_attack"] == before["visual_attack"]
+    assert got["visual_release"] == before["visual_release"]
+    assert got["visual_cues"][0]["brightness"] == before["visual_cues"][0][
+        "brightness"
+    ]
+    assert got["visual_cues"][0]["rate"] == before["visual_cues"][0]["rate"]
+    assert got["visual_cues"][0]["length"] == before["visual_cues"][0]["length"]
+
+
 def test_volume_panel_round_trips_cap(qtbot, design_session, monkeypatch):
     # The read-only Windows volume read-out uses COM; stub it so the panel builds
     # deterministically off any audio endpoint.
@@ -134,6 +187,19 @@ def test_volume_panel_round_trips_cap(qtbot, design_session, monkeypatch):
     # callbacks) and the latency mode (read when a stimulus stream opens).
     assert design_session.volume_cap == pytest.approx(0.50)
     assert design_session.output_latency == "low"
+
+
+def test_volume_panel_ignores_malformed_numeric_settings(
+    qtbot, design_session, monkeypatch
+):
+    monkeypatch.setattr(winvolume, "endpoint_volume", lambda: None)
+    monkeypatch.setattr(winvolume, "app_volume", lambda: None)
+    panel = VolumeWindow(design_session)
+    qtbot.addWidget(panel)
+    before = panel.gather_state()["volume_cap"]
+    panel.apply_state({"volume_cap": "full"})
+    assert panel.gather_state()["volume_cap"] == before
+    assert design_session.volume_cap == before
 
 
 def test_biocals_panel_round_trips_stack(qtbot, design_session):

--- a/tests/test_panels_state.py
+++ b/tests/test_panels_state.py
@@ -164,9 +164,7 @@ def test_visual_panel_ignores_malformed_numeric_settings(qtbot, design_session):
     got = panel.gather_state()
     assert got["visual_attack"] == before["visual_attack"]
     assert got["visual_release"] == before["visual_release"]
-    assert got["visual_cues"][0]["brightness"] == before["visual_cues"][0][
-        "brightness"
-    ]
+    assert got["visual_cues"][0]["brightness"] == before["visual_cues"][0]["brightness"]
     assert got["visual_cues"][0]["rate"] == before["visual_cues"][0]["rate"]
     assert got["visual_cues"][0]["length"] == before["visual_cues"][0]["length"]
 


### PR DESCRIPTION
- Harden settings restore so malformed numeric values in hand-edited `.smacc` files do not crash panel loading
- Export BIDS events TSVs with `csv.writer` so user text containing tabs/newlines is escaped correctly
- Add regression tests for numeric settings coercion and TSV quoting