### PR TITLE
feat: manual update check in the launcher

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,6 +52,16 @@ installer's conveniences (Start menu entry, uninstaller); it offers to associate
     AppLocker policies on `%LOCALAPPDATA%` — run the same installer machine-wide
     instead: `SMACC-Setup.exe /ALLUSERS` (elevates, installs to Program Files).
 
+## Updating SMACC
+
+From the Launcher, **File &rsaquo; Check for updates…** asks GitHub whether a
+newer release exists and, if one does, offers to open the download page in your
+browser — run the new installer and it upgrades the existing install in place.
+SMACC never checks on its own: lab machines are often offline, and studies
+usually pin one version for their whole run, so checking is always an explicit
+click. If you use the portable `SMACC.exe`, download the new one and replace
+your old copy.
+
 ## Optional setup
 
 ### Data directory

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from . import preferences, settings, winassoc, windowstate
+from . import preferences, settings, updates, winassoc, windowstate
 from .analyze import AnalyzeWindow
 from .config import VERSION
 from .cuedesigner import CueDesignerWindow
@@ -175,6 +175,14 @@ class LauncherWindow(QtWidgets.QMainWindow):
             )
             associateAction.triggered.connect(self.associate_files)
             fileMenu.addSeparator()
+        updateAction = fileMenu.addAction("Check for &updates…")
+        assert updateAction is not None
+        updateAction.setStatusTip(
+            "Check GitHub for a newer SMACC release (manual only; SMACC never "
+            "checks on its own)."
+        )
+        updateAction.triggered.connect(self.check_for_updates)
+        self._updateAction = updateAction
         aboutAction = fileMenu.addAction(
             style.standardIcon(
                 QtWidgets.QStyle.StandardPixmap.SP_MessageBoxInformation
@@ -341,6 +349,52 @@ class LauncherWindow(QtWidgets.QMainWindow):
             "File association",
             "SMACC now handles .smacc files — double-click a SMACC file to open it.",
         )
+
+    def check_for_updates(self) -> None:
+        """Ask GitHub for a newer release (manual only — never runs on its own).
+
+        The query runs off the GUI thread (:class:`smacc.updates.UpdateChecker`);
+        the action is disabled until the result lands so a double-click can't
+        stack two checks/dialogs. The checker is kept on ``self`` so it outlives
+        this call.
+        """
+        self._updateAction.setEnabled(False)
+        bar = self.statusBar()
+        if bar is not None:
+            bar.showMessage("Checking for updates…")
+        self._update_checker = updates.UpdateChecker(self)
+        self._update_checker.finished.connect(self._on_update_result)
+        self._update_checker.check()
+
+    def _on_update_result(self, result: updates.UpdateResult) -> None:
+        """Show the outcome of a finished update check (GUI thread)."""
+        self._updateAction.setEnabled(True)
+        bar = self.statusBar()
+        if bar is not None:
+            bar.clearMessage()
+        if result.latest is None:
+            QtWidgets.QMessageBox.information(
+                self,
+                "Check for updates",
+                "Could not reach GitHub to check for updates (no internet "
+                f"connection?).\n\nReleases are listed at:\n{updates.RELEASES_URL}",
+            )
+            return
+        if not result.newer:
+            QtWidgets.QMessageBox.information(
+                self,
+                "Check for updates",
+                f"You are running the latest version of SMACC (v{VERSION}).",
+            )
+            return
+        reply = QtWidgets.QMessageBox.question(
+            self,
+            "Update available",
+            f"SMACC {result.latest} is available (you are running v{VERSION}).\n\n"
+            "Open the download page in your browser?",
+        )
+        if reply == QtWidgets.QMessageBox.StandardButton.Yes:
+            QtGui.QDesktopServices.openUrl(QtCore.QUrl(result.url))
 
     def show_about_popup(self) -> None:
         """Show SMACC's About dialog (version and links)."""

--- a/src/smacc/updates.py
+++ b/src/smacc/updates.py
@@ -1,0 +1,100 @@
+"""Manual check for a newer SMACC release on GitHub (#116).
+
+The Launcher's **File › Check for updates…** action is the only caller, and the
+check is deliberately manual-only: lab machines are often offline, and a study
+typically pins one SMACC version for its whole run, so the app never phones home
+or nags on its own. The check asks the GitHub API for the latest (non-pre-release)
+release and hands the user to the browser for the download — SMACC does not
+download or install anything itself.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.request
+from dataclasses import dataclass
+
+from PyQt6 import QtCore
+
+from .config import VERSION
+
+# Human-facing fallback when the API can't be reached or gives no usable URL.
+RELEASES_URL = "https://github.com/remrama/smacc/releases"
+# The newest release not marked Pre-release (404 until one exists).
+_LATEST_API_URL = "https://api.github.com/repos/remrama/smacc/releases/latest"
+_TIMEOUT_S = 10.0
+
+
+@dataclass(frozen=True)
+class UpdateResult:
+    """Outcome of one update check, delivered to the GUI thread."""
+
+    latest: str | None  # the latest release tag (e.g. "v0.1.2"); None if check failed
+    newer: bool  # that tag parses as strictly newer than the running version
+    url: str  # where to get it (the release's page, else RELEASES_URL)
+
+
+def parse_version(tag: str) -> tuple[int, ...] | None:
+    """``"v0.1.2"`` → ``(0, 1, 2)``; ``None`` for anything not dotted numbers."""
+    parts = tag.strip().lstrip("vV").split(".")
+    try:
+        return tuple(int(part) for part in parts)
+    except ValueError:
+        return None
+
+
+def is_newer(latest_tag: str, current: str = VERSION) -> bool:
+    """True if ``latest_tag`` is strictly newer than the running version.
+
+    An unparseable tag reads as "not newer" — a malformed release tag must never
+    produce an update nag. Tuple ordering handles unequal lengths the obvious way
+    (``0.1 < 0.1.1``).
+    """
+    latest = parse_version(latest_tag)
+    running = parse_version(current)
+    return latest is not None and running is not None and latest > running
+
+
+def fetch_latest_release() -> tuple[str, str]:
+    """Return ``(tag, html_url)`` of the latest stable release.
+
+    Blocking (network) — call it off the GUI thread; see :class:`UpdateChecker`.
+
+    Raises:
+        OSError: the request failed (offline, timeout, HTTP error — including the
+            404 GitHub returns while every release is marked Pre-release).
+        ValueError, KeyError: the response wasn't the expected JSON.
+    """
+    request = urllib.request.Request(
+        _LATEST_API_URL, headers={"Accept": "application/vnd.github+json"}
+    )
+    with urllib.request.urlopen(request, timeout=_TIMEOUT_S) as response:
+        payload = json.load(response)
+    return payload["tag_name"], payload.get("html_url") or RELEASES_URL
+
+
+class UpdateChecker(QtCore.QObject):
+    """Runs the blocking GitHub query off the GUI thread and signals the result.
+
+    The worker emits :attr:`finished` from its own thread; Qt delivers a
+    cross-thread signal as a queued call on the receiver's (GUI) thread, so the
+    slot may touch widgets. The thread is a daemon so a hung network call can
+    never keep SMACC from exiting.
+    """
+
+    finished = QtCore.pyqtSignal(object)  # UpdateResult
+
+    def check(self) -> None:
+        """Start one check; ``finished`` fires exactly once with the result."""
+        threading.Thread(target=self._run, name="update-check", daemon=True).start()
+
+    def _run(self) -> None:
+        try:
+            tag, url = fetch_latest_release()
+        except (OSError, ValueError, KeyError):
+            # Offline, blocked, timed out, or unexpected payload: report "couldn't
+            # check" (latest=None) rather than guessing — never a false update nag.
+            self.finished.emit(UpdateResult(latest=None, newer=False, url=RELEASES_URL))
+            return
+        self.finished.emit(UpdateResult(latest=tag, newer=is_newer(tag), url=url))

--- a/tests/test_updates.py
+++ b/tests/test_updates.py
@@ -1,0 +1,184 @@
+"""Tests for the manual update check: version logic, checker thread, dialogs."""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+
+import pytest
+from PyQt6 import QtGui, QtWidgets
+
+from smacc import launcher as launcher_mod
+from smacc import updates
+from smacc.config import VERSION
+from smacc.launcher import LauncherWindow
+
+
+@pytest.mark.parametrize(
+    ("tag", "expected"),
+    [
+        ("v0.1.2", (0, 1, 2)),
+        ("0.1.2", (0, 1, 2)),
+        ("V2.0", (2, 0)),
+        (" v1.2.3 ", (1, 2, 3)),
+        ("v0.1.0rc1", None),  # pre-release suffixes are never used on smacc tags
+        ("nightly", None),
+        ("", None),
+    ],
+)
+def test_parse_version(tag, expected):
+    assert updates.parse_version(tag) == expected
+
+
+@pytest.mark.parametrize(
+    ("latest", "current", "newer"),
+    [
+        ("v0.2.0", "0.1.0", True),
+        ("v0.1.0", "0.1.0", False),
+        ("v0.0.9", "0.1.0", False),
+        ("v0.1.1", "0.1", True),  # longer tuple wins when the prefix matches
+        ("not-a-version", "0.1.0", False),  # malformed tag must never nag
+        ("v1.0.0", "garbage", False),
+    ],
+)
+def test_is_newer(latest, current, newer):
+    assert updates.is_newer(latest, current) is newer
+
+
+def _fake_urlopen(payload: dict):
+    """A stand-in for urllib.request.urlopen returning ``payload`` as JSON."""
+
+    def fake(request, timeout=None):
+        return io.BytesIO(json.dumps(payload).encode())  # context manager + .read()
+
+    return fake
+
+
+def test_fetch_latest_release_parses_tag_and_url(monkeypatch):
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        _fake_urlopen({"tag_name": "v9.9.9", "html_url": "https://example.test/rel"}),
+    )
+    assert updates.fetch_latest_release() == ("v9.9.9", "https://example.test/rel")
+
+
+def test_fetch_latest_release_falls_back_to_releases_page(monkeypatch):
+    monkeypatch.setattr("urllib.request.urlopen", _fake_urlopen({"tag_name": "v9.9.9"}))
+    assert updates.fetch_latest_release() == ("v9.9.9", updates.RELEASES_URL)
+
+
+def test_checker_emits_newer_result(qtbot, monkeypatch):
+    monkeypatch.setattr(
+        "urllib.request.urlopen",
+        _fake_urlopen({"tag_name": "v999.0.0", "html_url": "https://example.test/rel"}),
+    )
+    checker = updates.UpdateChecker()
+    with qtbot.waitSignal(checker.finished, timeout=5000) as blocker:
+        checker.check()
+    assert blocker.args[0] == updates.UpdateResult(
+        latest="v999.0.0", newer=True, url="https://example.test/rel"
+    )
+
+
+def test_checker_reports_failure_without_raising(qtbot, monkeypatch):
+    def offline(request, timeout=None):
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr("urllib.request.urlopen", offline)
+    checker = updates.UpdateChecker()
+    with qtbot.waitSignal(checker.finished, timeout=5000) as blocker:
+        checker.check()
+    assert blocker.args[0] == updates.UpdateResult(
+        latest=None, newer=False, url=updates.RELEASES_URL
+    )
+
+
+@pytest.fixture
+def launcher_win(qtbot, tmp_path, monkeypatch):
+    # Point preferences at a temp file so building the launcher can't touch real prefs.
+    monkeypatch.setattr(launcher_mod, "preferences_path", tmp_path / "preferences.yaml")
+    win = LauncherWindow(settings_path=None)
+    qtbot.addWidget(win)
+    return win
+
+
+def test_update_dialog_offers_download_when_newer(launcher_win, monkeypatch):
+    opened = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.Yes,
+    )
+    monkeypatch.setattr(
+        QtGui.QDesktopServices, "openUrl", lambda url: opened.append(url.toString())
+    )
+    launcher_win._on_update_result(
+        updates.UpdateResult(
+            latest="v999.0.0", newer=True, url="https://example.test/rel"
+        )
+    )
+    assert opened == ["https://example.test/rel"]
+
+
+def test_update_dialog_respects_a_declined_download(launcher_win, monkeypatch):
+    opened = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *args, **kwargs: QtWidgets.QMessageBox.StandardButton.No,
+    )
+    monkeypatch.setattr(
+        QtGui.QDesktopServices, "openUrl", lambda url: opened.append(url.toString())
+    )
+    launcher_win._on_update_result(
+        updates.UpdateResult(
+            latest="v999.0.0", newer=True, url="https://example.test/rel"
+        )
+    )
+    assert opened == []
+
+
+def test_update_dialog_up_to_date(launcher_win, monkeypatch):
+    seen = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "information",
+        lambda parent, title, text: seen.append(text),
+    )
+    launcher_win._on_update_result(
+        updates.UpdateResult(
+            latest=f"v{VERSION}", newer=False, url=updates.RELEASES_URL
+        )
+    )
+    assert seen and VERSION in seen[0] and "latest version" in seen[0]
+
+
+def test_update_dialog_points_at_releases_page_when_check_fails(
+    launcher_win, monkeypatch
+):
+    seen = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "information",
+        lambda parent, title, text: seen.append(text),
+    )
+    launcher_win._on_update_result(
+        updates.UpdateResult(latest=None, newer=False, url=updates.RELEASES_URL)
+    )
+    assert seen and updates.RELEASES_URL in seen[0]
+
+
+def test_check_for_updates_disables_action_until_the_result_lands(
+    launcher_win, qtbot, monkeypatch
+):
+    def offline(request, timeout=None):
+        raise urllib.error.URLError("offline")
+
+    monkeypatch.setattr("urllib.request.urlopen", offline)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox, "information", lambda *args, **kwargs: None
+    )
+    launcher_win.check_for_updates()
+    assert not launcher_win._updateAction.isEnabled()  # no stacked double-checks
+    qtbot.waitUntil(lambda: launcher_win._updateAction.isEnabled(), timeout=5000)


### PR DESCRIPTION
Adds **File › Check for updates…** to the Launcher (#116). It queries the GitHub releases API off the GUI thread (stdlib urllib in a daemon thread — no new dependency, no Qt TLS-plugin risk in the frozen build), compares the latest tag against `smacc.__version__`, and offers to open the release page in the browser. Deliberately manual-only — no startup auto-check, ever: lab machines are often offline and studies pin a version mid-study. Offline/failed checks show one calm dialog pointing at the releases page.

Stacked on #145 (merge that first; squash, then this retargets to main). Note: the GitHub `releases/latest` endpoint ignores pre-releases, so until a release is marked as a full release the check reports "could not reach GitHub" — self-resolving at v0.1.0.

Verified: full suite (635 passed, 22 new tests covering version parsing/compare, the checker thread via qtbot, and all three dialog outcomes), ruff, mypy, `mkdocs build --strict`.