### PR TITLE
refactor: drop pre-release compat paths and reset schemas to v1

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,8 +32,7 @@ the *docs* only — older copies of SMACC itself come from the releases page.)
 
 By default SMACC stores everything under `~/SMACC`. To use a different location,
 set an environment variable called `SMACC_DIRECTORY` to whatever directory you
-want (the older `SMACC_DATA_DIRECTORY` is still honored as a fallback). SMACC
-will create it and all of the subfolders (if not already present).
+want. SMACC will create it and all of the subfolders (if not already present).
 
 Your reusable setup lives in a **SMACC file** (`.smacc`): cue files, volumes,
 event codes, and the **data directory** where its runs are written. SMACC seeds a

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -10,7 +10,7 @@ from the task-oriented [Usage](../usage.md) guide.
 | [`preferences.yaml`](preferences-file.md) | Per-machine operator preferences | YAML | `schema_version: 1` |
 | [Session `.log`](session-log.md) | The per-run record (events + settings) | Text | — |
 | [BIDS export](bids-export.md) | `events.tsv` + JSON sidecar | TSV / JSON | follows BIDS |
-| [Survey definition](../surveys.md) | An in-app survey (built-in or custom) | YAML | `schema_version: 1`–`2` |
+| [Survey definition](../surveys.md) | An in-app survey (built-in or custom) | YAML | `schema_version: 1` |
 | [Survey response](../surveys.md#response-files) | One administration's answers | JSON | — |
 
 ## Where each file lives

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -14,8 +14,8 @@ guide (creating, editing, sharing). This page is the field reference.
 ```yaml
 # SMACC settings — YAML (.smacc). Edit with care.
 kind: smacc/settings
-schema_version: 3
-smacc_version: "0.0.7"
+schema_version: 1
+smacc_version: "0.0.9"
 metadata:
   subject: "001"
   session: "1"
@@ -90,7 +90,7 @@ settings:
 | Key | Type | Meaning |
 |---|---|---|
 | `kind` | string | Always `smacc/settings`; a file with a different `kind` is rejected. |
-| `schema_version` | integer | The settings schema version — currently **3**. Older versions are upgraded on load (see [Version history](#version-history)). |
+| `schema_version` | integer | The settings schema version — currently **1**. Only the current version loads; any other is rejected (see [Version history](#version-history)). |
 | `smacc_version` | string | The SMACC version that wrote the file (informational). |
 | `metadata` | mapping | Optional run metadata: `subject`, `session`, `notes`, and `created` (ISO timestamp). Blank by default; recorded in the log, not baked into filenames. |
 | `settings` | mapping | The configuration itself (below). |
@@ -217,6 +217,4 @@ folder stays valid when moved, copied, or zipped.
 
 | Version | Changes |
 |---|---|
-| 1 | First stable schema. Envelope (`kind` / `schema_version` / `smacc_version` / `metadata` / `settings`); panel state; the `biocals`, `devices`, `event_codes` + `event_code_safe_max`, `trigger_output`, `data_directory`, `preview_levels`, `always_on_top`, and `tool_always_on_top` blocks. |
-| 2 | The single visual cue (`blink_color` / `blink_length`) became the multi-slot `visual_cues` list with the shared `visual_attack` / `visual_release` fades. A v1 file's blink keys load into the first slot. |
-| 3 | Each `event_codes` entry routes per transport: the single `trigger` flag was replaced by independent `lsl` + `ttl` booleans. Deliberately unmigrated (pre-release breaking change): an older file's `trigger` keys are ignored and the routing defaults apply. |
+| 1 | The v0.0.9 baseline (numbering restarted; pre-release schemas were retired without migration). Envelope (`kind` / `schema_version` / `smacc_version` / `metadata` / `settings`); panel state; the `biocals`, `devices`, `event_codes` + `event_code_safe_max`, `trigger_output`, `data_directory`, `preview_levels`, `always_on_top`, and `tool_always_on_top` blocks. |

--- a/docs/surveys.md
+++ b/docs/surveys.md
@@ -155,9 +155,7 @@ items:
 
 A bare-string item is a **Likert** item rated against the survey's shared
 `scale` — the original shape, and all the builder produces. Definition files can
-also mix in other item types by writing an item as a mapping with a `type`
-(this requires `schema_version: 2`; an older SMACC then refuses the file cleanly
-rather than mis-reading it):
+also mix in other item types by writing an item as a mapping with a `type`:
 
 | `type` | Renders as | Extra fields |
 |---|---|---|
@@ -176,7 +174,7 @@ and points at the path). For a full worked example, see the bundled
 
 ```yaml
 kind: smacc/survey
-schema_version: 2
+schema_version: 1
 key: intake
 name: Intake
 title: Session intake

--- a/src/smacc/assets/default.smacc
+++ b/src/smacc/assets/default.smacc
@@ -1,6 +1,6 @@
 # SMACC settings — YAML (.smacc). Edit with care.
 kind: smacc/settings
-schema_version: 3
+schema_version: 1
 smacc_version: 0.0.7
 metadata:
   subject: ''

--- a/src/smacc/assets/surveys/madre.yaml
+++ b/src/smacc/assets/surveys/madre.yaml
@@ -3,7 +3,7 @@
 # "Attitude towards dreams" matrix (likert). The 0–7 yearly-frequency scale is
 # defined once (&freq) and reused (*freq).
 kind: smacc/survey
-schema_version: 2
+schema_version: 1
 key: madre
 name: MADRE
 title: Mannheim Dream Questionnaire (MADRE)

--- a/src/smacc/devices.py
+++ b/src/smacc/devices.py
@@ -27,26 +27,9 @@ OUTPUT = "output"
 INPUT = "input"
 VISUAL = "visual"
 
-# SMACC enumerates only WASAPI audio devices, so device names used to carry a
-# redundant ", Windows WASAPI" suffix (the host-API name PortAudio appends). New
-# bindings store the bare name; this constant lets older settings that saved the
-# suffixed form still resolve. See :func:`strip_wasapi_suffix`.
+# The PortAudio host API SMACC enumerates (and pins streams to); bindings store
+# the bare device name without this host-API name appended.
 WASAPI_HOST_API = "Windows WASAPI"
-_WASAPI_SUFFIX = f", {WASAPI_HOST_API}"
-
-
-def strip_wasapi_suffix(device: str) -> str:
-    """Drop a trailing ", Windows WASAPI" from a stored device string.
-
-    Device names are no longer stored with the host-API suffix (SMACC only ever
-    lists WASAPI devices, so it added nothing). Older ``.smacc`` files saved the
-    suffixed form, though, so every place that matches a stored device string
-    normalizes through this first — the bare and suffixed forms then compare equal
-    and an existing binding keeps resolving to the same device.
-    """
-    if device.endswith(_WASAPI_SUFFIX):
-        return device[: -len(_WASAPI_SUFFIX)]
-    return device
 
 
 @dataclass(frozen=True)

--- a/src/smacc/panels/base.py
+++ b/src/smacc/panels/base.py
@@ -28,7 +28,6 @@ def resolve_device(device: str | None, kind: str) -> int | str | None:
     """
     if not device:
         return None
-    name = devices.strip_wasapi_suffix(device)
     chan_key = f"max_{kind}_channels"
     try:
         host_api_names = [api["name"] for api in sd.query_hostapis()]
@@ -37,12 +36,12 @@ def resolve_device(device: str | None, kind: str) -> int | str | None:
             if (
                 info["hostapi"] == hostapi
                 and info[chan_key] > 0
-                and info["name"] == name
+                and info["name"] == device
             ):
                 return index
     except Exception:
         pass  # no WASAPI host API (or query failed): fall through to the name
-    return name
+    return device
 
 
 def describe_target(session: SmaccSession, target_key: str) -> str:

--- a/src/smacc/panels/devices.py
+++ b/src/smacc/panels/devices.py
@@ -37,9 +37,7 @@ def wasapi_devices(kind: str) -> list[str]:
     ", Windows WASAPI" suffix — it added nothing and is what gets persisted as a
     role binding). A bare name is ambiguous to sounddevice when the same hardware
     appears under several host APIs, so stream-opening code resolves it back to
-    the WASAPI device via :func:`smacc.panels.base.resolve_device`; older settings
-    that stored the suffixed form are normalized on load (see
-    :func:`smacc.devices.strip_wasapi_suffix`).
+    the WASAPI device via :func:`smacc.panels.base.resolve_device`.
     """
     chan_key = "max_output_channels" if kind == devices.OUTPUT else "max_input_channels"
     try:

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -100,7 +100,7 @@ class SmaccSession:
         self.missing_devices: list[str] = []
         # Device roles + routing (which physical device each modality uses). The
         # Devices window edits this; modality panels resolve their device from it.
-        # A loaded study replaces it via devices.load() (migrating older files).
+        # A loaded study replaces it via devices.load().
         self.devices = devices.default_config()
         # Master output safety cap (0-1): a single ceiling multiplied into every
         # stimulus (cue + noise) in the audio callback, so a cue at full volume on a

--- a/src/smacc/settings.py
+++ b/src/smacc/settings.py
@@ -9,8 +9,8 @@ reject YAML that wasn't written by it.
 The on-disk shape (a ``.smacc`` file is YAML text with a leading comment header)::
 
     kind: smacc/settings
-    schema_version: 3
-    smacc_version: "0.0.7"
+    schema_version: 1
+    smacc_version: "0.0.9"
     metadata: {subject: "", session: "", notes: "", created: "..."}
     settings: { ...the panel state from SmaccWindow.gather_settings()... }
 
@@ -48,18 +48,13 @@ KIND = "smacc/settings"
 # ignores ``#`` comments, so this round-trips cleanly through ``safe_load``).
 _FILE_HEADER = "# SMACC settings — YAML (.smacc). Edit with care.\n"
 
-# v1 was the first stable on-disk schema; v2 reshaped the single visual cue
-# (``blink_color``/``blink_length``) into the multi-slot ``visual_cues`` list;
-# v3 (pre-release, deliberately unmigrated) replaced each event_codes entry's
-# ``trigger`` flag with per-transport ``lsl`` + ``ttl`` routing — an older file's
-# ``trigger`` keys are ignored and the routing defaults apply.
-# Bump this when the layout changes incompatibly — and when you do, extend
-# :func:`_migrate_settings` plus the version-history table in
-# docs/reference/settings-file.md. A file carrying a higher or otherwise-unknown
-# version is rejected on load. Missing *optional* keys are not a version concern:
-# each panel/sub-block fills its own default, so a partial or hand-edited file
-# still loads.
-SCHEMA_VERSION = 3
+# v1 is the v0.0.9 baseline (pre-release schemas were retired without migration).
+# Bump this when the layout changes incompatibly — and when you do, update the
+# version-history table in docs/reference/settings-file.md. A file carrying any
+# other version is rejected on load. Missing *optional* keys are not a version
+# concern: each panel/sub-block fills its own default, so a partial or
+# hand-edited file still loads.
+SCHEMA_VERSION = 1
 
 
 def build_payload(settings: dict[str, Any], metadata: dict) -> dict[str, Any]:
@@ -109,13 +104,13 @@ def parse_settings_mapping(payload: Any) -> tuple[dict, dict]:
     if kind is not None and kind != KIND:
         raise ValueError(f"Not a compatible SMACC settings file (kind={kind!r}).")
     version = payload.get("schema_version")
-    # Versions 1..current are accepted; older shapes are upgraded on the way in.
     if isinstance(version, bool) or not isinstance(version, int):
         raise ValueError(f"Unsupported settings schema version {version!r}.")
-    if not (1 <= version <= SCHEMA_VERSION):
+    if version != SCHEMA_VERSION:
         raise ValueError(
-            f"Unsupported settings schema version {version!r} "
-            f"(expected 1..{SCHEMA_VERSION})."
+            f"Unsupported settings schema version {version!r} (expected "
+            f"{SCHEMA_VERSION}). A file from a pre-release SMACC must be "
+            "recreated in the Editor."
         )
     settings = payload.get("settings")
     if not isinstance(settings, dict):
@@ -123,27 +118,7 @@ def parse_settings_mapping(payload: Any) -> tuple[dict, dict]:
     metadata = payload.get("metadata")
     if not isinstance(metadata, dict):
         metadata = {}
-    return _migrate_settings(settings, version), metadata
-
-
-def _migrate_settings(settings: dict, version: int) -> dict:
-    """Upgrade an older-schema ``settings`` mapping to the current shape, in place.
-
-    v1 -> v2: the single visual cue (``blink_color``/``blink_length``) became the
-    multi-slot ``visual_cues`` list; a v1 file's blink keys load into the first
-    slot (panels only ever see the current shape).
-    """
-    if version < 2:
-        color = settings.pop("blink_color", None)
-        length = settings.pop("blink_length", None)
-        if "visual_cues" not in settings and (color is not None or length is not None):
-            slot: dict[str, Any] = {"name": "Light 1"}
-            if color is not None:
-                slot["color"] = color
-            if length is not None:
-                slot["length"] = length
-            settings["visual_cues"] = [slot]
-    return settings
+    return settings, metadata
 
 
 def load_settings(path: str | Path) -> tuple[dict, dict]:

--- a/src/smacc/surveys.py
+++ b/src/smacc/surveys.py
@@ -11,7 +11,7 @@ The on-disk shape (a survey file is YAML with a ``kind`` discriminator, like the
 ``.smacc`` settings format)::
 
     kind: smacc/survey
-    schema_version: 2
+    schema_version: 1
     key: dlq                # stable id; also names response files
     name: DLQ               # short label (dropdown, File menu)
     title: Dream Lucidity Questionnaire (DLQ)
@@ -21,7 +21,7 @@ The on-disk shape (a survey file is YAML with a ``kind`` discriminator, like the
     scale: {min: 0, max: 4, anchors: [..., one per scale point, ...]}
     items:
       - a bare string               # a Likert item on the shared scale (above)
-      - text: Age                   # or a typed item (schema_version 2+):
+      - text: Age                   # or a typed item:
         type: number                #   likert | select | number | text | heading
         min: 0
         max: 99
@@ -31,11 +31,9 @@ The on-disk shape (a survey file is YAML with a ``kind`` discriminator, like the
         help: "shown under the item"
         levels: {0: never, 1: rarely, 2: often}
 
-A plain-string item is a Likert item on the survey's shared scale — the original
-(and still most common) shape, so the bundled single-scale instruments need no
-``type`` and stay ``schema_version: 1``. Typed items (anything but a bare-string
-Likert) require ``schema_version: 2``; an older SMACC then rejects the file with a
-clear version error instead of mis-reading it. Responses are written as one JSON
+A plain-string item is a Likert item on the survey's shared scale — the most
+common shape, so a single-scale instrument needs no ``type``; typed items mix
+freely with it. Responses are written as one JSON
 file per administration (see :func:`response_payload` / :func:`response_filename`),
 carrying the survey key *and* content version so an analysis can always tell which
 wording a given night used.
@@ -64,7 +62,7 @@ from .utils import format_elapsed
 # Discriminators for the two YAML/JSON shapes this module owns.
 KIND = "smacc/survey"
 RESPONSE_KIND = "smacc/survey-response"
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 1
 
 # Pseudo-URL scheme addressing an in-app survey in the dropdown / File menu /
 # saved ``survey_url``; anything else is a web URL for the browser.
@@ -297,10 +295,10 @@ def parse_survey_mapping(
     version = payload.get("schema_version")
     if isinstance(version, bool) or not isinstance(version, int):
         raise ValueError(f"Unsupported survey schema version {version!r}.")
-    if not (1 <= version <= SCHEMA_VERSION):
+    if version != SCHEMA_VERSION:
         raise ValueError(
             f"Unsupported survey schema version {version!r} "
-            f"(expected 1..{SCHEMA_VERSION})."
+            f"(expected {SCHEMA_VERSION})."
         )
     key = _require_str(payload, "key").lower()
     if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", key):
@@ -319,10 +317,6 @@ def parse_survey_mapping(
     items_raw = payload.get("items")
     if not isinstance(items_raw, list) or not items_raw:
         raise ValueError("Survey needs a non-empty 'items' list.")
-    # Typed items (anything but a bare-string Likert) are a v2 feature; reject them
-    # in a v1 file so the version cleanly signals the capability a reader needs.
-    if version < 2 and any(not isinstance(item, str) for item in items_raw):
-        raise ValueError("Typed survey items require schema_version 2.")
     items = tuple(_parse_item(item) for item in items_raw)
     if not any(it.collects_response for it in items):
         raise ValueError("Survey needs at least one item that collects a response.")
@@ -464,13 +458,12 @@ def _item_to_mapping(item: SurveyItem) -> str | dict[str, Any]:
 def survey_to_mapping(survey: SurveyDef) -> dict[str, Any]:
     """Serialize a definition for saving as a survey YAML (builder dialog).
 
-    Writes the lowest schema version that fits: a survey of plain Likert items
-    stays ``schema_version: 1`` (and emits bare-string items); anything with
-    typed items, help, or headings is ``schema_version: 2``.
+    A plain Likert item emits its bare-string shorthand; everything else emits
+    the typed-item mapping.
     """
     mapping: dict[str, Any] = {
         "kind": KIND,
-        "schema_version": 1 if survey.is_simple_likert else 2,
+        "schema_version": SCHEMA_VERSION,
         "key": survey.key,
         "name": survey.name,
         "title": survey.title,

--- a/src/smacc/utils.py
+++ b/src/smacc/utils.py
@@ -40,19 +40,11 @@ def index_of_device(candidates: Sequence[str], saved: str | None) -> int | None:
     ``saved`` (no prior selection) returns ``None``, as does a saved device that is
     no longer present (unplugged) — the caller then flags the miss and keeps the
     default.
-
-    Both sides are normalized with :func:`smacc.devices.strip_wasapi_suffix` first,
-    so a binding saved by an older SMACC as ``"Name, Windows WASAPI"`` still matches
-    the bare ``"Name"`` now advertised (and vice versa) — keeping existing ``.smacc``
-    files working without a fuzzy match.
     """
     if not saved:
         return None
-    from . import devices
-
-    target = devices.strip_wasapi_suffix(saved)
     for index, key in enumerate(candidates):
-        if devices.strip_wasapi_suffix(key) == target:
+        if key == saved:
             return index
     return None
 
@@ -80,16 +72,11 @@ def pick_random_demo_cue(cues_dir: Path) -> Path | None:
 def get_smacc_directory() -> Path:
     """Return the SMACC root directory, creating it if needed.
 
-    Honors the ``SMACC_DIRECTORY`` environment variable, falling back to the
-    legacy ``SMACC_DATA_DIRECTORY`` (deprecated) and then to ``~/SMACC``. This
-    root holds the per-study workspaces under ``studies/`` and the global,
-    machine-level ``preferences.yaml``.
+    Honors the ``SMACC_DIRECTORY`` environment variable, falling back to
+    ``~/SMACC``. This root holds the per-study workspaces under ``studies/`` and
+    the global, machine-level ``preferences.yaml``.
     """
-    raw = (
-        environ.get("SMACC_DIRECTORY")
-        or environ.get("SMACC_DATA_DIRECTORY")
-        or "~/SMACC"
-    )
+    raw = environ.get("SMACC_DIRECTORY") or "~/SMACC"
     root = Path(raw).expanduser()
     root.mkdir(parents=True, exist_ok=True)
     return root

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -3,23 +3,6 @@
 from smacc import devices
 
 
-def test_strip_wasapi_suffix_drops_trailing_host_api():
-    # Older settings stored the host-API suffix; it normalizes away to the bare name.
-    assert (
-        devices.strip_wasapi_suffix("Speakers (USB Audio), Windows WASAPI")
-        == "Speakers (USB Audio)"
-    )
-
-
-def test_strip_wasapi_suffix_leaves_bare_names_untouched():
-    # New bindings store the bare name already, so stripping is a no-op.
-    assert devices.strip_wasapi_suffix("Speakers (USB Audio)") == "Speakers (USB Audio)"
-    # Only a trailing host-API suffix is removed (not the bare host-API name alone,
-    # nor an interior occurrence).
-    assert devices.strip_wasapi_suffix("Windows WASAPI") == "Windows WASAPI"
-    assert devices.strip_wasapi_suffix("Windows WASAPI mixer") == "Windows WASAPI mixer"
-
-
 def test_default_config_routes_targets_to_their_defaults():
     cfg = devices.default_config()
     assert cfg.role_for("cue_out") == "bedroom_out"

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -154,7 +154,7 @@ def test_manage_surveys_guards_editing_typed_survey(qtbot, tmp_path, monkeypatch
     typed = surveys.parse_survey_mapping(
         {
             "kind": surveys.KIND,
-            "schema_version": 2,
+            "schema_version": 1,
             "key": "mine",
             "name": "Mine",
             "title": "Mine",

--- a/tests/test_panels_base.py
+++ b/tests/test_panels_base.py
@@ -119,12 +119,6 @@ def test_resolve_device_blank_is_system_default(monkeypatch):
     assert base.resolve_device(None, devices.OUTPUT) is None
 
 
-def test_resolve_device_strips_legacy_wasapi_suffix(monkeypatch):
-    _patch_sd(monkeypatch)
-    saved = "Speakers (Realtek(R) Audio), Windows WASAPI"  # pre-#-strip settings
-    assert base.resolve_device(saved, devices.OUTPUT) == 3
-
-
 def test_resolve_device_unplugged_name_passes_through(monkeypatch):
     _patch_sd(monkeypatch)
     assert base.resolve_device("Speakers (USB)", devices.OUTPUT) == "Speakers (USB)"

--- a/tests/test_panels_devices.py
+++ b/tests/test_panels_devices.py
@@ -74,19 +74,6 @@ def test_reload_flags_missing_bound_device(qtbot, design_session, mock_devices):
     assert any("Unplugged speaker" in entry for entry in design_session.missing_devices)
 
 
-def test_reload_resolves_legacy_suffixed_binding(qtbot, design_session, mock_devices):
-    # An older .smacc stored the device with the ", Windows WASAPI" suffix, but
-    # enumeration now advertises the bare name. The binding must still resolve to
-    # that device (no "missing device" notice) for backward compatibility.
-    bare = mock_devices["outputs"][1]
-    design_session.devices.bindings["bedroom_out"] = f"{bare}, Windows WASAPI"
-    window = DevicesWindow(design_session)
-    qtbot.addWidget(window)
-    window.reload_from_config()
-    assert window._role_combos["bedroom_out"].currentText() == bare
-    assert design_session.missing_devices == []
-
-
 def test_refresh_button_emits_refresh_requested(qtbot, design_session, mock_devices):
     # The in-window Refresh button defers to the session window's rescan via this
     # signal (rather than duplicating the PortAudio re-init).

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -66,7 +66,7 @@ def test_saved_file_is_tagged_yaml(tmp_path):
     assert text.splitlines()[0].startswith("#")  # self-identifying header comment
     payload = yaml.safe_load(text)  # comment is ignored, so it still parses
     assert payload["kind"] == settings.KIND
-    assert payload["schema_version"] == settings.SCHEMA_VERSION == 3
+    assert payload["schema_version"] == settings.SCHEMA_VERSION == 1
     assert payload["smacc_version"] == smacc.__version__
     assert payload["settings"] == {"cue_attack": 0.2}
 
@@ -192,8 +192,7 @@ def test_load_rejects_unsupported_schema(tmp_path):
 
 
 def test_load_rejects_higher_schema_version(tmp_path):
-    # Older versions migrate forward, but there is no *backward* migration, so a
-    # higher version (e.g. a file from a future SMACC) is rejected.
+    # Only the current version loads — a file from a future SMACC is rejected.
     path = tmp_path / "future.smacc"
     path.write_text(
         yaml.safe_dump(
@@ -298,34 +297,10 @@ def test_resolve_keeps_absolute_and_skips_empty(tmp_path):
     assert out["noise_file"] == ""  # empty untouched
 
 
-def test_v1_blink_keys_migrate_into_the_first_visual_slot():
-    payload = {
-        "kind": settings.KIND,
-        "schema_version": 1,
-        "settings": {
-            "blink_color": "#123456",
-            "blink_length": 2.5,
-            "noise_volume": 0.1,
-        },
-    }
-    state, _ = settings.parse_settings_mapping(payload)
-    assert "blink_color" not in state and "blink_length" not in state
-    assert state["visual_cues"] == [
-        {"name": "Light 1", "color": "#123456", "length": 2.5}
-    ]
-    assert state["noise_volume"] == 0.1  # everything else is untouched
-
-
-def test_v1_without_blink_keys_gains_no_visual_block():
-    payload = {"kind": settings.KIND, "schema_version": 1, "settings": {}}
-    state, _ = settings.parse_settings_mapping(payload)
-    assert "visual_cues" not in state
-
-
-def test_current_version_settings_are_not_migrated():
-    # A stray hand-edited blink key in a v2 file is left alone (panels ignore it)
-    # and never overwrites the real visual_cues block.
-    original = {"blink_color": "#123456", "visual_cues": [{"name": "A"}]}
+def test_settings_pass_through_unaltered():
+    # The data layer never rewrites the settings mapping — stray hand-edited keys
+    # are left alone (panels ignore them).
+    original = {"stray_key": "#123456", "visual_cues": [{"name": "A"}]}
     payload = {
         "kind": settings.KIND,
         "schema_version": settings.SCHEMA_VERSION,

--- a/tests/test_survey_window.py
+++ b/tests/test_survey_window.py
@@ -132,7 +132,7 @@ def mixed_survey():
     return surveys.parse_survey_mapping(
         {
             "kind": surveys.KIND,
-            "schema_version": 2,
+            "schema_version": 1,
             "key": "mixed",
             "name": "Mixed",
             "title": "Mixed survey",

--- a/tests/test_surveys.py
+++ b/tests/test_surveys.py
@@ -104,9 +104,8 @@ def test_parse_rejects_non_mapping():
 
 
 def _typed_mapping(items, **overrides):
-    """A valid schema_version 2 mapping carrying the given (typed) items."""
+    """A valid survey mapping carrying the given (typed) items."""
     payload = _mapping(**overrides)
-    payload["schema_version"] = 2
     payload["items"] = items
     return payload
 
@@ -148,19 +147,11 @@ def test_parse_select_number_text_heading_items():
     assert len(survey.response_items) == 4  # the heading collects nothing
 
 
-def test_typed_items_require_schema_version_2():
-    # A mapping (typed) item in a v1 file is rejected with a clear message.
-    payload = _mapping()  # schema_version 1, string items
-    payload["items"] = ["ok", {"text": "Age", "type": "number"}]
-    with pytest.raises(ValueError, match="schema_version 2"):
-        surveys.parse_survey_mapping(payload)
-
-
 def test_scale_optional_when_no_likert_items():
     survey = surveys.parse_survey_mapping(
         {
             "kind": surveys.KIND,
-            "schema_version": 2,
+            "schema_version": surveys.SCHEMA_VERSION,
             "key": "demo",
             "name": "Demo",
             "items": [{"text": "Job", "type": "text"}],  # no Likert -> no scale needed
@@ -213,15 +204,10 @@ def test_typed_survey_round_trips_through_mapping():
         )
     )
     mapping = surveys.survey_to_mapping(survey)
-    assert mapping["schema_version"] == 2  # typed items force v2
+    assert mapping["schema_version"] == surveys.SCHEMA_VERSION
     assert mapping["items"][1] == "A Likert item"  # plain Likert collapses to a string
     reloaded = surveys.parse_survey_mapping(mapping)
     assert reloaded.items == survey.items
-
-
-def test_simple_likert_round_trips_as_version_1():
-    survey = surveys.parse_survey_mapping(_mapping())
-    assert surveys.survey_to_mapping(survey)["schema_version"] == 1
 
 
 # ----- save / load round trip ---------------------------------------------------

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,25 +42,10 @@ def test_index_of_device_empty_candidates_is_none():
 
 
 def test_index_of_device_new_bare_name_matches_bare_candidate():
-    # The current world: enumeration advertises bare names and a fresh binding
-    # stored the same bare name, so it resolves directly.
+    # Enumeration advertises bare names and a fresh binding stored the same bare
+    # name, so it resolves directly.
     candidates = ["Speakers (USB Audio)", "Headphones"]
     assert utils.index_of_device(candidates, "Headphones") == 1
-
-
-def test_index_of_device_old_suffixed_binding_matches_bare_candidate():
-    # Backward-compat: a binding saved by an older SMACC carries the ", Windows
-    # WASAPI" suffix, but enumeration now lists the bare name. The suffix is
-    # normalized away on both sides, so the old .smacc still resolves.
-    candidates = ["Speakers (USB Audio)", "Headphones"]
-    assert utils.index_of_device(candidates, "Headphones, Windows WASAPI") == 1
-
-
-def test_index_of_device_bare_binding_matches_legacy_suffixed_candidate():
-    # The symmetric case (defensive): even if a candidate still carried the suffix,
-    # a bare saved value would match it.
-    candidates = ["Speakers (USB Audio), Windows WASAPI"]
-    assert utils.index_of_device(candidates, "Speakers (USB Audio)") == 0
 
 
 def test_note_returns_int16_of_expected_length():
@@ -93,27 +78,10 @@ def test_noise_generators_produce_finite_samples(noise_func):
 
 def test_get_smacc_directory_uses_env_var(tmp_path, monkeypatch):
     target = tmp_path / "smacc_root"
-    monkeypatch.delenv("SMACC_DATA_DIRECTORY", raising=False)
     monkeypatch.setenv("SMACC_DIRECTORY", str(target))
     result = utils.get_smacc_directory()
     assert result == target
     assert result.is_dir()
-
-
-def test_get_smacc_directory_falls_back_to_legacy_env_var(tmp_path, monkeypatch):
-    target = tmp_path / "legacy_root"
-    monkeypatch.delenv("SMACC_DIRECTORY", raising=False)
-    monkeypatch.setenv("SMACC_DATA_DIRECTORY", str(target))
-    result = utils.get_smacc_directory()
-    assert result == target
-    assert result.is_dir()
-
-
-def test_get_smacc_directory_prefers_new_env_var(tmp_path, monkeypatch):
-    new = tmp_path / "new_root"
-    monkeypatch.setenv("SMACC_DIRECTORY", str(new))
-    monkeypatch.setenv("SMACC_DATA_DIRECTORY", str(tmp_path / "legacy_root"))
-    assert utils.get_smacc_directory() == new
 
 
 def test_wav_round_trip(tmp_path):


### PR DESCRIPTION
Part of the #124 audit. There are no users and no installed instances, so all accommodation of pre-release files goes away:

- Delete the settings v1→v2 migration and reset `.smacc` `schema_version` to **1** (the v0.0.9 baseline); only the current version loads, with a clear error pointing at the Editor.
- Collapse the survey schema to a single version **1** (drop the write-lowest-version-that-fits logic and the typed-items-require-v2 gate); bundled `madre.yaml` updated.
- Delete `strip_wasapi_suffix` and its call sites — bindings have stored bare device names for a while; matching is now exact.
- Drop the deprecated `SMACC_DATA_DIRECTORY` env-var fallback (`SMACC_DIRECTORY` only).
- Docs updated to match (`settings-file.md` version history collapsed, `surveys.md`, `installation.md`, reference index).