### PR TITLE
feat: add text-chat mode to the intercom

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -50,7 +50,8 @@ Three optional routes cover the things you reach for mid-study:
 * **Listen through intercom.** The intercom is two-way: **Speak through intercom**
   sends your voice to the participant (and is marked in the EEG record), while
   **Listen through intercom** brings the participant's mic to your control-room
-  speakers.
+  speakers. The intercom also has a typed [text-chat mode](usage.md#text-chat)
+  (no audio device involved) for hearing-impaired participants.
 * **Monitor the bedroom.** A microphone meter in the Audio cue window that confirms a
   cue is audible in the bedroom (see
   [below](#is-the-cue-reaching-the-bedroom)). It defaults to the **Bedroom mic**, or

--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -49,6 +49,21 @@ marker lines up with the sound rather than SMACC's buffer (see
 That `DEBUG` line is deliberately **not** a `" - portcode N"` line, so the
 [BIDS export](bids-export.md) counts the event once, at its onset.
 
+### Text-chat transcript
+
+Each [text-chat](../usage.md#text-chat) message is written verbatim to a `DEBUG`
+line, one per message — in the file for the record, out of the live preview and
+the BIDS export by default:
+
+```text
+2026-06-09 23:41:12.402, DEBUG, Chat to participant: Are you comfortable?
+2026-06-09 23:41:35.118, DEBUG, Chat from participant: yes
+```
+
+If a study flips the chat events' triggers on, the marker lines fire alongside —
+bare (`Chat to participant - portcode 69`), without the message text, so the
+trigger channel and the export stay legible.
+
 ## Embedded settings blocks
 
 The log carries the **complete settings the run used**, so a session stays

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -40,6 +40,9 @@ settings:
   # --- Survey ----------------------------------------------------------------
   survey_url: ""
   survey_options: {}
+  # --- Participant text chat ---------------------------------------------------
+  chat_font_size: 18
+  chat_red_text: false
   # --- Biocals ---------------------------------------------------------------
   biocals:
     voice_volume: 0.5
@@ -95,7 +98,7 @@ settings:
 Every panel contributes its own keys; a few window-level blocks travel alongside.
 Any key may be omitted — each falls back to its default.
 
-### Audio, noise, visual, survey, volume
+### Audio, noise, visual, survey, chat, volume
 
 | Key | Type | Meaning |
 |---|---|---|
@@ -111,6 +114,8 @@ Any key may be omitted — each falls back to its default.
 | `visual_release` | seconds | Brightness fade-out applied to a stopping visual cue. |
 | `survey_url` | string | The selected survey URL. |
 | `survey_options` | mapping | Named survey presets: label → URL. |
+| `chat_font_size` | integer | Participant chat window text size, in points (8–72). |
+| `chat_red_text` | boolean | Red-shifted night text in the participant chat window. |
 | `volume_cap` | 0–1 | Master output safety cap multiplied into every stimulus (`1.0` = no cap). |
 | `output_latency` | `high` \| `low` | Output buffer for the cue + noise streams: `high` is robust (default), `low` trims marker-to-sound delay where the device allows it (often unchanged on shared-mode WASAPI). See [Latency](../latency.md). |
 

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -50,6 +50,8 @@ study can retune any code in the **Event codes** editor; the change travels in i
 | 66 | Visual started | `VisualStarted` | |
 | 67 | Survey opened | `SurveyOpened` | |
 | 68 | Visual stopped | `VisualStopped` | the light is actually off (pairs with 66) |
+| 69 | Chat to participant | `ChatMessageSent` | typed intercom message; log-only by default |
+| 70 | Chat from participant | `ChatMessageReceived` | participant's typed reply; log-only by default |
 | 100 | SMACC initialized | `TriggerInitialization` | startup connection test; not a stimulus marker |
 | 105 | Biocal sequence started | `BiocalSequenceStarted` | brackets a played biocal sequence |
 | 106 | Biocal sequence stopped | `BiocalSequenceStopped` | completed or aborted |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -140,6 +140,47 @@ are missing (a biocal with a missing voice still runs, just unvoiced). The share
 **Voice volume** rides the cue route, so the master output cap and the
 control-room monitor fan-out apply to instructions exactly as they do to cues.
 
+## Intercom
+
+The **Intercom** window is the live channel between the control room and the
+bedroom. **Talk** pipes your mic to the participant's output (click to latch, or
+hold the **spacebar** anywhere in SMACC as push-to-talk) and is marked in the EEG
+record; **Listen** brings the bedroom mic to your control-room speakers, unmarked.
+The two directions route through roles set once in the **Devices** window (see
+[Audio &amp; routing](audio.md)).
+
+### Text chat
+
+Below the voice controls is a **typed channel** — for hearing-impaired
+participants, or whenever audio would intrude or you want the exchange in writing.
+You type in the Intercom panel; the participant reads and replies in a separate
+**Participant chat** window made for a dark bedroom: always dark regardless of the
+lights toggle, large text (default 18 pt, resize with `Ctrl+=` / `Ctrl+-`), and an
+optional **red night text** mode (**Display** menu), with no flashing and no
+sounds.
+
+**Setup.** The first cut assumes one computer: extend the desktop onto a
+bedroom-facing monitor and plug in a second keyboard for the participant. Click
+**Pass keyboard to participant** to open the participant window, drag it onto the
+bedroom display once, and it reopens there next session.
+
+**One keyboard at a time.** Windows gives the machine a single input focus, so the
+two keyboards type into whichever window is active — text chat is half-duplex,
+like push-to-talk. **Pass keyboard to participant** (or `Ctrl+Enter`, which sends
+your message first) activates the participant window so their keystrokes land
+there; clicking back into SMACC takes the focus back. The participant window shows
+a banner — *"● The keyboard is yours"* / *"○ Waiting"* — so a drowsy participant
+always knows whether typing will land.
+
+**What's recorded.** Every message is written verbatim to the session log as a
+DEBUG line (tick *Debug* above the log preview to watch the exchange live). By
+default no portcodes fire and nothing reaches the BIDS events export — a typed
+exchange is rapid and conversational, and would flood the marker channel. If a
+study needs marker timestamps, flip the trigger on for `Chat to participant`
+(code 69) and/or `Chat from participant` (code 70) in **File &rsaquo; Event
+codes…**; the markers stay bare (no message text) so the trigger channel remains
+legible.
+
 ## EEG portcodes
 
 SMACC marks experiment events — a cue played, a dream report, observed REM, the

--- a/src/smacc/assets/default.smacc
+++ b/src/smacc/assets/default.smacc
@@ -27,6 +27,8 @@ settings:
   noise_file: ''
   survey_url: ''
   survey_options: {}
+  chat_font_size: 18
+  chat_red_text: false
   # biocal rows omitted on purpose: the stack starts with every standard biocal
   # (plus the unchecked lucid-dreaming signals); saving from the app writes the
   # configured stack back here (#78).
@@ -132,6 +134,16 @@ settings:
     code: 67
     trigger: true
     preview: true
+    increment: false
+  - key: ChatMessageSent
+    code: 69
+    trigger: false
+    preview: false
+    increment: false
+  - key: ChatMessageReceived
+    code: 70
+    trigger: false
+    preview: false
     increment: false
   - key: BiocalSequenceStarted
     code: 105

--- a/src/smacc/events.py
+++ b/src/smacc/events.py
@@ -200,6 +200,25 @@ def default_events() -> list[EventDef]:
         # The stop pairs with 66 at the next free code (67 predates it).
         EventDef("VisualStopped", "Visual stopped", 68),
         EventDef("SurveyOpened", "Survey opened", 67),
+        # --- Text chat (#92): log-only by default. A typed exchange is rapid and
+        # conversational, so neither direction triggers (or previews) unless a
+        # study flips it on; the verbatim text always lands on a DEBUG log line.
+        EventDef(
+            "ChatMessageSent",
+            "Chat to participant",
+            69,
+            trigger=False,
+            preview=False,
+            tooltip="Mark a typed intercom message shown to the participant",
+        ),
+        EventDef(
+            "ChatMessageReceived",
+            "Chat from participant",
+            70,
+            trigger=False,
+            preview=False,
+            tooltip="Mark a typed reply from the participant",
+        ),
         # --- Biocals: run from the Biocals window (#78) -------------------------
         *_biocal_events(),
         # --- System -----------------------------------------------------------

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -32,6 +32,7 @@ from .dialogs import (
 from .panels.audio import AudioCueWindow
 from .panels.base import ModalityWindow
 from .panels.biocals import BiocalsWindow
+from .panels.chat import ChatTranscript, ParticipantChatWindow
 from .panels.devices import DevicesWindow
 from .panels.events import EventsWindow
 from .panels.intercom import IntercomWindow
@@ -84,6 +85,9 @@ class SmaccWindow(ToolWindow):
         # others show a read-only indicator and resolve their device from
         # session.devices, refreshed whenever the Devices window emits ``changed``.
         self.devices_window = DevicesWindow(self.session)
+        # The text chat's conversation, shared by its two views: the experimenter's
+        # section in the Intercom panel and the participant-facing window (#92).
+        chat_transcript = ChatTranscript(self)
         self.panels: dict[str, ModalityWindow] = {
             "events": EventsWindow(self.session),
             "biocals": BiocalsWindow(self.session),
@@ -91,10 +95,16 @@ class SmaccWindow(ToolWindow):
             "audio": AudioCueWindow(self.session),
             "noise": NoiseWindow(self.session),
             "recording": RecordingWindow(self.session),
-            "intercom": IntercomWindow(self.session),
+            "intercom": IntercomWindow(self.session, chat_transcript),
+            # No launcher button (absent from PANEL_LABELS): opened via the Intercom
+            # panel's "Pass keyboard" button, which also hands it keyboard focus.
+            "chat": ParticipantChatWindow(self.session, chat_transcript),
             "devices": self.devices_window,
             "volume": VolumeWindow(self.session),
         }
+        cast(IntercomWindow, self.panels["intercom"]).open_participant_chat.connect(
+            partial(self._open_panel, "chat")
+        )
         self.devices_window.changed.connect(self._refresh_device_indicators)
         # The Devices window's Refresh button (and its F5 shortcut) runs this rescan
         # (PortAudio re-init + BlinkStick scan); it's the only entry point now.
@@ -192,7 +202,9 @@ class SmaccWindow(ToolWindow):
         label.setFont(font)
         return label
 
-    # Modality windows openable from the launcher (key -> button label).
+    # Modality windows openable from the launcher (key -> button label). Panels
+    # absent from this map get no button ("chat" opens from the Intercom panel)
+    # but keep the rest of the machinery: state, geometry, always-on-top, cleanup.
     PANEL_LABELS = {
         "events": "Event logging",
         "biocals": "Biocals",
@@ -214,7 +226,7 @@ class SmaccWindow(ToolWindow):
         "audio": "Play audio cues from a multi-slot cue board.",
         "noise": "Stream continuous background noise (colored noise or a file).",
         "recording": "Record a spoken dream report, monitor input level, open surveys.",
-        "intercom": "Talk to and listen to the participant over the intercom.",
+        "intercom": "Talk, listen, or text-chat with the participant over the intercom.",
         "devices": "Bind devices to roles and route each modality to a role.",
         "volume": "Set a master output volume safety cap.",
     }

--- a/src/smacc/panels/chat.py
+++ b/src/smacc/panels/chat.py
@@ -1,0 +1,310 @@
+"""Participant-facing text chat: the shared transcript and the bedroom window (#92).
+
+The intercom's typed channel, for hearing-impaired participants or whenever audio
+would intrude: the experimenter types in the Intercom panel, the participant reads
+and replies in this window, dragged once onto a bedroom-facing display. Same-machine
+by design — both views live in one SMACC process sharing one :class:`ChatTranscript`,
+so there is no network transport.
+
+Two realities shape the design:
+
+* **One keyboard focus.** Windows gives the machine a single input focus, so the two
+  keyboards (control room + bedroom) both type into whichever window is active. The
+  exchange is half-duplex, like push-to-talk: the experimenter *passes* the keyboard
+  explicitly (the Intercom panel's button, which activates this window), and this
+  window says loudly whether the keyboard is "here" — a participant typing blind
+  into an unfocused window would otherwise lose keystrokes silently. The bedroom has
+  a keyboard but no mouse, so the entry holds focus whenever the window is active.
+* **A dark bedroom.** The window keeps its own always-dark stylesheet, independent
+  of the app theme (the lightswitch tracks the *control room's* lights): large text,
+  a red-shifted night option, no flashing.
+
+Messages are log-only by default: the verbatim text lands on a DEBUG line in the
+session log (always in the file; out of the live preview and the BIDS export), and
+the registry pair (``ChatMessageSent``/``ChatMessageReceived``) stays untriggered
+unless a study flips it on — and even then the marker line stays bare, so the
+trigger channel and the exported ``trial_type`` aren't flooded with conversation.
+"""
+
+from __future__ import annotations
+
+import re
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from ..session import SmaccSession
+from .base import ModalityWindow
+
+# Sender keys for transcript entries (and their registry/log identities below).
+EXPERIMENTER = "experimenter"
+PARTICIPANT = "participant"
+
+_EVENT_KEYS = {EXPERIMENTER: "ChatMessageSent", PARTICIPANT: "ChatMessageReceived"}
+_LOG_LABELS = {
+    EXPERIMENTER: "Chat to participant",
+    PARTICIPANT: "Chat from participant",
+}
+
+# Font bounds for the participant view (points). Wide on purpose: "large readable
+# text" depends on monitor size and viewing distance, both rig-specific.
+FONT_MIN = 8
+FONT_MAX = 72
+FONT_DEFAULT = 18
+
+# Always-dark palettes for the bedroom-facing window. Neutral is dim gray-on-black;
+# red shifts the text warm for labs that prefer red light at night. Both stay
+# deliberately low-contrast — the window must never glow in a dark bedroom.
+_NEUTRAL = {
+    "fg": "#c8c8c8",
+    "dim": "#7a7a7a",
+    "bg": "#0e0e0e",
+    "field": "#1a1a1a",
+    "banner_bg": "#262626",
+}
+_RED = {
+    "fg": "#cc7766",
+    "dim": "#7e4a40",
+    "bg": "#0e0a09",
+    "field": "#1c1210",
+    "banner_bg": "#2a1814",
+}
+
+
+def sanitize_message(text: str) -> str:
+    """Collapse a typed message to one clean, log-safe line.
+
+    The session log and the BIDS parser are line-based, so embedded newlines/tabs
+    (e.g. pasted text) are collapsed to single spaces. A message *ending* in
+    ``" - portcode N"`` would make an untriggered log line read as a marker to the
+    BIDS parser, so that tail gets a period appended to neutralize it.
+    """
+    text = " ".join(text.split())
+    if re.search(r" - portcode \d+$", text):
+        text += "."
+    return text
+
+
+class ChatTranscript(QtCore.QObject):
+    """The shared conversation: an ordered list of ``(sender, text)`` messages.
+
+    One instance is shared by the experimenter view (in the Intercom panel) and the
+    participant window; both render from :attr:`message_posted`. Run data, not
+    config — it is never persisted in a study (the session log is the record).
+    """
+
+    message_posted = QtCore.pyqtSignal(str, str)  # (sender key, sanitized text)
+
+    def __init__(self, parent: QtCore.QObject | None = None) -> None:
+        super().__init__(parent)
+        self.messages: list[tuple[str, str]] = []
+
+    def post(self, sender: str, text: str) -> None:
+        """Append a message and notify both views."""
+        self.messages.append((sender, text))
+        self.message_posted.emit(sender, text)
+
+
+def post_chat_message(
+    session: SmaccSession, transcript: ChatTranscript, sender: str, text: str
+) -> str | None:
+    """Sanitize, record, and log one chat message; return it (None if empty).
+
+    The verbatim text always goes to a DEBUG log line — in the session file for the
+    record, out of the live preview and the BIDS export by default. The registry
+    event fires only when a study has flipped its trigger on, and then *bare* (no
+    message text), so the marker channel stays legible however chatty the exchange.
+    """
+    clean = sanitize_message(text)
+    if not clean:
+        return None
+    transcript.post(sender, clean)
+    event = session.events.get(_EVENT_KEYS[sender])
+    if event is not None and event.trigger:
+        session.emit_event(event.key)
+    label = event.label if event is not None else _LOG_LABELS[sender]
+    session.log_debug_msg(f"{label}: {clean}")
+    return clean
+
+
+def _stylesheet(pal: dict[str, str]) -> str:
+    """The participant window's fixed dark stylesheet for one palette."""
+    return (
+        f"QMainWindow, QWidget {{ background-color: {pal['bg']}; color: {pal['fg']}; }}"
+        f"QPlainTextEdit {{ background-color: {pal['bg']}; color: {pal['fg']};"
+        f" border: none; }}"
+        f"QLineEdit {{ background-color: {pal['field']}; color: {pal['fg']};"
+        f" border: 1px solid {pal['dim']}; border-radius: 4px; padding: 6px; }}"
+        f"QMenuBar {{ background-color: {pal['bg']}; color: {pal['dim']}; }}"
+        f"QMenuBar::item:selected {{ background-color: {pal['field']}; }}"
+        f"QMenu {{ background-color: {pal['field']}; color: {pal['fg']}; }}"
+    )
+
+
+class ParticipantChatWindow(ModalityWindow):
+    """The bedroom-facing chat window: always dark, big text, keyboard-only.
+
+    Opened (and given keyboard focus) from the Intercom panel's *Pass keyboard*
+    button; the operator drags it onto the bedroom display once, and its geometry
+    persists machine-locally like every tool window, so it reopens there. Closing
+    hides it (the conversation survives in the shared transcript).
+    """
+
+    TITLE = "Participant chat"
+
+    def __init__(
+        self,
+        session: SmaccSession,
+        transcript: ChatTranscript | None = None,
+        parent: QtWidgets.QWidget | None = None,
+    ):
+        super().__init__(session, parent)
+        self._transcript = (
+            transcript if transcript is not None else ChatTranscript(self)
+        )
+        self._font_size = FONT_DEFAULT
+        self.setCentralWidget(self._build())
+        self._build_display_menu()
+        self._transcript.message_posted.connect(self._append_message)
+        self._apply_font()
+        self._apply_theme()
+        self.resize(560, 420)
+
+    def _build(self) -> QtWidgets.QWidget:
+        # The banner is the participant's only feedback about where the machine's
+        # single keyboard focus is — it must be readable from bed, half asleep.
+        self.keyboardBanner = QtWidgets.QLabel(self)
+        self.keyboardBanner.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        self.keyboardBanner.setWordWrap(True)
+
+        view = QtWidgets.QPlainTextEdit(self)
+        view.setReadOnly(True)
+        # Not focusable: the entry below must keep focus — the participant has a
+        # keyboard but no mouse, so stranded focus can't be clicked back.
+        view.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
+        self.view = view
+
+        entry = QtWidgets.QLineEdit(self)
+        entry.setPlaceholderText("Type here, then press Enter to send")
+        entry.returnPressed.connect(self._send)
+        self.entry = entry
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(self.keyboardBanner)
+        layout.addWidget(view, 1)
+        layout.addWidget(entry)
+        central = QtWidgets.QWidget()
+        central.setLayout(layout)
+        return central
+
+    def _build_display_menu(self) -> None:
+        """Add the Display menu: red night text and the text-size actions."""
+        menu_bar = self.menuBar()
+        assert menu_bar is not None
+        menu = menu_bar.addMenu("&Display")
+        assert menu is not None
+        red = QtGui.QAction("&Red night text", self)
+        red.setCheckable(True)
+        red.toggled.connect(self._on_red_toggled)
+        self._red_action = red
+        bigger = QtGui.QAction("&Increase text size", self)
+        bigger.setShortcuts(
+            [QtGui.QKeySequence("Ctrl+="), QtGui.QKeySequence("Ctrl++")]
+        )
+        bigger.triggered.connect(lambda: self._step_font(+2))
+        smaller = QtGui.QAction("&Decrease text size", self)
+        smaller.setShortcut(QtGui.QKeySequence("Ctrl+-"))
+        smaller.triggered.connect(lambda: self._step_font(-2))
+        for action in (red, bigger, smaller):
+            menu.addAction(action)
+
+    # ----- appearance ---------------------------------------------------------
+
+    def _palette_colors(self) -> dict[str, str]:
+        return _RED if self._red_action.isChecked() else _NEUTRAL
+
+    def _apply_theme(self) -> None:
+        """Apply the always-dark stylesheet (independent of the app-wide theme)."""
+        self.setStyleSheet(_stylesheet(self._palette_colors()))
+        self._refresh_keyboard_banner()
+
+    def _on_red_toggled(self, enabled: bool) -> None:
+        self._apply_theme()
+        self.session.log_interaction(
+            f"Chat red night text {'enabled' if enabled else 'disabled'}"
+        )
+
+    def _apply_font(self) -> None:
+        font = QtGui.QFont()
+        font.setPointSize(self._font_size)
+        for widget in (self.view, self.entry, self.keyboardBanner):
+            widget.setFont(font)
+
+    def _step_font(self, delta: int) -> None:
+        self._font_size = max(FONT_MIN, min(FONT_MAX, self._font_size + delta))
+        self._apply_font()
+        self.session.log_interaction(f"Chat text size {self._font_size}pt", debug=True)
+
+    def _refresh_keyboard_banner(self) -> None:
+        """Show, unmissably, whether keystrokes will land in this window."""
+        pal = self._palette_colors()
+        if self.isActiveWindow():
+            self.keyboardBanner.setText("● The keyboard is yours — type below")
+            style = (
+                f"background-color: {pal['banner_bg']}; color: {pal['fg']};"
+                " padding: 8px; border-radius: 6px;"
+            )
+        else:
+            self.keyboardBanner.setText("○ Waiting — the keyboard is not here")
+            style = (
+                f"background-color: transparent; color: {pal['dim']};"
+                " padding: 8px; border-radius: 6px;"
+            )
+        self.keyboardBanner.setStyleSheet(style)
+
+    # ----- conversation -------------------------------------------------------
+
+    def _append_message(self, sender: str, text: str) -> None:
+        name = "You" if sender == PARTICIPANT else "Experimenter"
+        self.view.appendPlainText(f"{name}:  {text}")
+        scrollbar = self.view.verticalScrollBar()
+        if scrollbar is not None:
+            scrollbar.setValue(scrollbar.maximum())
+
+    def _send(self) -> None:
+        posted = post_chat_message(
+            self.session, self._transcript, PARTICIPANT, self.entry.text()
+        )
+        if posted is not None:
+            self.entry.clear()
+
+    # ----- window behaviour ---------------------------------------------------
+
+    def changeEvent(self, event) -> None:
+        if event is not None and event.type() == QtCore.QEvent.Type.ActivationChange:
+            self._refresh_keyboard_banner()
+        super().changeEvent(event)
+
+    def showEvent(self, event) -> None:
+        super().showEvent(event)
+        self.entry.setFocus()
+        self._refresh_keyboard_banner()
+
+    # ----- persisted state ----------------------------------------------------
+
+    def gather_state(self) -> dict:
+        return {
+            "chat_font_size": self._font_size,
+            "chat_red_text": self._red_action.isChecked(),
+        }
+
+    def apply_state(self, state: dict) -> None:
+        try:
+            self._font_size = max(FONT_MIN, min(FONT_MAX, int(state["chat_font_size"])))
+        except (KeyError, TypeError, ValueError):
+            pass  # keep the current size; hand-edited studies must not crash a load
+        self._apply_font()
+        red = bool(state.get("chat_red_text", False))
+        self._red_action.blockSignals(True)
+        self._red_action.setChecked(red)
+        self._red_action.blockSignals(False)
+        self._apply_theme()

--- a/src/smacc/panels/intercom.py
+++ b/src/smacc/panels/intercom.py
@@ -5,6 +5,12 @@ participant's output (``intercom_talk``), and **Listen** pipes the participant's
 (``bedroom_mic``) to the control-room output (``intercom_listen``). Each is a pair of
 single-direction streams bridged by a queue + resampler, so mismatched device rates
 are fine, and the two can run together (full duplex).
+
+Below the voice controls sits the **text chat** (#92): the experimenter's view of
+the typed channel for hearing-impaired participants, sharing a transcript with the
+participant-facing window (:mod:`smacc.panels.chat`). A section rather than a
+Voice/Text mode toggle, on purpose — voice and text run together (a participant may
+read text but reply by voice), and nothing live should hide behind an inactive tab.
 """
 
 from __future__ import annotations
@@ -12,11 +18,12 @@ from __future__ import annotations
 import queue
 
 import sounddevice as sd
-from PyQt6 import QtCore, QtWidgets
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import audio, devices
 from ..session import SmaccSession
 from .base import ModalityWindow, describe_target, make_section_title
+from .chat import EXPERIMENTER, ChatTranscript, post_chat_message
 
 
 class _Bridge:
@@ -102,12 +109,26 @@ class IntercomWindow(ModalityWindow):
 
     TITLE = "Intercom"
 
-    def __init__(self, session: SmaccSession, parent: QtWidgets.QWidget | None = None):
+    # Asks the main window to show + activate the participant chat window. Routed
+    # there because activating it is also how the machine's single keyboard focus
+    # is handed to the participant (see panels/chat.py).
+    open_participant_chat = QtCore.pyqtSignal()
+
+    def __init__(
+        self,
+        session: SmaccSession,
+        transcript: ChatTranscript | None = None,
+        parent: QtWidgets.QWidget | None = None,
+    ):
         super().__init__(session, parent)
         self._talk = _Bridge()  # experimenter mic -> participant output
         self._listen = _Bridge()  # participant mic -> control-room output
         self._talk_push = False  # True while talk is held via the spacebar
+        self._transcript = (
+            transcript if transcript is not None else ChatTranscript(self)
+        )
         self.setCentralWidget(self._build())
+        self._transcript.message_posted.connect(self._append_chat_message)
         # App-wide spacebar push-to-talk works regardless of the focused window.
         app = QtWidgets.QApplication.instance()
         if app is not None:
@@ -137,6 +158,41 @@ class IntercomWindow(ModalityWindow):
         listenButton.toggled.connect(self.toggle_listen)
         self.listenButton = listenButton
 
+        # --- Text chat (#92): the experimenter's view of the typed channel -----
+        chatView = QtWidgets.QPlainTextEdit(self)
+        chatView.setReadOnly(True)
+        chatView.setMinimumHeight(120)
+        chatView.setStatusTip(
+            "The typed conversation (always recorded in the session log)."
+        )
+        self.chatView = chatView
+
+        chatEntry = QtWidgets.QLineEdit(self)
+        chatEntry.setPlaceholderText("Type to the participant…")
+        chatEntry.setStatusTip(
+            "Enter sends; Ctrl+Enter sends and passes the keyboard to the participant."
+        )
+        chatEntry.returnPressed.connect(self.send_chat_message)
+        self.chatEntry = chatEntry
+        # Ctrl+Enter = send-and-pass, only while the entry itself has focus.
+        sendAndPass = QtGui.QShortcut(QtGui.QKeySequence("Ctrl+Return"), chatEntry)
+        sendAndPass.setContext(QtCore.Qt.ShortcutContext.WidgetShortcut)
+        sendAndPass.activated.connect(self.send_and_pass_keyboard)
+
+        sendButton = QtWidgets.QPushButton("Send", self)
+        sendButton.setStatusTip("Show the typed message to the participant.")
+        sendButton.clicked.connect(self.send_chat_message)
+        entryRow = QtWidgets.QHBoxLayout()
+        entryRow.addWidget(chatEntry, 1)
+        entryRow.addWidget(sendButton)
+
+        passButton = QtWidgets.QPushButton("Pass keyboard to participant", self)
+        passButton.setStatusTip(
+            "Show the participant chat window and give it keyboard focus — the "
+            "machine has one focus, so only one side can type at a time."
+        )
+        passButton.clicked.connect(self.open_participant_chat.emit)
+
         layout = QtWidgets.QFormLayout()
         layout.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         layout.addRow(make_section_title("Intercom"))
@@ -144,9 +200,33 @@ class IntercomWindow(ModalityWindow):
         layout.addRow(talkButton)
         layout.addRow("From participant:", self.listenDeviceLabel)
         layout.addRow(listenButton)
+        layout.addRow(make_section_title("Text chat"))
+        layout.addRow(chatView)
+        layout.addRow(entryRow)
+        layout.addRow(passButton)
         central = QtWidgets.QWidget()
         central.setLayout(layout)
         return central
+
+    def send_chat_message(self) -> None:
+        """Post the typed entry to the shared transcript (logged; marker if enabled)."""
+        posted = post_chat_message(
+            self.session, self._transcript, EXPERIMENTER, self.chatEntry.text()
+        )
+        if posted is not None:
+            self.chatEntry.clear()
+
+    def send_and_pass_keyboard(self) -> None:
+        """Send the entry (if any), then hand the keyboard to the participant."""
+        self.send_chat_message()
+        self.open_participant_chat.emit()
+
+    def _append_chat_message(self, sender: str, text: str) -> None:
+        name = "You" if sender == EXPERIMENTER else "Participant"
+        self.chatView.appendPlainText(f"{name}:  {text}")
+        scrollbar = self.chatView.verticalScrollBar()
+        if scrollbar is not None:
+            scrollbar.setValue(scrollbar.maximum())
 
     def refresh_device_indicator(self) -> None:
         """Show where each direction routes (devices set in the Devices window)."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -31,6 +31,20 @@ def test_recording_started_is_a_default_manual_marker():
     assert rec.increment is False
 
 
+def test_chat_events_are_log_only_by_default():
+    # #92: a typed exchange is rapid and conversational, so neither chat direction
+    # triggers (or previews) unless a study flips it on; the codes extend the
+    # control band right after the intercom pair.
+    defs = {e.key: e for e in events.default_events()}
+    sent, received = defs["ChatMessageSent"], defs["ChatMessageReceived"]
+    assert (sent.code, received.code) == (69, 70)
+    for event in (sent, received):
+        assert event.category == "control"  # no event-grid button
+        assert event.trigger is False
+        assert event.preview is False
+        assert event.increment is False
+
+
 def test_dream_start_increments_and_others_dont():
     defs = {e.key: e for e in events.default_events()}
     start = defs["DreamReportStarted"]

--- a/tests/test_panels_chat.py
+++ b/tests/test_panels_chat.py
@@ -1,0 +1,227 @@
+"""Tests for the text chat (#92): transcript, logging contract, and both views.
+
+The logging contract is the heart: messages are log-only by default (verbatim text
+on a DEBUG line, nothing in the BIDS export), and a study that flips a chat
+trigger on gets a *bare* marker line — the message text never rides into the
+trigger channel or ``trial_type``.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+
+from PyQt6 import QtCore
+
+from smacc import bids, winvolume
+from smacc.gui import SmaccWindow
+from smacc.panels.chat import (
+    EXPERIMENTER,
+    FONT_DEFAULT,
+    FONT_MAX,
+    PARTICIPANT,
+    ChatTranscript,
+    ParticipantChatWindow,
+    post_chat_message,
+    sanitize_message,
+)
+from smacc.panels.intercom import IntercomWindow
+
+
+def _capture_session_log(session) -> list[logging.LogRecord]:
+    """Attach a recording handler to a session's logger and return its record list.
+
+    The session logger sets ``propagate=False`` (and design mode only has a
+    NullHandler), so pytest's ``caplog`` never sees these records; capture on the
+    logger directly instead.
+    """
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    session.logger.addHandler(_Capture())
+    return records
+
+
+# ----- sanitization -----------------------------------------------------------
+
+
+def test_sanitize_collapses_to_one_log_safe_line():
+    assert sanitize_message("  hello\nthere\tworld  ") == "hello there world"
+    assert sanitize_message("   \n\t ") == ""
+
+
+def test_sanitize_neutralizes_a_marker_lookalike_tail():
+    # A message *ending* in " - portcode N" on an untriggered (DEBUG) line would
+    # read as a marker to the BIDS parser; the appended period defuses it.
+    sanitized = sanitize_message("ok done - portcode 7")
+    assert sanitized == "ok done - portcode 7."
+    line = f"2026-06-09 23:00:00.000, DEBUG, Chat from participant: {sanitized}"
+    assert bids.log_to_events(line) == []
+
+
+# ----- the logging contract ---------------------------------------------------
+
+
+def test_chat_message_is_a_debug_line_and_no_marker_by_default(design_session):
+    records = _capture_session_log(design_session)
+    transcript = ChatTranscript()
+    posted = post_chat_message(
+        design_session, transcript, EXPERIMENTER, "  hello\nthere  "
+    )
+    assert posted == "hello there"
+    assert transcript.messages == [(EXPERIMENTER, "hello there")]
+    messages = [r.getMessage() for r in records]
+    assert "Chat to participant: hello there" in messages
+    assert all(r.levelno == logging.DEBUG for r in records)
+    assert not any("portcode" in m for m in messages)  # log-only by default
+
+
+def test_empty_message_posts_nothing(design_session):
+    records = _capture_session_log(design_session)
+    transcript = ChatTranscript()
+    assert post_chat_message(design_session, transcript, PARTICIPANT, "  \n ") is None
+    assert transcript.messages == []
+    assert records == []
+
+
+def test_flipped_on_trigger_fires_a_bare_marker(live_session):
+    # A study that wants marker timestamps flips the trigger in the Event codes
+    # dialog; the marker line stays bare so trial_type/trigger channel stay legible.
+    live_session.events["ChatMessageSent"] = replace(
+        live_session.events["ChatMessageSent"], trigger=True
+    )
+    transcript = ChatTranscript()
+    post_chat_message(live_session, transcript, EXPERIMENTER, "Are you comfortable?")
+    post_chat_message(live_session, transcript, PARTICIPANT, "yes")  # still log-only
+    log_text = live_session.log_path.read_text(encoding="utf-8")
+    rows = bids.log_to_events(log_text)
+    assert [(r["trial_type"], r["value"]) for r in rows] == [
+        ("Chat to participant", 69)
+    ]
+    # The verbatim exchange is still in the log file, on DEBUG lines.
+    assert "Chat to participant: Are you comfortable?" in log_text
+    assert "Chat from participant: yes" in log_text
+
+
+# ----- participant window -----------------------------------------------------
+
+
+def test_participant_window_defaults_and_state_round_trip(qtbot, design_session):
+    window = ParticipantChatWindow(design_session)
+    qtbot.addWidget(window)
+    assert window.gather_state() == {
+        "chat_font_size": FONT_DEFAULT,
+        "chat_red_text": False,
+    }
+    window.apply_state({"chat_font_size": 24, "chat_red_text": True})
+    assert window.gather_state() == {"chat_font_size": 24, "chat_red_text": True}
+    assert window.view.font().pointSize() == 24
+
+
+def test_participant_window_tolerates_malformed_state(qtbot, design_session):
+    window = ParticipantChatWindow(design_session)
+    qtbot.addWidget(window)
+    window.apply_state({"chat_font_size": "huge"})  # hand-edited study: keep default
+    assert window.gather_state()["chat_font_size"] == FONT_DEFAULT
+    window.apply_state({"chat_font_size": 999})  # clamped into the sane band
+    assert window.gather_state()["chat_font_size"] == FONT_MAX
+
+
+def test_participant_window_is_always_dark_and_red_shiftable(qtbot, design_session):
+    window = ParticipantChatWindow(design_session)
+    qtbot.addWidget(window)
+    assert "#c8c8c8" in window.styleSheet()  # dim neutral gray on near-black
+    window._red_action.setChecked(True)
+    assert "#cc7766" in window.styleSheet()  # red-shifted night text
+
+
+def test_participant_window_banner_tracks_keyboard_focus(
+    qtbot, design_session, monkeypatch
+):
+    window = ParticipantChatWindow(design_session)
+    qtbot.addWidget(window)
+    monkeypatch.setattr(ParticipantChatWindow, "isActiveWindow", lambda self: True)
+    window._refresh_keyboard_banner()
+    assert "keyboard is yours" in window.keyboardBanner.text()
+    monkeypatch.setattr(ParticipantChatWindow, "isActiveWindow", lambda self: False)
+    window._refresh_keyboard_banner()
+    assert "not here" in window.keyboardBanner.text()
+
+
+def test_participant_enter_sends_and_clears(qtbot, design_session):
+    window = ParticipantChatWindow(design_session)
+    qtbot.addWidget(window)
+    window.entry.setText("I'm awake")
+    qtbot.keyClick(window.entry, QtCore.Qt.Key.Key_Return)
+    assert window._transcript.messages == [(PARTICIPANT, "I'm awake")]
+    assert window.entry.text() == ""
+    assert "You:  I'm awake" in window.view.toPlainText()
+
+
+# ----- experimenter view (Intercom panel) + the shared transcript --------------
+
+
+def test_intercom_send_clears_entry_and_renders(qtbot, design_session):
+    panel = IntercomWindow(design_session)
+    qtbot.addWidget(panel)
+    panel.chatEntry.setText("hello")
+    panel.send_chat_message()
+    assert panel.chatEntry.text() == ""
+    assert "You:  hello" in panel.chatView.toPlainText()
+
+
+def test_intercom_pass_keyboard_emits_even_with_empty_entry(qtbot, design_session):
+    panel = IntercomWindow(design_session)
+    qtbot.addWidget(panel)
+    fired: list[bool] = []
+    panel.open_participant_chat.connect(lambda: fired.append(True))
+    panel.send_and_pass_keyboard()  # nothing typed: pass the keyboard, post nothing
+    assert fired == [True]
+    assert panel.chatView.toPlainText() == ""
+
+
+def test_transcript_is_shared_between_both_views(qtbot, design_session):
+    transcript = ChatTranscript()
+    intercom = IntercomWindow(design_session, transcript)
+    participant = ParticipantChatWindow(design_session, transcript)
+    qtbot.addWidget(intercom)
+    qtbot.addWidget(participant)
+    intercom.chatEntry.setText("Are you awake?")
+    intercom.send_chat_message()
+    assert "Experimenter:  Are you awake?" in participant.view.toPlainText()
+    participant.entry.setText("yes")
+    qtbot.keyClick(participant.entry, QtCore.Qt.Key.Key_Return)
+    assert "Participant:  yes" in intercom.chatView.toPlainText()
+
+
+# ----- main-window wiring -----------------------------------------------------
+
+
+def test_window_wires_chat_panel_without_launcher_button(
+    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+):
+    monkeypatch.setattr(winvolume, "endpoint_volume", lambda: None)
+    monkeypatch.setattr(winvolume, "app_volume", lambda: None)
+    window = SmaccWindow(design_session)
+    qtbot.addWidget(window)
+    assert "chat" not in SmaccWindow.PANEL_LABELS  # no Tools-column button
+    chat = window.panels["chat"]
+    assert isinstance(chat, ParticipantChatWindow)
+    # The Intercom panel's signal opens (and would focus) the participant window.
+    intercom = window.panels["intercom"]
+    assert isinstance(intercom, IntercomWindow)
+    assert not chat.isVisible()
+    intercom.open_participant_chat.emit()
+    assert chat.isVisible()
+    # One transcript spans both views.
+    intercom.chatEntry.setText("hi")
+    intercom.send_chat_message()
+    assert "Experimenter:  hi" in chat.view.toPlainText()
+    # The chat window's interface state travels with the study settings.
+    state = window.gather_settings()
+    assert state["chat_font_size"] == FONT_DEFAULT
+    assert state["chat_red_text"] is False
+    assert "chat" in state["tool_always_on_top"]


### PR DESCRIPTION
Closes #92.

A typed channel beside the voice intercom, for hearing-impaired participants (or whenever audio would intrude). Same-machine first cut per the issue discussion: extended/shared monitor, a keyboard in each room.

- **Intercom panel** gains a *Text chat* section (transcript, entry, Send) below the voice controls — a section rather than a Voice/Text toggle, so voice and text run together.
- **Participant chat window** (new `panels/chat.py`): always-dark independent of the lights theme, dim gray-on-black with a red-shifted night option, 18 pt default text with `Ctrl+=`/`Ctrl+-` zoom, keyboard-only (entry holds focus). Registered as a buttonless panel, so its geometry persists to the bedroom monitor and its state travels with the study.
- **One keyboard focus**: exchange is half-duplex like push-to-talk — *Pass keyboard to participant* (or `Ctrl+Enter` send-and-pass) activates the participant window, and a loud banner there shows whether keystrokes will land.
- **Logging**: each message is a verbatim DEBUG line in the session log; nothing fires portcodes or reaches the BIDS export by default. New registry pair `ChatMessageSent` (69) / `ChatMessageReceived` (70) is log-only until a study flips a trigger on — and the marker stays bare (no message text) so the trigger channel stays legible.

Quick-reply presets are split out to #112.

Docs: usage (Intercom section), triggers catalog, settings/session-log references. Tests cover sanitization, the logging contract (incl. a BIDS round-trip), both views, and the main-window wiring.