### PR TITLE
feat: refresh bundled assets on upgrade

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,9 +59,10 @@ run a session with it**; you can also (re)enable this from
 ### Audio cues
 
 SMACC seeds a few `demo-*` cue files into the default data directory's `cues/`
-folder (restored if you delete them), so there is always something to test with. You
-can also place your own sound files there — `.wav`, `.mp3`, `.flac`, `.ogg`, and
-`.aiff` are all supported.
+folder (restored if you delete them, and refreshed when you upgrade SMACC), so
+there is always something to test with. You can also place your own sound files
+there — `.wav`, `.mp3`, `.flac`, `.ogg`, and `.aiff` are all supported; only the
+`demo-` files are managed by SMACC, so your own are never touched.
 
 ### Dream report survey
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -24,6 +24,11 @@ from the task-oriented [Usage](../usage.md) guide.
   responses, and exports.
 - **Custom survey definitions** live in the SMACC directory's `surveys/` folder;
   built-in ones ship inside SMACC itself.
+- **Bundled assets refresh on upgrade.** `default.smacc` (a read-only template) and
+  the `demo-` cues are re-seeded from the bundle when they change, so a newer
+  SMACC's improvements reach an existing directory; your own files are untouched.
+  Biocal voice recordings are read straight from the bundle, with the SMACC
+  directory's `biocals/` folder as an optional per-recording override.
 
 ## Stability promise
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -134,14 +134,15 @@ use **+ Add** to add another instance), be reordered with **▲/▼**, and remov
 with **✕**; the stack is locked while something is running. Need a biocal SMACC
 doesn't ship? Use a custom event button in the Event logging panel instead.
 
-**Voice recordings** live in your SMACC directory's `biocals/` folder (e.g.
-`~/SMACC/biocals/`), seeded from a bundled set on first launch (generated with
-[ElevenLabs](https://elevenlabs.io) text-to-speech). Prefer another voice or
-language? Replace any file with your own recording under the same name — SMACC
-never overwrites existing files, and each session start warns about any that
-are missing (a biocal with a missing voice still runs, just unvoiced). The shared
-**Voice volume** rides the cue route, so the master output cap and the
-control-room monitor fan-out apply to instructions exactly as they do to cues.
+**Voice recordings** ship inside SMACC (generated with
+[ElevenLabs](https://elevenlabs.io) text-to-speech) and are read straight from
+the bundle, so they stay current when you upgrade. Prefer another voice or
+language? Drop your own recording under the same name in your SMACC directory's
+`biocals/` folder (e.g. `~/SMACC/biocals/`) — a file there overrides the bundled
+one. (A biocal with no recording in either place still runs, just unvoiced;
+session start warns if that happens.) The shared **Voice volume** rides the cue
+route, so the master output cap and the control-room monitor fan-out apply to
+instructions exactly as they do to cues.
 
 ## Intercom
 

--- a/src/smacc/__main__.py
+++ b/src/smacc/__main__.py
@@ -15,8 +15,6 @@ from PyQt6.QtWidgets import QApplication, QMessageBox
 from . import preferences
 from .launcher import LauncherWindow, resolve_initial_settings
 from .paths import (
-    BIOCALS_DIR,
-    BUNDLED_BIOCALS_DIR,
     BUNDLED_CUES_DIR,
     BUNDLED_DEFAULT_SETTINGS,
     DEFAULT_DATA_DIR,
@@ -24,7 +22,7 @@ from .paths import (
     LOGO_PATH,
     preferences_path,
 )
-from .utils import seed_biocal_voices, seed_default_settings, seed_demo_cues
+from .utils import seed_default_settings, seed_demo_cues
 
 # Study-file extensions SMACC will open when launched with a file (or double-click).
 _STUDY_SUFFIXES = {".smacc"}
@@ -143,12 +141,13 @@ def main() -> None:
     # Application-wide icon (taskbar + windows).
     if LOGO_PATH.is_file():
         app.setWindowIcon(QIcon(str(LOGO_PATH)))
-    # First-run seeding (best-effort): a readable default.smacc, demo cues, and
-    # the biocal voice recordings, so there's always a working setup to open,
-    # something to play, and voiced biocals out of the box.
+    # Seed/refresh on every launch (best-effort): a readable default.smacc and
+    # the demo cues, so there's always a working setup to open and something to
+    # play — and so upgrade improvements reach existing installs (#122). Biocal
+    # voices are read straight from the bundle (with an optional per-lab override
+    # dir), so they need no seeding.
     seed_default_settings(DEFAULT_SETTINGS_PATH, BUNDLED_DEFAULT_SETTINGS)
     seed_demo_cues(DEFAULT_DATA_DIR / "cues", BUNDLED_CUES_DIR)
-    seed_biocal_voices(BIOCALS_DIR, BUNDLED_BIOCALS_DIR)
     file_arg = pick_settings_path(app.arguments())
     if file_arg:
         # A double-clicked / CLI .smacc opens straight into a session for it; the

--- a/src/smacc/biocals.py
+++ b/src/smacc/biocals.py
@@ -360,16 +360,26 @@ def rows_from_list(loaded: Any) -> list[BiocalRow] | None:
 
 
 def missing_voice_files(
-    directory: Path, defs: Sequence[BiocalDef] | None = None
+    directory: Path,
+    defs: Sequence[BiocalDef] | None = None,
+    fallback: Path | None = None,
 ) -> list[str]:
-    """Return the (sorted) voice filenames absent from ``directory``.
+    """Return the (sorted) voice filenames absent from both dirs.
 
-    Checked once at session start so the operator learns about a failed seed or
-    a deleted file before the night begins; a biocal with a missing voice still
-    runs, just unvoiced.
+    A recording counts as present if it is in ``directory`` (a lab override) or
+    in ``fallback`` (the bundled set, #122). Checked once at session start so the
+    operator learns about a genuinely missing recording before the night begins;
+    a biocal with a missing voice still runs, just unvoiced.
     """
     table = list(defs) if defs is not None else default_biocals()
-    return sorted(b.filename for b in table if not (directory / b.filename).is_file())
+    missing = []
+    for b in table:
+        if (directory / b.filename).is_file():
+            continue
+        if fallback is not None and (fallback / b.filename).is_file():
+            continue
+        missing.append(b.filename)
+    return sorted(missing)
 
 
 # ---------------------------------------------------------------------------

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -40,7 +40,13 @@ from .panels.noise import NoiseWindow
 from .panels.recording import RecordingWindow
 from .panels.visual import VisualWindow
 from .panels.volume import VolumeWindow
-from .paths import BIOCALS_DIR, LOGO_PATH, is_default_settings, preferences_path
+from .paths import (
+    BIOCALS_DIR,
+    BUNDLED_BIOCALS_DIR,
+    LOGO_PATH,
+    is_default_settings,
+    preferences_path,
+)
 from .qtlog import QtLogHandler
 from .session import SmaccSession
 from .toolwindow import ToolWindow
@@ -844,16 +850,14 @@ class SmaccWindow(ToolWindow):
         would warn spuriously. A biocal with a missing voice still runs, just
         unvoiced, so this is a heads-up rather than a blocker.
         """
-        missing = biocals.missing_voice_files(BIOCALS_DIR)
+        missing = biocals.missing_voice_files(BIOCALS_DIR, fallback=BUNDLED_BIOCALS_DIR)
         if not missing:
             return
         items = "\n".join(f"  • {name}" for name in missing)
         self.session.show_info_popup(
             "Some biocal voice recordings are missing.",
-            f"Not found in {BIOCALS_DIR}:\n{items}\n\n"
-            "These biocals will run without their spoken instruction. Restore "
-            "the files (or relaunch SMACC to re-seed the bundled set) to "
-            "re-enable them.",
+            f"No recording (bundled or in {BIOCALS_DIR}) for:\n{items}\n\n"
+            "These biocals will run without their spoken instruction.",
             parent=self,
         )
 

--- a/src/smacc/panels/biocals.py
+++ b/src/smacc/panels/biocals.py
@@ -29,7 +29,7 @@ import soundfile as sf
 from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import audio, biocals, utils
-from ..paths import BIOCALS_DIR
+from ..paths import resolve_biocal_voice
 from ..session import SmaccSession
 from ..utils import format_elapsed
 from .audio import CueOutput
@@ -562,7 +562,7 @@ class BiocalsWindow(ModalityWindow):
         """
         if key in self._voice_cache:
             return self._voice_cache[key]
-        path = BIOCALS_DIR / biocals.BIOCALS_BY_KEY[key].filename
+        path = resolve_biocal_voice(biocals.BIOCALS_BY_KEY[key].filename)
         try:
             data, rate = sf.read(path, dtype="float32")
         except Exception as exc:

--- a/src/smacc/paths.py
+++ b/src/smacc/paths.py
@@ -37,14 +37,27 @@ preferences_path = smacc_directory / "preferences.yaml"
 DEFAULT_SETTINGS_PATH = smacc_directory / "default.smacc"
 # Where runs go when a settings file doesn't name its own data directory.
 DEFAULT_DATA_DIR = smacc_directory / "data"
-# Biocal voice recordings, seeded from the bundled set on first run (#78). A lab
-# can replace any file with its own recording (same name) — seeding never
-# overwrites — and their presence is verified at each session start.
+# Biocal voice recordings (#78). The standard set is read straight from the
+# bundle (so it tracks the app on upgrade, #122); this folder is an optional
+# *override* — a lab drops a same-named WAV here to replace one — and is not
+# seeded, so it may not exist until a lab adds one.
 BIOCALS_DIR = smacc_directory / "biocals"
 # User-built survey definitions (#114), written by the in-app builder (or by
 # hand, same YAML format); loaded alongside the bundled built-ins. Created lazily
 # on the first build.
 SURVEYS_DIR = smacc_directory / "surveys"
+
+
+def resolve_biocal_voice(filename: str) -> Path:
+    """The biocal voice WAV to play: a lab override if present, else the bundle.
+
+    A same-named file in :data:`BIOCALS_DIR` wins (a lab's own recording);
+    otherwise the bundled copy is used directly, so the standard set needs no
+    seeding and stays current across upgrades (#122). The returned path may not
+    exist if a (custom) biocal has no recording in either place.
+    """
+    override = BIOCALS_DIR / filename
+    return override if override.is_file() else BUNDLED_BIOCALS_DIR / filename
 
 
 def is_default_settings(path: str | Path) -> bool:

--- a/src/smacc/utils.py
+++ b/src/smacc/utils.py
@@ -302,52 +302,49 @@ def generate_demo_cues(dest_dir: Path) -> list[Path]:
 
 
 def seed_default_settings(dest_path: Path, bundled_path: Path) -> None:
-    """Copy the shipped ``default.smacc`` to ``dest_path`` if absent (best-effort).
+    """Mirror the shipped ``default.smacc`` to ``dest_path`` (best-effort).
 
     Keeps the out-of-the-box settings in a readable ``.smacc`` that doubles as an
-    example for technical users; restored if deleted. Never fatal.
+    example for technical users; restored if deleted. It is SMACC's read-only
+    template (the editor refuses to save over it), so it is refreshed from the
+    bundle whenever the on-disk copy differs — i.e. on upgrade improvements (new
+    event codes, defaults) reach existing installs (#122). Never fatal.
     """
     try:
-        if not dest_path.exists() and bundled_path.is_file():
-            dest_path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(bundled_path, dest_path)
+        if not bundled_path.is_file():
+            return
+        if dest_path.exists() and dest_path.read_bytes() == bundled_path.read_bytes():
+            return
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(bundled_path, dest_path)
     except Exception:
         logging.getLogger("smacc").exception("Could not seed default settings")
 
 
-def seed_biocal_voices(biocals_dir: Path, bundled_dir: Path) -> None:
-    """Ensure the bundled biocal voice WAVs exist in ``biocals_dir`` (best-effort).
-
-    Copies any shipped recording missing from the folder; existing files are
-    never overwritten, so a lab's replacement recordings survive upgrades.
-    Unlike the demo cues there is no synthesis fallback — a file still missing
-    is surfaced at session start instead (see the Biocals window, #78).
-    """
-    try:
-        biocals_dir.mkdir(parents=True, exist_ok=True)
-        if bundled_dir.is_dir():
-            for src in sorted(bundled_dir.iterdir()):
-                dest = biocals_dir / src.name
-                if src.suffix.lower() in _WAV_SUFFIXES and not dest.exists():
-                    shutil.copy2(src, dest)
-    except Exception:
-        logging.getLogger("smacc").exception("Could not seed biocal voices")
-
-
 def seed_demo_cues(cues_dir: Path, bundled_dir: Path) -> None:
-    """Ensure the demo cues exist in ``cues_dir`` (best-effort; never fatal).
+    """Ensure the demo cues exist and are current in ``cues_dir`` (best-effort).
 
     Copies any shipped demo file missing from ``cues_dir`` (restoring a deleted
-    demo and adding bundled clips), then synthesizes any built-in demo still
-    absent. Existing files are never overwritten, so a user's own cues -- and any
-    demos they choose to keep -- are left untouched.
+    demo and adding bundled clips), and refreshes a ``demo-`` file whose content
+    has changed in a newer bundle so upgrade improvements reach existing installs
+    (#122). The ``demo-`` prefix marks SMACC's own clips, so a user's cues — and
+    any non-demo file — are never touched. Synthesizes any built-in demo that is
+    still absent (no bundle). Never fatal.
     """
     try:
         cues_dir.mkdir(parents=True, exist_ok=True)
         if bundled_dir.is_dir():
             for src in sorted(bundled_dir.iterdir()):
+                if src.suffix.lower() not in AUDIO_SUFFIXES:
+                    continue
                 dest = cues_dir / src.name
-                if src.suffix.lower() in AUDIO_SUFFIXES and not dest.exists():
+                # Refresh only our own demos; a user's same-named file is theirs.
+                refresh = (
+                    dest.exists()
+                    and src.name.startswith("demo-")
+                    and dest.read_bytes() != src.read_bytes()
+                )
+                if not dest.exists() or refresh:
                     shutil.copy2(src, dest)
         for name, synth in DEMO_CUES.items():
             dest = cues_dir / name

--- a/tests/test_biocals.py
+++ b/tests/test_biocals.py
@@ -84,12 +84,39 @@ def test_missing_voice_files(tmp_path):
     assert biocals.missing_voice_files(tmp_path) == []
 
 
+def test_missing_voice_files_counts_fallback_as_present(tmp_path):
+    # A recording in the fallback (bundle) dir counts as present (#122), so the
+    # override dir being empty no longer means "missing".
+    override = tmp_path / "override"
+    override.mkdir()
+    from smacc.paths import BUNDLED_BIOCALS_DIR
+
+    assert biocals.missing_voice_files(override, fallback=BUNDLED_BIOCALS_DIR) == []
+
+
 def test_bundled_voice_assets_ship_complete():
-    # The repo carries a recording for every biocal in the table (seeded to the
-    # SMACC directory on first launch); a phrase change must re-render them.
+    # The repo carries a recording for every biocal in the table (read straight
+    # from the bundle at play time); a phrase change must re-render them.
     from smacc.paths import BUNDLED_BIOCALS_DIR
 
     assert biocals.missing_voice_files(BUNDLED_BIOCALS_DIR) == []
+
+
+def test_resolve_biocal_voice_prefers_override(tmp_path, monkeypatch):
+    from smacc import paths
+
+    name = biocals.default_biocals()[0].filename
+    # With no override dir, it resolves into the bundle (a real, existing file).
+    monkeypatch.setattr(paths, "BIOCALS_DIR", tmp_path / "absent")
+    bundled = paths.resolve_biocal_voice(name)
+    assert bundled == paths.BUNDLED_BIOCALS_DIR / name
+    assert bundled.is_file()
+    # A same-named file in the override dir wins.
+    override_dir = tmp_path / "override"
+    override_dir.mkdir()
+    (override_dir / name).write_bytes(b"lab recording")
+    monkeypatch.setattr(paths, "BIOCALS_DIR", override_dir)
+    assert paths.resolve_biocal_voice(name) == override_dir / name
 
 
 # ----- the run engine ------------------------------------------------------------

--- a/tests/test_panels_biocals.py
+++ b/tests/test_panels_biocals.py
@@ -77,9 +77,12 @@ def test_press_runs_and_press_again_cancels(qtbot, design_session):
 def test_missing_voice_skips_straight_to_the_window(
     qtbot, design_session, monkeypatch, tmp_path
 ):
-    # Voice enabled but no recording on disk: warn, then open the task window
-    # immediately — a lost WAV must never block a calibration.
-    monkeypatch.setattr("smacc.panels.biocals.BIOCALS_DIR", tmp_path)
+    # Voice enabled but no recording anywhere (override nor bundle): warn, then
+    # open the task window immediately — a lost WAV must never block a calibration.
+    monkeypatch.setattr(
+        "smacc.panels.biocals.resolve_biocal_voice",
+        lambda filename: tmp_path / filename,  # an empty dir == no recording
+    )
     panel = _make_panel(qtbot, design_session)
     records = _capture(design_session)
     row = panel.rows[0]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import shutil
 from datetime import timedelta
 from pathlib import Path
 
@@ -215,6 +216,61 @@ def test_seed_demo_cues_coexists_with_user_files_and_restores(tmp_path):
     assert (cues / "mysong.wav").read_bytes() == user_bytes  # user file untouched
     assert (cues / "demo-chime.wav").exists()  # deleted demo restored
     assert kept.read_bytes() == kept_bytes  # existing demo not overwritten
+
+
+def test_seed_demo_cues_refreshes_only_demo_files(tmp_path):
+    # On upgrade (#122), a changed demo is refreshed from the bundle, but a
+    # user's same-named non-demo clip is theirs and is left alone.
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    rate = 8000
+    write(bundled / "demo-chord.wav", rate, utils.note(440, 1, 1e4, rate))
+    write(bundled / "ambient.wav", rate, utils.note(330, 1, 1e4, rate))
+    cues = tmp_path / "cues"
+    cues.mkdir()
+    (cues / "demo-chord.wav").write_bytes(b"stale demo")  # ours -> refreshed
+    (cues / "ambient.wav").write_bytes(b"user ambient")  # not demo- -> kept
+    utils.seed_demo_cues(cues, bundled)
+    assert (cues / "demo-chord.wav").read_bytes() == (
+        bundled / "demo-chord.wav"
+    ).read_bytes()
+    assert (cues / "ambient.wav").read_bytes() == b"user ambient"
+
+
+def test_seed_demo_cues_leaves_identical_demo_untouched(tmp_path):
+    # An unchanged demo is not rewritten, so its mtime (the ensure_wav cache key)
+    # is stable across launches.
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+    write(bundled / "demo-chord.wav", 8000, utils.note(440, 1, 1e4, 8000))
+    cues = tmp_path / "cues"
+    cues.mkdir()
+    shutil.copy2(bundled / "demo-chord.wav", cues / "demo-chord.wav")
+    mtime = (cues / "demo-chord.wav").stat().st_mtime_ns
+    utils.seed_demo_cues(cues, bundled)
+    assert (cues / "demo-chord.wav").stat().st_mtime_ns == mtime
+
+
+def test_seed_default_settings_mirrors_bundle(tmp_path):
+    bundled = tmp_path / "default.smacc"
+    bundled.write_text("kind: smacc/settings\nschema_version: 2\n", encoding="utf-8")
+    dest = tmp_path / "out" / "default.smacc"
+    utils.seed_default_settings(dest, bundled)  # seeded when absent
+    assert dest.read_text(encoding="utf-8") == bundled.read_text(encoding="utf-8")
+    # An upgraded bundle is mirrored over the stale on-disk copy.
+    bundled.write_text("kind: smacc/settings\nschema_version: 3\n", encoding="utf-8")
+    utils.seed_default_settings(dest, bundled)
+    assert "schema_version: 3" in dest.read_text(encoding="utf-8")
+
+
+def test_seed_default_settings_no_op_when_identical(tmp_path):
+    bundled = tmp_path / "default.smacc"
+    bundled.write_text("same", encoding="utf-8")
+    dest = tmp_path / "dest.smacc"
+    utils.seed_default_settings(dest, bundled)
+    mtime = dest.stat().st_mtime_ns
+    utils.seed_default_settings(dest, bundled)  # identical: not rewritten
+    assert dest.stat().st_mtime_ns == mtime
 
 
 def test_committed_demo_assets_match_generator():


### PR DESCRIPTION
Closes #122.

Shipped assets seeded into `~/SMACC` were copy-if-absent, so they never updated when `SMACC.exe` was upgraded — improvements to the bundled `default.smacc`, demo cues, and biocal voices stayed frozen at whatever version first ran. This makes each asset track the bundle, using the ownership signals already in the code (no manifest/hashes):

- **Biocal voices** are now read straight from the bundle, with `~/SMACC/biocals/` kept only as an optional per-recording override (a same-named file wins). They're looked up by name and never stored as paths, so this is clean — no seeding, never stale. `seed_biocal_voices` is removed; `resolve_biocal_voice` resolves override-then-bundle.
- **Demo cues** stay an on-disk folder (a saved `.smacc` references cue files by path, and users add their own audio there), but a `demo-` file is refreshed from the bundle when it changes. The `demo-` prefix already marks SMACC's own clips, so user files are never touched.
- **`default.smacc`** (the read-only template the editor won't save over) is mirrored from the bundle when the on-disk copy differs.

All silent — standard upkeep. Orthogonal to #116 (distribution/installer/signing): this keeps `~/SMACC` current after any upgrade, portable or installed.

Verified: 539 tests pass (new coverage for the refresh, the `demo-` guard, override-wins resolution, and the bundle-fallback missing check), ruff and mypy clean.