### PR TITLE
Resolve role-bound device names to their WASAPI index

### DIFF
--- a/src/smacc/panels/audio.py
+++ b/src/smacc/panels/audio.py
@@ -20,13 +20,14 @@ import sounddevice as sd
 import soundfile as sf
 from PyQt6 import QtCore, QtWidgets
 
-from .. import audio, utils
+from .. import audio, devices, utils
 from ..session import SmaccSession
 from ..utils import pick_random_demo_cue
 from .base import (
     ModalityWindow,
     describe_target,
     make_section_title,
+    resolve_device,
     restore_spin_value,
 )
 from .meter import InputLevelMeter, LevelMeter
@@ -319,7 +320,7 @@ class AudioCueWindow(ModalityWindow):
         """True while a cue is playing or the room monitor mic is open."""
         return bool(self._outputs) or self.roomMeter.is_active()
 
-    def _device_samplerate(self, device: str | None) -> int:
+    def _device_samplerate(self, device: int | str | None) -> int:
         """Best output sample rate for ``device`` (WASAPI opens only at its own)."""
         try:
             return int(sd.query_devices(device, "output")["default_samplerate"])
@@ -405,13 +406,17 @@ class AudioCueWindow(ModalityWindow):
         # *different* cue is replaced (re-playing the same slot is just a restart).
         if self._active_slot is not None:
             self._finish_active(mark=self._active_slot is not slot)
-        device = self.session.devices.device_for("cue_out") or None
+        device = resolve_device(
+            self.session.devices.device_for("cue_out"), devices.OUTPUT
+        )
         primary = self._open_output(slot, device)
         if primary is None:
             return  # primary failed (error already shown)
         self._outputs = [primary]
-        monitor_device = self.session.devices.device_for("cue_monitor") or None
-        if monitor_device and monitor_device != device:
+        monitor_device = resolve_device(
+            self.session.devices.device_for("cue_monitor"), devices.OUTPUT
+        )
+        if monitor_device is not None and monitor_device != device:
             monitor = self._open_output(slot, monitor_device, optional=True)
             if monitor is not None:
                 self._outputs.append(monitor)
@@ -427,7 +432,7 @@ class AudioCueWindow(ModalityWindow):
         )
 
     def _open_output(
-        self, slot: CueSlot, device: str | None, *, optional: bool = False
+        self, slot: CueSlot, device: int | str | None, *, optional: bool = False
     ) -> CueOutput | None:
         """Open one cue output (mixer + stream) on ``device``; ``None`` on failure.
 
@@ -564,7 +569,9 @@ class AudioCueWindow(ModalityWindow):
         """Start/stop the bedroom monitor-mic meter (the objective acoustic check)."""
         self.session.log_interaction(f"Cue room monitor {'on' if enabled else 'off'}")
         if enabled:
-            device = self.session.devices.device_for("monitor_in") or None
+            device = resolve_device(
+                self.session.devices.device_for("monitor_in"), devices.INPUT
+            )
             try:
                 self.roomMeter.start(device)
             except Exception as exc:  # PortAudio errors, no device, busy, etc.

--- a/src/smacc/panels/base.py
+++ b/src/smacc/panels/base.py
@@ -2,11 +2,47 @@
 
 from __future__ import annotations
 
+import sounddevice as sd
 from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import devices, utils
 from ..paths import LOGO_PATH
 from ..session import SmaccSession
+
+
+def resolve_device(device: str | None, kind: str) -> int | str | None:
+    """Resolve a stored device name to its WASAPI device index for sounddevice.
+
+    Role bindings persist the bare device name. Passing that name straight to
+    sounddevice matches it against *every* host API, and on Windows the same
+    hardware appears once per host API (MME, DirectSound, WASAPI, …). A name
+    short enough to escape MME's 31-char truncation is then identical across
+    host APIs and sounddevice raises "Multiple input/output devices found".
+    Resolving here pins the stream to the one host API SMACC enumerates (see
+    :func:`smacc.panels.devices.wasapi_devices`).
+
+    ``kind`` is :data:`smacc.devices.OUTPUT` or :data:`smacc.devices.INPUT`.
+    ``None``/"" (system default) stays ``None``; a name with no current WASAPI
+    match is returned unchanged, so opening it fails with sounddevice's usual
+    "no device matching" error rather than silently using another device.
+    """
+    if not device:
+        return None
+    name = devices.strip_wasapi_suffix(device)
+    chan_key = f"max_{kind}_channels"
+    try:
+        host_api_names = [api["name"] for api in sd.query_hostapis()]
+        hostapi = host_api_names.index(devices.WASAPI_HOST_API)
+        for index, info in enumerate(sd.query_devices()):
+            if (
+                info["hostapi"] == hostapi
+                and info[chan_key] > 0
+                and info["name"] == name
+            ):
+                return index
+    except Exception:
+        pass  # no WASAPI host API (or query failed): fall through to the name
+    return name
 
 
 def describe_target(session: SmaccSession, target_key: str) -> str:

--- a/src/smacc/panels/biocals.py
+++ b/src/smacc/panels/biocals.py
@@ -28,12 +28,12 @@ import sounddevice as sd
 import soundfile as sf
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from .. import audio, biocals, utils
+from .. import audio, biocals, devices, utils
 from ..paths import resolve_biocal_voice
 from ..session import SmaccSession
 from ..utils import format_elapsed
 from .audio import CueOutput
-from .base import ModalityWindow, describe_target, make_section_title
+from .base import ModalityWindow, describe_target, make_section_title, resolve_device
 
 # Rows are instances, not definitions, so a stack can repeat biocals freely; the
 # cap just keeps the window and a played sequence manageable.
@@ -42,7 +42,7 @@ MAX_BIOCAL_ROWS = 40
 _FALLBACK_RATE = 44100
 
 
-def _device_samplerate(device: str | None) -> int:
+def _device_samplerate(device: int | str | None) -> int:
     """Best output sample rate for ``device`` (WASAPI opens only at its own)."""
     try:
         return int(sd.query_devices(device, "output")["default_samplerate"])
@@ -583,13 +583,17 @@ class BiocalsWindow(ModalityWindow):
             return False
         data, rate = loaded
         self._stop_voice()  # safety: never two announcements at once
-        device = self.session.devices.device_for("cue_out") or None
+        device = resolve_device(
+            self.session.devices.device_for("cue_out"), devices.OUTPUT
+        )
         primary = self._open_output(data, rate, device)
         if primary is None:
             return False
         self._outputs = [primary]
-        monitor_device = self.session.devices.device_for("cue_monitor") or None
-        if monitor_device and monitor_device != device:
+        monitor_device = resolve_device(
+            self.session.devices.device_for("cue_monitor"), devices.OUTPUT
+        )
+        if monitor_device is not None and monitor_device != device:
             monitor = self._open_output(data, rate, monitor_device, optional=True)
             if monitor is not None:
                 self._outputs.append(monitor)
@@ -599,7 +603,7 @@ class BiocalsWindow(ModalityWindow):
         self,
         data: np.ndarray,
         file_rate: int,
-        device: str | None,
+        device: int | str | None,
         *,
         optional: bool = False,
     ) -> CueOutput | None:

--- a/src/smacc/panels/devices.py
+++ b/src/smacc/panels/devices.py
@@ -35,8 +35,10 @@ def wasapi_devices(kind: str) -> list[str]:
 
     Only WASAPI devices are listed, so the bare device name is returned (no
     ", Windows WASAPI" suffix — it added nothing and is what gets persisted as a
-    role binding). sounddevice still resolves a bare name to the right device, and
-    older settings that stored the suffixed form are normalized on load (see
+    role binding). A bare name is ambiguous to sounddevice when the same hardware
+    appears under several host APIs, so stream-opening code resolves it back to
+    the WASAPI device via :func:`smacc.panels.base.resolve_device`; older settings
+    that stored the suffixed form are normalized on load (see
     :func:`smacc.devices.strip_wasapi_suffix`).
     """
     chan_key = "max_output_channels" if kind == devices.OUTPUT else "max_input_channels"

--- a/src/smacc/panels/intercom.py
+++ b/src/smacc/panels/intercom.py
@@ -24,7 +24,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 from .. import audio, devices
 from ..dialogs import ManageChatPresetsDialog
 from ..session import SmaccSession
-from .base import ModalityWindow, describe_target, make_section_title
+from .base import ModalityWindow, describe_target, make_section_title, resolve_device
 from .chat import EXPERIMENTER, ChatPresets, ChatTranscript, post_chat_message
 
 # Cap an experimenter prompt's button label so a long standardized question doesn't
@@ -55,7 +55,9 @@ class _Bridge:
         """True while either stream is open."""
         return self._input is not None or self._output is not None
 
-    def start(self, input_device: str | None, output_device: str | None) -> None:
+    def start(
+        self, input_device: int | str | None, output_device: int | str | None
+    ) -> None:
         """Open and start the streams; raises (and tears down) on a PortAudio error."""
         try:
             in_rate = int(sd.query_devices(input_device, "input")["default_samplerate"])
@@ -305,7 +307,9 @@ class IntercomWindow(ModalityWindow):
         the participant hears). The mic is the system default input.
         """
         if enabled:
-            output = self.session.devices.device_for("intercom_talk") or None
+            output = resolve_device(
+                self.session.devices.device_for("intercom_talk"), devices.OUTPUT
+            )
             try:
                 self._talk.start(None, output)
             except Exception as exc:  # PortAudio errors, no device, busy, etc.
@@ -325,10 +329,13 @@ class IntercomWindow(ModalityWindow):
         the source, the ``intercom_listen`` route the destination.
         """
         if enabled:
-            mic = (
-                self.session.devices.device_for_role(devices.LISTEN_SOURCE_ROLE) or None
+            mic = resolve_device(
+                self.session.devices.device_for_role(devices.LISTEN_SOURCE_ROLE),
+                devices.INPUT,
             )
-            output = self.session.devices.device_for("intercom_listen") or None
+            output = resolve_device(
+                self.session.devices.device_for("intercom_listen"), devices.OUTPUT
+            )
             try:
                 self._listen.start(mic, output)
             except Exception as exc:  # PortAudio errors, no device, busy, etc.

--- a/src/smacc/panels/meter.py
+++ b/src/smacc/panels/meter.py
@@ -72,7 +72,7 @@ class InputLevelMeter(LevelMeter):
         """True while the input stream is open."""
         return self._stream is not None
 
-    def start(self, device: str | None) -> None:
+    def start(self, device: int | str | None) -> None:
         """Open the input stream on ``device`` (raises on a PortAudio error).
 
         The caller surfaces any error (and reverts its toggle); this leaves the meter

--- a/src/smacc/panels/noise.py
+++ b/src/smacc/panels/noise.py
@@ -10,12 +10,13 @@ import sounddevice as sd
 import soundfile as sf
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from .. import utils
+from .. import devices, utils
 from ..session import SmaccSession
 from .base import (
     ModalityWindow,
     describe_target,
     make_section_title,
+    resolve_device,
     restore_spin_value,
 )
 
@@ -196,7 +197,7 @@ class NoiseWindow(ModalityWindow):
 
     # ----- playback ---------------------------------------------------------
 
-    def _device_samplerate(self, device: str | None) -> int:
+    def _device_samplerate(self, device: int | str | None) -> int:
         """Best output sample rate for ``device`` (WASAPI opens only at its own)."""
         try:
             return int(sd.query_devices(device, "output")["default_samplerate"])
@@ -255,7 +256,9 @@ class NoiseWindow(ModalityWindow):
         """Start streaming the selected noise (built-in color or file) on loop."""
         if self.noise_stream is not None:
             return  # already playing
-        device = self.session.devices.device_for("noise_out") or None
+        device = resolve_device(
+            self.session.devices.device_for("noise_out"), devices.OUTPUT
+        )
         rate = self._device_samplerate(device)
         try:
             buf = self._build_noise_buffer(rate)

--- a/src/smacc/panels/recording.py
+++ b/src/smacc/panels/recording.py
@@ -9,13 +9,13 @@ import sounddevice as sd
 import soundfile as sf
 from PyQt6 import QtCore, QtWidgets
 
-from .. import surveys
+from .. import devices, surveys
 from ..config import SURVEY_OPTIONS
 from ..dialogs import ManageSurveysDialog
 from ..paths import BUNDLED_SURVEYS_DIR, SURVEYS_DIR
 from ..session import SmaccSession
 from ..utils import format_elapsed
-from .base import ModalityWindow, describe_target, make_section_title
+from .base import ModalityWindow, describe_target, make_section_title, resolve_device
 from .meter import InputLevelMeter
 from .survey import SurveyWindow
 
@@ -118,9 +118,11 @@ class RecordingWindow(ModalityWindow):
         self._record_stream: sd.InputStream | None = None
         self._record_file: sf.SoundFile | None = None
 
-    def _selected_input_device(self) -> str | None:
+    def _selected_input_device(self) -> int | str | None:
         """The mic device for the dream-report role (None == system default)."""
-        return self.session.devices.device_for("report_in") or None
+        return resolve_device(
+            self.session.devices.device_for("report_in"), devices.INPUT
+        )
 
     def refresh_device_indicator(self) -> None:
         """Show where the mic resolves and switch a live meter over to it."""

--- a/tests/test_panels_base.py
+++ b/tests/test_panels_base.py
@@ -47,6 +47,108 @@ def test_describe_target_off_route_reads_off(design_session):
     assert base.describe_target(session, "cue_monitor") == "off"
 
 
+# ----- resolve_device --------------------------------------------------------
+
+# A Realtek-style layout: the same short name once per host API (the MME name is
+# only truncated past 31 chars, so short names collide exactly — issue seen live:
+# sounddevice raises "Multiple output devices found" on the bare name).
+_HOST_APIS = [
+    {"name": "MME"},
+    {"name": "Windows DirectSound"},
+    {"name": "Windows WASAPI"},
+]
+_DEVICES = [
+    {
+        "name": "Speakers (Realtek(R) Audio)",
+        "hostapi": 0,
+        "max_output_channels": 2,
+        "max_input_channels": 0,
+    },
+    {
+        "name": "Microphone (Realtek(R) Audio)",
+        "hostapi": 0,
+        "max_output_channels": 0,
+        "max_input_channels": 2,
+    },
+    {
+        "name": "Speakers (Realtek(R) Audio)",
+        "hostapi": 1,
+        "max_output_channels": 2,
+        "max_input_channels": 0,
+    },
+    {
+        "name": "Speakers (Realtek(R) Audio)",
+        "hostapi": 2,
+        "max_output_channels": 2,
+        "max_input_channels": 0,
+    },
+    {
+        "name": "Microphone (Realtek(R) Audio)",
+        "hostapi": 2,
+        "max_output_channels": 0,
+        "max_input_channels": 2,
+    },
+]
+
+
+def _patch_sd(monkeypatch, host_apis=_HOST_APIS, device_list=_DEVICES):
+    monkeypatch.setattr(base.sd, "query_hostapis", lambda: host_apis)
+    monkeypatch.setattr(base.sd, "query_devices", lambda: device_list)
+
+
+def test_resolve_device_picks_the_wasapi_index(monkeypatch):
+    _patch_sd(monkeypatch)
+    assert base.resolve_device("Speakers (Realtek(R) Audio)", devices.OUTPUT) == 3
+    assert base.resolve_device("Microphone (Realtek(R) Audio)", devices.INPUT) == 4
+
+
+def test_resolve_device_respects_the_channel_kind(monkeypatch):
+    # The speaker name only exists as an output; resolving it as an *input*
+    # finds no WASAPI match and falls back to the name (sounddevice then raises
+    # its usual "no matching device" error).
+    _patch_sd(monkeypatch)
+    assert (
+        base.resolve_device("Speakers (Realtek(R) Audio)", devices.INPUT)
+        == "Speakers (Realtek(R) Audio)"
+    )
+
+
+def test_resolve_device_blank_is_system_default(monkeypatch):
+    _patch_sd(monkeypatch)
+    assert base.resolve_device("", devices.OUTPUT) is None
+    assert base.resolve_device(None, devices.OUTPUT) is None
+
+
+def test_resolve_device_strips_legacy_wasapi_suffix(monkeypatch):
+    _patch_sd(monkeypatch)
+    saved = "Speakers (Realtek(R) Audio), Windows WASAPI"  # pre-#-strip settings
+    assert base.resolve_device(saved, devices.OUTPUT) == 3
+
+
+def test_resolve_device_unplugged_name_passes_through(monkeypatch):
+    _patch_sd(monkeypatch)
+    assert base.resolve_device("Speakers (USB)", devices.OUTPUT) == "Speakers (USB)"
+
+
+def test_resolve_device_no_wasapi_host_api_passes_through(monkeypatch):
+    _patch_sd(monkeypatch, host_apis=[{"name": "MME"}])
+    assert (
+        base.resolve_device("Speakers (Realtek(R) Audio)", devices.OUTPUT)
+        == "Speakers (Realtek(R) Audio)"
+    )
+
+
+def test_resolve_device_query_failure_passes_through(monkeypatch):
+    def boom():
+        raise RuntimeError("PortAudio not initialized")
+
+    monkeypatch.setattr(base.sd, "query_hostapis", boom)
+    assert (
+        base.resolve_device("Speakers (Realtek(R) Audio)", devices.OUTPUT)
+        == "Speakers (Realtek(R) Audio)"
+    )
+
+
 # ----- current_device_key ----------------------------------------------------
 
 


### PR DESCRIPTION
## Problem

Playing an audio cue failed with a sounddevice error:

```
Could not start cue output
Multiple output devices found for 'Speakers (Realtek(R) Audio)':
[5] Speakers (Realtek(R) Audio), MME
[12] Speakers (Realtek(R) Audio), Windows DirectSound
[15] Speakers (Realtek(R) Audio), Windows WASAPI
```

Role bindings persist a bare device name, and panels passed that name straight to `sd.OutputStream`/`sd.query_devices`. sounddevice matches a name string against **every** host API, and on Windows PortAudio lists the same hardware once per host API. Usually MME's 31-char name truncation makes the WASAPI name unique — but a name ≤31 chars (like `Speakers (Realtek(R) Audio)`) is identical across all host APIs, leaving sounddevice with several exact matches and no way to choose. The same latent bug existed in every stream-opening panel.

## Fix

- Add `panels.base.resolve_device()`: maps a stored bare name to its **WASAPI device index** before it reaches sounddevice, pinning streams to the one host API SMACC enumerates.
  - Blank/`None` still means system default.
  - Legacy `", Windows WASAPI"`-suffixed settings are normalized via `strip_wasapi_suffix`.
  - A name with no current WASAPI match passes through unchanged, so an unplugged device still fails loudly (the "flag, don't silently swap" rule) with sounddevice's usual error.
- Apply it at every config → sounddevice boundary: cue output + monitor fan-out and room-monitor mic (`panels/audio.py`), noise (`panels/noise.py`), both intercom directions (`panels/intercom.py`), dream-report recorder and its level meter (`panels/recording.py`), and biocal voices (`panels/biocals.py`).
- The cue/biocal monitor-device comparisons now use `is not None` since a resolved device index of `0` is falsy.
- Correct the `wasapi_devices()` docstring that asserted bare names always resolve.

## Tests

7 new tests in `tests/test_panels_base.py` reproduce the exact Realtek layout (same name under MME/DirectSound/WASAPI) plus edge cases: kind mismatch, legacy suffix, unplugged name, missing WASAPI host API, and query failure. Full suite: **546 passed**.