### PR TITLE
ci: smoke-test the frozen exe before attaching it to a release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,13 @@ jobs:
       - run: uv sync --extra dev
       - name: Build SMACC.exe
         run: uv run pyinstaller entry.py --name SMACC --onefile --noconsole --icon src/smacc/assets/icon.ico --add-data "src/smacc/assets/icon.png;smacc/assets" --add-data "src/smacc/assets/default.smacc;smacc/assets" --add-data "src/smacc/assets/cues;smacc/assets/cues" --add-data "src/smacc/assets/biocals;smacc/assets/biocals" --add-data "src/smacc/assets/surveys;smacc/assets/surveys"
+      # A broken bundle (missing data file, import error) otherwise ships silently:
+      # the exe is windowed (--noconsole), so PowerShell won't wait for it on its
+      # own and there is no stdout — Start-Process -Wait + the exit code is the test.
+      - name: Smoke-test the exe
+        run: |
+          $p = Start-Process -FilePath dist/SMACC.exe -ArgumentList '--version' -Wait -PassThru
+          if ($p.ExitCode -ne 0) { throw "SMACC.exe --version exited with code $($p.ExitCode)" }
       - name: Attach exe to release
         uses: softprops/action-gh-release@v2
         with:

--- a/src/smacc/__main__.py
+++ b/src/smacc/__main__.py
@@ -13,6 +13,7 @@ from PyQt6.QtGui import QIcon
 from PyQt6.QtWidgets import QApplication, QMessageBox
 
 from . import preferences
+from .config import VERSION
 from .launcher import LauncherWindow, resolve_initial_settings
 from .paths import (
     BUNDLED_CUES_DIR,
@@ -122,7 +123,16 @@ def main() -> None:
     the menu and goes straight to a session for it. Ending a session quits SMACC
     (the other tools return to the launcher). Run folders and logs are created only
     when a session starts, not the instant the app launches.
+
+    ``--version`` exits immediately (code 0) without opening any window. The
+    release workflow smoke-tests the frozen exe with it — reaching this point
+    proves the bundle unpacks and every import resolves. The exe is built
+    ``--noconsole`` (no stdout), so the check is the exit code, not the output.
     """
+    if "--version" in sys.argv[1:]:
+        if sys.stdout is not None:  # absent in a --noconsole build
+            print(f"SMACC {VERSION}")
+        return
     _quiet_qt_multimedia_logging()  # before QApplication: Qt reads the rule at startup
     app = QApplication(sys.argv)
     _install_excepthook()

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -1,12 +1,15 @@
 """Tests for launch-with-a-file argument picking (no GUI required)."""
 
 import os
+import sys
 
 from smacc.__main__ import (
     _FFMPEG_QUIET_RULE,
     _quiet_qt_multimedia_logging,
+    main,
     pick_settings_path,
 )
+from smacc.config import VERSION
 
 
 def test_no_positional_returns_none():
@@ -30,6 +33,14 @@ def test_ignores_flags_and_other_files():
 
 def test_last_study_file_wins():
     assert pick_settings_path(["SMACC.exe", "a.smacc", "b.smacc"]) == "b.smacc"
+
+
+def test_version_flag_exits_before_any_window(monkeypatch, capsys):
+    # The release workflow's smoke test: --version must return (exit code 0)
+    # without constructing a QApplication or touching the SMACC directory.
+    monkeypatch.setattr(sys, "argv", ["SMACC.exe", "--version"])
+    main()  # returns instead of entering the Qt event loop
+    assert f"SMACC {VERSION}" in capsys.readouterr().out
 
 
 # ----- Qt-multimedia logging rule (quiet the FFmpeg startup banner) ----------


### PR DESCRIPTION
Part of the #124 audit. `release.yaml` built and uploaded `SMACC.exe` with no verification — a bundle missing a data file or failing an import would ship silently.

- Add a `--version` flag to `main()` that exits (code 0) before any Qt work. Reaching it proves the frozen bundle unpacks and every import resolves; the exe is `--noconsole` so the exit code, not stdout, is the contract.
- Add a post-build workflow step that runs the exe with `Start-Process -Wait` (PowerShell doesn't wait for windowed exes on its own) and fails the release on a nonzero exit code.

Rehearsable with a pre-release tag before v0.0.9.