### PR TITLE
feat: flag undetected TTL hardware in Markers and bump to v0.0.9

### DIFF
--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -121,7 +121,9 @@ neither is log-only).
 !!! note "LSL stays on"
     Enabling a hardware transport does **not** turn LSL off — events routed to both
     (the default) reach the LSL stream and the hardware line together. The hardware
-    path is purely additional.
+    path is purely additional. LSL support ships inside SMACC itself — there is
+    nothing separate to install on the *sending* side (the recorder, e.g.
+    LabRecorder, is its own program).
 
 !!! tip "Why route per event?"
     Most studies leave every event on both transports. Per-event routing earns its

--- a/src/smacc/__init__.py
+++ b/src/smacc/__init__.py
@@ -1,4 +1,4 @@
 """SMACC: Sleep Manipulation And Communication Clickything."""
 
 __author__ = "Remington Mallett <mallett.remy@gmail.com>"
-__version__ = "0.0.8"
+__version__ = "0.0.9"

--- a/src/smacc/panels/markers.py
+++ b/src/smacc/panels/markers.py
@@ -211,6 +211,15 @@ class MarkersWindow(ModalityWindow):
         portRow = QtWidgets.QHBoxLayout()
         portRow.addWidget(self.portCombo, 1)
         portRow.addWidget(refreshButton)
+        # Detection hint, not a gate: the combo stays editable and the per-event
+        # TTL routing is kept, because studies are usually configured away from
+        # the rig — the hint just says nothing is attached *right now*.
+        self.portStatusLabel = QtWidgets.QLabel(
+            "⚠ No serial ports detected — attach the trigger box and click "
+            "Refresh. A typed/saved port is kept and used once attached.",
+            box,
+        )
+        self.portStatusLabel.setWordWrap(True)
         self.baudCombo = QtWidgets.QComboBox(box)
         self.baudCombo.setEditable(True)
         self.baudCombo.addItems([str(b) for b in _COMMON_BAUDS])
@@ -218,6 +227,7 @@ class MarkersWindow(ModalityWindow):
         serialForm = QtWidgets.QFormLayout(serialPage)
         serialForm.setContentsMargins(0, 0, 0, 0)
         serialForm.addRow("Port", portRow)
+        serialForm.addRow("", self.portStatusLabel)
         serialForm.addRow("Baud", self.baudCombo)
 
         # Parallel page: base address (hex), with help on finding it.
@@ -229,10 +239,19 @@ class MarkersWindow(ModalityWindow):
             "(see the Triggers docs)."
         )
         addressHelp.setWordWrap(True)
+        # Same idea as the serial hint: warn that the driver isn't loadable here
+        # and now, without gating any configuration on it.
+        self.driverStatusLabel = QtWidgets.QLabel(
+            "⚠ InpOut32 driver not detected on this machine — parallel output "
+            "will fail until it is installed (see the Triggers docs).",
+            box,
+        )
+        self.driverStatusLabel.setWordWrap(True)
         parallelPage = QtWidgets.QWidget(box)
         parallelForm = QtWidgets.QFormLayout(parallelPage)
         parallelForm.setContentsMargins(0, 0, 0, 0)
         parallelForm.addRow("Address", self.addressEdit)
+        parallelForm.addRow("", self.driverStatusLabel)
         parallelForm.addRow("", addressHelp)
 
         self.transportStack = QtWidgets.QStackedWidget(box)
@@ -283,7 +302,9 @@ class MarkersWindow(ModalityWindow):
         if selected is None:
             selected = self._current_port()
         self.portCombo.clear()
-        for device, description in triggers.list_serial_ports():
+        ports = triggers.list_serial_ports()
+        self.portStatusLabel.setVisible(not ports)
+        for device, description in ports:
             label = device if description == device else f"{device} — {description}"
             self.portCombo.addItem(label, device)
         if selected:
@@ -372,6 +393,9 @@ class MarkersWindow(ModalityWindow):
         self._select_data(self.transportCombo, config.transport)
         self._select_data(self.modeCombo, config.mode)
         self._refresh_ports(selected=config.port)
+        # Re-probed on every (re)load, so installing the driver and reopening the
+        # window clears the hint without restarting SMACC.
+        self.driverStatusLabel.setVisible(not triggers.parallel_driver_available())
         self.baudCombo.setCurrentText(str(config.baud))
         self.addressEdit.setText(config.address)
         self.pulseSpin.setValue(config.pulse_ms)

--- a/src/smacc/triggers.py
+++ b/src/smacc/triggers.py
@@ -275,6 +275,20 @@ def _load_inpout() -> Any:
     )
 
 
+def parallel_driver_available() -> bool:
+    """True if the InpOut32 / inpoutx64 driver DLL loads (Windows, installed).
+
+    The Markers window uses this to *warn* that parallel output would fail — it
+    gates nothing. A study is often configured away from the rig, so a missing
+    driver only becomes an error when an enabled transport actually opens.
+    """
+    try:
+        _load_inpout()
+    except TriggerError:
+        return False
+    return True
+
+
 def open_trigger(config: TriggerConfig) -> TriggerOutput | None:
     """Open the configured transport, or ``None`` when disabled.
 

--- a/tests/test_panels_markers.py
+++ b/tests/test_panels_markers.py
@@ -182,6 +182,47 @@ def test_ttl_column_grays_out_without_a_transport(window):
     assert all(box.isEnabled() for box in window._ttl_boxes)
 
 
+# ----- hardware detection hints ---------------------------------------------------
+
+
+def test_no_serial_ports_shows_the_hint_but_gates_nothing(
+    qtbot, design_session, monkeypatch
+):
+    monkeypatch.setattr(triggers, "list_serial_ports", lambda: [])
+    win = MarkersWindow(design_session)
+    qtbot.addWidget(win)
+    assert not win.portStatusLabel.isHidden()
+    # A hint, not a gate: the per-event TTL routing is untouched (not emptied).
+    assert win._ttl_boxes[_index_of(win, "REMDetected")].isChecked() is True
+
+
+def test_attached_serial_ports_hide_the_hint(stub_serial_ports, window):
+    assert window.portStatusLabel.isHidden()
+
+
+def test_refresh_updates_the_port_hint(window, monkeypatch):
+    monkeypatch.setattr(triggers, "list_serial_ports", lambda: [])
+    window._refresh_ports()
+    assert not window.portStatusLabel.isHidden()
+    monkeypatch.setattr(triggers, "list_serial_ports", lambda: [("COM2", "COM2")])
+    window._refresh_ports()
+    assert window.portStatusLabel.isHidden()
+
+
+def test_missing_inpout_driver_shows_the_hint(qtbot, design_session, monkeypatch):
+    monkeypatch.setattr(triggers, "parallel_driver_available", lambda: False)
+    win = MarkersWindow(design_session)
+    qtbot.addWidget(win)
+    assert not win.driverStatusLabel.isHidden()
+
+
+def test_present_inpout_driver_hides_the_hint(qtbot, design_session, monkeypatch):
+    monkeypatch.setattr(triggers, "parallel_driver_available", lambda: True)
+    win = MarkersWindow(design_session)
+    qtbot.addWidget(win)
+    assert win.driverStatusLabel.isHidden()
+
+
 # ----- hardware transport (the former Trigger output dialog, #28) ----------------
 
 

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -165,3 +165,13 @@ def test_summary_describes_each_transport():
 def test_list_serial_ports_returns_a_list():
     # No hardware is required; on a port-less CI box this is just empty.
     assert isinstance(triggers.list_serial_ports(), list)
+
+
+def test_parallel_driver_available_reflects_dll_load(monkeypatch):
+    def _no_driver():
+        raise triggers.TriggerError("not installed")
+
+    monkeypatch.setattr(triggers, "_load_inpout", _no_driver)
+    assert triggers.parallel_driver_available() is False
+    monkeypatch.setattr(triggers, "_load_inpout", lambda: object())
+    assert triggers.parallel_driver_available() is True


### PR DESCRIPTION
Bumps `__version__` to 0.0.9 for the (hopefully last) pre-release, and folds in the TTL/LSL availability concern:

- **TTL:** the Markers window now shows a detection hint when no serial ports are attached (next to the port dropdown, updates on Refresh) and when the InpOut32 driver isn't loadable (on the parallel page, re-probed each time the window reloads). These are **warnings, not gates** — the per-event TTL checkboxes keep their existing behavior (grayed while no transport is enabled, values always kept) and nothing is ever emptied, since studies are usually configured away from the rig and the routing travels in the SMACC file.
- **LSL:** no check added, deliberately — pylsl is a hard dependency imported at startup and bundled into the frozen exe (the release smoke test exercises exactly this), so "LSL not installed" cannot happen in a build a user runs. Added a docs note that LSL ships inside SMACC.

Verified: 641 tests pass (6 new), ruff, mypy, `mkdocs build --strict`. The driver hint will correctly show on machines without InpOut32; seeing it disappear after a real driver install is hardware-only validation.