### PR TITLE
docs: marker terminology glossary and log-level conventions

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -16,6 +16,15 @@
 
 * Always use [uv](https://docs.astral.sh/uv/) to run Python scripts and install
   dependencies. Never `pip install` or run naked `python`.
+* Use the marker vocabulary consistently in UI text, docs, and docstrings — *event*,
+  *marker*, *port code*, *trigger*, *transport* each mean exactly one thing; see the
+  [terminology table](triggers.md#terminology).
+* Pick log levels by the [session-log convention](reference/session-log.md#log-levels):
+  `DEBUG` for housekeeping/high-frequency detail, `INFO` for markers and meaningful
+  operator actions, `WARNING` for mid-session config changes and recoverable faults,
+  `ERROR` for faults that cost something. The file records every level, so demoting a
+  line to `DEBUG` only moves it out of the default live preview, never out of the
+  record.
 
 ## Commit and pull-request style
 

--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -32,6 +32,20 @@ just `"{label}"` when it does not. The code-to-event map is the study's
 [`event_codes`](settings-file.md#event_codes) registry; see the
 [default code catalog](../triggers.md#default-event-codes).
 
+## Log levels
+
+The file records **every** level — a level never decides whether something is
+written, only whether it shows in the live preview (whose default gate starts at
+`INFO`). SMACC assigns levels by one convention:
+
+| Level | What it carries |
+|---|---|
+| `DEBUG` | Housekeeping and high-frequency detail: settings loads/saves, device rescans, live volume edits, raw trigger instants, chat text. In the file for the record; out of the preview by default. |
+| `INFO` | **Event markers** and meaningful operator actions — the session's scientific narrative. |
+| `WARNING` | Mid-session configuration changes (a port code or trigger transport edited during a run — loud so the code map stays traceable) and recoverable faults (a saved device not connected). |
+| `ERROR` | Faults that cost something: a hardware trigger write failing, a stream that couldn't open. |
+| `CRITICAL` | Uncaught exceptions — the app is in an unknown state. |
+
 ### Stimulus marker timing
 
 Most markers are stamped when SMACC fires them. **Audio cue and noise** markers are

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -20,6 +20,21 @@ bits), and the amplifier reads them as one byte. SMACC keeps every code inside 1
 for this reason. See [Configuring codes](usage.md#configuring-codes) for how to view
 and edit which event sends which code.
 
+## Terminology
+
+The words *event*, *marker*, *trigger*, and *port code* get used loosely in the
+field; SMACC uses each one for exactly one thing, in the UI, the docs, and the
+session log:
+
+| Term | Meaning in SMACC |
+|---|---|
+| **Event** | A named thing that can happen during a session — a cue started, REM observed, lights off. Each is an entry in the study's event registry, with a label and a port code. |
+| **Marker** | The durable record produced when an event fires. A marker is always a [log line](reference/session-log.md); if the event is routed to a transport, it also carries the port code there. |
+| **Port code** | The 8-bit number (**1–255**) identifying an event on the amplifier's trigger channel. Also called a *trigger code*. |
+| **Trigger** | The act of *sending* a port code over a transport. An event can be logged without being triggered. |
+| **Transport** | A path that carries the code to the recording: the **LSL** marker stream, or a hardware **TTL** line (serial trigger box / parallel port). |
+| **Log level** | The severity tag on a log line (`DEBUG`…`CRITICAL`). The log *file* records every level; levels only filter the live preview. See [log levels](reference/session-log.md#log-levels). |
+
 ## Default event codes
 
 These are SMACC's built-in event markers and their default port codes — the

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -923,7 +923,7 @@ class SmaccWindow(ToolWindow):
                 parent=self,
             )
         else:
-            self.session.log_info_msg("Refreshed devices")
+            self.session.log_debug_msg("Refreshed devices")
 
     # ----- preferences / launch-file / file association ----------------------
 
@@ -988,7 +988,7 @@ class SmaccWindow(ToolWindow):
             self.show_error_popup("Could not open settings file.", str(exc))
             return
         self._apply_loaded_settings(state, metadata)
-        self.session.log_info_msg(f"Loaded settings from {settings_path}")
+        self.session.log_debug_msg(f"Loaded settings from {settings_path}")
 
     def _maybe_prompt_association(self) -> None:
         """Once, on the first packaged-build launch, offer to associate .smacc files."""
@@ -1069,7 +1069,7 @@ class SmaccWindow(ToolWindow):
             self.show_error_popup("Could not save settings.", str(exc))
             return False
         self.settings_path = path  # subsequent saves update this file
-        self.session.log_info_msg(f"Saved settings to {path}")
+        self.session.log_debug_msg(f"Saved settings to {path}")
         # Status-bar confirmation: the editor has no log viewer to show the line.
         status_bar = self.statusBar()
         assert status_bar is not None
@@ -1093,7 +1093,7 @@ class SmaccWindow(ToolWindow):
             self.show_error_popup("Could not open settings.", str(exc))
             return
         self._apply_loaded_settings(state, metadata)
-        self.session.log_info_msg(f"Loaded settings from {path}")
+        self.session.log_debug_msg(f"Loaded settings from {path}")
 
     def load_settings_from_log(self) -> None:
         """Load the initial or final settings recorded in a SMACC .log file."""
@@ -1127,7 +1127,7 @@ class SmaccWindow(ToolWindow):
             self.show_error_popup("Could not load settings from log.", str(exc))
             return
         self._apply_loaded_settings(state, metadata)
-        self.session.log_info_msg(f"Loaded {which} settings from {path}")
+        self.session.log_debug_msg(f"Loaded {which} settings from {path}")
 
     def _ask_initial_or_final(self) -> str | None:
         """Ask whether to load the initial or final settings block (None on cancel)."""

--- a/src/smacc/panels/volume.py
+++ b/src/smacc/panels/volume.py
@@ -109,8 +109,9 @@ class VolumeWindow(ModalityWindow):
         self.endpointLabel.setText(self._format_level(endpoint))
         self.appLabel.setText(self._format_level(app))
         # Record the OS-side volumes on each actual read (not on slider drags), so a
-        # run's cue levels stay reproducible from the log alone.
-        self.session.log_info_msg(
+        # run's cue levels stay reproducible from the log alone (the file records
+        # DEBUG; only the live preview hides it).
+        self.session.log_debug_msg(
             "Windows output volume: "
             f"endpoint {self._format_level(endpoint)}, "
             f"SMACC mixer {self._format_level(app)}"

--- a/tests/test_panels_state.py
+++ b/tests/test_panels_state.py
@@ -328,7 +328,9 @@ def _capture_session_log(session) -> list[logging.LogRecord]:
 def test_volume_panel_logs_windows_levels_on_refresh(
     qtbot, design_session, monkeypatch
 ):
-    # Each actual read of the Windows volumes is logged at INFO for reproducibility.
+    # Each actual read of the Windows volumes is logged for reproducibility — at
+    # DEBUG, per the level convention (housekeeping detail: in the file, out of the
+    # default preview).
     monkeypatch.setattr(winvolume, "endpoint_volume", lambda: 0.85)
     monkeypatch.setattr(winvolume, "app_volume", lambda: 0.50)
     panel = VolumeWindow(design_session)  # constructor calls refresh_levels() once
@@ -340,7 +342,7 @@ def test_volume_panel_logs_windows_levels_on_refresh(
     ]
     assert windows_lines, "a refresh should log the read Windows volumes"
     record = windows_lines[-1]
-    assert record.levelno == logging.INFO
+    assert record.levelno == logging.DEBUG
     assert "endpoint 85%" in record.getMessage()
     assert "SMACC mixer 50%" in record.getMessage()
 


### PR DESCRIPTION
Part 1 of 3 for #132 (followed by the LSL/TTL data model and the Markers window).

- Adds a **Terminology** table to the Triggers docs pinning down *event / marker / port code / trigger / transport / log level*, referenced from the contributing conventions.
- Documents the **log-level convention** in the session-log reference (DEBUG = housekeeping, INFO = markers + meaningful operator actions, WARNING = mid-session config changes + recoverable faults, ERROR/CRITICAL = faults) and adds it to the contributor conventions.
- Re-levels the housekeeping lines that previously sat at INFO (settings load/save, manual device refresh, the Windows volume read-out) to DEBUG. Marker lines stay INFO; the log file records every level either way, so only the default live-preview view changes.

Verified: full pytest suite, ruff, mypy, `mkdocs build --strict`.
