### PR TITLE
docs: use the glossary's 'port code' in prose and fix README roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Used for dream engineering by the [Paller Lab](https://sites.northwestern.edu/pa
 * Trigger audio cues
 * Trigger visual cues (BlinkStick or Philips Hue)
 * Collect dream reports
-* Trigger EEG portcodes
+* Trigger EEG port codes
 * Save a detailed event log
 * and more!
 
@@ -37,7 +37,7 @@ Note that for some features, you will need to open SMACC with Administrator priv
 
 * There is a `Record Dream Report` button that will start to record from whatever mic is routed to the **Capture dream report** modality (set in the **Devices** window). It can also pop open a survey URL — I use this to open a dream report survey I have set up on Qualtrics. Add your surveys with the `Manage…` button next to the survey dropdown (each has a name and URL, saved to your SMACC file); pick one to open automatically when recording starts, or open any saved survey on its own from `File > Surveys`. If planning to record dreams, bind your mic to the **Bedroom mic** role in the Devices window.
 
-* All device selection lives in one **Devices** window (in the *Tools* column): bind each **role** — Bedroom speakers, Control-room speakers, Bedroom mic, Bedroom lights — to a device once, then route each modality to a role. Because cue, noise, and your voice can all share one speaker, re-pointing it is a single change. Optional routes add a **Monitor audio cue** (the cue also plays in the control room) and a **Listen through intercom** (hear the participant on the Control-room speakers). The whole setup is saved in the SMACC file and restored on the next launch; a bound device that isn't connected is flagged. Plugging a device in is detected automatically, or click `Refresh devices (F5)` in the Devices window — audio devices rescan only while nothing is playing or recording.
+* All device selection lives in one **Devices** window (in the *Tools* column): bind each **role** — Bedroom speakers, Control-room speakers, Bedroom mic, the lights (BlinkStick or Philips Hue) — to a device once, then route each modality to a role. Because cue, noise, and your voice can all share one speaker, re-pointing it is a single change. Optional routes add a **Monitor audio cue** (the cue also plays in the control room) and a **Listen through intercom** (hear the participant on the Control-room speakers). The whole setup is saved in the SMACC file and restored on the next launch; a bound device that isn't connected is flagged. Plugging a device in is detected automatically, or click `Refresh devices (F5)` in the Devices window — audio devices rescan only while nothing is playing or recording.
 
 ## Documentation
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -43,7 +43,7 @@ Keep the history skimmable and merge commits clean.
 ```text
 feat: optional hardware TTL trigger output
 docs: document audio routing
-fix: clamp incrementing portcodes to 255
+fix: clamp incrementing port codes to 255
 ```
 
 **Pull requests**

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,7 +8,7 @@ a simple, clickable interface and is commonly used in dream engineering research
 * Trigger audio cues
 * Trigger visual cues (BlinkStick or Philips Hue)
 * Collect dream reports
-* Trigger EEG portcodes
+* Trigger EEG port codes
 * Save a detailed event log
 * and more!
 
@@ -26,7 +26,7 @@ download, or for downloading older versions.
 ## Get started
 
 * [Installation](installation.md) — download and run SMACC.
-* [Usage](usage.md) — trigger cues, record dream reports, send portcodes, and more.
+* [Usage](usage.md) — trigger cues, record dream reports, send port codes, and more.
 * [SMACC files](smacc-files.md) — create and reuse a study's configuration (`.smacc`).
 * [Audio & routing](audio.md) — assign devices to roles, route cues/noise/intercom, and set volume.
 * [Visual cues](visual.md) — light cues on a BlinkStick or Philips Hue: patterns, timing, and safety.

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -124,7 +124,7 @@ rig**. To characterise yours:
 
 - **Against the EEG, per session (authoritative).** Record the real stimulus onset on
   a spare amplifier channel — a microphone for the cue, a photodiode for the light —
-  alongside the LSL portcode. The difference between the portcode and the recorded
+  alongside the LSL port code. The difference between the port code and the recorded
   onset, across the night, is the true distribution, and it can be visualised in the
   Analyze tool. This needs a spare channel and is tracked in
   [#104](https://github.com/remrama/smacc/issues/104).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -206,16 +206,16 @@ message.
 
 **What's recorded.** Every message is written verbatim to the session log as a
 DEBUG line (tick *Debug* above the log preview to watch the exchange live). By
-default no portcodes fire and nothing reaches the BIDS events export — a typed
+default no port codes fire and nothing reaches the BIDS events export — a typed
 exchange is rapid and conversational, and would flood the marker channel. If a
 study needs marker timestamps, route `Chat to participant` (code 69) and/or
 `Chat from participant` (code 70) to LSL/TTL in the **Markers** window;
 the markers stay bare (no message text) so the trigger channel remains legible.
 
-## EEG portcodes
+## EEG port codes
 
 SMACC marks experiment events — a cue played, a dream report, observed REM, the
-lights toggled — by sending a numeric **portcode** to its marker stream and writing a
+lights toggled — by sending a numeric **port code** to its marker stream and writing a
 matching line to the session log, keeping cue delivery and your neural data in sync.
 
 ### Configuring codes
@@ -229,7 +229,7 @@ biocals, chat, system) — and the
 [hardware TTL transport](triggers.md#configuring-trigger-output-in-smacc).
 For each event you can set:
 
-- **Code** — the 8-bit portcode (1–255) sent when the event triggers.
+- **Code** — the 8-bit port code (1–255) sent when the event triggers.
 - **LSL** — whether a firing sends the code over the LSL marker stream.
 - **TTL** — whether a firing sends the code over the hardware TTL trigger. The
   column is grayed out until a transport is enabled in the window's **Hardware
@@ -258,8 +258,8 @@ re-reads the session's current setup. The window stays available throughout a
 session. If you change a code mid-session, the change is written to the log with a
 timestamp, so the code-to-event mapping for that session is always recoverable.
 
-Beyond portcodes, SMACC logs the important interactions too — volume, color, device,
-and fade changes — as plain log lines (no portcode), so the session record is complete.
+Beyond port codes, SMACC logs the important interactions too — volume, color, device,
+and fade changes — as plain log lines (no port code), so the session record is complete.
 
 ### Event logging panel
 

--- a/src/smacc/biocals.py
+++ b/src/smacc/biocals.py
@@ -10,7 +10,7 @@ the timing/marker state machine; the Qt window that renders it lives in
 Three layers, all Qt-free and unit-testable:
 
 * :class:`BiocalDef` — the app-defined table of biocals (label, task-window
-  duration, spoken instruction, default portcode). Like event labels, these stay
+  duration, spoken instruction, default port code). Like event labels, these stay
   app-defined so improvements reach old studies; only the *stack* below travels
   with a study.
 * :class:`BiocalRow` — one row of a study's biocal stack: which biocal, whether
@@ -21,7 +21,7 @@ Three layers, all Qt-free and unit-testable:
   The GUI feeds it presses/ticks and executes the :data:`Action` values it
   returns (emit a marker, start/stop the voice).
 
-Marker timing: the start portcode marks the *task window* opening — with the
+Marker timing: the start port code marks the *task window* opening — with the
 voice enabled it fires when the announcement ends, matching the manual practice
 of speaking the instruction first and marking when the participant complies.
 So the trigger channel reads the same whether the voice or the experimenter

--- a/src/smacc/events.py
+++ b/src/smacc/events.py
@@ -1,14 +1,14 @@
 """The configurable event-marker registry: codes, labels, and per-event routing.
 
 SMACC marks experiment events (a cue played, a dream report, observed REM, …) by
-pushing a numeric *portcode* to its marker stream and writing a matching log line.
+pushing a numeric *port code* to its marker stream and writing a matching log line.
 Those codes used to live as hardcoded dicts in :mod:`smacc.config`; this module
 makes them a single editable registry a study can tune, persist in its ``.smacc``
 file, and recover from any session log.
 
 Each :class:`EventDef` carries:
 
-* ``code`` — the 8-bit portcode (``1..255``) sent on a trigger.
+* ``code`` — the 8-bit port code (``1..255``) sent on a trigger.
 * ``lsl`` / ``ttl`` — per-transport routing: whether a firing pushes the code over
   the LSL marker stream and/or the hardware TTL trigger (when one is configured).
   An event routed to neither transport is log-only.
@@ -34,7 +34,7 @@ from typing import Any
 
 from . import biocals
 
-# 8-bit parallel/serial trigger byte: the universally safe portcode range.
+# 8-bit parallel/serial trigger byte: the universally safe port code range.
 CODE_MIN = 1
 CODE_MAX = 255
 # Default soft ceiling; a study can lower it to match older trigger hardware.
@@ -514,7 +514,7 @@ def routing_summary(event: EventDef) -> str:
 
     Shown in the Event logging grid's button tooltips (and anywhere else a
     one-liner is wanted) so an operator can tell, without opening the Markers
-    window, whether pressing a button sends a portcode and where.
+    window, whether pressing a button sends a port code and where.
     """
     if event.triggered:
         code = f"codes {event.code}+" if event.increment else f"code {event.code}"
@@ -526,7 +526,7 @@ def routing_summary(event: EventDef) -> str:
             where = "TTL only"
         summary = f"{code} → {where}"
     else:
-        summary = "log only (no portcode sent)"
+        summary = "log only (no port code sent)"
     if not event.preview:
         summary += " · hidden from the live preview"
     return summary

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -457,7 +457,7 @@ class SmaccSession:
 
         Gated by ``log_interactions`` so the programmatic widget setup that runs
         during construction or a study load doesn't spam the log; the main window
-        flips the gate on after startup. These lines never carry a portcode.
+        flips the gate on after startup. These lines never carry a port code.
 
         ``debug=True`` logs at DEBUG instead of INFO, for high-frequency lines
         (e.g. live volume edits) that should still hit the file but stay out of

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -122,7 +122,7 @@ def test_routing_summary_describes_each_shape():
     unrouted_hidden = events.EventDef("A", "A", 69, lsl=False, ttl=False, preview=False)
     assert (
         events.routing_summary(unrouted_hidden)
-        == "log only (no portcode sent) · hidden from the live preview"
+        == "log only (no port code sent) · hidden from the live preview"
     )
 
 


### PR DESCRIPTION
Part of the #124 audit. The #133 glossary standardized **"port code"** (two words); this aligns the remaining prose in README, docs (index, usage incl. the section heading, latency, contributing), and the events/biocals docstrings, plus the Markers-window routing summary string.

The literal session-log token `" - portcode N"` is untouched — it's a machine contract parsed by `bids.py` and guarded in the chat sanitizer, and `session-log.md`/`bids-export.md` describe that token verbatim.

Also fixes the README's device-role list: there is no "Bedroom lights" role — the visual roles are **BlinkStick** and **Philips Hue**.