### PR TITLE
feat: revise default event markers and add a signal-observed marker

### DIFF
--- a/.claude/skills/dream-engineering/SKILL.md
+++ b/.claude/skills/dream-engineering/SKILL.md
@@ -22,7 +22,8 @@ for that room at 3 a.m.
   strengthen that specific memory. The cue must land in the right sleep stage.
 - **TLR (targeted lucidity reactivation)** — a TMR-style protocol that re-presents
   cues associated with "notice you're dreaming" training during REM, to prompt
-  **lucid dreaming**. SMACC's registry has explicit `TLRTrainingStart`/`End` markers.
+  **lucid dreaming**. SMACC's registry has generic `TrainingStart`/`End` markers for
+  the learning phase (TMR cue learning, TLR practice).
 - **Cueing** — playing the audio (or light) cue at the moment that matters. Timing
   relative to sleep stage is the whole game; a cue at the wrong time is wasted or
   wakes the participant.
@@ -38,7 +39,9 @@ and observations sit at the right point in that record.
 
 - A trained lucid dreamer can signal awareness from inside REM with a deliberate
   **left-right-left-right (LRLR) eye-movement** pattern, visible on EOG/EEG (the
-  classic lucid-signaling paradigm). SMACC has an `LRLRDetected` marker.
+  classic lucid-signaling paradigm). SMACC marks any such signal (LRLR, sniff,
+  facial, …) with one generic `SignalObserved` marker, tagged with the signal type
+  and a confidence.
 - The **intercom** lets the experimenter **Talk** to the participant (marked in the
   EEG) and **Listen** back — two-way communication with a sleeping or lucid person.
 - After an awakening, the participant gives a **dream report** (recorded audio + an
@@ -53,7 +56,7 @@ and observations sit at the right point in that record.
    observations (`REMDetected`, `TechInRoom`, notes).
 4. At the target stage, fire a **cue** (audio, sometimes a **BlinkStick** light),
    optionally with masking **noise**; each fires its marker.
-5. Watch for a lucidity signal (`LRLRDetected`); use the intercom as needed.
+5. Watch for a lucidity signal (`SignalObserved`); use the intercom as needed.
 6. **Wake** the participant and **record a dream report** (`DreamReportStarted`,
    which increments so each report is unique); maybe open a survey.
 7. Repeat across the night, then review the event log.

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -32,15 +32,21 @@ study can retune any code in the **Event codes** editor; the change travels in i
 |------|-------|-----|-------|
 | 41 | REM detected | `REMDetected` | |
 | 42 | Tech in room | `TechInRoom` | |
-| 43 | TLR training start | `TLRTrainingStart` | |
-| 44 | TLR training end | `TLRTrainingEnd` | |
-| 45 | LRLR detected | `LRLRDetected` | lucid left-right-left-right signal |
+| 43 | Training start | `TrainingStart` | start of a training/learning phase (TMR cue learning, TLR practice) |
+| 44 | Training end | `TrainingEnd` | |
+| 45 | Signal observed | `SignalObserved` | a lucidity/communication signal; the signal type + confidence are logged as the detail |
 | 46 | Sleep onset | `SleepOnset` | |
 | 47 | Lights off | `LightsOff` | |
 | 48 | Lights on | `LightsOn` | |
 | 49 | Clapper | `Clapper` | sync marker |
 | 50 | Note | `Note` | |
 | 51 | Start recording | `RecordingStarted` | sets the reference clock for dream-report timestamps |
+| 52 | Wake detected | `WakeDetected` | sleep-stage observation (keypad 0 in the Event logging window) |
+| 53 | N1 detected | `N1Detected` | sleep-stage observation (keypad 1) |
+| 54 | N2 detected | `N2Detected` | sleep-stage observation (keypad 2) |
+| 55 | N3 detected | `N3Detected` | sleep-stage observation (keypad 3) |
+| 56 | Arousal detected | `ArousalDetected` | a brief transient arousal (distinct from a sustained Wake) |
+| 57 | Artifact detected | `ArtifactDetected` | EEG artifact (movement, electrode noise, etc.) |
 | 60 | Cue started | `CueStarted` | |
 | 61 | Cue stopped | `CueStopped` | |
 | 62 | Noise started | `NoiseStarted` | |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -232,10 +232,20 @@ and fade changes — as plain log lines (no portcode), so the session record is 
 
 ### Event logging panel
 
-The manual event buttons (Start recording, REM detected, Sleep onset, your custom events, …) live in the
-**Event logging** panel — open it from the session window's **Tools** column; the
-first nine buttons take the 1–9 keyboard shortcuts while it's focused. The **Lights**
-toggle stays on the main window (it also flips the dark theme).
+The manual event buttons (the sleep-stage family, Signal observed, Sleep onset, Note,
+your custom events, …) live in the **Event logging** panel — open it from the session
+window's **Tools** column. The sleep-stage buttons take a fixed keypad — **0** Wake,
+**1** N1, **2** N2, **3** N3, **4** REM — and the remaining buttons take **5**–**9** in
+order; the shortcuts are active while the panel is focused. The **Lights** toggle stays
+on the main window (it also flips the dark theme).
+
+**Signal observed.** One button covers every lucidity/communication signal a study uses
+(LRLR, sniff, facial, …), so you don't need a separate button per signal. Pick the
+**signal** type (the box is editable — type your own and it's remembered for the rest of
+the session) and a **confidence** (certain / probable / possible) beside the button;
+pressing it fires the marker immediately and logs your selection as the detail, so the
+marker's timing tracks the observation. Confidence is recorded as a comment — it never
+changes whether the marker reaches the EEG.
 
 ### Where codes live
 

--- a/src/smacc/assets/default.smacc
+++ b/src/smacc/assets/default.smacc
@@ -38,28 +38,23 @@ settings:
   biocals:
     voice_volume: 0.5
   event_codes:
-  - key: RecordingStarted
-    code: 51
+  - key: WakeDetected
+    code: 52
     trigger: true
     preview: true
     increment: false
-  - key: TLRTrainingStart
-    code: 43
+  - key: N1Detected
+    code: 53
     trigger: true
     preview: true
     increment: false
-  - key: TLRTrainingEnd
-    code: 44
+  - key: N2Detected
+    code: 54
     trigger: true
     preview: true
     increment: false
-  - key: TechInRoom
-    code: 42
-    trigger: true
-    preview: true
-    increment: false
-  - key: SleepOnset
-    code: 46
+  - key: N3Detected
+    code: 55
     trigger: true
     preview: true
     increment: false
@@ -68,8 +63,28 @@ settings:
     trigger: true
     preview: true
     increment: false
-  - key: LRLRDetected
+  - key: SleepOnset
+    code: 46
+    trigger: true
+    preview: true
+    increment: false
+  - key: ArousalDetected
+    code: 56
+    trigger: true
+    preview: true
+    increment: false
+  - key: ArtifactDetected
+    code: 57
+    trigger: true
+    preview: true
+    increment: false
+  - key: SignalObserved
     code: 45
+    trigger: true
+    preview: true
+    increment: false
+  - key: Note
+    code: 50
     trigger: true
     preview: true
     increment: false
@@ -78,8 +93,23 @@ settings:
     trigger: true
     preview: true
     increment: false
-  - key: Note
-    code: 50
+  - key: TechInRoom
+    code: 42
+    trigger: true
+    preview: true
+    increment: false
+  - key: TrainingStart
+    code: 43
+    trigger: true
+    preview: true
+    increment: false
+  - key: TrainingEnd
+    code: 44
+    trigger: true
+    preview: true
+    increment: false
+  - key: RecordingStarted
+    code: 51
     trigger: true
     preview: true
     increment: false

--- a/src/smacc/events.py
+++ b/src/smacc/events.py
@@ -120,43 +120,36 @@ def default_events() -> list[EventDef]:
     """
     return [
         # --- Manual / observational: the auto-built event-grid buttons --------
+        # Sleep-stage observations. These mark when the operator *observes* a stage
+        # (which can lag its true onset) — not continuous scoring. The grid binds
+        # them to a fixed keypad 0=Wake, 1=N1, 2=N2, 3=N3, 4=REM (panels/events.py).
         EventDef(
-            "RecordingStarted",
-            "Start recording",
-            51,
+            "WakeDetected",
+            "Wake detected",
+            52,
             category="manual",
-            tooltip=(
-                "Mark the start of the EEG recording; sets the reference clock "
-                "for dream-report timestamps"
-            ),
+            tooltip="Mark observed wakefulness (the participant is awake)",
         ),
         EventDef(
-            "TLRTrainingStart",
-            "TLR training start",
-            43,
+            "N1Detected",
+            "N1 detected",
+            53,
             category="manual",
-            tooltip="Mark the start of Targeted Lucidity Reactivation training",
+            tooltip="Mark observed stage N1 (light sleep)",
         ),
         EventDef(
-            "TLRTrainingEnd",
-            "TLR training end",
-            44,
+            "N2Detected",
+            "N2 detected",
+            54,
             category="manual",
-            tooltip="Mark the end of Targeted Lucidity Reactivation training",
+            tooltip="Mark observed stage N2",
         ),
         EventDef(
-            "TechInRoom",
-            "Tech in room",
-            42,
+            "N3Detected",
+            "N3 detected",
+            55,
             category="manual",
-            tooltip="Mark the entry of an experimenter/technician in the bedroom",
-        ),
-        EventDef(
-            "SleepOnset",
-            "Sleep onset",
-            46,
-            category="manual",
-            tooltip="Mark observed sleep onset",
+            tooltip="Mark observed stage N3 (slow-wave sleep)",
         ),
         EventDef(
             "REMDetected",
@@ -166,11 +159,50 @@ def default_events() -> list[EventDef]:
             tooltip="Mark observed REM",
         ),
         EventDef(
-            "LRLRDetected",
-            "LRLR detected",
+            "SleepOnset",
+            "Sleep onset",
+            46,
+            category="manual",
+            tooltip=(
+                "Mark observed sleep onset (the first persistent transition into "
+                "sleep), distinct from a per-stage N1 observation"
+            ),
+        ),
+        EventDef(
+            "ArousalDetected",
+            "Arousal detected",
+            56,
+            category="manual",
+            tooltip="Mark an observed transient arousal (a brief intrusion of wakefulness)",
+        ),
+        EventDef(
+            "ArtifactDetected",
+            "Artifact detected",
+            57,
+            category="manual",
+            tooltip="Mark an observed EEG artifact (movement, electrode noise, etc.)",
+        ),
+        # The generic lucidity/communication-signal marker (#121). One button covers
+        # every signal a study uses (LRLR, sniff, facial, …): the signal type and an
+        # optional confidence are picked beside the button and logged as the detail,
+        # so the marker fires instantly (timing tracks the observation) with no
+        # blocking dialog. Keeps the old LRLR slot (code 45).
+        EventDef(
+            "SignalObserved",
+            "Signal observed",
             45,
             category="manual",
-            tooltip="Mark an observed left-right-left-right lucid signal",
+            tooltip=(
+                "Mark an observed lucidity/communication signal; set its type and "
+                "confidence beside the button"
+            ),
+        ),
+        EventDef(
+            "Note",
+            "Note",
+            50,
+            category="manual",
+            tooltip="Mark a note and enter free text",
         ),
         EventDef(
             "Clapper",
@@ -180,11 +212,38 @@ def default_events() -> list[EventDef]:
             tooltip="Synchronize a marker with EEG",
         ),
         EventDef(
-            "Note",
-            "Note",
-            50,
+            "TechInRoom",
+            "Tech in room",
+            42,
             category="manual",
-            tooltip="Mark a note and enter free text",
+            tooltip="Mark the entry of an experimenter/technician in the bedroom",
+        ),
+        # Training/learning phase — was the TLR-specific pair; generalized in #121
+        # since a learning phase is common to memory- and lucidity-reactivation
+        # studies alike (TMR cue learning, TLR practice, …).
+        EventDef(
+            "TrainingStart",
+            "Training start",
+            43,
+            category="manual",
+            tooltip="Mark the start of a training/learning phase (e.g. TMR cue learning, TLR practice)",
+        ),
+        EventDef(
+            "TrainingEnd",
+            "Training end",
+            44,
+            category="manual",
+            tooltip="Mark the end of a training/learning phase",
+        ),
+        EventDef(
+            "RecordingStarted",
+            "Start recording",
+            51,
+            category="manual",
+            tooltip=(
+                "Mark the start of the EEG recording; sets the reference clock "
+                "for dream-report timestamps"
+            ),
         ),
         # --- Lights: driven by the lightswitch toggle, not the grid -----------
         EventDef("LightsOff", "Lights off", 47),

--- a/src/smacc/panels/events.py
+++ b/src/smacc/panels/events.py
@@ -21,6 +21,20 @@ class EventsWindow(ModalityWindow):
 
     TITLE = "Event logging"
 
+    # Sleep-stage buttons get a fixed keypad regardless of grid position; the rest
+    # take the leftover digits 5-9 in order (only 0-9 exist, so extras get none).
+    _STAGE_SHORTCUTS = {
+        "WakeDetected": "0",
+        "N1Detected": "1",
+        "N2Detected": "2",
+        "N3Detected": "3",
+        "REMDetected": "4",
+    }
+    # Common signals seeded into the editable picker (#121); a study types its own
+    # and they are remembered for the rest of the session.
+    _SIGNAL_SEEDS = ("LRLR", "LRLRLR", "Sniff", "Eyes up-down", "Facial (EMG)")
+    _CONFIDENCE_LEVELS = ("certain", "probable", "possible")
+
     def __init__(self, session: SmaccSession, parent: QtWidgets.QWidget | None = None):
         super().__init__(session, parent)
         self._grid = QtWidgets.QGridLayout()
@@ -28,15 +42,46 @@ class EventsWindow(ModalityWindow):
         outer = QtWidgets.QVBoxLayout(container)
         outer.addWidget(make_section_title("Event logging"))
         outer.addLayout(self._grid)
+        outer.addLayout(self._build_signal_controls())
         outer.addStretch(1)
         self.setCentralWidget(container)
         self.rebuild()
 
+    def _build_signal_controls(self) -> QtWidgets.QHBoxLayout:
+        """Build the pre-arm widgets for the Signal observed marker (#121).
+
+        The marker fires the instant its button is pressed — no blocking dialog —
+        so its timing tracks the observation; these selectors only supply the
+        free-text detail (signal type + confidence) attached to that marker. The
+        type combo is editable for any study-specific signal and remembers entries
+        used this session.
+        """
+        self._signal_combo = QtWidgets.QComboBox(self)
+        self._signal_combo.setEditable(True)
+        self._signal_combo.addItems(self._SIGNAL_SEEDS)
+        self._signal_combo.setStatusTip(
+            "Signal type tagged onto the next Signal observed marker"
+        )
+        self._confidence_group = QtWidgets.QButtonGroup(self)
+        row = QtWidgets.QHBoxLayout()
+        row.addWidget(QtWidgets.QLabel("Signal:"))
+        row.addWidget(self._signal_combo, 1)
+        row.addWidget(QtWidgets.QLabel("Confidence:"))
+        for i, level in enumerate(self._CONFIDENCE_LEVELS):
+            radio = QtWidgets.QRadioButton(level, self)
+            if i == 0:
+                radio.setChecked(True)
+            self._confidence_group.addButton(radio)
+            row.addWidget(radio)
+        return row
+
     def rebuild(self) -> None:
         """Regenerate the buttons from the session's manual-category events.
 
-        Two-column layout sized to the button count; the first nine buttons get a
-        1–9 keyboard shortcut (active while this window is focused).
+        Two-column layout sized to the button count. Sleep-stage buttons get a
+        fixed keypad shortcut (0=Wake … 4=REM); the remaining buttons take the
+        leftover digits 5-9 in order, and any past that get none. Shortcuts are
+        active while this window is focused.
         """
         while self._grid.count():
             item = self._grid.takeAt(0)
@@ -45,14 +90,18 @@ class EventsWindow(ModalityWindow):
                 widget.deleteLater()
         manual = [e for e in self.session.events.values() if e.category == "manual"]
         half = (len(manual) + 1) // 2
+        fill = iter("56789")
         for i, event in enumerate(manual):
+            shortcut = self._STAGE_SHORTCUTS.get(event.key) or next(fill, None)
             label = event.label
             button = QtWidgets.QPushButton(label, self)
             button.setStatusTip(event.tooltip)
-            if i < 9:  # single-key shortcuts only go 1..9
-                button.setText(f"{label} ({i + 1})")
-                button.setShortcut(str(i + 1))
-            if event.key == "Note":
+            if shortcut is not None:
+                button.setText(f"{label} ({shortcut})")
+                button.setShortcut(shortcut)
+            if event.key == "SignalObserved":
+                button.clicked.connect(self._emit_signal_observed)
+            elif event.key == "Note":
                 button.clicked.connect(self.open_note_marker_dialogue)
             elif event.key == "RecordingStarted":
                 button.clicked.connect(self._mark_recording_start)
@@ -64,6 +113,25 @@ class EventsWindow(ModalityWindow):
 
     def _emit(self, key: str, _checked: bool = False) -> None:
         self.session.emit_event(key)
+
+    def _emit_signal_observed(self, _checked: bool = False) -> None:
+        """Emit a Signal observed marker tagged with the pre-armed type + confidence.
+
+        Fires immediately so the marker tracks the observation; the picked signal
+        type and confidence ride along as the log detail (a comment — confidence
+        never gates routing). A freshly typed signal is remembered in the combo.
+        """
+        signal = self._signal_combo.currentText().strip()
+        checked = self._confidence_group.checkedButton()
+        confidence = checked.text() if checked is not None else ""
+        detail: str | None
+        if signal and confidence:
+            detail = f"{signal} ({confidence})"
+        else:
+            detail = signal or confidence or None
+        self.session.emit_event("SignalObserved", detail=detail)
+        if signal and self._signal_combo.findText(signal) < 0:
+            self._signal_combo.addItem(signal)
 
     def _mark_recording_start(self, _checked: bool = False) -> None:
         """Stamp the recording-start reference clock and emit its marker (#60)."""

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -31,6 +31,33 @@ def test_recording_started_is_a_default_manual_marker():
     assert rec.increment is False
 
 
+def test_signal_and_stage_markers_are_default_manual_triggers():
+    # #121: the residual single-study buttons were revised. The sleep-stage family,
+    # the generic signal marker, and arousal/artifact are manual, triggered, fixed
+    # codes (occurrences are counted in the log, not incremented on the channel).
+    by_key = {e.key: e for e in events.default_events()}
+    expected = {
+        "WakeDetected": 52,
+        "N1Detected": 53,
+        "N2Detected": 54,
+        "N3Detected": 55,
+        "REMDetected": 41,
+        "SignalObserved": 45,
+        "ArousalDetected": 56,
+        "ArtifactDetected": 57,
+    }
+    for key, code in expected.items():
+        marker = by_key[key]
+        assert marker.code == code
+        assert marker.category == "manual"
+        assert marker.trigger is True
+        assert marker.increment is False
+    # The TLR-specific pair was generalized and the LRLR button folded into the
+    # generic signal marker — the old keys are gone.
+    assert {"TrainingStart", "TrainingEnd"} <= by_key.keys()
+    assert not {"TLRTrainingStart", "TLRTrainingEnd", "LRLRDetected"} & by_key.keys()
+
+
 def test_chat_events_are_log_only_by_default():
     # #92: a typed exchange is rapid and conversational, so neither chat direction
     # triggers (or previews) unless a study flips it on; the codes extend the

--- a/tests/test_panels_events.py
+++ b/tests/test_panels_events.py
@@ -1,0 +1,60 @@
+"""Tests for the Event logging panel (#121): the stage keypad and Signal observed.
+
+The panel auto-builds its buttons from the manual registry. Two behaviors are
+specific to the panel (not the registry): sleep-stage buttons take a fixed 0–4
+keypad regardless of grid position, and the Signal observed button fires instantly
+with the pre-armed signal type + confidence composed into the marker's log detail.
+"""
+
+from __future__ import annotations
+
+from PyQt6 import QtWidgets
+
+from smacc.panels.events import EventsWindow
+from smacc.session import SmaccSession
+
+
+def _events_window(tmp_path, qtbot):
+    session = SmaccSession(tmp_path / "s", design=True)
+    win = EventsWindow(session)
+    qtbot.addWidget(win)
+    return win, session
+
+
+def _button_shortcuts(win) -> dict[str, str]:
+    """Map each grid button's visible text -> its assigned shortcut string."""
+    return {
+        b.text(): b.shortcut().toString()
+        for b in win.findChildren(QtWidgets.QPushButton)
+    }
+
+
+def test_sleep_stage_buttons_use_a_fixed_keypad(tmp_path, qtbot):
+    win, _ = _events_window(tmp_path, qtbot)
+    shortcuts = _button_shortcuts(win)
+    # Each button renders its key in parens; the stage family is pinned 0=Wake..4=REM.
+    assert shortcuts["Wake detected (0)"] == "0"
+    assert shortcuts["N1 detected (1)"] == "1"
+    assert shortcuts["N2 detected (2)"] == "2"
+    assert shortcuts["N3 detected (3)"] == "3"
+    assert shortcuts["REM detected (4)"] == "4"
+
+
+def test_signal_observed_tags_type_and_confidence(tmp_path, qtbot, monkeypatch):
+    win, session = _events_window(tmp_path, qtbot)
+    calls: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        session, "emit_event", lambda key, **kw: calls.append((key, kw))
+    )
+    win._signal_combo.setCurrentText("Sniff")  # confidence defaults to "certain"
+    win._emit_signal_observed()
+    assert calls == [("SignalObserved", {"detail": "Sniff (certain)"})]
+
+
+def test_signal_observed_remembers_a_typed_signal(tmp_path, qtbot, monkeypatch):
+    win, session = _events_window(tmp_path, qtbot)
+    monkeypatch.setattr(session, "emit_event", lambda *a, **k: None)
+    assert win._signal_combo.findText("Mouth twitch") < 0  # not a seeded option
+    win._signal_combo.setCurrentText("Mouth twitch")
+    win._emit_signal_observed()
+    assert win._signal_combo.findText("Mouth twitch") >= 0  # remembered this session

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -229,7 +229,7 @@ def test_emit_event_hardware_failure_disables_transport_and_keeps_lsl():
     assert sess.trigger_out is None  # transport dropped after the failure
     assert any("Hardware trigger failed" in m for m, _ in records)
     # A later event still logs and pushes LSL without raising.
-    sess.emit_event("LRLRDetected")
+    sess.emit_event("SignalObserved")
     assert sess.outlet.samples == [["41"], ["45"]]
 
 


### PR DESCRIPTION
Closes #121.

Revises the residual single-study event markers into a set common to sleep / TMR / dream-engineering work, and adds a flexible signal-observation marker.

**What changed**
- Sleep-stage observations: `WakeDetected`, `N1Detected`, `N2Detected`, `N3Detected` alongside the existing `REMDetected`. The Event logging window binds them to a fixed keypad (0=Wake, 1=N1, 2=N2, 3=N3, 4=REM); other buttons take 5–9.
- New `ArousalDetected` (transient arousal) and `ArtifactDetected` markers.
- Replaced the single-purpose `LRLRDetected` with a generic `SignalObserved` (keeps code 45): one button covers any signal a study uses. The signal type (editable, remembered per session) and a confidence (certain/probable/possible) are picked beside the button; pressing it fires the marker immediately — no blocking dialog, so timing tracks the observation — with the selection logged as the detail. Confidence is a comment; it never gates routing.
- Generalized the TLR-specific `TLRTrainingStart/End` to `TrainingStart/End` (codes unchanged), since a learning phase is common to TMR and TLR alike. `SleepOnset` kept, distinct from N1.

**Why**
The old manual buttons were leftovers from one study. Signals vary widely across studies (LRLR, sniff, facial, …) and recur per session, so one tagged button beats a button-per-signal or rigid fill-ins.

**Verification**
`pytest` (incl. new registry + panel tests), `ruff check`/`format`, `mypy`, and `mkdocs build --strict` all pass. Real trigger-channel output on the lab amp still needs hardware validation.