### PR TITLE
build: ship an Inno Setup installer alongside the portable exe

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,8 +20,22 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync --extra dev
+      # The tag is the release's public version; smacc.__version__ is what the app
+      # reports (About dialog, --version) and what the installer is stamped with.
+      # A mismatch would ship an installer that misidentifies itself, so fail fast.
+      - name: Check the tag matches smacc.__version__
+        run: |
+          $version = (uv run python -c "import smacc; print(smacc.__version__)")
+          if ("v$version" -ne "${{ github.ref_name }}") {
+            throw "Tag ${{ github.ref_name }} does not match smacc.__version__ ($version)"
+          }
+          "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
+      # Embeds product name/version/publisher in the exe's Properties dialog —
+      # metadata IT departments look at when vetting or whitelisting a binary.
+      - name: Generate the exe version-info resource
+        run: uv run python tools/make_versionfile.py version_info.txt
       - name: Build SMACC.exe
-        run: uv run pyinstaller entry.py --name SMACC --onefile --noconsole --icon src/smacc/assets/icon.ico --add-data "src/smacc/assets/icon.png;smacc/assets" --add-data "src/smacc/assets/default.smacc;smacc/assets" --add-data "src/smacc/assets/cues;smacc/assets/cues" --add-data "src/smacc/assets/biocals;smacc/assets/biocals" --add-data "src/smacc/assets/surveys;smacc/assets/surveys"
+        run: uv run pyinstaller entry.py --name SMACC --onefile --noconsole --icon src/smacc/assets/icon.ico --version-file version_info.txt --add-data "src/smacc/assets/icon.png;smacc/assets" --add-data "src/smacc/assets/default.smacc;smacc/assets" --add-data "src/smacc/assets/cues;smacc/assets/cues" --add-data "src/smacc/assets/biocals;smacc/assets/biocals" --add-data "src/smacc/assets/surveys;smacc/assets/surveys"
       # A broken bundle (missing data file, import error) otherwise ships silently:
       # the exe is windowed (--noconsole), so PowerShell won't wait for it on its
       # own and there is no stdout — Start-Process -Wait + the exit code is the test.
@@ -29,7 +43,28 @@ jobs:
         run: |
           $p = Start-Process -FilePath dist/SMACC.exe -ArgumentList '--version' -Wait -PassThru
           if ($p.ExitCode -ne 0) { throw "SMACC.exe --version exited with code $($p.ExitCode)" }
-      - name: Attach exe to release
+      # Inno Setup is preinstalled on the GitHub Windows runner images.
+      - name: Build SMACC-Setup.exe (Inno Setup installer)
+        run: |
+          & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAppVersion=$env:VERSION tools\smacc.iss
+          if ($LASTEXITCODE -ne 0) { throw "ISCC exited with code $LASTEXITCODE" }
+      # Same idea as the exe smoke test, one level up: a broken installer (bad
+      # source path, registry section typo) would otherwise ship silently. Install
+      # per-user, run the *installed* exe, and confirm the .smacc association the
+      # [Registry] section is responsible for actually landed.
+      - name: Smoke-test the installer
+        run: |
+          $p = Start-Process -FilePath dist/SMACC-Setup.exe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/CURRENTUSER' -Wait -PassThru
+          if ($p.ExitCode -ne 0) { throw "SMACC-Setup.exe exited with code $($p.ExitCode)" }
+          $exe = "$env:LOCALAPPDATA\Programs\SMACC\SMACC.exe"
+          if (-not (Test-Path $exe)) { throw "Installed exe not found at $exe" }
+          $p = Start-Process -FilePath $exe -ArgumentList '--version' -Wait -PassThru
+          if ($p.ExitCode -ne 0) { throw "Installed SMACC.exe --version exited with code $($p.ExitCode)" }
+          $progid = (Get-ItemProperty -Path 'HKCU:\Software\Classes\.smacc').'(default)'
+          if ($progid -ne 'SMACC.Study') { throw ".smacc association not registered (got '$progid')" }
+      - name: Attach exe and installer to release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/SMACC.exe
+          files: |
+            dist/SMACC.exe
+            dist/SMACC-Setup.exe

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ smacc.egg-info/
 dist/
 build/
 *.spec
+version_info.txt
 .venv/
 .*_cache/
 .coverage

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -121,7 +121,15 @@ the driver, add `--hidden-import pywinusb`.
 
 Releases are built automatically: pushing a `v*` tag (e.g. `v0.0.7`) triggers the
 [release workflow](https://github.com/remrama/smacc/blob/main/.github/workflows/release.yaml),
-which builds `SMACC.exe` and attaches it to the GitHub Release.
+which checks the tag against `smacc.__version__`, builds `SMACC.exe` (stamped with
+version metadata from `tools/make_versionfile.py`), wraps it in an Inno Setup
+installer (`tools/smacc.iss` → `SMACC-Setup.exe`), smoke-tests both, and attaches
+the two artifacts to the GitHub Release. The installer's asset name is a stable
+contract — the docs' download button links
+`releases/latest/download/SMACC-Setup.exe` — so don't rename it. The installer's
+`[Registry]` section must mirror `winassoc.association_entries()` exactly (so an
+installed build sees the association as already registered);
+`tests/test_winassoc.py` cross-checks them.
 
 ## Building the docs
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,30 +1,56 @@
 # Installation
 
-[Download SMACC](https://github.com/remrama/smacc/releases/latest/download/SMACC.exe){ .md-button .md-button--primary }
+[Download SMACC](https://github.com/remrama/smacc/releases/latest/download/SMACC-Setup.exe){ .md-button .md-button--primary }
 
-The button above always downloads the **latest** version. To get an older or
-specific version, browse the
+The button above always downloads the installer for the **latest** version —
+double-click `SMACC-Setup.exe` and click through. The installer:
+
+- installs SMACC **per-user** — no administrator rights or IT involvement needed;
+- adds a **Start menu** entry (and, if you opt in, a desktop shortcut);
+- associates **`.smacc` files**, so double-clicking a SMACC file opens a session
+  with it;
+- registers an uninstaller — remove SMACC from **Settings › Apps** like any other
+  program. Uninstalling never touches your data: SMACC files, recordings, and
+  logs under `~/SMACC` (or your data directories) all stay put.
+
+Installing a newer version over an existing one upgrades it in place.
+
+To get an older or specific version, browse the
 [releases page](https://github.com/remrama/smacc/releases): pick the release you
-want, open its _Assets_ dropdown, and download SMACC from there. Every version is
-the same kind of single portable file: once downloaded, double-click it to run.
-There is no installer. (The version switcher on this documentation site switches
-the *docs* only — older copies of SMACC itself come from the releases page.)
+want, open its _Assets_ dropdown, and download from there. (The version switcher
+on this documentation site switches the *docs* only — older copies of SMACC
+itself come from the releases page.)
 
 !!! note "System requirements"
     SMACC runs on 64-bit Windows 10 or later.
 
 !!! warning "Windows SmartScreen — “Windows protected your PC”"
-    SMACC isn't code-signed, so the first time you run it Windows SmartScreen may show
-    a blue **“Windows protected your PC”** box. This is expected for any new,
-    unsigned program. To run SMACC anyway, click **More info**, then **Run anyway**.
-    Windows usually stops warning after the first launch.
+    SMACC isn't code-signed yet, so when you run the installer Windows SmartScreen
+    may show a blue **“Windows protected your PC”** box. This is expected for any
+    new, unsigned program. To proceed anyway, click **More info**, then
+    **Run anyway**.
 
 !!! note "Administrator privileges and the UAC prompt"
     For some features you will need to open SMACC with Administrator privileges
-    (right-click the file and select **Run as administrator**). Windows then shows a
-    **User Account Control (UAC)** prompt asking whether to allow the app to make
-    changes — click **Yes** to continue. For everyday use (audio cues, dream reports,
-    LSL markers) you can run SMACC normally, without administrator rights.
+    (right-click the Start menu entry and select **Run as administrator**). Windows
+    then shows a **User Account Control (UAC)** prompt asking whether to allow the
+    app to make changes — click **Yes** to continue. For everyday use (audio cues,
+    dream reports, LSL markers) you can run SMACC normally, without administrator
+    rights.
+
+## Portable SMACC.exe (no install)
+
+Every release also ships the same app as a single portable `SMACC.exe` — download
+it, double-click it, no installation. This suits USB-stick deployment, machines
+where nothing may be installed, and quick tests. The portable build skips the
+installer's conveniences (Start menu entry, uninstaller); it offers to associate
+`.smacc` files itself the first time it runs (see below).
+
+!!! note "For IT departments"
+    The default install is per-user (under `%LOCALAPPDATA%\Programs\SMACC`, no
+    elevation). On managed machines where per-user installs are blocked — e.g.
+    AppLocker policies on `%LOCALAPPDATA%` — run the same installer machine-wide
+    instead: `SMACC-Setup.exe /ALLUSERS` (elevates, installs to Program Files).
 
 ## Optional setup
 
@@ -52,10 +78,11 @@ itself remembers window positions and sizes and your recent files in
 ### SMACC files (`.smacc`)
 
 Your reusable setup is saved to a portable SMACC file (see
-[SMACC files](smacc-files.md)). On the Windows build, the first launch
-offers to associate `.smacc` files so you can **double-click one to open SMACC and
-run a session with it**; you can also (re)enable this from
-**File &rsaquo; Associate .smacc files (Windows)** in the Launcher.
+[SMACC files](smacc-files.md)). The installer associates `.smacc` files so you can
+**double-click one to open SMACC and run a session with it**. The portable
+`SMACC.exe` offers the same association the first time it runs; you can also
+(re)enable it any time from **File &rsaquo; Associate .smacc files (Windows)** in
+the Launcher.
 
 ### Audio cues
 

--- a/tests/test_winassoc.py
+++ b/tests/test_winassoc.py
@@ -1,5 +1,8 @@
 """Tests for the .smacc Windows association layout (pure; no registry writes)."""
 
+import re
+from pathlib import Path
+
 from smacc import winassoc
 
 
@@ -35,3 +38,26 @@ def test_is_registered_false_for_unknown_exe():
     # Nothing associates .smacc with this throwaway path (and on non-Windows the
     # check is always False), so it must read as not registered. No registry writes.
     assert winassoc.is_registered(r"C:\Nope\DoesNotExist\SMACC.exe") is False
+
+
+def test_installer_registry_section_matches_association_entries():
+    # The installer (tools/smacc.iss) writes the association itself so that
+    # is_registered() finds it and the in-app first-run prompt skips itself. That
+    # only works while its [Registry] section and association_entries() agree
+    # exactly — value for value — so cross-check them here to catch drift.
+    iss_text = (Path(__file__).parent.parent / "tools" / "smacc.iss").read_text(
+        encoding="utf-8"
+    )
+    # Inno escapes a literal quote inside a quoted parameter by doubling it.
+    quoted = r'"((?:[^"]|"")*)"'
+    entry_re = re.compile(
+        rf"^Root: HKA; Subkey: {quoted}; ValueType: string; "
+        rf"ValueName: {quoted}; ValueData: {quoted}",
+        re.MULTILINE,
+    )
+    found = [
+        tuple(field.replace('""', '"') for field in match.groups())
+        for match in entry_re.finditer(iss_text)
+    ]
+    expected = winassoc.association_entries(r"{app}\SMACC.exe")
+    assert sorted(found) == sorted(expected)

--- a/tools/make_versionfile.py
+++ b/tools/make_versionfile.py
@@ -1,0 +1,76 @@
+"""Generate the PyInstaller version-info file for the frozen SMACC.exe (#116).
+
+Writes the ``VSVersionInfo`` resource PyInstaller embeds via ``--version-file``,
+so the exe's Properties dialog (and tools IT departments use to vet binaries)
+show the product name, version, and publisher instead of nothing. The version is
+read from ``smacc.__version__`` — the single source of truth — so the resource
+can never drift from the release tag (the release workflow checks the tag against
+the same attribute). Run by the release workflow before PyInstaller::
+
+    uv run python tools/make_versionfile.py version_info.txt
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from smacc import __version__
+
+_TEMPLATE = """\
+VSVersionInfo(
+    ffi=FixedFileInfo(
+        filevers={vers_tuple},
+        prodvers={vers_tuple},
+    ),
+    kids=[
+        StringFileInfo(
+            [
+                StringTable(
+                    "040904B0",
+                    [
+                        StringStruct("CompanyName", "Remington Mallett"),
+                        StringStruct(
+                            "FileDescription",
+                            "Sleep Manipulation and Communication Clickything",
+                        ),
+                        StringStruct("FileVersion", "{version}"),
+                        StringStruct("ProductName", "SMACC"),
+                        StringStruct("ProductVersion", "{version}"),
+                        StringStruct("OriginalFilename", "SMACC.exe"),
+                        StringStruct(
+                            "LegalCopyright", "Remington Mallett, GPL-3.0-or-later"
+                        ),
+                    ],
+                )
+            ]
+        ),
+        VarFileInfo([VarStruct("Translation", [1033, 1200])]),
+    ],
+)
+"""
+
+
+def version_tuple(version: str) -> tuple[int, int, int, int]:
+    """``"0.1.0"`` → ``(0, 1, 0, 0)`` — the four-part numeric form VS_FIXEDFILEINFO needs."""
+    parts = [int(part) for part in version.split(".")]
+    return tuple(parts + [0] * (4 - len(parts)))[:4]  # type: ignore[return-value]
+
+
+def render(version: str) -> str:
+    """The version-file text for ``version`` (pure, for tests)."""
+    return _TEMPLATE.format(version=version, vers_tuple=version_tuple(version))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "output", type=Path, help="path to write (e.g. version_info.txt)"
+    )
+    args = parser.parse_args()
+    args.output.write_text(render(__version__), encoding="utf-8")
+    print(f"Wrote VSVersionInfo for SMACC {__version__} to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/smacc.iss
+++ b/tools/smacc.iss
@@ -1,0 +1,69 @@
+; Inno Setup script for the SMACC installer (#116).
+;
+; Compiled by the release workflow after PyInstaller has produced dist\SMACC.exe:
+;
+;   ISCC /DAppVersion=<version> tools\smacc.iss
+;
+; Installs per-user by default (no admin rights, no UAC prompt), matching the
+; per-user HKCU file association in src/smacc/winassoc.py. IT departments that
+; block per-user installs (e.g. AppLocker on %LOCALAPPDATA%) can run the same
+; installer machine-wide with /ALLUSERS, which elevates and installs to Program
+; Files instead.
+
+#ifndef AppVersion
+  #error Pass the app version on the command line: ISCC /DAppVersion=x.y.z tools\smacc.iss
+#endif
+
+[Setup]
+; Fixed AppId so a newer installer upgrades the existing install in place.
+AppId={{3F14E584-7D0C-457A-8041-B8982ADEC19D}
+AppName=SMACC
+AppVersion={#AppVersion}
+AppPublisher=Remington Mallett
+AppPublisherURL=https://github.com/remrama/smacc
+AppSupportURL=https://github.com/remrama/smacc/issues
+; Per-user by default: with PrivilegesRequired=lowest, {autopf} resolves to
+; {localappdata}\Programs and nothing needs elevation. The commandline override
+; allows /ALLUSERS for an IT-managed machine-wide install (Program Files + HKLM).
+PrivilegesRequired=lowest
+PrivilegesRequiredOverridesAllowed=commandline
+DefaultDirName={autopf}\SMACC
+DisableProgramGroupPage=yes
+; SMACC ships only a 64-bit build (Windows 10+, set by Qt 6).
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+MinVersion=10.0
+OutputDir=..\dist
+OutputBaseFilename=SMACC-Setup
+SetupIconFile=..\src\smacc\assets\icon.ico
+UninstallDisplayIcon={app}\SMACC.exe
+; Tells Windows to refresh Explorer's file-association cache after (un)install.
+ChangesAssociations=yes
+WizardStyle=modern
+Compression=lzma2
+SolidCompression=yes
+
+[Tasks]
+; Desktop shortcut is opt-in (unchecked by default); the Start menu entry is always created.
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "..\dist\SMACC.exe"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{autoprograms}\SMACC"; Filename: "{app}\SMACC.exe"
+Name: "{autodesktop}\SMACC"; Filename: "{app}\SMACC.exe"; Tasks: desktopicon
+
+[Registry]
+; The .smacc file association — these entries mirror winassoc.association_entries()
+; exactly (tests/test_winassoc.py cross-checks them), so an installed build passes
+; winassoc.is_registered() and the in-app first-run prompt skips itself. HKA is
+; HKCU for the default per-user install and HKLM for an /ALLUSERS install.
+Root: HKA; Subkey: "Software\Classes\.smacc"; ValueType: string; ValueName: ""; ValueData: "SMACC.Study"; Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\.smacc"; ValueType: string; ValueName: "Content Type"; ValueData: "application/x-smacc"; Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\SMACC.Study"; ValueType: string; ValueName: ""; ValueData: "SMACC study configuration"; Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\SMACC.Study\DefaultIcon"; ValueType: string; ValueName: ""; ValueData: """{app}\SMACC.exe"",0"
+Root: HKA; Subkey: "Software\Classes\SMACC.Study\shell\open\command"; ValueType: string; ValueName: ""; ValueData: """{app}\SMACC.exe"" ""%1"""
+
+[Run]
+Filename: "{app}\SMACC.exe"; Description: "{cm:LaunchProgram,SMACC}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
Adds a per-user Inno Setup installer (#116): Start menu entry, opt-in desktop shortcut, automatic .smacc association, and clean uninstall — no admin needed (`/ALLUSERS` available for IT-managed machine-wide installs). The release workflow now guards the tag against `smacc.__version__`, stamps the exe with VSVersionInfo metadata, builds `SMACC-Setup.exe`, silently installs it and smoke-tests the installed exe + registry association, and attaches both artifacts. The installer's registry section mirrors `winassoc.association_entries()` exactly (cross-checked by a new test), so an installed build's first-run association prompt skips itself. The portable `SMACC.exe` remains a release asset; docs updated to be installer-first.

Verified: full test suite, ruff, mypy, and `mkdocs build --strict` all pass; the generated VSVersionInfo file validates with PyInstaller's own loader. The installer build/install path itself runs only in the release workflow, so the first `v*` tag is the real test.