### PR TITLE
Touch-ups round 2: hotplug crash, shortcuts, intercom meters, add-event button

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -159,7 +159,10 @@ bedroom. **Talk** pipes your mic to the participant's output (click to latch, or
 hold the **spacebar** anywhere in SMACC as push-to-talk) and is marked in the EEG
 record; **Listen** brings the bedroom mic to your control-room speakers, unmarked.
 The two directions route through roles set once in the **Devices** window (see
-[Audio &amp; routing](audio.md)).
+[Audio &amp; routing](audio.md)). A **level meter** beside each button shows the
+live input level while that direction is on — signal on the bar means audio is
+actually flowing (your mic for Talk, the participant's mic for Listen), not just
+a latched button.
 
 ### Text chat
 
@@ -227,9 +230,10 @@ can set:
 hardware only accepts a limited range (some older systems do). Codes must be unique
 among triggered events and within 1–255; the editor blocks anything else.
 
-**Custom events.** Use **Add event…** to create your own button events (a label and a
-code); they appear in the **Event logging** panel alongside the built-ins and can be
-removed again with **Remove**. Built-in events can be retuned but not removed or renamed.
+**Custom events.** Use **Add event…** — in the **Event logging** panel itself, or in
+this editor — to create your own button events (a label and a code); they appear in
+the Event logging panel alongside the built-ins and can be removed again with the
+editor's **Remove**. Built-in events can be retuned but not removed or renamed.
 
 The editor stays available throughout a session. If you change a code mid-session, the
 change is written to the log with a timestamp, so the code-to-event mapping for that
@@ -284,10 +288,14 @@ story (creating, the data directory, opening by double-click), and the
 
 Some display choices apply to a session and travel with the study in the SMACC
 file: **always-on-top** (toggled per window — the Session window's **File**
-menu, or each tool window's **View** menu) and which **log levels** show in the
-preview (the checkboxes above the log preview). Save them with the rest of the
-configuration from the Editor or with **File &rsaquo; Save SMACC file as…** in a
-Session.
+menu, or each tool window's **View** menu, or **Ctrl+T** in whichever window is
+active) and which **log levels** show in the preview (the checkboxes above the
+log preview). Save them with the rest of the configuration from the Editor or
+with **File &rsaquo; Save SMACC file as…** in a Session.
+
+Tool windows close with **Ctrl+W** (or **File &rsaquo; Close window**) — that
+only hides the window, with its state intact; the session keeps running and the
+Session window's Tools column reopens it.
 
 Separately, the machine remembers window positions and sizes and your recent files in
 `~/SMACC/preferences.yaml`, restored on the next launch.

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -396,6 +396,9 @@ class SmaccWindow(ToolWindow):
         # can set its state, but only surfaced in a session's menu (tool windows carry
         # their own toggle on the ModalityWindow base).
         alwaysOnTopAction = QtGui.QAction("Always on &top", self)
+        # The same Ctrl+T every tool window carries (see ModalityWindow); the
+        # default WindowShortcut context pins whichever window is active.
+        alwaysOnTopAction.setShortcut("Ctrl+T")
         alwaysOnTopAction.setStatusTip(
             "Keep the SMACC window above other applications."
         )

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -121,9 +121,18 @@ class SmaccWindow(ToolWindow):
         # Hot-plug doorbell: Qt6's QMediaDevices fires when an audio device is added
         # or removed; that triggers an automatic rescan. Audio I/O stays on
         # sounddevice — QMediaDevices is used only as the "something changed" signal.
+        # Debounced through a single-shot timer: Windows fires these in bursts
+        # (dozens within a second, e.g. when a Bluetooth device renegotiates or a
+        # stream opens/closes), and each rescan tears PortAudio down and back up —
+        # doing that dozens of times back-to-back has crashed the app mid-burst.
+        # Restarting the timer per signal coalesces a burst into one rescan.
         self._media_devices = QMediaDevices(self)
-        self._media_devices.audioOutputsChanged.connect(self._on_devices_hotplug)
-        self._media_devices.audioInputsChanged.connect(self._on_devices_hotplug)
+        self._hotplug_timer = QtCore.QTimer(self)
+        self._hotplug_timer.setSingleShot(True)
+        self._hotplug_timer.setInterval(1000)  # rescan once a burst has gone quiet
+        self._hotplug_timer.timeout.connect(self._on_devices_hotplug)
+        self._media_devices.audioOutputsChanged.connect(self._hotplug_timer.start)
+        self._media_devices.audioInputsChanged.connect(self._hotplug_timer.start)
 
         self.init_main_window()  # builds the menu + log handler (does not show yet)
         self._apply_preferences(self._prefs)
@@ -818,10 +827,12 @@ class SmaccWindow(ToolWindow):
             panel.refresh_device_indicator()
 
     def _on_devices_hotplug(self) -> None:
-        """A device was added/removed: quietly rescan when nothing is streaming.
+        """Devices changed (debounce timer fired): rescan when nothing is streaming.
 
-        Skipped while audio is live (a PortAudio re-init would cut it); the operator
-        can use the Devices window's Refresh button once idle.
+        Reached only via ``_hotplug_timer``, which coalesces Windows' bursts of
+        change signals into one rescan. Skipped while audio is live (a PortAudio
+        re-init would cut it); the operator can use the Devices window's Refresh
+        button once idle.
         """
         if any(panel.is_streaming() for panel in self.panels.values()):
             return

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -159,6 +159,8 @@ class LauncherWindow(QtWidgets.QMainWindow):
         self.move(avail.left() + 48, avail.top() + 48)
 
     def _build_menu(self) -> None:
+        style = self.style()
+        assert style is not None
         menu_bar = self.menuBar()
         assert menu_bar is not None
         fileMenu = menu_bar.addMenu("&File")
@@ -173,11 +175,19 @@ class LauncherWindow(QtWidgets.QMainWindow):
             )
             associateAction.triggered.connect(self.associate_files)
             fileMenu.addSeparator()
-        aboutAction = fileMenu.addAction("&About")
+        aboutAction = fileMenu.addAction(
+            style.standardIcon(
+                QtWidgets.QStyle.StandardPixmap.SP_MessageBoxInformation
+            ),
+            "&About",
+        )
         assert aboutAction is not None
         aboutAction.setStatusTip("About SMACC (version and links).")
         aboutAction.triggered.connect(self.show_about_popup)
-        quitAction = fileMenu.addAction("&Quit")
+        quitAction = fileMenu.addAction(
+            style.standardIcon(QtWidgets.QStyle.StandardPixmap.SP_DialogCloseButton),
+            "&Quit",
+        )
         assert quitAction is not None
         quitAction.setShortcut("Ctrl+Q")
         quitAction.setStatusTip("Quit SMACC.")

--- a/src/smacc/panels/base.py
+++ b/src/smacc/panels/base.py
@@ -158,6 +158,10 @@ class ModalityWindow(QtWidgets.QMainWindow):
         viewMenu = menu_bar.addMenu("&View")
         assert viewMenu is not None
         action = QtGui.QAction("Always on &top", self)
+        # Every window carries the same shortcut; the default WindowShortcut
+        # context scopes each to its own window, so Ctrl+T pins whichever
+        # window is active.
+        action.setShortcut("Ctrl+T")
         action.setStatusTip(f"Keep the {self.TITLE} window above other applications.")
         action.setCheckable(True)
         action.toggled.connect(self.toggle_always_on_top)

--- a/src/smacc/panels/base.py
+++ b/src/smacc/panels/base.py
@@ -149,7 +149,28 @@ class ModalityWindow(QtWidgets.QMainWindow):
         self.setWindowTitle(self.TITLE)
         if LOGO_PATH.is_file():
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
+        self._build_file_menu()
         self._build_view_menu()
+
+    def _build_file_menu(self) -> None:
+        """Add a minimal File menu carrying this window's close action.
+
+        Closing a tool window only hides it (see :meth:`closeEvent`) — the
+        session keeps running — so Ctrl+W is safe to reach for, unlike the
+        session window's Ctrl+Q, which ends the whole session.
+        """
+        menu_bar = self.menuBar()
+        assert menu_bar is not None
+        fileMenu = menu_bar.addMenu("&File")
+        assert fileMenu is not None
+        closeAction = QtGui.QAction("&Close window", self)
+        closeAction.setShortcut("Ctrl+W")
+        closeAction.setStatusTip(
+            f"Close the {self.TITLE} window (the session keeps running; "
+            "reopen it from the session window)."
+        )
+        closeAction.triggered.connect(self.close)
+        fileMenu.addAction(closeAction)
 
     def _build_view_menu(self) -> None:
         """Add a minimal View menu carrying this window's always-on-top toggle."""

--- a/src/smacc/panels/events.py
+++ b/src/smacc/panels/events.py
@@ -12,6 +12,8 @@ from functools import partial
 
 from PyQt6 import QtWidgets
 
+from .. import events
+from ..dialogs import AddEventDialog
 from ..session import SmaccSession
 from .base import ModalityWindow, make_section_title
 
@@ -43,6 +45,7 @@ class EventsWindow(ModalityWindow):
         outer.addWidget(make_section_title("Event logging"))
         outer.addLayout(self._grid)
         outer.addLayout(self._build_signal_controls())
+        outer.addLayout(self._build_add_event_row())
         outer.addStretch(1)
         self.setCentralWidget(container)
         self.rebuild()
@@ -74,6 +77,64 @@ class EventsWindow(ModalityWindow):
             self._confidence_group.addButton(radio)
             row.addWidget(radio)
         return row
+
+    def _build_add_event_row(self) -> QtWidgets.QHBoxLayout:
+        """A row with the Add event… button (the natural place to look for it).
+
+        Removing or retuning an event still lives in File ▸ Event codes…, which
+        shows the whole registry; adding a button is the common mid-setup act,
+        so it's offered right here where the buttons appear.
+        """
+        addButton = QtWidgets.QPushButton("Add event…", self)
+        addButton.setStatusTip(
+            "Add a custom event button (label + port code); it appears here and "
+            "can be retuned or removed in File ▸ Event codes…."
+        )
+        addButton.clicked.connect(self.add_custom_event)
+        row = QtWidgets.QHBoxLayout()
+        row.addWidget(addButton)
+        row.addStretch(1)
+        return row
+
+    def add_custom_event(self, _checked: bool = False) -> None:
+        """Define a custom event and add it to the live registry (and this grid).
+
+        The same validation as the Event codes editor applies: hard errors
+        (duplicate triggered code, bad range) block the add, soft warnings (above
+        the safe max) ask first. A successful add is logged loudly (WARNING) like
+        any registry change, so the session's code map stays traceable.
+        """
+        used = [e.code for e in self.session.events.values() if isinstance(e.code, int)]
+        suggested = min((max(used) + 1) if used else events.CODE_MIN, events.CODE_MAX)
+        dialog = AddEventDialog(suggested, parent=self)
+        if not dialog.exec():
+            return
+        label, code, tooltip, increment = dialog.get_inputs()
+        event = events.make_custom_event(
+            label,
+            code,
+            self.session.events.keys(),
+            tooltip=tooltip,
+            increment=increment,
+        )
+        candidate = [*self.session.events.values(), event]
+        errors, warnings = events.validate_events(
+            candidate, self.session.event_code_safe_max
+        )
+        if errors:
+            QtWidgets.QMessageBox.warning(
+                self, "Add event", "Please fix these first:\n\n" + "\n".join(errors)
+            )
+            return
+        if warnings:
+            reply = QtWidgets.QMessageBox.question(
+                self, "Add event", "Add anyway?\n\n" + "\n".join(warnings)
+            )
+            if reply != QtWidgets.QMessageBox.StandardButton.Yes:
+                return
+        self.session.events[event.key] = event
+        self.session.logger.warning(f"Event added: {event.label} (code {event.code})")
+        self.rebuild()
 
     def rebuild(self) -> None:
         """Regenerate the buttons from the session's manual-category events.

--- a/src/smacc/panels/intercom.py
+++ b/src/smacc/panels/intercom.py
@@ -26,6 +26,7 @@ from ..dialogs import ManageChatPresetsDialog
 from ..session import SmaccSession
 from .base import ModalityWindow, describe_target, make_section_title, resolve_device
 from .chat import EXPERIMENTER, ChatPresets, ChatTranscript, post_chat_message
+from .meter import LevelMeter
 
 # Cap an experimenter prompt's button label so a long standardized question doesn't
 # stretch the panel; the full text rides along in the tooltip/status tip.
@@ -50,6 +51,9 @@ class _Bridge:
         self._output: sd.OutputStream | None = None
         self._queue: queue.Queue | None = None
         self._resampler: audio.LinearResampler | None = None
+        # Latest input level (dBFS), stashed by the audio callback for the
+        # window's level meters (a plain float store; the GUI timer reads it).
+        self.level_db = audio.FLOOR_DBFS
 
     def active(self) -> bool:
         """True while either stream is open."""
@@ -96,9 +100,11 @@ class _Bridge:
         self._output = None
         self._queue = None
         self._resampler = None
+        self.level_db = audio.FLOOR_DBFS
         return stopped
 
     def _in_callback(self, indata, frames, time, status) -> None:
+        self.level_db = audio.rms_dbfs(indata)
         if self._queue is not None:
             try:
                 self._queue.put_nowait(indata[:, 0].copy())
@@ -138,6 +144,11 @@ class IntercomWindow(ModalityWindow):
         self._talk = _Bridge()  # experimenter mic -> participant output
         self._listen = _Bridge()  # participant mic -> control-room output
         self._talk_push = False  # True while talk is held via the spacebar
+        # Renders each live bridge's input level onto its meter; runs only while
+        # a direction is on (started/stopped by the toggles).
+        self._level_timer = QtCore.QTimer(self)
+        self._level_timer.setInterval(50)  # ~20 Hz display refresh
+        self._level_timer.timeout.connect(self._render_levels)
         self._transcript = (
             transcript if transcript is not None else ChatTranscript(self)
         )
@@ -174,6 +185,22 @@ class IntercomWindow(ModalityWindow):
         listenButton.setCheckable(True)
         listenButton.toggled.connect(self.toggle_listen)
         self.listenButton = listenButton
+
+        # A level meter beside each direction, fed from that bridge's live input
+        # callback — signal on the bar means audio is actually flowing (your mic
+        # for Talk, the participant's mic for Listen), not just a latched button.
+        self.talkMeter = LevelMeter(self)
+        self.talkMeter.setStatusTip("Your mic's live level while Talk is on.")
+        self.listenMeter = LevelMeter(self)
+        self.listenMeter.setStatusTip(
+            "The participant mic's live level while Listen is on."
+        )
+        talkRow = QtWidgets.QHBoxLayout()
+        talkRow.addWidget(talkButton, 1)
+        talkRow.addWidget(self.talkMeter, 1)
+        listenRow = QtWidgets.QHBoxLayout()
+        listenRow.addWidget(listenButton, 1)
+        listenRow.addWidget(self.listenMeter, 1)
 
         # --- Text chat (#92): the experimenter's view of the typed channel -----
         chatView = QtWidgets.QPlainTextEdit(self)
@@ -228,9 +255,9 @@ class IntercomWindow(ModalityWindow):
         layout.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         layout.addRow(make_section_title("Intercom"))
         layout.addRow("To participant:", self.talkDeviceLabel)
-        layout.addRow(talkButton)
+        layout.addRow(talkRow)
         layout.addRow("From participant:", self.listenDeviceLabel)
-        layout.addRow(listenButton)
+        layout.addRow(listenRow)
         layout.addRow(make_section_title("Text chat"))
         layout.addRow(chatView)
         layout.addRow(self._presetContainer)
@@ -300,6 +327,26 @@ class IntercomWindow(ModalityWindow):
         """True while either direction is live."""
         return self._talk.active() or self._listen.active()
 
+    def _sync_level_timer(self) -> None:
+        """Run the meter refresh only while a direction is live; clear idle bars."""
+        if self.is_streaming():
+            if not self._level_timer.isActive():
+                self._level_timer.start()
+        else:
+            self._level_timer.stop()
+        self._render_levels()
+
+    def _render_levels(self) -> None:
+        """GUI-thread timer: render each live bridge's input level onto its meter."""
+        for bridge, meter in (
+            (self._talk, self.talkMeter),
+            (self._listen, self.listenMeter),
+        ):
+            if bridge.active():
+                meter.show_level(bridge.level_db)
+            else:
+                meter.clear_level()
+
     def toggle_talk(self, enabled: bool) -> None:
         """Start/stop piping the experimenter mic to the participant output.
 
@@ -321,6 +368,7 @@ class IntercomWindow(ModalityWindow):
             self.session.emit_event("IntercomStarted")
         elif self._talk.stop():
             self.session.emit_event("IntercomStopped")
+        self._sync_level_timer()
 
     def toggle_listen(self, enabled: bool) -> None:
         """Start/stop piping the participant mic to the control-room output.
@@ -348,6 +396,7 @@ class IntercomWindow(ModalityWindow):
         else:
             self._listen.stop()
             self.session.log_interaction("Intercom listen off")
+        self._sync_level_timer()
 
     @staticmethod
     def _is_text_widget_focused() -> bool:
@@ -401,5 +450,6 @@ class IntercomWindow(ModalityWindow):
         app = QtWidgets.QApplication.instance()
         if app is not None:
             app.removeEventFilter(self)
+        self._level_timer.stop()
         self._talk.stop()
         self._listen.stop()

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -97,6 +97,34 @@ def test_devices_refresh_button_runs_window_rescan(
     assert calls == [True]
 
 
+def test_hotplug_rescan_is_debounced_through_a_single_shot_timer(
+    qtbot, live_session, mock_devices, silence_dialogs, monkeypatch
+):
+    # Windows fires device-change signals in bursts; each rescan re-inits
+    # PortAudio, and doing that dozens of times back-to-back has crashed the app.
+    # The signals must therefore only restart a single-shot timer, with the
+    # rescan running once when the timer fires.
+    calls: list[bool] = []
+    monkeypatch.setattr(
+        SmaccWindow, "_on_devices_hotplug", lambda self: calls.append(True)
+    )
+    window = SmaccWindow(live_session)
+    qtbot.addWidget(window)
+    timer = window._hotplug_timer
+    assert timer.isSingleShot()
+    assert timer.interval() >= 500  # long enough to outlast a signal burst
+    # A burst of change signals leaves the timer pending without rescanning…
+    timer.start()
+    timer.start()
+    timer.start()
+    assert timer.isActive()
+    assert calls == []
+    # …and the rescan runs exactly once when the quiet-period timer fires.
+    timer.stop()
+    timer.timeout.emit()
+    assert calls == [True]
+
+
 # ----- default settings are protected from overwrite -------------------------
 
 

--- a/tests/test_panels_events.py
+++ b/tests/test_panels_events.py
@@ -58,3 +58,65 @@ def test_signal_observed_remembers_a_typed_signal(tmp_path, qtbot, monkeypatch):
     win._signal_combo.setCurrentText("Mouth twitch")
     win._emit_signal_observed()
     assert win._signal_combo.findText("Mouth twitch") >= 0  # remembered this session
+
+
+def test_add_event_button_adds_to_registry_and_grid(tmp_path, qtbot, monkeypatch):
+    # The panel's Add event… button defines a custom event in place: it lands in
+    # the session registry and its button appears in the grid without a detour
+    # through File ▸ Event codes….
+    from smacc import dialogs
+
+    win, session = _events_window(tmp_path, qtbot)
+    before = len(session.events)
+    monkeypatch.setattr(dialogs.AddEventDialog, "exec", lambda self: True)
+    # A code that's unused AND outside every incrementing event's code..255 band,
+    # so the add raises neither a hard error nor a soft-warning prompt.
+    evs = list(session.events.values())
+    taken = {e.code for e in evs}
+    free_code = next(
+        c
+        for c in range(1, 256)
+        if c not in taken
+        and all(not (e.increment and e.trigger and c >= e.code) for e in evs)
+    )
+    monkeypatch.setattr(
+        dialogs.AddEventDialog,
+        "get_inputs",
+        lambda self: ("Spontaneous arousal", free_code, "", False),
+    )
+
+    # Any popup here means the chosen code wasn't as clean as intended — fail
+    # loudly rather than hang the headless run on a modal box.
+    def _unexpected(*a, **k):
+        raise AssertionError(f"unexpected modal prompt: {a}")
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "warning", _unexpected)
+    monkeypatch.setattr(QtWidgets.QMessageBox, "question", _unexpected)
+    win.add_custom_event()
+    assert len(session.events) == before + 1
+    added = next(e for e in session.events.values() if not e.builtin)
+    assert added.label == "Spontaneous arousal"
+    assert added.code == free_code
+    labels = [b.text() for b in win.findChildren(QtWidgets.QPushButton)]
+    assert any("Spontaneous arousal" in label for label in labels)
+
+
+def test_add_event_with_duplicate_code_is_blocked(tmp_path, qtbot, monkeypatch):
+    from smacc import dialogs
+
+    win, session = _events_window(tmp_path, qtbot)
+    taken = next(e.code for e in session.events.values() if e.trigger)
+    before = len(session.events)
+    monkeypatch.setattr(dialogs.AddEventDialog, "exec", lambda self: True)
+    monkeypatch.setattr(
+        dialogs.AddEventDialog, "get_inputs", lambda self: ("Dupe", taken, "", False)
+    )
+    warned: list[str] = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "warning",
+        lambda *a, **k: warned.append(a[2]) or QtWidgets.QMessageBox.StandardButton.Ok,
+    )
+    win.add_custom_event()
+    assert len(session.events) == before  # blocked, nothing added
+    assert warned and "fix these first" in warned[0]

--- a/tests/test_panels_state.py
+++ b/tests/test_panels_state.py
@@ -400,3 +400,26 @@ def test_tool_window_stays_visible_across_always_on_top_toggle(qtbot, design_ses
     panel.hide()
     panel.set_always_on_top(True)
     assert not panel.isVisible()
+
+
+def test_tool_window_file_menu_close_hides_the_window(qtbot, design_session):
+    # Every tool window carries File → Close window (Ctrl+W); closing only hides
+    # the window (the session keeps running), exactly like the title-bar X.
+    panel = NoiseWindow(design_session)
+    qtbot.addWidget(panel)
+    panel.show()
+    qtbot.waitExposed(panel)
+    close = next(
+        (
+            a
+            for a in panel.menuBar().actions()[0].menu().actions()
+            if a.text().replace("&", "") == "Close window"
+        ),
+        None,
+    )
+    assert close is not None
+    assert close.shortcut().toString() == "Ctrl+W"
+    close.trigger()
+    assert not panel.isVisible()
+    panel.show()  # reopens with its state intact, like the launcher buttons do
+    assert panel.isVisible()

--- a/tests/test_panels_state.py
+++ b/tests/test_panels_state.py
@@ -367,6 +367,8 @@ def test_tool_window_always_on_top_toggle(qtbot, design_session):
     panel = NoiseWindow(design_session)
     qtbot.addWidget(panel)
     assert panel.is_always_on_top() is False  # default off
+    # Every window binds the same window-scoped shortcut to its own toggle.
+    assert panel._always_on_top_action.shortcut().toString() == "Ctrl+T"
     panel.set_always_on_top(True)
     assert panel.is_always_on_top() is True
     assert panel._always_on_top_action.isChecked() is True

--- a/tests/test_panels_state.py
+++ b/tests/test_panels_state.py
@@ -137,6 +137,24 @@ def test_intercom_panel_round_trips_chat_presets(qtbot, design_session):
     assert got["chat_participant_presets"] == ["Yes", "No"]
 
 
+def test_intercom_meters_track_each_live_bridge(qtbot, design_session):
+    # Each direction has a level meter fed from its bridge's input callback; an
+    # idle direction's meter reads empty, a live one shows the stashed level.
+    panel = IntercomWindow(design_session)
+    qtbot.addWidget(panel)
+    panel._render_levels()
+    assert panel.talkMeter.value() == 0  # both idle
+    assert panel.listenMeter.value() == 0
+    # Simulate a live talk bridge whose callback measured a -20 dBFS block.
+    panel._talk._input = object()  # active() keys off an open stream
+    panel._talk.level_db = -20.0
+    panel._render_levels()
+    assert panel.talkMeter.value() > 0
+    assert "-20 dBFS" in panel.talkMeter.format()
+    assert panel.listenMeter.value() == 0  # listen still idle
+    panel._talk._input = None
+
+
 def test_visual_panel_round_trips(qtbot, design_session):
     panel = VisualWindow(design_session)
     qtbot.addWidget(panel)


### PR DESCRIPTION
Second batch of touch-ups, one commit each:

- **fix: debounce hot-plug device rescans** — the likely cause of the crash after leaving the Event codes window open: session logs end abruptly mid-burst of `Devices changed; lists rescanned` lines (up to 14 within a second, 62 in one run), each doing a full PortAudio terminate/re-init — with no Python traceback, pointing at a native crash in that churn. Device-change signals now restart a 1 s single-shot timer, so a burst coalesces into one rescan.
- **feat: info and exit icons** on the Launcher's About and Quit menu actions.
- **feat: Ctrl+T toggles always-on-top** — bound per window (Session window + every tool window), so it pins whichever window is active.
- **feat: Ctrl+W closes a tool window** — via a new File ▸ Close window action on every session tool window; closing only hides it (session keeps running), same as the title-bar X.
- **feat: intercom level meters** — a live meter beside Talk and beside Listen, fed from each bridge's input callback (no extra streams): signal on the bar means audio is actually flowing, not just a latched button.
- **feat: Add event… button in the Event logging panel** — define a custom event right where its button will appear, with the same validation and loud logging as the Event codes editor (which keeps remove/retune).
- **docs** — usage.md notes the new shortcuts, meters, and panel add-event path.