### PR TITLE
fix: harden overnight sessions (log cap, LSL race, silent failures)

### DIFF
--- a/docs/reference/preferences-file.md
+++ b/docs/reference/preferences-file.md
@@ -23,6 +23,7 @@ preferences:
     - C:\Users\you\SMACC\peter.smacc
     - C:\Users\you\SMACC\paul.smacc
   last_settings: C:\Users\you\SMACC\peter.smacc
+  log_preview_max_lines: 1000
 ```
 
 ## Fields
@@ -41,6 +42,7 @@ preferences:
 | `association_prompted` | boolean | Whether the first-run "associate `.smacc` files (Windows)?" prompt has already been shown. |
 | `recent_settings` | list of paths | Recently opened `.smacc` files, most-recent first, de-duplicated and capped at 8. |
 | `last_settings` | path or `null` | The last `.smacc` opened, so the Launcher can preselect it. |
+| `log_preview_max_lines` | integer | How many lines the Session window's live log preview keeps (default **1000**); the oldest lines are dropped first. The log *file* always records everything, so nothing is lost. Very large values cost GUI memory and repaint time over an overnight session. |
 
 !!! note "Partial files are fine"
     Loading merges a file's keys over the defaults, so a file missing some keys still

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -509,7 +509,11 @@ class SmaccWindow(ToolWindow):
         self.logviewList = logviewList
 
         # Route log records to the preview pane, filtered by the level toggles.
-        self.preview_handler = QtLogHandler(logviewList)
+        # The preview keeps only the newest N lines (preferences.yaml's
+        # log_preview_max_lines); the log file records everything.
+        self.preview_handler = QtLogHandler(
+            logviewList, max_lines=preferences.log_preview_max_lines(self._prefs)
+        )
         self.preview_handler.setFormatter(
             logging.Formatter(
                 fmt="%(asctime)s  %(levelname)s  %(message)s", datefmt="%H:%M:%S"

--- a/src/smacc/lights.py
+++ b/src/smacc/lights.py
@@ -17,9 +17,12 @@ accumulated per tick — so a late or missed GUI tick can't drift the stimulus.
 
 from __future__ import annotations
 
+import logging
 import math
 import threading
 from typing import Protocol
+
+_logger = logging.getLogger("smacc")
 
 RGB = tuple[int, int, int]
 
@@ -197,7 +200,8 @@ def resolve_blinkstick(serial: str) -> BlinkStickBackend | None:
     The blinkstick import is local: the package is Windows-only and touches USB,
     so the engine half of this module stays importable (and testable) anywhere.
     A USB enumeration hiccup resolves to None rather than raising — the panel
-    treats that the same as no device bound.
+    treats that the same as no device bound — but is logged, so a dead stick is
+    distinguishable from an unbound one when debugging a rig.
     """
     if not serial:
         return None
@@ -206,6 +210,7 @@ def resolve_blinkstick(serial: str) -> BlinkStickBackend | None:
     try:
         device = blinkstick.find_by_serial(serial)
     except Exception:
+        _logger.warning(f"BlinkStick {serial!r} lookup failed", exc_info=True)
         return None
     return BlinkStickBackend(device) if device is not None else None
 

--- a/src/smacc/panels/recording.py
+++ b/src/smacc/panels/recording.py
@@ -177,11 +177,11 @@ class RecordingWindow(ModalityWindow):
         them, so a short report-NN name is enough.
         """
         device = self._selected_input_device()
-        self.n_report_counter += 1
         assert self.session.session_dir is not None  # recording is gated on can_record
-        export_path = (
-            self.session.session_dir / f"report-{self.n_report_counter:02d}.wav"
-        )
+        # The counter advances only after the stream starts, so a failed attempt
+        # can never leave a gap in the report numbering.
+        number = self.n_report_counter + 1
+        export_path = self.session.session_dir / f"report-{number:02d}.wav"
         try:
             rate = int(sd.query_devices(device, "input")["default_samplerate"])
             self._record_file = sf.SoundFile(
@@ -200,11 +200,11 @@ class RecordingWindow(ModalityWindow):
             self._record_stream.start()
         except Exception as exc:  # PortAudio / file-open errors
             self._teardown_recording()
-            self.n_report_counter -= 1  # this attempt produced no report
             self.session.show_error_popup(
                 "Could not start recording.", str(exc), parent=self
             )
             return False
+        self.n_report_counter = number
         self._set_recording_indicator(True)
         return True
 

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -41,6 +41,10 @@ DEFAULTS: dict[str, Any] = {
     # the last one opened, so the launcher can preselect it and offer quick switching.
     "recent_settings": [],
     "last_settings": None,
+    # How many lines the Session window's live log preview keeps (oldest dropped
+    # first; the log file always keeps everything). Large values cost GUI memory
+    # and repaint time over an overnight session.
+    "log_preview_max_lines": 1000,
 }
 
 _logger = logging.getLogger("smacc")
@@ -138,6 +142,18 @@ def update_window_geometry(
         windows = {}
     windows[window_id] = geometry
     update_preferences(path, {"windows": windows})
+
+
+def log_preview_max_lines(prefs: dict[str, Any]) -> int:
+    """Return the log-preview line cap (a positive int), else the default.
+
+    A hand-edited ``preferences.yaml`` may carry anything here; garbage or a
+    non-positive value falls back to the default rather than breaking the window.
+    """
+    value = prefs.get("log_preview_max_lines")
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        return int(DEFAULTS["log_preview_max_lines"])
+    return value
 
 
 def levels_to_names(levels: set[int]) -> list[str]:

--- a/src/smacc/qtlog.py
+++ b/src/smacc/qtlog.py
@@ -21,11 +21,18 @@ class QtLogHandler(logging.Handler):
     handler still receives every record regardless. The widget update is marshalled
     to the GUI thread via a Qt signal, so logging from a non-GUI thread (e.g. the
     audio callback) is safe.
+
+    The preview keeps only the newest ``max_lines`` items (the log *file* keeps
+    everything) — an overnight session logs thousands of lines, and an unbounded
+    list would grow the GUI's memory and repaint cost all night.
     """
 
-    def __init__(self, list_widget: QtWidgets.QListWidget) -> None:
+    def __init__(
+        self, list_widget: QtWidgets.QListWidget, max_lines: int = 1000
+    ) -> None:
         super().__init__()
         self._list = list_widget
+        self.max_lines = max(int(max_lines), 1)
         self.enabled_levels: set[int] = {
             logging.INFO,
             logging.WARNING,
@@ -50,5 +57,6 @@ class QtLogHandler(logging.Handler):
 
     def _append(self, msg: str) -> None:
         self._list.addItem(msg)
+        while self._list.count() > self.max_lines:
+            self._list.takeItem(0)
         self._list.scrollToBottom()
-        self._list.repaint()

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -271,11 +271,14 @@ class SmaccSession:
         # sleep) so both edges land as close together as possible. LSL is stamped at
         # the estimated onset (now + onset_offset) so it lines up with the stimulus;
         # the hardware TTL just fires its edge now (LSL is the timed path SMACC owns).
-        if event.lsl and self.outlet is not None:
+        # Snapshot the outlet: emit_event can fire from a non-GUI thread while the
+        # GUI thread closes the session and Nones the attribute.
+        outlet = self.outlet
+        if event.lsl and outlet is not None:
             if onset_offset > 0.0:
-                self.outlet.push_sample([str(code)], local_clock() + onset_offset)
+                outlet.push_sample([str(code)], local_clock() + onset_offset)
             else:
-                self.outlet.push_sample([str(code)])
+                outlet.push_sample([str(code)])
         if event.ttl and self.trigger_out is not None:
             try:
                 self.trigger_out.send(code)

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -39,6 +39,21 @@ def test_partial_file_merges_over_defaults(tmp_path):
     assert "association_prompted" in prefs  # every default key present
 
 
+def test_log_preview_max_lines_reads_a_positive_int():
+    assert preferences.log_preview_max_lines({"log_preview_max_lines": 50}) == 50
+
+
+def test_log_preview_max_lines_falls_back_on_garbage():
+    default = preferences.DEFAULTS["log_preview_max_lines"]
+    for bad in (
+        {},
+        {"log_preview_max_lines": 0},
+        {"log_preview_max_lines": "many"},
+        {"log_preview_max_lines": True},
+    ):
+        assert preferences.log_preview_max_lines(bad) == default
+
+
 def test_round_trip(tmp_path):
     path = tmp_path / "preferences.yaml"
     custom = preferences.default_preferences()

--- a/tests/test_qtlog.py
+++ b/tests/test_qtlog.py
@@ -59,3 +59,18 @@ def test_smacc_preview_false_hides_record_from_preview(qtbot):
 
     assert widget.count() == 1
     assert widget.item(0).text() == "shown"
+
+
+def test_preview_keeps_only_the_newest_max_lines(qtbot):
+    # An overnight session logs thousands of lines; the preview drops the oldest
+    # past the cap (the log file keeps everything).
+    widget = QtWidgets.QListWidget()
+    qtbot.addWidget(widget)
+    logger, handler = _logger_with_handler(widget, "smacc.test.cap")
+    handler.max_lines = 3
+
+    for i in range(5):
+        logger.info(f"line {i}")
+
+    assert widget.count() == 3
+    assert [widget.item(i).text() for i in range(3)] == ["line 2", "line 3", "line 4"]


### PR DESCRIPTION
Part of the #124 audit — fixes for things that only bite hours into a live night:

- **Cap the live log preview** at `log_preview_max_lines` (a new `preferences.yaml` key, default 1000, documented with a note about large values); oldest lines drop first and the per-line forced `repaint()` is gone. The log file still records everything.
- **Snapshot the LSL outlet** in `emit_event` so a marker firing from a non-GUI thread can't race session close and die between the None-check and the push.
- **Log BlinkStick lookup failures** instead of swallowing them — a dead stick is now distinguishable from an unbound one.
- **Advance the report counter only after the mic stream starts**, so a failed start can never desync report numbering (even if teardown itself fails).