### PR TITLE
feat: per-item survey types and the MADRE questionnaire

### DIFF
--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -10,7 +10,7 @@ from the task-oriented [Usage](../usage.md) guide.
 | [`preferences.yaml`](preferences-file.md) | Per-machine operator preferences | YAML | `schema_version: 1` |
 | [Session `.log`](session-log.md) | The per-run record (events + settings) | Text | — |
 | [BIDS export](bids-export.md) | `events.tsv` + JSON sidecar | TSV / JSON | follows BIDS |
-| [Survey definition](../surveys.md) | An in-app survey (built-in or custom) | YAML | `schema_version: 1` |
+| [Survey definition](../surveys.md) | An in-app survey (built-in or custom) | YAML | `schema_version: 1`–`2` |
 | [Survey response](../surveys.md#response-files) | One administration's answers | JSON | — |
 
 ## Where each file lives

--- a/docs/surveys.md
+++ b/docs/surveys.md
@@ -35,6 +35,18 @@ window):
 | **BLA** | Baseline Lucidity Assessment |
 | **MLA** | Morning Lucidity Assessment |
 
+**Dream traits / intake**
+
+| Survey | Full name |
+|---|---|
+| **MADRE** | Mannheim Dream Questionnaire |
+
+MADRE is a trait/intake questionnaire (dream-recall habits, attitudes, age,
+occupation), administered once at session setup rather than after each awakening —
+open it standalone from **File › Surveys**. It mixes response types (dropdowns,
+number and text entry, and a rating matrix), which is what motivated the typed
+items described under [Building your own](#building-your-own).
+
 **Mindfulness**
 
 | Survey | Full name |
@@ -83,9 +95,11 @@ One JSON file per administration, in the run folder:
 The payload records the survey's key, title, and content version, the optional
 subject/session metadata, opened/submitted timestamps, the time since the
 **Start recording** marker (like the dream-report stamp), the linked report
-number (or `null`), the scale with its anchors, one `{item, response, anchor}`
-entry per item (unanswered items are `null`; submitting warns first), and any
-free-text notes:
+number (or `null`), the shared scale with its anchors, one
+`{item, type, response, label}` entry per responding item, and any free-text
+notes. The `response` is the chosen value (or `null` for unanswered — submitting
+warns first); `label` is its human reading (the Likert anchor or the chosen
+dropdown option). Display-only headings collect nothing and are omitted:
 
 ```json
 {
@@ -94,7 +108,7 @@ free-text notes:
   "report_number": 2,
   "time_since_recording_start": "02:14:09",
   "responses": [
-    {"item": "…", "response": 3, "anchor": "…"}
+    {"item": "…", "type": "likert", "response": 3, "label": "…"}
   ]
 }
 ```
@@ -134,6 +148,50 @@ scale:
 items:
   - I was aware that I was dreaming.
   - ...
+```
+
+### Item types
+
+A bare-string item is a **Likert** item rated against the survey's shared
+`scale` — the original shape, and all the builder produces. Definition files can
+also mix in other item types by writing an item as a mapping with a `type`
+(this requires `schema_version: 2`; an older SMACC then refuses the file cleanly
+rather than mis-reading it):
+
+| `type` | Renders as | Extra fields |
+|---|---|---|
+| `likert` (default) | radio matrix on the shared `scale` | — |
+| `select` | dropdown | `levels` (a `value: label` mapping) |
+| `number` | number entry (blank = unanswered) | `min`, `max`, `unit` (all optional) |
+| `text` | single-line text entry | — |
+| `heading` | a bold section title (collects no response) | — |
+
+Any item may carry a `help:` line, shown under it (used for the definitions in
+MADRE). Consecutive Likert items collapse into one shared matrix; other types
+render as their own rows. The simple **Build survey…** dialog only authors plain
+Likert surveys; a survey with typed items is edited as a file (the dialog says so
+and points at the path). For a full worked example, see the bundled
+[`madre.yaml`](https://github.com/remrama/smacc/blob/main/src/smacc/assets/surveys/madre.yaml).
+
+```yaml
+kind: smacc/survey
+schema_version: 2
+key: intake
+name: Intake
+title: Session intake
+scale: {min: 0, max: 4, anchors: [Not at all, "", "", "", Totally]}
+items:
+  - text: Age
+    type: number
+    min: 0
+    max: 120
+    unit: years
+  - text: How often do you recall your dreams?
+    type: select
+    levels: {0: Never, 1: Sometimes, 2: Often}
+  - text: Attitude towards dreams        # a section title
+    type: heading
+  - I think that dreams are meaningful.  # a Likert item on the shared scale
 ```
 
 Web survey URLs, by contrast, are saved in the `.smacc` study file

--- a/src/smacc/assets/surveys/madre.yaml
+++ b/src/smacc/assets/surveys/madre.yaml
@@ -1,0 +1,153 @@
+# SMACC built-in survey — YAML (see docs/surveys.md). Mixed item types (#118):
+# demographics (number/text), per-item dropdowns (select), and the shared-scale
+# "Attitude towards dreams" matrix (likert). The 0–7 yearly-frequency scale is
+# defined once (&freq) and reused (*freq).
+kind: smacc/survey
+schema_version: 2
+key: madre
+name: MADRE
+title: Mannheim Dream Questionnaire (MADRE)
+version: '1.0'
+citation: doi:10.11588/ijodr.2014.2.16675
+instructions: ''
+scale:
+  min: 0
+  max: 4
+  anchors:
+  - Not at all
+  - Not that much
+  - Partly
+  - Somewhat
+  - Totally
+items:
+- text: Age
+  type: number
+  min: 0
+  max: 99
+  unit: years
+- text: Gender
+  type: select
+  levels:
+    0: Unspecified
+    1: Female
+    2: Male
+- text: Occupation
+  type: text
+- text: How often have you recalled your dreams recently (in the past several months)?
+  type: select
+  levels:
+    0: Never
+    1: Less than once a month
+    2: About once a month
+    3: Two or three times a month
+    4: About once a week
+    5: Several times a week
+    6: Almost every morning
+- text: How intense are your dreams emotionally?
+  type: select
+  levels:
+    0: Not at all intense
+    1: Not that intense
+    2: Somewhat intense
+    3: Quite intense
+    4: Very intense
+- text: What is the emotional tone of your dreams on average?
+  type: select
+  levels:
+    1: Very negative
+    2: Somewhat negative
+    3: Neutral
+    4: Somewhat positive
+    5: Very positive
+- text: How often have you experienced nightmares recently (in the past several months)?
+  type: select
+  help: Nightmares are dreams with strong negative emotions that result in awakening
+    from the dreams. The dream plot can be recalled very vividly upon awakening.
+  levels: &freq
+    0: Never
+    1: Less than once a year
+    2: About once a year
+    3: About two to four times a year
+    4: About once a month
+    5: Two to three times a month
+    6: About once a week
+    7: Several times a week
+- text: If you currently experience nightmares, how distressing are they to you?
+  type: select
+  levels:
+    0: Not at all distressing
+    1: Not that distressing
+    2: Somewhat distressing
+    3: Quite distressing
+    4: Very distressing
+    999: n/a
+- text: Do you experience recurring nightmares that relate to a situation that you
+    have experienced in your waking life?
+  type: select
+  levels:
+    0: 'No'
+    1: 'Yes'
+- text: How many of your nightmares are recurrent ones (in percent)?
+  type: number
+  min: 0
+  max: 100
+  unit: '%'
+- text: How often did you experience nightmares during your childhood (from 6 to 12
+    year of age)?
+  type: select
+  levels: *freq
+- text: How often do you experience so-called lucid dreams (see definition)?
+  type: select
+  help: In a lucid dream, one is aware that one is dreaming during the dream. Thus
+    it is possible to wake up deliberately, or to influence the action of the dream
+    actively, or to observe the course of the dream passively.
+  levels: *freq
+- text: If you have experienced lucid dreams, how old were you when they occurred the
+    first time?
+  type: number
+  min: 0
+  max: 100
+  unit: years
+- text: Attitude towards dreams
+  type: heading
+- How much meaning do you attribute to your dreams?
+- How strong is your interest in dreams?
+- I think that dreams are meaningful.
+- I want to know more about dreams.
+- If somebody can recall and interpret his/her dreams, his/her life will be enriched.
+- I think that dreaming is in general a very interesting phenomenon.
+- A person who reflects on her/his dreams is certainly able to learn more about her/himself.
+- Do you have the impression that dreams provide impulses or pointers for your waking
+  life?
+- text: How often do you tell your dreams to others?
+  type: select
+  levels: *freq
+- text: How often do you record your dreams?
+  type: select
+  levels: *freq
+- text: How often do your dreams affect your mood during the day?
+  type: select
+  levels: *freq
+- text: How often do your dreams give you creative ideas?
+  type: select
+  levels: *freq
+- text: How often do you experience Deja vus (see definition)?
+  type: select
+  help: During a deja vu experience one is convinced one is reliving a real-life situation
+    that was already experienced in a dream.
+  levels: *freq
+- text: Have you ever read something on the topic of dreams?
+  type: select
+  levels:
+    0: 'No'
+    1: One to two times
+    2: Several times
+- text: Did the literature about dreaming / dream interpretation help you to better
+    understand your dreams?
+  type: select
+  levels:
+    0: Not at all
+    1: Not that much
+    2: Somewhat
+    3: Quite
+    4: Very much

--- a/src/smacc/dialogs.py
+++ b/src/smacc/dialogs.py
@@ -212,7 +212,9 @@ class BuildSurveyDialog(QtWidgets.QDialog):
             self.minSpin.setValue(survey.scale_min)
             self.maxSpin.setValue(survey.scale_max)
             self.anchorsEdit.setPlainText("\n".join(survey.anchors))
-            self.itemsEdit.setPlainText("\n".join(survey.items))
+            # The builder only ever opens simple-Likert surveys (the caller
+            # guards this), so each item is a plain Likert statement.
+            self.itemsEdit.setPlainText("\n".join(it.text for it in survey.items))
 
         buttonBox = QtWidgets.QDialogButtonBox(
             QtWidgets.QDialogButtonBox.StandardButton.Save
@@ -459,6 +461,17 @@ class ManageSurveysDialog(QtWidgets.QDialog):
             return
         survey = cast(surveys.SurveyDef, payload)
         if kind == "custom":
+            # The builder authors only the simple shared-scale Likert shape; a
+            # survey with typed items/help/headings must be edited as a file.
+            if not survey.is_simple_likert:
+                where = f"\n\n{survey.path}" if survey.path else ""
+                QtWidgets.QMessageBox.information(
+                    self,
+                    "Manage surveys",
+                    "This survey uses advanced item types and can't be edited here. "
+                    f"Edit its file directly:{where}",
+                )
+                return
             existing = tuple(k for k in self._survey_keys() if k != survey.key)
             buildDialog = BuildSurveyDialog(survey, existing_keys=existing, parent=self)
             if buildDialog.exec():

--- a/src/smacc/panels/survey.py
+++ b/src/smacc/panels/survey.py
@@ -6,17 +6,23 @@ number) or standalone from File → Surveys. Non-modal on purpose: the operator
 must keep the intercom reachable while administering a questionnaire to a
 participant who is in bed in the dark.
 
-Submitting writes one JSON file per administration into the run folder (named to
-sort beside the report it accompanies; see :func:`smacc.surveys.response_filename`)
-and emits the ``SurveySubmitted`` marker. Without a run folder (the study
-designer, or a preview from the Manage-surveys dialog) the survey renders for
-inspection but Submit is disabled, mirroring how the record button is gated.
+Items render by type (#118): a run of consecutive Likert items collapses into one
+shared-scale radio matrix (the original single-scale look); ``select`` items are
+dropdowns, ``number`` and ``text`` are free entry, and ``heading`` items are
+display-only section titles. Submitting writes one JSON file per administration
+into the run folder (named to sort beside the report it accompanies; see
+:func:`smacc.surveys.response_filename`) and emits the ``SurveySubmitted`` marker.
+Without a run folder (the study designer, or a preview from the Manage-surveys
+dialog) the survey renders for inspection but Submit is disabled, mirroring how
+the record button is gated.
 """
 
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from datetime import datetime
+from typing import Any
 
 from PyQt6 import QtCore, QtWidgets
 
@@ -26,7 +32,7 @@ from .base import make_section_title
 
 
 class SurveyWindow(QtWidgets.QDialog):
-    """Administer one survey: a Likert matrix, optional notes, and Submit.
+    """Administer one survey: typed item widgets, optional notes, and Submit.
 
     One instance per administration (several can be open at once; each writes its
     own response file). ``report_number`` links an auto-opened survey to its dream
@@ -50,7 +56,13 @@ class SurveyWindow(QtWidgets.QDialog):
         self.setWindowFlags(
             self.windowFlags() ^ QtCore.Qt.WindowType.WindowContextHelpButtonHint
         )
+        # The Likert radio groups, in item order (kept for tests/inspection), and
+        # one (item, control, value-getter) per responding item, also in order, so
+        # responses() lines up with survey.response_items. ``control`` is the
+        # QButtonGroup (Likert) or the input widget (select/number/text).
         self._groups: list[QtWidgets.QButtonGroup] = []
+        self._fields: list[tuple[surveys.SurveyItem, QtCore.QObject, Callable[[], Any]]]
+        self._fields = []
         self._build()
 
     # ----- layout -------------------------------------------------------------
@@ -72,7 +84,7 @@ class SurveyWindow(QtWidgets.QDialog):
             instructions.setWordWrap(True)
             layout.addWidget(instructions)
 
-        layout.addWidget(self._build_matrix(), 1)
+        layout.addWidget(self._build_body(), 1)
 
         self.notesEdit = QtWidgets.QLineEdit(self)
         self.notesEdit.setPlaceholderText("Optional free-text notes")
@@ -99,12 +111,37 @@ class SurveyWindow(QtWidgets.QDialog):
         layout.addWidget(buttonBox)
         self.resize(720, 560)
 
-    def _build_matrix(self) -> QtWidgets.QScrollArea:
-        """The item × scale-point radio matrix, in a scroll area."""
+    def _build_body(self) -> QtWidgets.QScrollArea:
+        """Render items in order: Likert runs as matrices, other types as rows."""
+        container = QtWidgets.QWidget(self)
+        vbox = QtWidgets.QVBoxLayout(container)
+        vbox.setContentsMargins(0, 0, 0, 0)
+        items = list(self.survey.items)
+        index = 0
+        while index < len(items):
+            if items[index].type == surveys.LIKERT:
+                run = []
+                while index < len(items) and items[index].type == surveys.LIKERT:
+                    run.append(items[index])
+                    index += 1
+                vbox.addWidget(self._build_likert_matrix(run))
+            else:
+                vbox.addWidget(self._build_item_row(items[index]))
+                index += 1
+        vbox.addStretch(1)
+
+        scroll = QtWidgets.QScrollArea(self)
+        scroll.setWidgetResizable(True)
+        scroll.setWidget(container)
+        return scroll
+
+    def _build_likert_matrix(
+        self, items: list[surveys.SurveyItem]
+    ) -> QtWidgets.QWidget:
+        """A radio matrix for a run of Likert items sharing the survey scale."""
         survey = self.survey
         grid = QtWidgets.QGridLayout()
         grid.setHorizontalSpacing(12)
-        # Header row: each scale value with its anchor underneath.
         for col, value in enumerate(range(survey.scale_min, survey.scale_max + 1)):
             anchor = survey.anchor_for(value)
             text = f"{value}\n{anchor}" if anchor else str(value)
@@ -112,8 +149,8 @@ class SurveyWindow(QtWidgets.QDialog):
             header.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
             header.setWordWrap(True)
             grid.addWidget(header, 0, col + 1)
-        for row, item in enumerate(survey.items, start=1):
-            label = QtWidgets.QLabel(item, self)
+        for row, item in enumerate(items, start=1):
+            label = QtWidgets.QLabel(item.text, self)
             label.setWordWrap(True)
             grid.addWidget(label, row, 0)
             group = QtWidgets.QButtonGroup(self)
@@ -131,24 +168,95 @@ class SurveyWindow(QtWidgets.QDialog):
                 holder.setLayout(cell)
                 grid.addWidget(holder, row, col + 1)
             self._groups.append(group)
+            self._fields.append((item, group, self._likert_getter(group)))
         grid.setColumnStretch(0, 1)
+        wrapper = QtWidgets.QWidget(self)
+        wrapper.setLayout(grid)
+        return wrapper
 
-        inner = QtWidgets.QWidget(self)
-        inner.setLayout(grid)
-        scroll = QtWidgets.QScrollArea(self)
-        scroll.setWidgetResizable(True)
-        scroll.setWidget(inner)
-        return scroll
+    def _build_item_row(self, item: surveys.SurveyItem) -> QtWidgets.QWidget:
+        """Render a non-Likert item (heading, select, number, or text)."""
+        wrapper = QtWidgets.QWidget(self)
+        col = QtWidgets.QVBoxLayout(wrapper)
+        col.setContentsMargins(0, 4, 0, 4)
 
-    # ----- responses ------------------------------------------------------------
+        if item.type == surveys.HEADING:
+            heading = QtWidgets.QLabel(item.text, self)
+            heading.setWordWrap(True)
+            font = heading.font()
+            font.setBold(True)
+            heading.setFont(font)
+            col.addWidget(heading)
+            if item.help:
+                col.addWidget(self._help_label(item.help))
+            return wrapper
 
-    def responses(self) -> list[int | None]:
-        """One scale value per item, in order (None where unanswered)."""
-        out: list[int | None] = []
-        for group in self._groups:
-            checked = group.checkedId()
-            out.append(None if checked == -1 else checked)
-        return out
+        label = QtWidgets.QLabel(item.text, self)
+        label.setWordWrap(True)
+        col.addWidget(label)
+        if item.help:
+            col.addWidget(self._help_label(item.help))
+
+        field: QtWidgets.QWidget
+        getter: Callable[[], Any]
+        if item.type == surveys.SELECT:
+            field, getter = self._select_field(item)
+        elif item.type == surveys.NUMBER:
+            field, getter = self._number_field(item)
+        else:  # text
+            field, getter = self._text_field()
+        col.addWidget(field)
+        self._fields.append((item, field, getter))
+        return wrapper
+
+    def _help_label(self, text: str) -> QtWidgets.QLabel:
+        """A wrapped, italic sub-label for an item's help/definition text."""
+        help_label = QtWidgets.QLabel(text, self)
+        help_label.setWordWrap(True)
+        font = help_label.font()
+        font.setItalic(True)
+        help_label.setFont(font)
+        return help_label
+
+    # ----- typed field widgets + getters --------------------------------------
+
+    @staticmethod
+    def _likert_getter(group: QtWidgets.QButtonGroup) -> Callable[[], int | None]:
+        return lambda: None if group.checkedId() == -1 else group.checkedId()
+
+    def _select_field(
+        self, item: surveys.SurveyItem
+    ) -> tuple[QtWidgets.QWidget, Callable[[], int | None]]:
+        combo = QtWidgets.QComboBox(self)
+        combo.addItem("—", None)  # leading blank == unanswered
+        for value, label in item.levels:
+            combo.addItem(label, value)
+        return combo, lambda: combo.currentData()
+
+    def _number_field(
+        self, item: surveys.SurveyItem
+    ) -> tuple[QtWidgets.QWidget, Callable[[], int | None]]:
+        spin = QtWidgets.QSpinBox(self)
+        low = item.number_min if item.number_min is not None else 0
+        high = item.number_max if item.number_max is not None else 9999
+        # One step below the real minimum is the "unanswered" slot, shown as "—"
+        # (Qt's special value text), so a number field can be left blank.
+        spin.setRange(low - 1, high)
+        spin.setValue(low - 1)
+        spin.setSpecialValueText("—")
+        if item.unit:
+            spin.setSuffix(f" {item.unit}")
+        return spin, lambda: None if spin.value() < low else spin.value()
+
+    def _text_field(self) -> tuple[QtWidgets.QWidget, Callable[[], str | None]]:
+        edit = QtWidgets.QLineEdit(self)
+        return edit, lambda: edit.text().strip() or None
+
+    # ----- responses ----------------------------------------------------------
+
+    def responses(self) -> list[Any]:
+        """One value per responding item, in order (None where unanswered)."""
+        return [getter() for _, _, getter in self._fields]
 
     def _on_submit(self) -> None:
         """Confirm gaps, write the response JSON, emit the marker, and close."""

--- a/src/smacc/surveys.py
+++ b/src/smacc/surveys.py
@@ -11,7 +11,7 @@ The on-disk shape (a survey file is YAML with a ``kind`` discriminator, like the
 ``.smacc`` settings format)::
 
     kind: smacc/survey
-    schema_version: 1
+    schema_version: 2
     key: dlq                # stable id; also names response files
     name: DLQ               # short label (dropdown, File menu)
     title: Dream Lucidity Questionnaire (DLQ)
@@ -19,14 +19,26 @@ The on-disk shape (a survey file is YAML with a ``kind`` discriminator, like the
     citation: "..."
     instructions: "..."
     scale: {min: 0, max: 4, anchors: [..., one per scale point, ...]}
-    items: [..., one statement per item, ...]
+    items:
+      - a bare string               # a Likert item on the shared scale (above)
+      - text: Age                   # or a typed item (schema_version 2+):
+        type: number                #   likert | select | number | text | heading
+        min: 0
+        max: 99
+        unit: years
+      - text: How often do you recall dreams?
+        type: select                # a dropdown with its own ordered levels
+        help: "shown under the item"
+        levels: {0: never, 1: rarely, 2: often}
 
-Every survey is one shared Likert scale plus a list of item texts — exactly the
-shape of the bundled instruments — which keeps definitions hand-writable and the
-builder dialog simple. Responses are written as one JSON file per administration
-(see :func:`response_payload` / :func:`response_filename`), carrying the survey
-key *and* content version so an analysis can always tell which wording a given
-night used.
+A plain-string item is a Likert item on the survey's shared scale — the original
+(and still most common) shape, so the bundled single-scale instruments need no
+``type`` and stay ``schema_version: 1``. Typed items (anything but a bare-string
+Likert) require ``schema_version: 2``; an older SMACC then rejects the file with a
+clear version error instead of mis-reading it. Responses are written as one JSON
+file per administration (see :func:`response_payload` / :func:`response_filename`),
+carrying the survey key *and* content version so an analysis can always tell which
+wording a given night used.
 
 In the survey dropdown and the saved ``survey_url`` setting, an in-app survey is
 addressed by the pseudo-URL ``smacc://survey/<key>``; everything else is treated
@@ -52,19 +64,68 @@ from .utils import format_elapsed
 # Discriminators for the two YAML/JSON shapes this module owns.
 KIND = "smacc/survey"
 RESPONSE_KIND = "smacc/survey-response"
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 # Pseudo-URL scheme addressing an in-app survey in the dropdown / File menu /
 # saved ``survey_url``; anything else is a web URL for the browser.
 URL_PREFIX = "smacc://survey/"
 
-# Keep a hand-typed scale sane: 2..21 points covers every Likert in the wild.
+# Keep a hand-typed Likert scale sane: 2..21 points covers every Likert in the wild.
 _MAX_SCALE_POINTS = 21
+
+# Item response types. ``likert`` rates against the survey's shared scale (a radio
+# matrix); ``select`` is a dropdown with its own ordered levels; ``number`` and
+# ``text`` are free entry; ``heading`` is a display-only section title (no answer).
+LIKERT = "likert"
+SELECT = "select"
+NUMBER = "number"
+TEXT = "text"
+HEADING = "heading"
+ITEM_TYPES = (LIKERT, SELECT, NUMBER, TEXT, HEADING)
+# Types that collect an answer (everything but a heading) — used when aligning the
+# window's collected values to the items and when building the response payload.
+_RESPONSE_TYPES = (LIKERT, SELECT, NUMBER, TEXT)
+
+
+@dataclass(frozen=True)
+class SurveyItem:
+    """One survey item: its text, response type, and any per-type extras.
+
+    A ``likert`` item rates against the survey-level scale (``SurveyDef.scale_*``
+    / ``anchors``); ``select`` carries its own ordered ``levels``; ``number``
+    carries optional bounds and a ``unit``; ``text`` is free entry; ``heading`` is
+    a display-only separator that collects no response.
+    """
+
+    text: str
+    type: str = LIKERT
+    help: str = ""
+    levels: tuple[tuple[int, str], ...] = ()  # (value, label), select only
+    number_min: int | None = None
+    number_max: int | None = None
+    unit: str = ""
+
+    @property
+    def collects_response(self) -> bool:
+        """True for everything but a display-only heading."""
+        return self.type in _RESPONSE_TYPES
+
+    def level_label(self, value: int | None) -> str:
+        """The chosen level's label for a ``select`` item ("" if not found)."""
+        for level_value, label in self.levels:
+            if level_value == value:
+                return label
+        return ""
 
 
 @dataclass(frozen=True)
 class SurveyDef:
-    """One survey: identity, version, one shared Likert scale, and its items."""
+    """One survey: identity, version, a shared Likert scale, and its items.
+
+    ``scale_min``/``scale_max``/``anchors`` define the default scale that
+    ``likert`` items rate against; other item types carry their own scale (or
+    none). ``items`` is a tuple of :class:`SurveyItem`.
+    """
 
     key: str
     name: str  # short label (dropdown / File menu), e.g. "DLQ"
@@ -75,7 +136,7 @@ class SurveyDef:
     scale_min: int = 0
     scale_max: int = 4
     anchors: tuple[str, ...] = ()  # one label per scale point ("" allowed)
-    items: tuple[str, ...] = ()
+    items: tuple[SurveyItem, ...] = ()
     builtin: bool = True  # False for user-built surveys (editable/removable)
     path: Path | None = None  # source file (None for unsaved builder drafts)
 
@@ -86,11 +147,25 @@ class SurveyDef:
 
     @property
     def n_points(self) -> int:
-        """Number of points on the response scale."""
+        """Number of points on the shared Likert scale."""
         return self.scale_max - self.scale_min + 1
 
+    @property
+    def is_simple_likert(self) -> bool:
+        """True if every item is a plain Likert item with no help text.
+
+        Such a survey round-trips losslessly through the simple builder dialog;
+        anything richer (typed items, help, headings) must be edited as a file.
+        """
+        return all(it.type == LIKERT and not it.help for it in self.items)
+
+    @property
+    def response_items(self) -> tuple[SurveyItem, ...]:
+        """The items that collect a response (headings excluded)."""
+        return tuple(it for it in self.items if it.collects_response)
+
     def anchor_for(self, value: int) -> str:
-        """The anchor label for scale ``value`` ("" when anchors are absent)."""
+        """The shared-scale anchor label for ``value`` ("" when absent)."""
         index = value - self.scale_min
         if 0 <= index < len(self.anchors):
             return self.anchors[index]
@@ -110,16 +185,100 @@ def slugify_key(name: str) -> str:
     return slug or "survey"
 
 
-def _require_str(mapping: dict, field: str, *, required: bool = True) -> str:
-    value = mapping.get(field, "")
+def _require_str(mapping: dict, field_name: str, *, required: bool = True) -> str:
+    value = mapping.get(field_name, "")
     if value is None:
         value = ""
     if not isinstance(value, str):
-        raise ValueError(f"Survey field {field!r} must be text.")
+        raise ValueError(f"Survey field {field_name!r} must be text.")
     value = value.strip()
     if required and not value:
-        raise ValueError(f"Survey field {field!r} is required.")
+        raise ValueError(f"Survey field {field_name!r} is required.")
     return value
+
+
+def _parse_levels(raw: Any) -> tuple[tuple[int, str], ...]:
+    """Parse a ``select`` item's ``levels`` mapping into ordered (value, label)s."""
+    if not isinstance(raw, dict) or not raw:
+        raise ValueError("A 'select' item needs a non-empty 'levels' mapping.")
+    levels: list[tuple[int, str]] = []
+    for key, label in raw.items():
+        if isinstance(key, bool):
+            raise ValueError("Select level keys must be whole numbers.")
+        try:
+            value = int(key)
+        except (TypeError, ValueError):
+            raise ValueError(
+                f"Select level key {key!r} must be a whole number."
+            ) from None
+        if not isinstance(label, str) or not label.strip():
+            raise ValueError("Each 'select' level needs a non-empty text label.")
+        levels.append((value, label.strip()))
+    if len(levels) < 2:
+        raise ValueError("A 'select' item needs at least two levels.")
+    levels.sort(key=lambda pair: pair[0])
+    return tuple(levels)
+
+
+def _parse_bound(raw: dict, field_name: str) -> int | None:
+    """Parse an optional whole-number bound for a ``number`` item (None if absent)."""
+    value = raw.get(field_name)
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"Number item {field_name!r} must be a whole number.")
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"Number item {field_name!r} must be a whole number."
+        ) from None
+
+
+def _parse_item(raw: Any) -> SurveyItem:
+    """Parse one item entry (a bare string == a Likert item on the shared scale)."""
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            raise ValueError("Every survey item must be non-empty text.")
+        return SurveyItem(text=text, type=LIKERT)
+    if not isinstance(raw, dict):
+        raise ValueError("A survey item must be text or a mapping.")
+    text = _require_str(raw, "text")
+    item_type = raw.get("type") or LIKERT
+    if item_type not in ITEM_TYPES:
+        raise ValueError(
+            f"Unknown survey item type {item_type!r} "
+            f"(expected one of {', '.join(ITEM_TYPES)})."
+        )
+    help_text = _require_str(raw, "help", required=False)
+    if item_type == SELECT:
+        return SurveyItem(
+            text=text,
+            type=SELECT,
+            help=help_text,
+            levels=_parse_levels(raw.get("levels")),
+        )
+    if item_type == NUMBER:
+        number_min = _parse_bound(raw, "min")
+        number_max = _parse_bound(raw, "max")
+        if (
+            number_min is not None
+            and number_max is not None
+            and number_max <= number_min
+        ):
+            raise ValueError("Number item 'max' must be greater than 'min'.")
+        return SurveyItem(
+            text=text,
+            type=NUMBER,
+            help=help_text,
+            number_min=number_min,
+            number_max=number_max,
+            unit=_require_str(raw, "unit", required=False),
+        )
+    return SurveyItem(
+        text=text, type=item_type, help=help_text
+    )  # likert / text / heading
 
 
 def parse_survey_mapping(
@@ -157,40 +316,49 @@ def parse_survey_mapping(
     if not isinstance(content_version, str):
         raise ValueError("Survey field 'version' must be text.")
 
-    scale = payload.get("scale")
-    if not isinstance(scale, dict):
-        raise ValueError("Survey field 'scale' must be a mapping with min/max.")
-    try:
-        scale_min = int(scale["min"])
-        scale_max = int(scale["max"])
-    except (KeyError, TypeError, ValueError):
-        raise ValueError("Survey scale needs whole-number 'min' and 'max'.") from None
-    if scale_max <= scale_min:
-        raise ValueError("Survey scale 'max' must be greater than 'min'.")
-    n_points = scale_max - scale_min + 1
-    if n_points > _MAX_SCALE_POINTS:
-        raise ValueError(
-            f"Survey scale has {n_points} points (max {_MAX_SCALE_POINTS})."
-        )
-    anchors_raw = scale.get("anchors") or []
-    if not isinstance(anchors_raw, list) or not all(
-        isinstance(a, str) for a in anchors_raw
-    ):
-        raise ValueError("Survey scale 'anchors' must be a list of text labels.")
-    if anchors_raw and len(anchors_raw) != n_points:
-        raise ValueError(
-            f"Survey has {len(anchors_raw)} anchors for a {n_points}-point scale "
-            "(give one per point, or none)."
-        )
-
     items_raw = payload.get("items")
     if not isinstance(items_raw, list) or not items_raw:
         raise ValueError("Survey needs a non-empty 'items' list.")
-    items: list[str] = []
-    for item in items_raw:
-        if not isinstance(item, str) or not item.strip():
-            raise ValueError("Every survey item must be non-empty text.")
-        items.append(item.strip())
+    # Typed items (anything but a bare-string Likert) are a v2 feature; reject them
+    # in a v1 file so the version cleanly signals the capability a reader needs.
+    if version < 2 and any(not isinstance(item, str) for item in items_raw):
+        raise ValueError("Typed survey items require schema_version 2.")
+    items = tuple(_parse_item(item) for item in items_raw)
+    if not any(it.collects_response for it in items):
+        raise ValueError("Survey needs at least one item that collects a response.")
+
+    # A shared Likert scale is required only when a Likert item actually uses it.
+    needs_scale = any(it.type == LIKERT for it in items)
+    scale = payload.get("scale")
+    scale_min, scale_max, anchors = 0, 4, ()
+    if scale is not None or needs_scale:
+        if not isinstance(scale, dict):
+            raise ValueError("Survey field 'scale' must be a mapping with min/max.")
+        try:
+            scale_min = int(scale["min"])
+            scale_max = int(scale["max"])
+        except (KeyError, TypeError, ValueError):
+            raise ValueError(
+                "Survey scale needs whole-number 'min' and 'max'."
+            ) from None
+        if scale_max <= scale_min:
+            raise ValueError("Survey scale 'max' must be greater than 'min'.")
+        n_points = scale_max - scale_min + 1
+        if n_points > _MAX_SCALE_POINTS:
+            raise ValueError(
+                f"Survey scale has {n_points} points (max {_MAX_SCALE_POINTS})."
+            )
+        anchors_raw = scale.get("anchors") or []
+        if not isinstance(anchors_raw, list) or not all(
+            isinstance(a, str) for a in anchors_raw
+        ):
+            raise ValueError("Survey scale 'anchors' must be a list of text labels.")
+        if anchors_raw and len(anchors_raw) != n_points:
+            raise ValueError(
+                f"Survey has {len(anchors_raw)} anchors for a {n_points}-point scale "
+                "(give one per point, or none)."
+            )
+        anchors = tuple(a.strip() for a in anchors_raw)
 
     return SurveyDef(
         key=key,
@@ -201,8 +369,8 @@ def parse_survey_mapping(
         instructions=_require_str(payload, "instructions", required=False),
         scale_min=scale_min,
         scale_max=scale_max,
-        anchors=tuple(a.strip() for a in anchors_raw),
-        items=tuple(items),
+        anchors=anchors,
+        items=items,
         builtin=builtin,
         path=path,
     )
@@ -274,24 +442,50 @@ def all_surveys(
     return surveys, problems
 
 
+def _item_to_mapping(item: SurveyItem) -> str | dict[str, Any]:
+    """Serialize one item, collapsing a plain Likert item back to a bare string."""
+    if item.type == LIKERT and not item.help:
+        return item.text
+    out: dict[str, Any] = {"text": item.text, "type": item.type}
+    if item.help:
+        out["help"] = item.help
+    if item.type == SELECT:
+        out["levels"] = {value: label for value, label in item.levels}
+    elif item.type == NUMBER:
+        if item.number_min is not None:
+            out["min"] = item.number_min
+        if item.number_max is not None:
+            out["max"] = item.number_max
+        if item.unit:
+            out["unit"] = item.unit
+    return out
+
+
 def survey_to_mapping(survey: SurveyDef) -> dict[str, Any]:
-    """Serialize a definition for saving as a survey YAML (builder dialog)."""
-    return {
+    """Serialize a definition for saving as a survey YAML (builder dialog).
+
+    Writes the lowest schema version that fits: a survey of plain Likert items
+    stays ``schema_version: 1`` (and emits bare-string items); anything with
+    typed items, help, or headings is ``schema_version: 2``.
+    """
+    mapping: dict[str, Any] = {
         "kind": KIND,
-        "schema_version": SCHEMA_VERSION,
+        "schema_version": 1 if survey.is_simple_likert else 2,
         "key": survey.key,
         "name": survey.name,
         "title": survey.title,
         "version": survey.version,
         "citation": survey.citation,
         "instructions": survey.instructions,
-        "scale": {
+    }
+    if any(it.type == LIKERT for it in survey.items):
+        mapping["scale"] = {
             "min": survey.scale_min,
             "max": survey.scale_max,
             "anchors": list(survey.anchors),
-        },
-        "items": list(survey.items),
-    }
+        }
+    mapping["items"] = [_item_to_mapping(it) for it in survey.items]
+    return mapping
 
 
 def save_survey(survey: SurveyDef, directory: str | Path) -> Path:
@@ -362,9 +556,20 @@ def unique_response_path(directory: str | Path, stem: str) -> Path:
     return path
 
 
+def _response_label(survey: SurveyDef, item: SurveyItem, value: Any) -> str:
+    """The human label for a response value (the anchor / chosen option text)."""
+    if value is None:
+        return ""
+    if item.type == LIKERT and isinstance(value, int):
+        return survey.anchor_for(value)
+    if item.type == SELECT and isinstance(value, int):
+        return item.level_label(value)
+    return ""
+
+
 def response_payload(
     survey: SurveyDef,
-    responses: list[int | None],
+    responses: list[Any],
     *,
     metadata: dict | None = None,
     opened: datetime | None = None,
@@ -375,10 +580,12 @@ def response_payload(
 ) -> dict[str, Any]:
     """Build the JSON-ready payload for one submitted administration.
 
-    ``responses`` holds one scale value (or None for unanswered) per item, in
-    item order. The payload repeats each item's text and anchor so the response
-    file stands alone, and carries the survey's content version and the report
-    linkage (also encoded in the filename) so neither depends on the other.
+    ``responses`` holds one value (or None for unanswered) per *responding* item
+    — headings are display-only and excluded — in item order. Each entry records
+    the item's text, ``type``, ``response`` value, and a human ``label`` (the
+    Likert anchor or the chosen ``select`` option), so the file stands alone; the
+    survey's content version and the report linkage are carried too so neither
+    depends on the other.
     """
     metadata = metadata or {}
     return {
@@ -406,11 +613,12 @@ def response_payload(
         },
         "responses": [
             {
-                "item": text,
+                "item": item.text,
+                "type": item.type,
                 "response": value,
-                "anchor": survey.anchor_for(value) if value is not None else "",
+                "label": _response_label(survey, item, value),
             }
-            for text, value in zip(survey.items, responses, strict=True)
+            for item, value in zip(survey.response_items, responses, strict=True)
         ],
         "notes": notes.strip(),
     }

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -147,6 +147,35 @@ def test_manage_surveys_save_custom_writes_and_reloads(qtbot, tmp_path):
     assert dialog.listWidget.count() == 1
 
 
+def test_manage_surveys_guards_editing_typed_survey(qtbot, tmp_path, monkeypatch):
+    # A custom survey with typed items (#118) can't round-trip through the simple
+    # builder, so View/Edit explains that instead of opening (and mangling) it.
+    user_dir = tmp_path / "user"
+    typed = surveys.parse_survey_mapping(
+        {
+            "kind": surveys.KIND,
+            "schema_version": 2,
+            "key": "mine",
+            "name": "Mine",
+            "title": "Mine",
+            "items": [{"text": "Occupation", "type": "text"}],
+        }
+    )
+    surveys.save_survey(typed, user_dir)
+    informed = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox, "information", lambda *a, **k: informed.append(a)
+    )
+    monkeypatch.setattr(
+        dialogs.BuildSurveyDialog, "exec", lambda self: pytest.fail("builder opened")
+    )
+    dialog = dialogs.ManageSurveysDialog({}, tmp_path / "builtin", user_dir)
+    qtbot.addWidget(dialog)
+    dialog.listWidget.setCurrentRow(0)
+    dialog._view_or_edit_selected()  # would fail if it opened the builder
+    assert informed and dialog.files_changed is False
+
+
 # ----- BuildSurveyDialog -------------------------------------------------------
 
 
@@ -164,7 +193,9 @@ def test_build_survey_dialog_returns_validated_survey(qtbot):
     assert survey.title == "My Scale"  # defaults to the name
     assert survey.scale_min == 1 and survey.scale_max == 3
     assert survey.anchors == ("Low", "Mid", "High")
-    assert survey.items == ("First item", "Second item")
+    assert [it.text for it in survey.items] == ["First item", "Second item"]
+    assert all(it.type == surveys.LIKERT for it in survey.items)
+    assert survey.is_simple_likert  # the builder only makes shared-scale Likert
     assert survey.builtin is False
 
 

--- a/tests/test_survey_window.py
+++ b/tests/test_survey_window.py
@@ -122,3 +122,90 @@ def test_repeat_submission_for_same_report_is_suffixed(
         _answer(window, 1, 1)
         window._on_submit()
         assert (live_session.session_dir / expected).is_file()
+
+
+# ----- mixed item types (#118) -----------------------------------------------
+
+
+@pytest.fixture
+def mixed_survey():
+    return surveys.parse_survey_mapping(
+        {
+            "kind": surveys.KIND,
+            "schema_version": 2,
+            "key": "mixed",
+            "name": "Mixed",
+            "title": "Mixed survey",
+            "scale": {"min": 0, "max": 2, "anchors": ["No", "Some", "Yes"]},
+            "items": [
+                {"text": "Background", "type": "heading"},
+                "A Likert item",
+                {"text": "Age", "type": "number", "min": 0, "max": 99, "unit": "years"},
+                {"text": "Job", "type": "text"},
+                {
+                    "text": "How often?",
+                    "type": "select",
+                    "levels": {0: "never", 1: "sometimes", 2: "often"},
+                },
+            ],
+        }
+    )
+
+
+def _control(window: SurveyWindow, item_type: str):
+    """The input control for the (single) item of ``item_type`` in this survey."""
+    return next(c for it, c, _ in window._fields if it.type == item_type)
+
+
+def test_mixed_survey_builds_typed_widgets(qtbot, mixed_survey, design_session):
+    window = SurveyWindow(mixed_survey, design_session)
+    qtbot.addWidget(window)
+    kinds = {it.type: type(control) for it, control, _ in window._fields}
+    assert kinds["likert"] is QtWidgets.QButtonGroup
+    assert kinds["number"] is QtWidgets.QSpinBox
+    assert kinds["text"] is QtWidgets.QLineEdit
+    assert kinds["select"] is QtWidgets.QComboBox
+    # The heading is display-only: not a field, no response.
+    assert all(it.type != "heading" for it, _, _ in window._fields)
+    assert len(window._fields) == 4
+
+
+def test_mixed_survey_responses_read_each_widget(qtbot, mixed_survey, design_session):
+    window = SurveyWindow(mixed_survey, design_session)
+    qtbot.addWidget(window)
+    assert window.responses() == [None, None, None, None]
+    window._groups[0].button(2).setChecked(True)
+    _control(window, "number").setValue(42)
+    _control(window, "text").setText("  scientist  ")
+    combo = _control(window, "select")
+    combo.setCurrentIndex(combo.findData(1))
+    # _fields order follows item order: likert, number, text, select.
+    assert window.responses() == [2, 42, "scientist", 1]
+
+
+def test_number_left_blank_is_unanswered(qtbot, mixed_survey, design_session):
+    window = SurveyWindow(mixed_survey, design_session)
+    qtbot.addWidget(window)
+    spin = _control(window, "number")
+    assert spin.value() == spin.minimum()  # starts on the "—" special-value slot
+    assert window.responses()[1] is None
+
+
+def test_mixed_survey_submit_writes_typed_responses(qtbot, mixed_survey, live_session):
+    window = SurveyWindow(mixed_survey, live_session)
+    qtbot.addWidget(window)
+    window._groups[0].button(1).setChecked(True)
+    _control(window, "number").setValue(30)
+    _control(window, "text").setText("pilot")
+    combo = _control(window, "select")
+    combo.setCurrentIndex(combo.findData(2))
+    window._on_submit()
+    payload = json.loads(
+        (live_session.session_dir / "survey-01-mixed.json").read_text(encoding="utf-8")
+    )
+    by_type = {r["type"]: r for r in payload["responses"]}
+    assert len(payload["responses"]) == 4  # heading excluded
+    assert by_type["likert"]["response"] == 1 and by_type["likert"]["label"] == "Some"
+    assert by_type["number"]["response"] == 30 and by_type["number"]["label"] == ""
+    assert by_type["text"]["response"] == "pilot"
+    assert by_type["select"]["response"] == 2 and by_type["select"]["label"] == "often"

--- a/tests/test_surveys.py
+++ b/tests/test_surveys.py
@@ -100,6 +100,130 @@ def test_parse_rejects_non_mapping():
         surveys.parse_survey_mapping(["not", "a", "mapping"])
 
 
+# ----- typed items (#118) -------------------------------------------------------
+
+
+def _typed_mapping(items, **overrides):
+    """A valid schema_version 2 mapping carrying the given (typed) items."""
+    payload = _mapping(**overrides)
+    payload["schema_version"] = 2
+    payload["items"] = items
+    return payload
+
+
+def test_bare_string_item_is_likert():
+    survey = surveys.parse_survey_mapping(_mapping())
+    assert all(it.type == surveys.LIKERT for it in survey.items)
+    assert survey.items[0].text == "First item"
+    assert survey.is_simple_likert
+
+
+def test_parse_select_number_text_heading_items():
+    survey = surveys.parse_survey_mapping(
+        _typed_mapping(
+            [
+                {"text": "A section", "type": "heading"},
+                "A Likert item",
+                {"text": "Age", "type": "number", "min": 0, "max": 99, "unit": "years"},
+                {"text": "Job", "type": "text"},
+                {
+                    "text": "How often?",
+                    "type": "select",
+                    "help": "see note",
+                    "levels": {2: "often", 0: "never", 1: "sometimes"},
+                },
+            ]
+        )
+    )
+    heading, likert, number, text, select = survey.items
+    assert heading.type == surveys.HEADING and not heading.collects_response
+    assert likert.type == surveys.LIKERT
+    assert number.type == surveys.NUMBER
+    assert (number.number_min, number.number_max, number.unit) == (0, 99, "years")
+    assert text.type == surveys.TEXT
+    # Levels are sorted by value regardless of mapping order, and help is kept.
+    assert select.levels == ((0, "never"), (1, "sometimes"), (2, "often"))
+    assert select.help == "see note"
+    assert not survey.is_simple_likert
+    assert len(survey.response_items) == 4  # the heading collects nothing
+
+
+def test_typed_items_require_schema_version_2():
+    # A mapping (typed) item in a v1 file is rejected with a clear message.
+    payload = _mapping()  # schema_version 1, string items
+    payload["items"] = ["ok", {"text": "Age", "type": "number"}]
+    with pytest.raises(ValueError, match="schema_version 2"):
+        surveys.parse_survey_mapping(payload)
+
+
+def test_scale_optional_when_no_likert_items():
+    survey = surveys.parse_survey_mapping(
+        {
+            "kind": surveys.KIND,
+            "schema_version": 2,
+            "key": "demo",
+            "name": "Demo",
+            "items": [{"text": "Job", "type": "text"}],  # no Likert -> no scale needed
+        }
+    )
+    assert survey.items[0].type == surveys.TEXT
+
+
+@pytest.mark.parametrize(
+    "items",
+    [
+        [{"text": "Q", "type": "bogus"}],  # unknown type
+        [{"text": "Q", "type": "select"}],  # select needs levels
+        [{"text": "Q", "type": "select", "levels": {0: "only"}}],  # <2 levels
+        [{"text": "Q", "type": "select", "levels": {0: "a", 1: ""}}],  # blank label
+        [{"text": "Q", "type": "select", "levels": {"x": "a", "y": "b"}}],  # bad keys
+        [{"text": "Q", "type": "number", "min": 5, "max": 5}],  # max !> min
+        [{"type": "text"}],  # missing item text
+        [{"text": "only a heading", "type": "heading"}],  # nothing collects a response
+    ],
+)
+def test_parse_rejects_malformed_typed_items(items):
+    with pytest.raises(ValueError):
+        surveys.parse_survey_mapping(_typed_mapping(items))
+
+
+def test_madre_is_the_bundled_mixed_survey(tmp_path):
+    from smacc.paths import BUNDLED_SURVEYS_DIR
+
+    loaded, problems = surveys.all_surveys(BUNDLED_SURVEYS_DIR, tmp_path / "none")
+    assert problems == []
+    madre = loaded["madre"]
+    types = {it.type for it in madre.items}
+    assert {"select", "number", "text", "likert", "heading"} <= types
+    # "No"/"Yes" survive YAML's boolean coercion as text labels.
+    recurrence = next(
+        it for it in madre.items if it.text.startswith("Do you experience")
+    )
+    assert recurrence.levels == ((0, "No"), (1, "Yes"))
+
+
+def test_typed_survey_round_trips_through_mapping():
+    survey = surveys.parse_survey_mapping(
+        _typed_mapping(
+            [
+                {"text": "Sec", "type": "heading"},
+                "A Likert item",
+                {"text": "Pick", "type": "select", "levels": {0: "no", 1: "yes"}},
+            ]
+        )
+    )
+    mapping = surveys.survey_to_mapping(survey)
+    assert mapping["schema_version"] == 2  # typed items force v2
+    assert mapping["items"][1] == "A Likert item"  # plain Likert collapses to a string
+    reloaded = surveys.parse_survey_mapping(mapping)
+    assert reloaded.items == survey.items
+
+
+def test_simple_likert_round_trips_as_version_1():
+    survey = surveys.parse_survey_mapping(_mapping())
+    assert surveys.survey_to_mapping(survey)["schema_version"] == 1
+
+
 # ----- save / load round trip ---------------------------------------------------
 
 
@@ -204,8 +328,8 @@ def test_response_payload_carries_linkage_and_version():
     assert payload["submitted"] == "2026-06-10T03:04:05"
     assert payload["time_since_recording_start"] == "01:00:05"
     assert payload["responses"] == [
-        {"item": "First item", "response": 2, "anchor": "Yes"},
-        {"item": "Second item", "response": None, "anchor": ""},
+        {"item": "First item", "type": "likert", "response": 2, "label": "Yes"},
+        {"item": "Second item", "type": "likert", "response": None, "label": ""},
     ]
     assert payload["notes"] == "participant unsure on item 2"
 


### PR DESCRIPTION
Closes #118.

Generalizes survey definitions from a single shared Likert scale to optional per-item types, so mixed-format questionnaires can be bundled. A bare-string item is still a Likert item on the survey's shared scale (all 16 existing instruments are untouched and stay `schema_version: 1`); typed items require `schema_version: 2`, so an older SMACC refuses such a file cleanly instead of mis-reading it.

Item types: `likert` (shared-scale radio matrix, default), `select` (dropdown with its own `levels`), `number` (entry with optional `min`/`max`/`unit`; blank = unanswered), `text`, and `heading` (display-only section title). Any item may carry a `help:` line. Consecutive Likert items collapse into one matrix (preserving the original look); other types render as their own rows.

Bundles **MADRE** (Mannheim Dream Questionnaire) — a 28-item intake instrument exercising every type — converted by hand from the lab's HTML/JSON sources (DOI 10.11588/ijodr.2014.2.16675). Response files generalize each entry to `{item, type, response, label}`.

The simple Build-survey dialog still authors only plain Likert surveys; a custom survey with typed items is edited as a file (the dialog says so and points at the path).

Verified: 533 tests pass (incl. new parser/window/dialog coverage), ruff and mypy clean, and the MADRE window renders all 28 fields offscreen.