### PR TITLE
feat: quick-reply presets for the intercom text chat

### DIFF
--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -43,6 +43,8 @@ settings:
   # --- Participant text chat ---------------------------------------------------
   chat_font_size: 18
   chat_red_text: false
+  chat_experimenter_presets: ["Are you awake?", "Going back to sleep now."]
+  chat_participant_presets: ["Got it", "I'm awake", "Yes", "No"]
   # --- Biocals ---------------------------------------------------------------
   biocals:
     voice_volume: 0.5
@@ -116,6 +118,8 @@ Any key may be omitted — each falls back to its default.
 | `survey_options` | mapping | Named survey presets: label → URL. |
 | `chat_font_size` | integer | Participant chat window text size, in points (8–72). |
 | `chat_red_text` | boolean | Red-shifted night text in the participant chat window. |
+| `chat_experimenter_presets` | list | Intercom quick-reply prompts the experimenter sends with one click (verbatim, like a typed message). Omitted → seeded defaults; an empty list is respected. |
+| `chat_participant_presets` | list | Participant quick replies, shown as numbered chips and sent with the number keys 1–9 (max 9). Omitted → seeded defaults; an empty list is respected. |
 | `volume_cap` | 0–1 | Master output safety cap multiplied into every stimulus (`1.0` = no cap). |
 | `output_latency` | `high` \| `low` | Output buffer for the cue + noise streams: `high` is robust (default), `low` trims marker-to-sound delay where the device allows it (often unchanged on shared-mode WASAPI). See [Latency](../latency.md). |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -172,6 +172,16 @@ there; clicking back into SMACC takes the focus back. The participant window sho
 a banner — *"● The keyboard is yours"* / *"○ Waiting"* — so a drowsy participant
 always knows whether typing will land.
 
+**Quick replies.** Canned messages save both sides from typing a full sentence at
+3 a.m.; they travel with the study. Click **Manage quick messages…** on the Intercom
+panel to edit two lists — *experimenter prompts* (one click sends a standardized
+prompt, e.g. the lab's dream-report question or *"Are you awake?"*) and *participant
+replies* mapped to the number keys **1–9** (e.g. *"Got it"*, *"I'm awake"*, *"Yes"*,
+*"No"*). The participant's replies appear as large numbered chips; pressing a number
+sends that reply, but only while their entry box is empty, so a typed reply that
+contains digits still works. A sent preset is logged and marked exactly like a typed
+message.
+
 **What's recorded.** Every message is written verbatim to the session log as a
 DEBUG line (tick *Debug* above the log preview to watch the exchange live). By
 default no portcodes fire and nothing reaches the BIDS events export — a typed

--- a/src/smacc/assets/default.smacc
+++ b/src/smacc/assets/default.smacc
@@ -29,6 +29,9 @@ settings:
   survey_options: {}
   chat_font_size: 18
   chat_red_text: false
+  # chat quick-reply presets omitted on purpose: the defaults seed the experimenter's
+  # standard prompts and the participant's number-key replies; saving from the app
+  # writes the configured lists back here (#112).
   # biocal rows omitted on purpose: the stack starts with every standard biocal
   # (plus the unchecked lucid-dreaming signals); saving from the app writes the
   # configured stack back here (#78).

--- a/src/smacc/config.py
+++ b/src/smacc/config.py
@@ -10,3 +10,24 @@ DEFAULT_VOLUME = 0.5
 # Named survey presets shown in the dream-recording panel's survey dropdown.
 # Maps a display label to its URL. Extend per study (persisted in settings YAML).
 SURVEY_OPTIONS: dict[str, str] = {}
+
+# Quick-reply presets for the intercom text chat (#112). Study-level config edited
+# from the Intercom panel and persisted in the .smacc; these seed a study that
+# hasn't customized them (an explicitly empty list is respected on load). Sent
+# verbatim through the normal chat path, so standardized wording stays consistent
+# across nights and experimenters.
+CHAT_EXPERIMENTER_PRESETS: list[str] = [
+    "Please describe everything that was going through your mind before the alarm.",
+    "Are you awake?",
+    "Going back to sleep now.",
+]
+# The participant has a keyboard but no mouse; these map to the number keys 1-9 so a
+# drowsy participant can reply with one keystroke.
+CHAT_PARTICIPANT_PRESETS: list[str] = [
+    "Got it",
+    "I'm awake",
+    "Yes",
+    "No",
+]
+# Participant replies map to the number keys 1-9, so at most nine are usable.
+MAX_PARTICIPANT_PRESETS = 9

--- a/src/smacc/dialogs.py
+++ b/src/smacc/dialogs.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from . import events, hue, triggers
+from . import config, events, hue, triggers
 from .utils import normalize_survey_url
 
 
@@ -225,6 +225,160 @@ class ManageSurveysDialog(QtWidgets.QDialog):
             name, url = item.data(QtCore.Qt.ItemDataRole.UserRole)
             options[name] = url
         return options
+
+
+class _PresetListEditor(QtWidgets.QWidget):
+    """A titled, reorderable list of preset messages with add/edit/remove controls.
+
+    Used twice by :class:`ManageChatPresetsDialog`, once per chat direction. Order
+    matters for the participant replies (it maps to the number keys), so rows move
+    up and down; ``max_items`` caps the list (``None`` is unlimited).
+    """
+
+    def __init__(
+        self,
+        title: str,
+        items: list[str],
+        *,
+        max_items: int | None = None,
+        parent=None,
+    ) -> None:
+        super().__init__(parent)
+        self._max_items = max_items
+
+        self.listWidget = QtWidgets.QListWidget(self)
+        self.listWidget.addItems(items)
+        self.listWidget.itemDoubleClicked.connect(self._edit_selected)
+
+        addButton = QtWidgets.QPushButton("Add…", self)
+        editButton = QtWidgets.QPushButton("Edit…", self)
+        removeButton = QtWidgets.QPushButton("Remove", self)
+        upButton = QtWidgets.QPushButton("Move up", self)
+        downButton = QtWidgets.QPushButton("Move down", self)
+        addButton.clicked.connect(self._add)
+        editButton.clicked.connect(self._edit_selected)
+        removeButton.clicked.connect(self._remove_selected)
+        upButton.clicked.connect(lambda: self._move(-1))
+        downButton.clicked.connect(lambda: self._move(1))
+
+        buttonCol = QtWidgets.QVBoxLayout()
+        for button in (addButton, editButton, removeButton, upButton, downButton):
+            buttonCol.addWidget(button)
+        buttonCol.addStretch(1)
+
+        row = QtWidgets.QHBoxLayout()
+        row.addWidget(self.listWidget, 1)
+        row.addLayout(buttonCol)
+
+        label = QtWidgets.QLabel(title, self)
+        label.setWordWrap(True)
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(label)
+        layout.addLayout(row)
+
+    def items(self) -> list[str]:
+        """Return the current rows, in display order."""
+        rows: list[str] = []
+        for i in range(self.listWidget.count()):
+            item = self.listWidget.item(i)
+            if item is not None:
+                rows.append(item.text())
+        return rows
+
+    def _prompt(self, text: str = "") -> str | None:
+        """Ask for one message; return the trimmed text (None if cancelled/blank)."""
+        value, ok = QtWidgets.QInputDialog.getText(
+            self, "Quick message", "Message:", text=text
+        )
+        if not ok:
+            return None
+        return value.strip() or None
+
+    def _add(self) -> None:
+        if self._max_items is not None and self.listWidget.count() >= self._max_items:
+            QtWidgets.QMessageBox.information(
+                self,
+                "Quick messages",
+                f"Up to {self._max_items} replies — one per number key "
+                f"(1–{self._max_items}).",
+            )
+            return
+        text = self._prompt()
+        if text is not None:
+            self.listWidget.addItem(text)
+
+    def _edit_selected(self) -> None:
+        item = self.listWidget.currentItem()
+        if item is None:
+            return
+        text = self._prompt(item.text())
+        if text is not None:
+            item.setText(text)
+
+    def _remove_selected(self) -> None:
+        row = self.listWidget.currentRow()
+        if row >= 0:
+            self.listWidget.takeItem(row)
+
+    def _move(self, delta: int) -> None:
+        """Shift the selected row by ``delta`` (-1 up, +1 down), keeping it selected."""
+        row = self.listWidget.currentRow()
+        target = row + delta
+        if row < 0 or not (0 <= target < self.listWidget.count()):
+            return
+        item = self.listWidget.takeItem(row)
+        self.listWidget.insertItem(target, item)
+        self.listWidget.setCurrentRow(target)
+
+
+class ManageChatPresetsDialog(QtWidgets.QDialog):
+    """Add, edit, reorder, and remove the intercom's quick-reply presets (#112).
+
+    Opened from the Intercom panel. Two ordered lists — the experimenter's one-click
+    prompts and the participant's number-key replies (capped at the digit keys 1–9).
+    Edits copies; the caller reads :meth:`get_presets` only when accepted.
+    """
+
+    def __init__(
+        self, experimenter: list[str], participant: list[str], parent=None
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Quick-reply presets")
+        self.setWindowFlags(
+            self.windowFlags() ^ QtCore.Qt.WindowType.WindowContextHelpButtonHint
+        )
+        self.resize(520, 460)
+
+        self._experimenter = _PresetListEditor(
+            "Experimenter prompts — one click sends to the participant:",
+            experimenter,
+            parent=self,
+        )
+        self._participant = _PresetListEditor(
+            "Participant replies — sent with the number keys "
+            f"1–{config.MAX_PARTICIPANT_PRESETS}:",
+            participant,
+            max_items=config.MAX_PARTICIPANT_PRESETS,
+            parent=self,
+        )
+
+        buttonBox = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        buttonBox.accepted.connect(self.accept)
+        buttonBox.rejected.connect(self.reject)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(self._experimenter)
+        layout.addWidget(self._participant)
+        layout.addWidget(buttonBox)
+
+    def get_presets(self) -> tuple[list[str], list[str]]:
+        """Return the edited ``(experimenter, participant)`` lists, in order."""
+        return self._experimenter.items(), self._participant.items()
 
 
 class AddEventDialog(QtWidgets.QDialog):

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -32,7 +32,7 @@ from .dialogs import (
 from .panels.audio import AudioCueWindow
 from .panels.base import ModalityWindow
 from .panels.biocals import BiocalsWindow
-from .panels.chat import ChatTranscript, ParticipantChatWindow
+from .panels.chat import ChatPresets, ChatTranscript, ParticipantChatWindow
 from .panels.devices import DevicesWindow
 from .panels.events import EventsWindow
 from .panels.intercom import IntercomWindow
@@ -86,8 +86,11 @@ class SmaccWindow(ToolWindow):
         # session.devices, refreshed whenever the Devices window emits ``changed``.
         self.devices_window = DevicesWindow(self.session)
         # The text chat's conversation, shared by its two views: the experimenter's
-        # section in the Intercom panel and the participant-facing window (#92).
+        # section in the Intercom panel and the participant-facing window (#92). The
+        # quick-reply presets (#112) are shared the same way; the Intercom panel
+        # persists them with the study.
         chat_transcript = ChatTranscript(self)
+        chat_presets = ChatPresets(self)
         self.panels: dict[str, ModalityWindow] = {
             "events": EventsWindow(self.session),
             "biocals": BiocalsWindow(self.session),
@@ -95,10 +98,10 @@ class SmaccWindow(ToolWindow):
             "audio": AudioCueWindow(self.session),
             "noise": NoiseWindow(self.session),
             "recording": RecordingWindow(self.session),
-            "intercom": IntercomWindow(self.session, chat_transcript),
+            "intercom": IntercomWindow(self.session, chat_transcript, chat_presets),
             # No launcher button (absent from PANEL_LABELS): opened via the Intercom
             # panel's "Pass keyboard" button, which also hands it keyboard focus.
-            "chat": ParticipantChatWindow(self.session, chat_transcript),
+            "chat": ParticipantChatWindow(self.session, chat_transcript, chat_presets),
             "devices": self.devices_window,
             "volume": VolumeWindow(self.session),
         }

--- a/src/smacc/panels/chat.py
+++ b/src/smacc/panels/chat.py
@@ -29,9 +29,11 @@ trigger channel and the exported ``trial_type`` aren't flooded with conversation
 from __future__ import annotations
 
 import re
+from functools import partial
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
+from .. import config
 from ..session import SmaccSession
 from .base import ModalityWindow
 
@@ -84,6 +86,19 @@ def sanitize_message(text: str) -> str:
     return text
 
 
+def _clean_presets(items: object) -> list[str]:
+    """Coerce a saved/edited preset list to clean, non-empty, log-safe lines.
+
+    Hand-edited studies must not crash a load, so a non-list (or non-string entry)
+    is dropped rather than raised on; presets are sanitized like any message so a
+    one-click send and a typed send produce identical log lines.
+    """
+    if not isinstance(items, list):
+        return []
+    cleaned = (sanitize_message(item) for item in items if isinstance(item, str))
+    return [text for text in cleaned if text]
+
+
 class ChatTranscript(QtCore.QObject):
     """The shared conversation: an ordered list of ``(sender, text)`` messages.
 
@@ -102,6 +117,62 @@ class ChatTranscript(QtCore.QObject):
         """Append a message and notify both views."""
         self.messages.append((sender, text))
         self.message_posted.emit(sender, text)
+
+
+class ChatPresets(QtCore.QObject):
+    """Quick-reply presets (#112) shared by the two chat views.
+
+    Two ordered lists: the experimenter's one-click prompts (Intercom panel) and the
+    participant's number-key replies (their window). Study-level *config* — edited
+    from the Intercom panel and persisted in the ``.smacc`` (unlike
+    :class:`ChatTranscript`, which is run data) — so one instance is shared, like the
+    transcript, and both views rebuild from :attr:`changed`. The defaults seed a
+    study that hasn't customized them; an explicitly empty list is respected on load.
+    """
+
+    changed = QtCore.pyqtSignal()
+
+    def __init__(self, parent: QtCore.QObject | None = None) -> None:
+        super().__init__(parent)
+        self.experimenter: list[str] = _clean_presets(config.CHAT_EXPERIMENTER_PRESETS)
+        self.participant: list[str] = self._cap(
+            _clean_presets(config.CHAT_PARTICIPANT_PRESETS)
+        )
+
+    @staticmethod
+    def _cap(items: list[str]) -> list[str]:
+        """Participant replies past the ninth have no number key, so drop them."""
+        return items[: config.MAX_PARTICIPANT_PRESETS]
+
+    def set(self, experimenter: list[str], participant: list[str]) -> None:
+        """Replace both lists (e.g. from the manage dialog) and notify both views."""
+        self.experimenter = _clean_presets(experimenter)
+        self.participant = self._cap(_clean_presets(participant))
+        self.changed.emit()
+
+    def gather_state(self) -> dict:
+        return {
+            "chat_experimenter_presets": list(self.experimenter),
+            "chat_participant_presets": list(self.participant),
+        }
+
+    def apply_state(self, state: dict) -> None:
+        """Load saved presets; an absent key keeps the seeded defaults.
+
+        Mirrors the biocals stack: a missing key falls back to the shipped defaults,
+        while a present list (even empty) is honoured as a deliberate choice.
+        """
+        present = False
+        if "chat_experimenter_presets" in state:
+            self.experimenter = _clean_presets(state["chat_experimenter_presets"])
+            present = True
+        if "chat_participant_presets" in state:
+            self.participant = self._cap(
+                _clean_presets(state["chat_participant_presets"])
+            )
+            present = True
+        if present:
+            self.changed.emit()
 
 
 def post_chat_message(
@@ -134,6 +205,10 @@ def _stylesheet(pal: dict[str, str]) -> str:
         f" border: none; }}"
         f"QLineEdit {{ background-color: {pal['field']}; color: {pal['fg']};"
         f" border: 1px solid {pal['dim']}; border-radius: 4px; padding: 6px; }}"
+        # Reply chips: dim, padded, left-aligned — readable from bed, never glaring.
+        f"QPushButton {{ background-color: {pal['field']}; color: {pal['fg']};"
+        f" border: 1px solid {pal['dim']}; border-radius: 6px; padding: 10px;"
+        f" text-align: left; }}"
         f"QMenuBar {{ background-color: {pal['bg']}; color: {pal['dim']}; }}"
         f"QMenuBar::item:selected {{ background-color: {pal['field']}; }}"
         f"QMenu {{ background-color: {pal['field']}; color: {pal['fg']}; }}"
@@ -155,16 +230,20 @@ class ParticipantChatWindow(ModalityWindow):
         self,
         session: SmaccSession,
         transcript: ChatTranscript | None = None,
+        presets: ChatPresets | None = None,
         parent: QtWidgets.QWidget | None = None,
     ):
         super().__init__(session, parent)
         self._transcript = (
             transcript if transcript is not None else ChatTranscript(self)
         )
+        self._presets = presets if presets is not None else ChatPresets(self)
         self._font_size = FONT_DEFAULT
         self.setCentralWidget(self._build())
         self._build_display_menu()
         self._transcript.message_posted.connect(self._append_message)
+        self._presets.changed.connect(self._on_presets_changed)
+        self._rebuild_presets()
         self._apply_font()
         self._apply_theme()
         self.resize(560, 420)
@@ -183,14 +262,26 @@ class ParticipantChatWindow(ModalityWindow):
         view.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
         self.view = view
 
+        # Quick-reply chips (#112): numbered replies sent with the number keys 1-9.
+        # Non-focusable for the same reason as the view — the entry keeps focus.
+        self._preset_buttons: list[QtWidgets.QPushButton] = []
+        self.presetContainer = QtWidgets.QWidget(self)
+        self.presetLayout = QtWidgets.QVBoxLayout(self.presetContainer)
+        self.presetLayout.setContentsMargins(0, 0, 0, 0)
+
         entry = QtWidgets.QLineEdit(self)
         entry.setPlaceholderText("Type here, then press Enter to send")
         entry.returnPressed.connect(self._send)
+        # A bare number key (1-9) sends the matching quick reply, but only while the
+        # entry is empty, so a typed reply containing digits still works (see
+        # eventFilter).
+        entry.installEventFilter(self)
         self.entry = entry
 
         layout = QtWidgets.QVBoxLayout()
         layout.addWidget(self.keyboardBanner)
         layout.addWidget(view, 1)
+        layout.addWidget(self.presetContainer)
         layout.addWidget(entry)
         central = QtWidgets.QWidget()
         central.setLayout(layout)
@@ -236,7 +327,12 @@ class ParticipantChatWindow(ModalityWindow):
     def _apply_font(self) -> None:
         font = QtGui.QFont()
         font.setPointSize(self._font_size)
-        for widget in (self.view, self.entry, self.keyboardBanner):
+        for widget in (
+            self.view,
+            self.entry,
+            self.keyboardBanner,
+            *self._preset_buttons,
+        ):
             widget.setFont(font)
 
     def _step_font(self, delta: int) -> None:
@@ -271,11 +367,35 @@ class ParticipantChatWindow(ModalityWindow):
             scrollbar.setValue(scrollbar.maximum())
 
     def _send(self) -> None:
-        posted = post_chat_message(
-            self.session, self._transcript, PARTICIPANT, self.entry.text()
-        )
+        self._send_text(self.entry.text())
+
+    def _send_text(self, text: str) -> None:
+        """Post ``text`` as the participant — a typed entry or a quick reply."""
+        posted = post_chat_message(self.session, self._transcript, PARTICIPANT, text)
         if posted is not None:
             self.entry.clear()
+
+    # ----- quick replies ------------------------------------------------------
+
+    def _rebuild_presets(self) -> None:
+        """Rebuild the numbered reply chips from the shared presets."""
+        for button in self._preset_buttons:
+            button.deleteLater()
+        self._preset_buttons = []
+        for number, text in enumerate(self._presets.participant, start=1):
+            button = QtWidgets.QPushButton(f"{number}.  {text}", self.presetContainer)
+            # No mouse in the bedroom, so the number key is the real trigger; the chip
+            # stays clickable (harmless, ready for a future touch display) but never
+            # takes focus away from the entry.
+            button.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
+            button.clicked.connect(partial(self._send_text, text))
+            self.presetLayout.addWidget(button)
+            self._preset_buttons.append(button)
+        self.presetContainer.setVisible(bool(self._preset_buttons))
+
+    def _on_presets_changed(self) -> None:
+        self._rebuild_presets()
+        self._apply_font()
 
     # ----- window behaviour ---------------------------------------------------
 
@@ -288,6 +408,26 @@ class ParticipantChatWindow(ModalityWindow):
         super().showEvent(event)
         self.entry.setFocus()
         self._refresh_keyboard_banner()
+
+    def eventFilter(self, obj, event) -> bool:
+        """Send a quick reply when a number key is pressed on an empty entry.
+
+        The participant types into ``self.entry``; a bare ``1``-``9`` there fires the
+        matching chip, but only while nothing is typed, so a free-text reply that
+        contains digits is left alone. The keystroke is consumed so the digit isn't
+        also inserted.
+        """
+        if (
+            obj is self.entry
+            and event is not None
+            and event.type() == QtCore.QEvent.Type.KeyPress
+            and not self.entry.text()
+        ):
+            index = event.key() - QtCore.Qt.Key.Key_1
+            if 0 <= index < len(self._presets.participant):
+                self._send_text(self._presets.participant[index])
+                return True
+        return super().eventFilter(obj, event)
 
     # ----- persisted state ----------------------------------------------------
 

--- a/src/smacc/panels/intercom.py
+++ b/src/smacc/panels/intercom.py
@@ -16,14 +16,25 @@ read text but reply by voice), and nothing live should hide behind an inactive t
 from __future__ import annotations
 
 import queue
+from functools import partial
 
 import sounddevice as sd
 from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import audio, devices
+from ..dialogs import ManageChatPresetsDialog
 from ..session import SmaccSession
 from .base import ModalityWindow, describe_target, make_section_title
-from .chat import EXPERIMENTER, ChatTranscript, post_chat_message
+from .chat import EXPERIMENTER, ChatPresets, ChatTranscript, post_chat_message
+
+# Cap an experimenter prompt's button label so a long standardized question doesn't
+# stretch the panel; the full text rides along in the tooltip/status tip.
+_PRESET_LABEL_LIMIT = 48
+
+
+def _elide(text: str, limit: int = _PRESET_LABEL_LIMIT) -> str:
+    """Shorten ``text`` to ``limit`` chars with an ellipsis (full text in a tooltip)."""
+    return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
 
 
 class _Bridge:
@@ -118,6 +129,7 @@ class IntercomWindow(ModalityWindow):
         self,
         session: SmaccSession,
         transcript: ChatTranscript | None = None,
+        presets: ChatPresets | None = None,
         parent: QtWidgets.QWidget | None = None,
     ):
         super().__init__(session, parent)
@@ -127,8 +139,11 @@ class IntercomWindow(ModalityWindow):
         self._transcript = (
             transcript if transcript is not None else ChatTranscript(self)
         )
+        self._presets = presets if presets is not None else ChatPresets(self)
         self.setCentralWidget(self._build())
         self._transcript.message_posted.connect(self._append_chat_message)
+        self._presets.changed.connect(self._rebuild_preset_buttons)
+        self._rebuild_preset_buttons()
         # App-wide spacebar push-to-talk works regardless of the focused window.
         app = QtWidgets.QApplication.instance()
         if app is not None:
@@ -193,6 +208,20 @@ class IntercomWindow(ModalityWindow):
         )
         passButton.clicked.connect(self.open_participant_chat.emit)
 
+        # Quick messages (#112): one-click standardized prompts, sent verbatim through
+        # the same path as a typed message. Rebuilt from the shared presets.
+        self._presetContainer = QtWidgets.QWidget(self)
+        self._presetLayout = QtWidgets.QVBoxLayout(self._presetContainer)
+        self._presetLayout.setContentsMargins(0, 0, 0, 0)
+        self._preset_buttons: list[QtWidgets.QPushButton] = []
+
+        manageButton = QtWidgets.QPushButton("Manage quick messages…", self)
+        manageButton.setStatusTip(
+            "Add, edit, or reorder the experimenter prompts and the participant's "
+            "number-key replies (saved with the study)."
+        )
+        manageButton.clicked.connect(self.manage_presets)
+
         layout = QtWidgets.QFormLayout()
         layout.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         layout.addRow(make_section_title("Intercom"))
@@ -202,8 +231,10 @@ class IntercomWindow(ModalityWindow):
         layout.addRow(listenButton)
         layout.addRow(make_section_title("Text chat"))
         layout.addRow(chatView)
+        layout.addRow(self._presetContainer)
         layout.addRow(entryRow)
         layout.addRow(passButton)
+        layout.addRow(manageButton)
         central = QtWidgets.QWidget()
         central.setLayout(layout)
         return central
@@ -227,6 +258,36 @@ class IntercomWindow(ModalityWindow):
         scrollbar = self.chatView.verticalScrollBar()
         if scrollbar is not None:
             scrollbar.setValue(scrollbar.maximum())
+
+    # ----- quick messages (#112) ----------------------------------------------
+
+    def _rebuild_preset_buttons(self) -> None:
+        """Rebuild the one-click prompt buttons from the shared presets."""
+        for button in self._preset_buttons:
+            button.deleteLater()
+        self._preset_buttons = []
+        for text in self._presets.experimenter:
+            button = QtWidgets.QPushButton(_elide(text), self._presetContainer)
+            button.setToolTip(text)
+            button.setStatusTip(f"Send to the participant: {text}")
+            button.clicked.connect(partial(self._send_preset, text))
+            self._presetLayout.addWidget(button)
+            self._preset_buttons.append(button)
+        self._presetContainer.setVisible(bool(self._preset_buttons))
+
+    def _send_preset(self, text: str) -> None:
+        """Send a standardized prompt through the same path as a typed message."""
+        post_chat_message(self.session, self._transcript, EXPERIMENTER, text)
+
+    def manage_presets(self) -> None:
+        """Edit both preset lists; on accept, update the shared presets in place."""
+        dialog = ManageChatPresetsDialog(
+            self._presets.experimenter, self._presets.participant, parent=self
+        )
+        if dialog.exec():
+            experimenter, participant = dialog.get_presets()
+            self._presets.set(experimenter, participant)  # -> both views rebuild
+            self.session.log_interaction("Edited chat quick-reply presets")
 
     def refresh_device_indicator(self) -> None:
         """Show where each direction routes (devices set in the Devices window)."""
@@ -318,6 +379,16 @@ class IntercomWindow(ModalityWindow):
                 self.talkButton.setChecked(False)  # -> toggle_talk(False)
             return True  # consume so the focused widget doesn't also see space
         return super().eventFilter(obj, event)
+
+    # ----- persisted state ----------------------------------------------------
+
+    def gather_state(self) -> dict:
+        """Persist the quick-reply presets (the shared object's view)."""
+        return self._presets.gather_state()
+
+    def apply_state(self, state: dict) -> None:
+        """Load the quick-reply presets; both chat views rebuild via the signal."""
+        self._presets.apply_state(state)
 
     def cleanup(self) -> None:
         app = QtWidgets.QApplication.instance()

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import pytest
 from PyQt6 import QtWidgets
 
-from smacc import dialogs, events, triggers
+from smacc import config, dialogs, events, triggers
 
 # ----- ask_initial_or_final --------------------------------------------------
 
@@ -78,6 +78,60 @@ def test_manage_surveys_remove_selected(qtbot):
     dialog.listWidget.setCurrentRow(0)
     dialog._remove_selected()
     assert dialog.get_options() == {"Pre survey": "https://b.example"}
+
+
+# ----- ManageChatPresetsDialog (#112) ----------------------------------------
+
+
+def test_manage_chat_presets_round_trips_both_lists(qtbot):
+    dialog = dialogs.ManageChatPresetsDialog(
+        ["Are you awake?", "Going back to sleep now."], ["Got it", "Yes"]
+    )
+    qtbot.addWidget(dialog)
+    experimenter, participant = dialog.get_presets()
+    assert experimenter == ["Are you awake?", "Going back to sleep now."]
+    assert participant == ["Got it", "Yes"]
+
+
+def test_manage_chat_presets_reorders_participant_replies(qtbot):
+    # Order is meaningful: it maps to the number keys, so rows can be moved.
+    dialog = dialogs.ManageChatPresetsDialog([], ["Yes", "No", "Maybe"])
+    qtbot.addWidget(dialog)
+    editor = dialog._participant
+    editor.listWidget.setCurrentRow(2)
+    editor._move(-1)  # "Maybe" moves up past "No"
+    assert dialog.get_presets()[1] == ["Yes", "Maybe", "No"]
+    editor.listWidget.setCurrentRow(0)
+    editor._move(-1)  # already at the top: a no-op
+    assert dialog.get_presets()[1] == ["Yes", "Maybe", "No"]
+
+
+def test_manage_chat_presets_remove_selected(qtbot):
+    dialog = dialogs.ManageChatPresetsDialog(["A", "B"], ["Yes"])
+    qtbot.addWidget(dialog)
+    dialog._experimenter.listWidget.setCurrentRow(0)
+    dialog._experimenter._remove_selected()
+    assert dialog.get_presets()[0] == ["B"]
+
+
+def test_manage_chat_presets_caps_participant_replies(qtbot, monkeypatch):
+    full = [f"r{i}" for i in range(config.MAX_PARTICIPANT_PRESETS)]
+    dialog = dialogs.ManageChatPresetsDialog([], full)
+    qtbot.addWidget(dialog)
+    # At the cap, Add warns (a blocking QMessageBox) and refuses to grow the list.
+    monkeypatch.setattr(QtWidgets.QMessageBox, "information", lambda *a, **k: None)
+    dialog._participant._add()
+    assert len(dialog.get_presets()[1]) == config.MAX_PARTICIPANT_PRESETS
+
+
+def test_manage_chat_presets_add_trims_via_input_dialog(qtbot, monkeypatch):
+    dialog = dialogs.ManageChatPresetsDialog(["A"], [])
+    qtbot.addWidget(dialog)
+    monkeypatch.setattr(
+        QtWidgets.QInputDialog, "getText", lambda *a, **k: ("  Are you awake?  ", True)
+    )
+    dialog._experimenter._add()
+    assert dialog.get_presets()[0] == ["A", "Are you awake?"]
 
 
 # ----- AddEventDialog --------------------------------------------------------

--- a/tests/test_panels_chat.py
+++ b/tests/test_panels_chat.py
@@ -13,15 +13,17 @@ from dataclasses import replace
 
 from PyQt6 import QtCore
 
-from smacc import bids, winvolume
+from smacc import bids, config, winvolume
 from smacc.gui import SmaccWindow
 from smacc.panels.chat import (
     EXPERIMENTER,
     FONT_DEFAULT,
     FONT_MAX,
     PARTICIPANT,
+    ChatPresets,
     ChatTranscript,
     ParticipantChatWindow,
+    _clean_presets,
     post_chat_message,
     sanitize_message,
 )
@@ -197,6 +199,82 @@ def test_transcript_is_shared_between_both_views(qtbot, design_session):
     assert "Participant:  yes" in intercom.chatView.toPlainText()
 
 
+# ----- quick-reply presets (#112) ---------------------------------------------
+
+
+def test_chat_presets_seed_defaults_and_round_trip():
+    presets = ChatPresets()
+    # Seeded from the config defaults (cleaned), and gathered back verbatim.
+    assert presets.experimenter == _clean_presets(config.CHAT_EXPERIMENTER_PRESETS)
+    assert presets.participant == _clean_presets(config.CHAT_PARTICIPANT_PRESETS)
+    assert presets.gather_state() == {
+        "chat_experimenter_presets": presets.experimenter,
+        "chat_participant_presets": presets.participant,
+    }
+    # A present list replaces; an absent key keeps the current (default) list.
+    presets.apply_state({"chat_experimenter_presets": ["Are you awake?"]})
+    assert presets.experimenter == ["Are you awake?"]
+    assert presets.participant == _clean_presets(config.CHAT_PARTICIPANT_PRESETS)
+    # An explicitly empty list is respected as a deliberately cleared one.
+    presets.apply_state({"chat_participant_presets": []})
+    assert presets.participant == []
+
+
+def test_chat_presets_cap_participant_and_tolerate_garbage():
+    presets = ChatPresets()
+    presets.apply_state(
+        {
+            "chat_participant_presets": [f"reply {i}" for i in range(20)],
+            "chat_experimenter_presets": "not a list",  # hand-edited junk
+        }
+    )
+    assert len(presets.participant) == config.MAX_PARTICIPANT_PRESETS
+    assert presets.experimenter == []  # coerced to empty rather than crashing a load
+
+
+def test_intercom_preset_button_sends_through_chat_path(design_session):
+    records = _capture_session_log(design_session)
+    presets = ChatPresets()
+    presets.set(["Are you awake?"], [])
+    panel = IntercomWindow(design_session, presets=presets)
+    assert len(panel._preset_buttons) == 1
+    panel._preset_buttons[0].click()
+    assert "You:  Are you awake?" in panel.chatView.toPlainText()
+    messages = [r.getMessage() for r in records]
+    assert "Chat to participant: Are you awake?" in messages
+    assert all(r.levelno == logging.DEBUG for r in records)  # log-only by default
+
+
+def test_participant_number_key_sends_only_when_entry_empty(qtbot, design_session):
+    presets = ChatPresets()
+    presets.set([], ["I'm awake", "Got it"])
+    window = ParticipantChatWindow(design_session, presets=presets)
+    qtbot.addWidget(window)
+    assert len(window._preset_buttons) == 2
+    # Empty entry: a bare number key sends the matching reply (key not typed).
+    qtbot.keyClick(window.entry, QtCore.Qt.Key.Key_2)
+    assert window._transcript.messages == [(PARTICIPANT, "Got it")]
+    assert window.entry.text() == ""
+    # With text already typed, digits type normally — no preset fires.
+    window.entry.setText("3")
+    qtbot.keyClick(window.entry, QtCore.Qt.Key.Key_1)
+    assert window._transcript.messages == [(PARTICIPANT, "Got it")]  # unchanged
+    assert window.entry.text() == "31"
+
+
+def test_presets_shared_object_updates_both_views(qtbot, design_session):
+    presets = ChatPresets()
+    intercom = IntercomWindow(design_session, presets=presets)
+    participant = ParticipantChatWindow(design_session, presets=presets)
+    qtbot.addWidget(intercom)
+    qtbot.addWidget(participant)
+    presets.set(["Are you awake?"], ["Yes", "No"])
+    # One shared object; both views rebuilt from its `changed` signal.
+    assert [b.toolTip() for b in intercom._preset_buttons] == ["Are you awake?"]
+    assert len(participant._preset_buttons) == 2
+    assert participant._preset_buttons[0].text() == "1.  Yes"
+
+
 # ----- main-window wiring -----------------------------------------------------
 
 
@@ -225,3 +303,6 @@ def test_window_wires_chat_panel_without_launcher_button(
     assert state["chat_font_size"] == FONT_DEFAULT
     assert state["chat_red_text"] is False
     assert "chat" in state["tool_always_on_top"]
+    # The quick-reply presets travel too (persisted by the Intercom panel).
+    assert state["chat_experimenter_presets"] == intercom._presets.experimenter
+    assert state["chat_participant_presets"] == intercom._presets.participant

--- a/tests/test_panels_state.py
+++ b/tests/test_panels_state.py
@@ -3,9 +3,9 @@
 Panels construct headlessly from a design session (no run folder, no hardware);
 streams open only on play/record, not at construction. The Devices panel
 enumerates hardware at build time, so it takes the ``mock_devices`` fixture. The
-five stateful panels round-trip their persisted keys; the three that keep no
-per-panel state (their config lives at the window/session level) just confirm an
-empty contribution.
+stateful panels round-trip their persisted keys; the panels that keep no per-panel
+state (their config lives at the window/session level) just confirm an empty
+contribution.
 """
 
 from __future__ import annotations
@@ -104,6 +104,21 @@ def test_recording_panel_round_trips_surveys(qtbot, design_session):
     got = panel.gather_state()
     assert got["survey_url"] == "https://survey.example/post"
     assert got["survey_options"] == {"Post survey": "https://survey.example/post"}
+
+
+def test_intercom_panel_round_trips_chat_presets(qtbot, design_session):
+    # The Intercom panel persists the shared chat quick-reply presets (#112).
+    panel = IntercomWindow(design_session)
+    qtbot.addWidget(panel)
+    panel.apply_state(
+        {
+            "chat_experimenter_presets": ["Are you awake?"],
+            "chat_participant_presets": ["Yes", "No"],
+        }
+    )
+    got = panel.gather_state()
+    assert got["chat_experimenter_presets"] == ["Are you awake?"]
+    assert got["chat_participant_presets"] == ["Yes", "No"]
 
 
 def test_visual_panel_round_trips(qtbot, design_session):
@@ -319,12 +334,6 @@ def test_volume_panel_refresh_reports_unavailable_levels(
 
 def test_events_panel_has_no_persisted_state(qtbot, design_session):
     panel = EventsWindow(design_session)
-    qtbot.addWidget(panel)
-    assert panel.gather_state() == {}
-
-
-def test_intercom_panel_has_no_persisted_state(qtbot, design_session):
-    panel = IntercomWindow(design_session)
     qtbot.addWidget(panel)
     assert panel.gather_state() == {}
 


### PR DESCRIPTION
Closes #112. Builds on the text chat from #113.

One-click / one-key canned messages on both sides of the intercom chat, saved with the study.

- **Experimenter**: a stack of one-click prompt buttons in the Text chat section (standardized wording — the dream-report question, "Are you awake?", "Going back to sleep now") plus a **Manage quick messages…** dialog.
- **Participant**: large numbered reply chips sent with the **number keys 1–9** — but only while the entry box is empty, so typed free text stays primary. Chips are non-focusable (no mouse in the bedroom), dark-themed, and scale with the text-size zoom.
- **Shared `ChatPresets`** (mirrors `ChatTranscript`): two ordered lists + a `changed` signal, constructed once and handed to both views; persisted by the Intercom panel (`chat_experimenter_presets` / `chat_participant_presets`). Defaults seed from config; an absent key keeps the defaults and an explicit empty list is respected (like the biocals stack). Participant list capped at 9 (the digit keys).
- **Markers**: a sent preset flows through the same path as a typed message, so it reuses the bare `ChatMessageSent` (69) / `ChatMessageReceived` (70) markers — no new codes.

Docs: usage (Intercom → quick replies) and the settings-file reference. Tests cover the presets model (defaults/round-trip/cap/malformed), both send paths, the empty-entry number-key rule, the shared live update across views, and the manage dialog (round-trip/reorder/remove/cap).