### PR TITLE
test: cover the recording, noise, and intercom panels

### DIFF
--- a/tests/test_panels_intercom.py
+++ b/tests/test_panels_intercom.py
@@ -1,0 +1,229 @@
+"""Tests for the intercom window (#20) and its audio bridge, plus the chat section.
+
+The ``_Bridge`` queue/resampler logic is tested directly (no Qt, no hardware);
+window tests stub the bridge so toggles, markers, and push-to-talk are exercised
+headless.
+"""
+
+from __future__ import annotations
+
+import queue
+
+import numpy as np
+import pytest
+from PyQt6 import QtCore, QtGui
+
+from smacc import audio
+from smacc.panels import intercom
+from smacc.panels.intercom import IntercomWindow, _Bridge
+
+# ----- _Bridge (pure queue/resampler logic) ----------------------------------
+
+
+def _primed_bridge(in_rate=8000, out_rate=8000, maxsize=4) -> _Bridge:
+    bridge = _Bridge()
+    bridge._queue = queue.Queue(maxsize=maxsize)
+    bridge._resampler = audio.LinearResampler(in_rate, out_rate)
+    return bridge
+
+
+def test_bridge_in_callback_queues_audio_and_meters_level():
+    bridge = _primed_bridge()
+    block = np.full((128, 1), 1.0, dtype="float32")
+    bridge._in_callback(block, 128, None, None)
+    assert bridge._queue.qsize() == 1
+    assert bridge.level_db == pytest.approx(0.0)  # full scale -> 0 dBFS
+
+
+def test_bridge_drops_blocks_instead_of_blocking_when_full():
+    bridge = _primed_bridge(maxsize=1)
+    block = np.zeros((64, 1), dtype="float32")
+    bridge._in_callback(block, 64, None, None)
+    bridge._in_callback(block, 64, None, None)  # queue full: dropped, no raise
+    assert bridge._queue.qsize() == 1
+
+
+def test_bridge_out_callback_drains_the_queue_into_the_output():
+    bridge = _primed_bridge()
+    bridge._in_callback(np.full((64, 1), 0.5, dtype="float32"), 64, None, None)
+    out = np.zeros((32, 1), dtype="float32")
+    bridge._out_callback(out, 32, None, None)
+    assert bridge._queue.qsize() == 0  # drained into the resampler
+    assert out.any()  # and the output carries the bridged audio
+
+
+def test_bridge_out_callback_is_silent_when_inactive():
+    bridge = _Bridge()  # never started: no queue, no resampler
+    out = np.ones((32, 1), dtype="float32")
+    bridge._out_callback(out, 32, None, None)
+    assert not out.any()
+
+
+def test_bridge_start_failure_tears_down_cleanly(monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("no such device")
+
+    monkeypatch.setattr(intercom.sd, "query_devices", boom)
+    bridge = _Bridge()
+    with pytest.raises(RuntimeError):
+        bridge.start(None, None)
+    assert not bridge.active()
+    assert bridge._queue is None and bridge._resampler is None
+    assert bridge.level_db == audio.FLOOR_DBFS
+
+
+# ----- IntercomWindow ---------------------------------------------------------
+
+
+def _stub_bridges(monkeypatch, fail=False):
+    """Replace _Bridge.start/stop with recorders so no stream ever opens."""
+    calls = {"start": 0, "stop": 0}
+
+    def fake_start(self, input_device, output_device):
+        if fail:
+            raise RuntimeError("PortAudio error")
+        calls["start"] += 1
+        self._queue = queue.Queue()  # marks the bridge "active enough" for stop()
+
+    def fake_stop(self):
+        running = self._queue is not None
+        calls["stop"] += 1
+        self._queue = None
+        return running
+
+    monkeypatch.setattr(_Bridge, "start", fake_start)
+    monkeypatch.setattr(_Bridge, "stop", fake_stop)
+    monkeypatch.setattr(_Bridge, "active", lambda self: self._queue is not None)
+    return calls
+
+
+def test_toggle_talk_starts_the_bridge_and_marks(qtbot, design_session, monkeypatch):
+    calls = _stub_bridges(monkeypatch)
+    window = IntercomWindow(design_session)
+    qtbot.addWidget(window)
+    emitted = []
+    monkeypatch.setattr(
+        design_session, "emit_event", lambda key, **k: emitted.append(key)
+    )
+
+    window.talkButton.setChecked(True)
+    assert calls["start"] == 1
+    assert emitted == ["IntercomStarted"]
+    assert window._level_timer.isActive()
+
+    window.talkButton.setChecked(False)
+    assert emitted == ["IntercomStarted", "IntercomStopped"]
+    assert not window._level_timer.isActive()
+    window.cleanup()
+
+
+def test_talk_start_failure_reverts_the_button(
+    qtbot, design_session, monkeypatch, silence_dialogs
+):
+    _stub_bridges(monkeypatch, fail=True)
+    window = IntercomWindow(design_session)
+    qtbot.addWidget(window)
+    emitted = []
+    monkeypatch.setattr(
+        design_session, "emit_event", lambda key, **k: emitted.append(key)
+    )
+    window.talkButton.setChecked(True)
+    assert not window.talkButton.isChecked()  # reverted by the error path
+    assert emitted == []  # a failed start is never marked
+    window.cleanup()
+
+
+def test_listen_toggles_without_markers(qtbot, design_session, monkeypatch):
+    calls = _stub_bridges(monkeypatch)
+    window = IntercomWindow(design_session)
+    qtbot.addWidget(window)
+    emitted = []
+    monkeypatch.setattr(
+        design_session, "emit_event", lambda key, **k: emitted.append(key)
+    )
+    window.listenButton.setChecked(True)
+    window.listenButton.setChecked(False)
+    assert calls["start"] == 1
+    assert emitted == []  # passive monitoring: log line only, no EEG marker
+    window.cleanup()
+
+
+def _space_event(etype) -> QtGui.QKeyEvent:
+    return QtGui.QKeyEvent(
+        etype, QtCore.Qt.Key.Key_Space, QtCore.Qt.KeyboardModifier.NoModifier
+    )
+
+
+def test_spacebar_push_to_talk_holds_and_releases(qtbot, design_session, monkeypatch):
+    _stub_bridges(monkeypatch)
+    window = IntercomWindow(design_session)
+    qtbot.addWidget(window)
+    monkeypatch.setattr(
+        IntercomWindow, "_is_text_widget_focused", staticmethod(lambda: False)
+    )
+
+    consumed = window.eventFilter(window, _space_event(QtCore.QEvent.Type.KeyPress))
+    assert consumed and window.talkButton.isChecked()
+    consumed = window.eventFilter(window, _space_event(QtCore.QEvent.Type.KeyRelease))
+    assert consumed and not window.talkButton.isChecked()
+    window.cleanup()
+
+
+def test_spacebar_passes_through_while_typing(qtbot, design_session, monkeypatch):
+    _stub_bridges(monkeypatch)
+    window = IntercomWindow(design_session)
+    qtbot.addWidget(window)
+    monkeypatch.setattr(
+        IntercomWindow, "_is_text_widget_focused", staticmethod(lambda: True)
+    )
+
+    consumed = window.eventFilter(window, _space_event(QtCore.QEvent.Type.KeyPress))
+    assert not consumed and not window.talkButton.isChecked()
+    window.cleanup()
+
+
+def test_send_chat_message_posts_and_clears_the_entry(qtbot, design_session):
+    window = IntercomWindow(design_session)
+    qtbot.addWidget(window)
+    window.chatEntry.setText("  Are you comfortable?  ")
+    window.send_chat_message()
+    assert "You:  Are you comfortable?" in window.chatView.toPlainText()
+    assert window.chatEntry.text() == ""
+    window.cleanup()
+
+
+def test_empty_chat_message_is_not_posted(qtbot, design_session):
+    window = IntercomWindow(design_session)
+    qtbot.addWidget(window)
+    window.chatEntry.setText("   ")
+    window.send_chat_message()
+    assert window.chatView.toPlainText() == ""
+    window.cleanup()
+
+
+def test_preset_buttons_rebuild_and_send_verbatim(qtbot, design_session):
+    window = IntercomWindow(design_session)
+    qtbot.addWidget(window)
+    long = "Please describe everything that was going through your mind just now."
+    window._presets.set([long], [])
+    assert len(window._preset_buttons) == 1
+    button = window._preset_buttons[0]
+    assert button.text().endswith("…")  # elided label
+    assert button.toolTip() == long  # full text preserved
+    button.click()
+    assert f"You:  {long}" in window.chatView.toPlainText()
+    window.cleanup()
+
+
+def test_preset_state_round_trips(qtbot, design_session):
+    window = IntercomWindow(design_session)
+    qtbot.addWidget(window)
+    window._presets.set(["Prompt one"], ["Yes", "No"])
+    state = window.gather_state()
+    other = IntercomWindow(design_session)
+    qtbot.addWidget(other)
+    other.apply_state(state)
+    assert other._presets.experimenter == ["Prompt one"]
+    assert other._presets.participant == ["Yes", "No"]
+    window.cleanup()
+    other.cleanup()

--- a/tests/test_panels_noise.py
+++ b/tests/test_panels_noise.py
@@ -1,0 +1,169 @@
+"""Tests for the noise-machine window: playback lifecycle, callback, and state.
+
+Headless: sounddevice is stubbed, the loop buffer and callback are driven by hand.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from smacc.panels import noise
+from smacc.panels.noise import NOISE_LOOP_SECONDS, NoiseWindow
+
+
+class _FakeOutput:
+    """Stand-in for sd.OutputStream that records its lifecycle calls."""
+
+    last: _FakeOutput | None = None
+    latency = 0.01  # the panel reads it for the marker's onset offset
+
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+        self.started = False
+        self.aborted = False
+        self.closed = False
+        _FakeOutput.last = self
+
+    def start(self):
+        self.started = True
+
+    def abort(self):
+        self.aborted = True
+
+    def close(self):
+        self.closed = True
+
+
+def _stub_output(monkeypatch, stream_cls=_FakeOutput, rate=8000.0):
+    monkeypatch.setattr(
+        noise.sd, "query_devices", lambda *a, **k: {"default_samplerate": rate}
+    )
+    monkeypatch.setattr(noise.sd, "OutputStream", stream_cls)
+
+
+def test_play_then_stop_builds_buffer_and_updates_status(
+    qtbot, design_session, monkeypatch
+):
+    _stub_output(monkeypatch)
+    window = NoiseWindow(design_session)
+    qtbot.addWidget(window)
+    assert not window.is_streaming()
+
+    window.play_noise()
+    assert window.is_streaming()
+    assert _FakeOutput.last is not None and _FakeOutput.last.started
+    assert window._noise_buffer is not None
+    assert window._noise_buffer.shape == (NOISE_LOOP_SECONDS * 8000,)
+    assert "playing" in window.noiseStatusLabel.text()
+
+    window.stop_noise()
+    assert not window.is_streaming()
+    assert window._noise_buffer is None
+    assert "stopped" in window.noiseStatusLabel.text()
+    assert _FakeOutput.last.aborted and _FakeOutput.last.closed
+
+
+def test_play_marks_once_but_not_on_silent_restart(qtbot, design_session, monkeypatch):
+    _stub_output(monkeypatch)
+    window = NoiseWindow(design_session)
+    qtbot.addWidget(window)
+    emitted = []
+    monkeypatch.setattr(
+        design_session, "emit_event", lambda key, **k: emitted.append(key)
+    )
+
+    window.on_play_noise_clicked()
+    assert emitted == ["NoiseStarted"]
+    # A color change mid-playback restarts the stream silently (no new marker).
+    window.available_noisecolors_dropdown.setCurrentIndex(1)  # white -> pink
+    assert window.is_streaming()
+    assert emitted == ["NoiseStarted"]
+
+    window.on_stop_noise_clicked()
+    assert emitted == ["NoiseStarted", "NoiseStopped"]
+    # Stop when already stopped marks nothing.
+    window.on_stop_noise_clicked()
+    assert emitted == ["NoiseStarted", "NoiseStopped"]
+
+
+def test_callback_loops_the_buffer_and_applies_gain_and_cap(qtbot, design_session):
+    window = NoiseWindow(design_session)
+    qtbot.addWidget(window)
+    window._noise_buffer = np.array([0.0, 1.0, 2.0, 3.0], dtype="float32")
+    window._noise_pos = 2
+    window.noise_stream_volume = 0.5
+    design_session.volume_cap = 0.5  # the master safety cap is the final gain stage
+    out = np.zeros((6, 1), dtype="float32")
+    window._noise_callback(out, 6, None, None)
+    # Reads wrap around the loop seam; gain = volume * cap = 0.25.
+    np.testing.assert_allclose(out[:, 0], np.array([2, 3, 0, 1, 2, 3]) * 0.25)
+
+
+def test_callback_outputs_silence_without_a_buffer(qtbot, design_session):
+    window = NoiseWindow(design_session)
+    qtbot.addWidget(window)
+    out = np.ones((8, 1), dtype="float32")
+    window._noise_callback(out, 8, None, None)
+    assert not out.any()
+
+
+def test_file_source_without_a_file_shows_error_and_no_stream(
+    qtbot, design_session, monkeypatch, silence_dialogs
+):
+    _stub_output(monkeypatch)
+    window = NoiseWindow(design_session)
+    qtbot.addWidget(window)
+    window.fileRadio.setChecked(True)
+    window.play_noise()
+    assert not window.is_streaming()
+    assert window._noise_buffer is None
+
+
+def test_failed_stream_start_clears_the_buffer(
+    qtbot, design_session, monkeypatch, silence_dialogs
+):
+    def boom(*args, **kwargs):
+        raise RuntimeError("no output device")
+
+    _stub_output(monkeypatch, stream_cls=boom)
+    window = NoiseWindow(design_session)
+    qtbot.addWidget(window)
+    window.play_noise()
+    assert not window.is_streaming()
+    assert window._noise_buffer is None
+    assert "stopped" in window.noiseStatusLabel.text()
+
+
+@pytest.mark.parametrize("color", ["white", "pink", "brown"])
+def test_each_builtin_color_builds_a_normalized_buffer(qtbot, design_session, color):
+    window = NoiseWindow(design_session)
+    qtbot.addWidget(window)
+    idx = window.available_noisecolors_dropdown.findText(color)
+    window.available_noisecolors_dropdown.setCurrentIndex(idx)
+    buf = window._build_noise_buffer(2000)
+    assert buf.shape == (NOISE_LOOP_SECONDS * 2000,)
+    assert np.all(np.isfinite(buf))
+    assert np.abs(buf).max() <= 1.0  # normalized for the volume/cap gain stage
+
+
+def test_state_round_trips_between_windows(qtbot, design_session):
+    first = NoiseWindow(design_session)
+    qtbot.addWidget(first)
+    first.noisevolumeSpinBox.setValue(0.42)
+    first.fileRadio.setChecked(True)
+    first.noiseFileEdit.setText("C:/sounds/rain.wav")
+    idx = first.available_noisecolors_dropdown.findText("brown")
+    first.available_noisecolors_dropdown.setCurrentIndex(idx)
+    state = first.gather_state()
+
+    second = NoiseWindow(design_session)
+    qtbot.addWidget(second)
+    second.apply_state(state)
+    assert second.noisevolumeSpinBox.value() == pytest.approx(0.42)
+    assert second.fileRadio.isChecked()
+    assert second.noiseFileEdit.text() == "C:/sounds/rain.wav"
+    assert second.available_noisecolors_dropdown.currentText() == "brown"
+    # The file row is enabled (and the color picker not) to match the source.
+    assert second.noiseFileEdit.isEnabled()
+    assert not second.available_noisecolors_dropdown.isEnabled()

--- a/tests/test_panels_recording.py
+++ b/tests/test_panels_recording.py
@@ -1,0 +1,164 @@
+"""Tests for the dream-recording window: capture lifecycle, surveys, and state.
+
+Headless like the other panel tests: sounddevice is stubbed (no hardware), but the
+report WAV is written with the real soundfile into the live session's run folder,
+so the on-disk artifact is exercised end to end.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import soundfile as sf
+
+from smacc.panels import recording
+from smacc.panels.recording import RecordingWindow
+
+
+class _FakeInput:
+    """Stand-in for sd.InputStream that records its lifecycle calls."""
+
+    last: _FakeInput | None = None
+
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+        self.started = False
+        self.aborted = False
+        self.closed = False
+        _FakeInput.last = self
+
+    def start(self):
+        self.started = True
+
+    def abort(self):
+        self.aborted = True
+
+    def close(self):
+        self.closed = True
+
+
+def _stub_recorder(monkeypatch, stream_cls=_FakeInput, rate=8000.0):
+    monkeypatch.setattr(
+        recording.sd, "query_devices", lambda *a, **k: {"default_samplerate": rate}
+    )
+    monkeypatch.setattr(recording.sd, "InputStream", stream_cls)
+
+
+def test_designer_disables_the_record_button(qtbot, design_session):
+    window = RecordingWindow(design_session)
+    qtbot.addWidget(window)
+    assert not window.micrecordButton.isEnabled()
+    window.cleanup()
+
+
+def test_record_start_to_stop_writes_the_report_wav(
+    qtbot, live_session, monkeypatch, silence_dialogs
+):
+    _stub_recorder(monkeypatch)
+    window = RecordingWindow(live_session)
+    qtbot.addWidget(window)
+
+    window.micrecordButton.setChecked(True)
+    window.start_or_stop_recording()
+    assert window.n_report_counter == 1
+    assert window.is_streaming()
+    assert _FakeInput.last is not None and _FakeInput.last.started
+    assert "recording" in window.recordingIndicatorLabel.text()
+
+    # The audio thread delivers a block; it lands in the report file.
+    window._record_callback(np.full((64, 1), 0.25, dtype="float32"), 64, None, None)
+
+    window.micrecordButton.setChecked(False)
+    window.start_or_stop_recording()
+    assert not window.is_streaming()
+    assert "idle" in window.recordingIndicatorLabel.text()
+    path = live_session.session_dir / "report-01.wav"
+    assert path.is_file()
+    data, rate = sf.read(path)
+    assert rate == 8000 and len(data) == 64
+    window.cleanup()
+
+
+def test_failed_start_reverts_button_and_leaves_no_numbering_gap(
+    qtbot, live_session, monkeypatch, silence_dialogs
+):
+    def boom(*args, **kwargs):
+        raise RuntimeError("device busy")
+
+    _stub_recorder(monkeypatch, stream_cls=boom)
+    window = RecordingWindow(live_session)
+    qtbot.addWidget(window)
+
+    window.micrecordButton.setChecked(True)
+    window.start_or_stop_recording()
+    assert not window.micrecordButton.isChecked()  # start failed -> reverted
+    assert window.n_report_counter == 0
+    assert not window.is_streaming()
+
+    # The next (successful) attempt is still report 1 — no gap from the failure.
+    _stub_recorder(monkeypatch)
+    window.micrecordButton.setChecked(True)
+    window.start_or_stop_recording()
+    assert window.n_report_counter == 1
+    window.micrecordButton.setChecked(False)
+    window.start_or_stop_recording()
+    assert (live_session.session_dir / "report-01.wav").is_file()
+    window.cleanup()
+
+
+def test_open_in_app_survey_opens_window_and_marks(qtbot, live_session, monkeypatch):
+    window = RecordingWindow(live_session)
+    qtbot.addWidget(window)
+    emitted = []
+    monkeypatch.setattr(
+        live_session, "emit_event", lambda key, detail=None, **k: emitted.append(key)
+    )
+    lucid = window._survey_registry["lucid"]  # a bundled built-in
+    window.open_survey_url(lucid.url)
+    assert len(window._survey_windows) == 1
+    assert emitted == ["SurveyOpened"]
+    window.cleanup()
+    assert window._survey_windows == []  # cleanup closes (and forgets) it
+
+
+def test_open_web_survey_uses_the_browser(qtbot, live_session, monkeypatch):
+    window = RecordingWindow(live_session)
+    qtbot.addWidget(window)
+    opened = []
+    monkeypatch.setattr(
+        recording.webbrowser, "open", lambda url, **k: opened.append(url)
+    )
+    window.open_survey_url("https://example.com/form", "Post survey")
+    assert opened == ["https://example.com/form"]
+    assert window._survey_windows == []  # no in-app window for a web URL
+    window.cleanup()
+
+
+def test_open_unknown_in_app_survey_shows_error_not_a_window(
+    qtbot, live_session, silence_dialogs
+):
+    window = RecordingWindow(live_session)
+    qtbot.addWidget(window)
+    window.open_survey_url("smacc://survey/not-a-real-key")
+    assert window._survey_windows == []
+    window.cleanup()
+
+
+def test_survey_state_round_trips_web_urls_only(qtbot, design_session):
+    window = RecordingWindow(design_session)
+    qtbot.addWidget(window)
+    options = {"Post survey": "https://example.com/post"}
+    window.apply_state(
+        {"survey_options": options, "survey_url": options["Post survey"]}
+    )
+    state = window.gather_state()
+    assert state["survey_options"] == options  # in-app smacc:// entries excluded
+    assert state["survey_url"] == "https://example.com/post"
+    window.cleanup()
+
+
+def test_typed_url_wins_over_blank_preset(qtbot, design_session):
+    window = RecordingWindow(design_session)
+    qtbot.addWidget(window)
+    window.surveyComboBox.setEditText("  example.com/typed  ")
+    assert window.current_survey_url() == "example.com/typed"
+    window.cleanup()


### PR DESCRIPTION
Part of the #124 audit — the last three panels with real logic and no tests.

- **Recording** (`test_panels_recording.py`): full record start→stop lifecycle writing a real report WAV into the run folder; failed start reverts the button with no report-numbering gap; in-app vs web survey opening (window + marker vs browser); unknown-survey error path; survey state round-trip persisting web URLs only.
- **Noise** (`test_panels_noise.py`): play/stop lifecycle and status; marker fires once on Play but not on a silent color-change restart; callback loop-seam wraparound with volume × safety-cap gain; silence without a buffer; missing-file and failed-stream error paths; per-color buffer generation; state round-trip.
- **Intercom** (`test_panels_intercom.py`): `_Bridge` queue/resampler logic directly (drop-don't-block on overrun, drain into output, silent when inactive, clean teardown on start failure); talk/listen toggles and their marker semantics; spacebar push-to-talk hold/release and pass-through while typing; chat send/clear, empty-message guard, preset buttons, and preset state round-trip.

All headless: sounddevice stubbed, callbacks driven by hand; the report WAV uses the real soundfile so the on-disk artifact is exercised.