### PR TITLE
feat: add the EEG review viewer (trace view, review window, entry point)

### DIFF
--- a/src/smacc/eeg/__main__.py
+++ b/src/smacc/eeg/__main__.py
@@ -1,0 +1,51 @@
+"""Run the EEG review tool: ``python -m smacc.eeg [recording]``.
+
+The component's own entry point — its own process and ``QApplication``, never
+sharing one with a live session (see the package docstring). The frozen
+``SMACC-EEG.exe`` targets the same :func:`main` via ``entry_eeg.py``.
+
+``--version`` exits immediately (code 0) without opening any window, mirroring
+the base app: the release workflow smoke-tests the frozen exe with it, and
+reaching that point proves the bundle unpacks and every import — including the
+MNE/pyqtgraph tree — resolves. The exe is built ``--noconsole`` (no stdout),
+so the check is the exit code, not the output.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from PyQt6.QtWidgets import QApplication
+
+from ..config import VERSION
+
+# Imported eagerly, on purpose: --version must prove the whole MNE/pyqtgraph
+# import tree resolves in the frozen bundle (that is the point of the smoke
+# test — a lazy import would make it pass on a bundle that can't open a file).
+from .window import EegReviewWindow
+
+
+def pick_recording_path(args: list[str]) -> str | None:
+    """Return the recording to open from CLI args, or ``None``.
+
+    The last non-flag argument wins, mirroring the base app's settings-file
+    handling; existence and format errors are left to the window so the user
+    sees a dialog, not a vanishing process.
+    """
+    candidates = [arg for arg in args[1:] if not arg.startswith("-")]
+    return candidates[-1] if candidates else None
+
+
+def main() -> None:
+    if "--version" in sys.argv:
+        print(f"SMACC EEG review v{VERSION}")
+        sys.exit(0)
+    app = QApplication(sys.argv)
+    app.setApplicationName("SMACC EEG review")
+    window = EegReviewWindow(pick_recording_path(sys.argv))
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/smacc/eeg/view.py
+++ b/src/smacc/eeg/view.py
@@ -1,0 +1,407 @@
+"""The multichannel trace view for the EEG review tool (#136).
+
+One pyqtgraph ``PlotWidget``, all channels stacked in a single ViewBox by
+vertical offset (channel *i* centered at ``y = -i``), channel names as y-axis
+ticks — not one ViewBox per channel, which is slow to sync and slow to draw.
+Performance comes from rendering only the visible window (fetched per scroll,
+filtered by :mod:`smacc.eeg.dsp`, never the whole file) and from pyqtgraph's
+min/max *peak* downsampling on each curve, which keeps extremes — a spindle or
+artifact stays visible no matter how far the trace is decimated. Deliberately
+no OpenGL: pyqtgraph's raster path plus downsampling is the proven approach
+(it is what mne-qt-browser ships with; the GL option is off by default there
+for Windows driver reasons).
+
+Interaction is built for annotation, not navigation: a left-drag *draws* a
+region (it never pans), a click selects the annotation under the cursor, and
+the wheel scrolls time. Paging/zoom shortcuts and every other control live in
+:mod:`smacc.eeg.window`, which owns this widget.
+
+The view draws from any :class:`SliceProvider` — :class:`smacc.eeg.io.Recording`
+in the app, a synthetic fake in tests and benchmarks — so this module imports
+no MNE and nothing from the wider app.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import numpy as np
+import pyqtgraph as pg
+from PyQt6 import QtCore, QtGui
+
+from . import dsp
+from .annotations import Annotation
+
+# Bioelectric channels are recorded in volts and displayed in microvolts.
+# Other kinds (stim/misc/…) carry arbitrary units — a trigger channel holds
+# integer event codes like 255, which on a 100 µV lane scale would paint
+# straight across every EEG lane — so they are auto-fit into their own lane
+# per visible slice instead (see _refresh_data).
+_MICROVOLT_TYPES = {"eeg", "eog", "emg", "ecg", "seeg", "ecog", "dbs", "bio"}
+_VOLTS_TO_MICROVOLTS = 1e6
+# Lane-units excursion an auto-fit (non-bioelectric) channel is normalized to.
+_AUTOFIT_EXCURSION = 0.4
+
+# Per-channel-type display gain applied on top of the global scale. EMG rides
+# hotter than EEG on most montages; halving it keeps the trace inside its lane
+# without a per-channel scaling UI (cut deliberately — see issue #136).
+TYPE_GAINS = {"emg": 0.5}
+
+# Clicking selects the annotation under the cursor; a zero-duration mark gets
+# this much slack on each side, as a fraction of the visible window.
+_CLICK_TOLERANCE_FRACTION = 0.005
+
+# Annotation paint: translucent fills so traces stay readable through them.
+_REGION_BRUSH = (70, 130, 180, 50)  # steel blue wash
+_REGION_BRUSH_SELECTED = (70, 130, 180, 110)
+_REGION_PEN = (70, 130, 180, 160)
+_LINE_PEN = (178, 34, 34, 160)  # firebrick for instantaneous marks
+_LINE_PEN_SELECTED = (178, 34, 34, 255)
+
+
+class SliceProvider(Protocol):
+    """What the view needs from a recording (satisfied by ``io.Recording``)."""
+
+    @property
+    def ch_names(self) -> list[str]: ...
+
+    @property
+    def ch_types(self) -> list[str]: ...
+
+    @property
+    def sfreq(self) -> float: ...
+
+    @property
+    def duration(self) -> float: ...
+
+    def get_slice(self, start_s: float, stop_s: float) -> tuple[Any, Any]: ...
+
+
+class _AnnotateViewBox(pg.ViewBox):
+    """A ViewBox where the left mouse annotates instead of panning.
+
+    Pan/zoom-by-mouse is disabled outright: a misdrag that silently shifts the
+    time axis would make the operator distrust where their annotations landed.
+    Dragging rubber-bands a span (live region preview, then ``dragFinished``);
+    a plain click reports its time so the view can select/deselect.
+    """
+
+    dragFinished = QtCore.pyqtSignal(float, float)  # span in data seconds
+    clicked = QtCore.pyqtSignal(float)  # click time in data seconds
+
+    def __init__(self) -> None:
+        super().__init__(enableMouse=False, enableMenu=False)
+        self._preview: pg.LinearRegionItem | None = None
+
+    def mouseDragEvent(self, ev: Any, axis: int | None = None) -> None:
+        if ev.button() != QtCore.Qt.MouseButton.LeftButton:
+            ev.ignore()
+            return
+        ev.accept()
+        start = float(self.mapToView(ev.buttonDownPos()).x())
+        current = float(self.mapToView(ev.pos()).x())
+        lo, hi = sorted((start, current))
+        if self._preview is None:
+            self._preview = pg.LinearRegionItem(
+                values=(lo, hi), movable=False, brush=_REGION_BRUSH
+            )
+            self._preview.setZValue(20)
+            self.addItem(self._preview)
+        self._preview.setRegion((lo, hi))
+        if ev.isFinish():
+            self.removeItem(self._preview)
+            self._preview = None
+            self.dragFinished.emit(lo, hi)
+
+    def mouseClickEvent(self, ev: Any) -> None:
+        if ev.button() != QtCore.Qt.MouseButton.LeftButton:
+            ev.ignore()
+            return
+        ev.accept()
+        self.clicked.emit(float(self.mapToView(ev.pos()).x()))
+
+
+class TraceView(pg.PlotWidget):
+    """Stacked-channel trace display with drag-to-annotate.
+
+    Owns the display state (window position/length, filter spec, amplitude
+    scale, the annotation list and selection) and emits user intent upward:
+
+    * ``regionDrawn(start, stop)`` — a drag finished; the window asks for a label.
+    * ``annotationSelected(index)`` — click selected an annotation (-1: none).
+    * ``windowChanged(start)`` — the view scrolled itself (mouse wheel), so the
+      window can sync its scrollbar.
+    * ``cursorMoved(seconds)`` — mouse position, for the status-bar clock.
+    """
+
+    regionDrawn = QtCore.pyqtSignal(float, float)
+    annotationSelected = QtCore.pyqtSignal(int)
+    windowChanged = QtCore.pyqtSignal(float)
+    cursorMoved = QtCore.pyqtSignal(float)
+
+    def __init__(self) -> None:
+        self._viewbox = _AnnotateViewBox()
+        super().__init__(viewBox=self._viewbox, background=None)
+        self._provider: SliceProvider | None = None
+        self._spec = dsp.UNFILTERED
+        self._window_start = 0.0
+        self._window_seconds = 30.0  # the standard sleep-scoring epoch
+        self._scale_uv = 100.0  # microvolts per channel lane
+        self._annotations: list[Annotation] = []
+        self._selected = -1
+        self._annotation_items: list[pg.LinearRegionItem | pg.InfiniteLine] = []
+        self._curves: list[pg.PlotDataItem] = []
+
+        self._viewbox.dragFinished.connect(self._on_drag_finished)
+        self._viewbox.clicked.connect(self._on_clicked)
+        # Click-to-focus so the arrow-key navigation in keyPressEvent reaches
+        # the traces after the operator clicks them.
+        self.setFocusPolicy(QtCore.Qt.FocusPolicy.ClickFocus)
+        self.setAntialiasing(False)  # measurably faster, invisible at 1 px pens
+        plot_item = self.getPlotItem()
+        assert plot_item is not None
+        plot_item.hideButtons()  # the autoscale "A" makes no sense here
+        plot_item.setMenuEnabled(False)
+        left_axis = plot_item.getAxis("left")
+        left_axis.setStyle(tickLength=0)
+        bottom_axis = plot_item.getAxis("bottom")
+        bottom_axis.setLabel("time (s)")
+        # Track the mouse for the status-bar clock readout.
+        self.scene().sigMouseMoved.connect(self._on_mouse_moved)
+
+    # ----- display state ----------------------------------------------------
+
+    @property
+    def window_start(self) -> float:
+        return self._window_start
+
+    @property
+    def window_seconds(self) -> float:
+        return self._window_seconds
+
+    @property
+    def annotations(self) -> list[Annotation]:
+        return list(self._annotations)
+
+    @property
+    def selected(self) -> int:
+        return self._selected
+
+    def set_provider(self, provider: SliceProvider | None) -> None:
+        """Show a (new) recording from its start; ``None`` clears the view."""
+        self._provider = provider
+        self._window_start = 0.0
+        self._build_curves()
+        self._refresh_data()
+        self._refresh_annotations()
+
+    def set_spec(self, spec: dsp.FilterSpec) -> None:
+        self._spec = spec
+        self._refresh_data()
+
+    def set_scale(self, microvolts: float) -> None:
+        """Set the lane height in µV (smaller value → visually bigger traces)."""
+        self._scale_uv = max(1e-9, microvolts)
+        self._refresh_data()
+
+    def set_window_seconds(self, seconds: float) -> None:
+        self._window_seconds = max(1.0, seconds)
+        self._clamp_window_start()
+        self._refresh_data()
+        self._refresh_annotations()
+
+    def set_window_start(self, seconds: float) -> None:
+        self._window_start = seconds
+        self._clamp_window_start()
+        self._refresh_data()
+        self._refresh_annotations()
+
+    def scroll_by(self, fraction: float) -> None:
+        """Scroll by a fraction of the window (±1.0 is a full page)."""
+        self.set_window_start(self._window_start + fraction * self._window_seconds)
+        self.windowChanged.emit(self._window_start)
+
+    def set_annotations(
+        self, annotations: list[Annotation], selected: int = -1
+    ) -> None:
+        """Replace the displayed annotations (and selection) — no refilter."""
+        self._annotations = list(annotations)
+        self._selected = selected
+        self._refresh_annotations()
+
+    # ----- interaction ---------------------------------------------------------
+
+    def _on_drag_finished(self, lo: float, hi: float) -> None:
+        if self._provider is None:
+            return
+        # Clamp to the recording so a drag past an edge yields a valid span.
+        lo = max(0.0, lo)
+        hi = min(self._provider.duration, hi)
+        if hi > lo:
+            self.regionDrawn.emit(lo, hi)
+
+    def _on_clicked(self, seconds: float) -> None:
+        index = self._annotation_at(seconds)
+        self._selected = index
+        self._refresh_annotations()
+        self.annotationSelected.emit(index)
+
+    def _annotation_at(self, seconds: float) -> int:
+        """The index of the annotation under ``seconds``, or -1.
+
+        Prefers the latest-starting (typically narrowest/topmost) hit so a
+        point mark inside a long region is still clickable. Zero-duration
+        marks get a small symmetric tolerance.
+        """
+        tolerance = self._window_seconds * _CLICK_TOLERANCE_FRACTION
+        hit = -1
+        for index, a in enumerate(self._annotations):
+            lo, hi = a.onset, a.onset + a.duration
+            if a.duration == 0:
+                lo, hi = lo - tolerance, hi + tolerance
+            if lo <= seconds <= hi:
+                hit = index
+        return hit
+
+    def _on_mouse_moved(self, scene_pos: Any) -> None:
+        plot_item = self.getPlotItem()
+        # sceneBoundingRect lives on the PlotItem (a QGraphicsWidget) — the
+        # PlotWidget itself is the QGraphicsView and has no scene rect.
+        if plot_item is not None and plot_item.sceneBoundingRect().contains(scene_pos):
+            self.cursorMoved.emit(float(self._viewbox.mapSceneToView(scene_pos).x()))
+
+    def wheelEvent(self, ev: QtGui.QWheelEvent | None) -> None:
+        """Wheel scrolls time (a tenth of a window per notch), never zooms."""
+        if ev is None:
+            return
+        notches = ev.angleDelta().y() / 120.0
+        self.scroll_by(-0.1 * notches)
+        ev.accept()
+
+    def keyPressEvent(self, ev: QtGui.QKeyEvent | None) -> None:
+        """Arrow/Home/End navigation while the traces have focus.
+
+        These live here (with click-to-focus) rather than as window shortcuts
+        because a focused spin box consumes cursor keys via ShortcutOverride —
+        a window-level Left/Right would silently die right after the operator
+        adjusts a filter. Clicking the traces focuses them, and from there the
+        arrows always work. PageUp/PageDown are window shortcuts (no text
+        widget steals them), so paging works regardless of focus.
+        """
+        if ev is None:
+            return
+        key = ev.key()
+        if key == QtCore.Qt.Key.Key_Right:
+            self.scroll_by(0.1)
+        elif key == QtCore.Qt.Key.Key_Left:
+            self.scroll_by(-0.1)
+        elif key == QtCore.Qt.Key.Key_Home:
+            self.set_window_start(0.0)
+            self.windowChanged.emit(self._window_start)
+        elif key == QtCore.Qt.Key.Key_End:
+            self.set_window_start(float("inf"))
+            self.windowChanged.emit(self._window_start)
+        else:
+            super().keyPressEvent(ev)
+            return
+        ev.accept()
+
+    # ----- drawing ---------------------------------------------------------------
+
+    def _clamp_window_start(self) -> None:
+        if self._provider is None:
+            self._window_start = 0.0
+            return
+        latest = max(0.0, self._provider.duration - self._window_seconds)
+        self._window_start = min(max(0.0, self._window_start), latest)
+
+    def _build_curves(self) -> None:
+        """Recreate one curve per channel (on open/clear), tuned for speed."""
+        plot_item = self.getPlotItem()
+        assert plot_item is not None
+        for curve in self._curves:
+            plot_item.removeItem(curve)
+        self._curves = []
+        if self._provider is None:
+            plot_item.getAxis("left").setTicks([[]])
+            return
+        pen = pg.mkPen(self.palette().color(QtGui.QPalette.ColorRole.Text), width=1)
+        names = self._provider.ch_names
+        for _ in names:
+            curve = pg.PlotDataItem(pen=pen)
+            # Peak (min/max) downsampling keeps extremes visible at any zoom;
+            # clip-to-view skips offscreen points when a margin is set.
+            curve.setDownsampling(auto=True, method="peak")
+            curve.setClipToView(True)
+            plot_item.addItem(curve)
+            self._curves.append(curve)
+        plot_item.getAxis("left").setTicks(
+            [[(-i, name) for i, name in enumerate(names)]]
+        )
+        self.setYRange(-len(names) + 0.4, 0.6, padding=0)
+
+    def _refresh_data(self) -> None:
+        """Fetch, filter, scale, and draw the visible slice of every channel."""
+        if self._provider is None:
+            return
+        pad = dsp.pad_seconds(self._spec)
+        lo = self._window_start
+        hi = self._window_start + self._window_seconds
+        times, data = self._provider.get_slice(lo - pad, hi + pad)
+        data = dsp.apply(np.asarray(data), self._provider.sfreq, self._spec)
+        times = np.asarray(times)
+        # Trim the filter margin so its edge transients never reach the screen.
+        keep = (times >= lo) & (times <= hi)
+        times, data = times[keep], data[:, keep]
+        ch_types = self._provider.ch_types
+        for i, curve in enumerate(self._curves):
+            trace = data[i]
+            if ch_types[i] in _MICROVOLT_TYPES:
+                gain = TYPE_GAINS.get(ch_types[i], 1.0)
+                scaled = trace * _VOLTS_TO_MICROVOLTS * (gain / self._scale_uv)
+            else:
+                # Unit-less channel (stim/misc/…): fit it to its own lane per
+                # visible slice. Absolute amplitude is meaningless for these;
+                # the edges (a trigger firing) are what a reviewer looks for.
+                peak = float(np.max(np.abs(trace))) if trace.size else 0.0
+                scaled = trace * (_AUTOFIT_EXCURSION / peak) if peak else trace
+            curve.setData(times, -i + scaled)
+        self.setXRange(lo, hi, padding=0)
+
+    def _refresh_annotations(self) -> None:
+        """Redraw the annotation overlay for the visible window (cheap)."""
+        plot_item = self.getPlotItem()
+        assert plot_item is not None
+        for old in self._annotation_items:
+            plot_item.removeItem(old)
+        self._annotation_items = []
+        if self._provider is None:
+            return
+        lo = self._window_start
+        hi = self._window_start + self._window_seconds
+        for index, a in enumerate(self._annotations):
+            if a.onset + a.duration < lo or a.onset > hi:
+                continue
+            selected = index == self._selected
+            item: pg.LinearRegionItem | pg.InfiniteLine
+            if a.duration > 0:
+                item = pg.LinearRegionItem(
+                    values=(a.onset, a.onset + a.duration),
+                    movable=False,
+                    brush=_REGION_BRUSH_SELECTED if selected else _REGION_BRUSH,
+                    pen=_REGION_PEN,
+                )
+            else:
+                item = pg.InfiniteLine(
+                    pos=a.onset,
+                    angle=90,
+                    movable=False,
+                    pen=pg.mkPen(
+                        _LINE_PEN_SELECTED if selected else _LINE_PEN,
+                        width=2 if selected else 1,
+                    ),
+                )
+            item.setToolTip(a.description)
+            item.setZValue(10)
+            plot_item.addItem(item)
+            self._annotation_items.append(item)

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -1,0 +1,630 @@
+"""The EEG review window: open a recording, scroll it, annotate it (#136).
+
+A standalone top-level window with its own process and ``QApplication`` (see
+the package docstring) — not a launcher-managed :class:`~smacc.toolwindow
+.ToolWindow`, since the launcher can't signal across processes. It owns a
+:class:`~smacc.eeg.view.TraceView` plus the controls around it: open/save,
+display filters, window length, amplitude scale, a scrollbar, and the
+annotation list.
+
+Annotation flow: a drag on the traces draws a span, the label dialog asks what
+it was (seeded with sleep-research vocabulary and the operator's recent
+labels), and Save writes the TSV/JSON sidecar next to the source recording.
+Opening a file that already has a sidecar resumes from it; only a *fresh*
+review imports the events embedded in the recording itself (re-importing on
+every open would duplicate them into the saved sidecar). Unsaved changes mark
+the title and prompt on close.
+
+This is a *daytime* analysis tool: unlike the session windows there is no dark
+theme, no always-on-top, and nothing here may import from the live-session
+modules (the frozen ``SMACC-EEG.exe`` doesn't ship them all — and review work
+must never share a process with a running night).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from .. import preferences, windowstate
+from ..paths import LOGO_PATH, preferences_path
+from . import dsp, io
+from .annotations import (
+    Annotation,
+    insert,
+    read_annotations_tsv,
+    remove,
+    replace,
+    sidecar_paths,
+    write_annotations_json,
+    write_annotations_tsv,
+)
+from .view import TraceView
+
+# Stable id for this window's geometry entry in the per-window prefs map.
+_EEG_WINDOW_ID = "eeg-review"
+
+# Starting points for the label dropdown before an operator has any recents:
+# the marks dream-engineering reviewers actually place (see the
+# dream-engineering skill / docs). Free text is always allowed on top.
+SEED_LABELS = ["LRLR", "Arousal", "Artifact", "Cue response"]
+_MAX_RECENT_LABELS = 12
+
+# Selectable page lengths, seconds. 30 s — the sleep-scoring epoch — is the
+# default; the rest bracket it for fine inspection and context.
+WINDOW_LENGTHS = (10, 30, 60, 120)
+DEFAULT_WINDOW_LENGTH = 30
+
+# The scrollbar works in tenths of a second: fine enough to land anywhere,
+# coarse enough that an 8 h night stays within QScrollBar's int range.
+_SCROLL_TICKS_PER_SECOND = 10
+
+
+def _section_title(text: str) -> QtWidgets.QLabel:
+    """A centered 18pt section header (QFont, not stylesheet, so it follows
+    the palette).
+
+    Deliberately duplicated from ``panels.base.make_section_title``: importing
+    ``panels.base`` executes ``import sounddevice`` and pulls in the whole
+    live-session stack, which this process must never load (see the module
+    docstring) and the frozen ``SMACC-EEG.exe`` will not ship.
+    """
+    label = QtWidgets.QLabel(text)
+    label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+    font = QtGui.QFont()
+    font.setPointSize(18)
+    label.setFont(font)
+    return label
+
+
+def wall_time(recording: io.Recording, seconds: float) -> datetime | None:
+    """The wall-clock time at ``seconds`` into ``recording``, or ``None``.
+
+    Format-aware on purpose: EDF/BrainVision start times are the tech's
+    wall-clock stamps that MNE only tags UTC pro forma, so they display as-is;
+    a FIF ``meas_date`` is a true UTC instant, so it converts to this
+    machine's local zone (the right answer whenever the file is reviewed in
+    the timezone it was recorded in — the overwhelmingly common case).
+    """
+    start = recording.meas_date
+    if start is None:
+        return None
+    if recording.path.suffix.lower() == ".fif":
+        start = start.astimezone()
+    return start + timedelta(seconds=seconds)
+
+
+class LabelDialog(QtWidgets.QDialog):
+    """Ask for an annotation's label: editable dropdown of recents + free text.
+
+    The "instant" checkbox turns a drawn span into a zero-duration mark — the
+    natural unit for events like an LRLR signal, where the moment matters and
+    the drawn width was just the drag.
+    """
+
+    def __init__(
+        self, parent: QtWidgets.QWidget | None, recents: list[str], initial: str = ""
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Annotation label")
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(QtWidgets.QLabel("Label for this annotation:", self))
+        self.labelCombo = QtWidgets.QComboBox(self)
+        self.labelCombo.setEditable(True)
+        seen: list[str] = []
+        for label in [*recents, *SEED_LABELS]:
+            if label not in seen:
+                seen.append(label)
+        self.labelCombo.addItems(seen)
+        self.labelCombo.setCurrentText(initial)
+        layout.addWidget(self.labelCombo)
+        self.instantCheck = QtWidgets.QCheckBox(
+            "Instantaneous mark (drop the drawn duration)", self
+        )
+        layout.addWidget(self.instantCheck)
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    @staticmethod
+    def get_label(
+        parent: QtWidgets.QWidget | None,
+        recents: list[str],
+        initial: str = "",
+        *,
+        offer_instant: bool = True,
+    ) -> tuple[str, bool] | None:
+        """Run the dialog; return ``(label, instant)`` or ``None`` on cancel.
+
+        Cancel includes confirming an empty label — there is nothing useful to
+        do with an unnamed span, so it reads as "never mind".
+        """
+        dialog = LabelDialog(parent, recents, initial)
+        dialog.instantCheck.setVisible(offer_instant)
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return None
+        label = " ".join(dialog.labelCombo.currentText().split())
+        if not label:
+            return None
+        return label, offer_instant and dialog.instantCheck.isChecked()
+
+
+class EegReviewWindow(QtWidgets.QMainWindow):
+    """Review and annotate one recording; the EEG component's main window."""
+
+    def __init__(self, file_path: str | Path | None = None) -> None:
+        super().__init__()
+        self._recording: io.Recording | None = None
+        self._annotations: list[Annotation] = []
+        self._dirty = False
+        self.setWindowTitle("SMACC — EEG review")
+        if LOGO_PATH.is_file():
+            self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
+        self._build()
+        self._set_loaded(False)
+        if file_path is not None:
+            # After the event loop starts, so the window is up before any
+            # open-error dialog (and a long load doesn't block the first paint).
+            QtCore.QTimer.singleShot(0, lambda: self._load(Path(file_path)))
+
+    # ----- UI construction ----------------------------------------------------
+
+    def _build(self) -> None:
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+        layout.setContentsMargins(12, 8, 12, 8)
+        layout.setSpacing(8)
+        layout.addWidget(_section_title("EEG review"))
+        layout.addLayout(self._build_controls_row())
+
+        body = QtWidgets.QHBoxLayout()
+        viewColumn = QtWidgets.QVBoxLayout()
+        self.view = TraceView()
+        self.view.regionDrawn.connect(self._on_region_drawn)
+        self.view.annotationSelected.connect(self._on_view_selection)
+        self.view.windowChanged.connect(self._sync_scrollbar)
+        self.view.cursorMoved.connect(self._on_cursor_moved)
+        viewColumn.addWidget(self.view, 1)
+        self.scrollBar = QtWidgets.QScrollBar(QtCore.Qt.Orientation.Horizontal, self)
+        self.scrollBar.setStatusTip("Scroll through the recording.")
+        self.scrollBar.valueChanged.connect(self._on_scrollbar)
+        viewColumn.addWidget(self.scrollBar)
+        body.addLayout(viewColumn, 1)
+        body.addLayout(self._build_annotation_panel())
+        layout.addLayout(body, 1)
+
+        self.statusBar()
+        # Permanent (right-aligned) recording summary; transient messages and
+        # the cursor clock use the normal message area.
+        self.fileInfoLabel = QtWidgets.QLabel("", self)
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.addPermanentWidget(self.fileInfoLabel)
+
+        self._build_shortcuts()
+        self.setCentralWidget(central)
+        prefs = preferences.load_preferences(preferences_path)
+        geometry = preferences.window_geometry(prefs, _EEG_WINDOW_ID)
+        windowstate.restore_geometry(self, geometry, default_size=(1150, 700))
+
+    def _build_controls_row(self) -> QtWidgets.QLayout:
+        row = QtWidgets.QHBoxLayout()
+        openButton = QtWidgets.QPushButton("Open recording…", self)
+        openButton.setStatusTip("Open an EEG recording (EDF, BrainVision, or FIF).")
+        openButton.clicked.connect(self.open_file)
+        row.addWidget(openButton)
+        row.addSpacing(12)
+
+        # Display filters. 0 reads as "Off" (special value text): the viewer
+        # opens unfiltered — silently rewriting amplitudes before the operator
+        # asked would misrepresent the recording.
+        row.addWidget(QtWidgets.QLabel("High-pass:", self))
+        self.highpassSpin = QtWidgets.QDoubleSpinBox(self)
+        self.highpassSpin.setRange(0.0, 100.0)
+        self.highpassSpin.setDecimals(2)
+        self.highpassSpin.setSingleStep(0.1)
+        self.highpassSpin.setSuffix(" Hz")
+        self.highpassSpin.setSpecialValueText("Off")
+        self.highpassSpin.setStatusTip(
+            "Drop slow drift below this frequency (0.3 Hz is the usual sleep view)."
+        )
+        row.addWidget(self.highpassSpin)
+        row.addWidget(QtWidgets.QLabel("Low-pass:", self))
+        self.lowpassSpin = QtWidgets.QDoubleSpinBox(self)
+        self.lowpassSpin.setRange(0.0, 500.0)
+        self.lowpassSpin.setDecimals(1)
+        self.lowpassSpin.setSingleStep(5.0)
+        self.lowpassSpin.setSuffix(" Hz")
+        self.lowpassSpin.setSpecialValueText("Off")
+        self.lowpassSpin.setStatusTip(
+            "Drop fast noise above this frequency (35 Hz is the usual sleep view)."
+        )
+        row.addWidget(self.lowpassSpin)
+        row.addWidget(QtWidgets.QLabel("Notch:", self))
+        self.notchCombo = QtWidgets.QComboBox(self)
+        self.notchCombo.addItem("Off", None)
+        self.notchCombo.addItem("50 Hz", 50.0)
+        self.notchCombo.addItem("60 Hz", 60.0)
+        self.notchCombo.setStatusTip("Remove mains interference (50 Hz EU, 60 Hz US).")
+        row.addWidget(self.notchCombo)
+        for widget in (self.highpassSpin, self.lowpassSpin):
+            widget.valueChanged.connect(self._on_filters_changed)
+        self.notchCombo.currentIndexChanged.connect(self._on_filters_changed)
+        row.addSpacing(12)
+
+        row.addWidget(QtWidgets.QLabel("Window:", self))
+        self.windowCombo = QtWidgets.QComboBox(self)
+        for seconds in WINDOW_LENGTHS:
+            self.windowCombo.addItem(f"{seconds} s", float(seconds))
+        self.windowCombo.setCurrentIndex(WINDOW_LENGTHS.index(DEFAULT_WINDOW_LENGTH))
+        self.windowCombo.setStatusTip(
+            "How many seconds are on screen (30 s is one scoring epoch)."
+        )
+        self.windowCombo.currentIndexChanged.connect(self._on_window_length_changed)
+        row.addWidget(self.windowCombo)
+
+        row.addWidget(QtWidgets.QLabel("Scale:", self))
+        self.scaleSpin = QtWidgets.QDoubleSpinBox(self)
+        self.scaleSpin.setRange(1.0, 10000.0)
+        self.scaleSpin.setDecimals(0)
+        self.scaleSpin.setValue(100.0)
+        self.scaleSpin.setSuffix(" µV")
+        self.scaleSpin.setStatusTip(
+            "Microvolts per channel lane — smaller means visually bigger traces."
+        )
+        self.scaleSpin.valueChanged.connect(
+            lambda value: self.view.set_scale(float(value))
+        )
+        row.addWidget(self.scaleSpin)
+
+        row.addStretch(1)
+        self.saveButton = QtWidgets.QPushButton("Save annotations", self)
+        self.saveButton.setStatusTip(
+            "Write the annotations TSV/JSON sidecar next to the recording."
+        )
+        self.saveButton.clicked.connect(self.save_annotations)
+        row.addWidget(self.saveButton)
+        return row
+
+    def _build_annotation_panel(self) -> QtWidgets.QLayout:
+        panel = QtWidgets.QVBoxLayout()
+        panel.addWidget(QtWidgets.QLabel("Annotations:", self))
+        self.annotationList = QtWidgets.QListWidget(self)
+        self.annotationList.setMinimumWidth(230)
+        self.annotationList.setStatusTip(
+            "Click to highlight; double-click to jump the view there."
+        )
+        self.annotationList.currentRowChanged.connect(self._on_list_selection)
+        self.annotationList.itemDoubleClicked.connect(
+            lambda _item: self.go_to_selected()
+        )
+        panel.addWidget(self.annotationList, 1)
+        buttons = QtWidgets.QHBoxLayout()
+        self.editButton = QtWidgets.QPushButton("Edit…", self)
+        self.editButton.setStatusTip("Rename the selected annotation.")
+        self.editButton.clicked.connect(self.edit_selected)
+        self.deleteButton = QtWidgets.QPushButton("Delete", self)
+        self.deleteButton.setStatusTip("Delete the selected annotation.")
+        self.deleteButton.clicked.connect(self.delete_selected)
+        buttons.addWidget(self.editButton)
+        buttons.addWidget(self.deleteButton)
+        panel.addLayout(buttons)
+        return panel
+
+    def _build_shortcuts(self) -> None:
+        """Window-wide paging on PageUp/PageDown only.
+
+        Arrows and Home/End live on the TraceView itself (click the traces,
+        then navigate): as window shortcuts they would be consumed by whichever
+        spin box or list last had focus. No text widget steals PageUp/Down, so
+        paging works from anywhere.
+        """
+        for keys, fraction in (
+            (QtCore.Qt.Key.Key_PageDown, 1.0),
+            (QtCore.Qt.Key.Key_PageUp, -1.0),
+        ):
+            shortcut = QtGui.QShortcut(QtGui.QKeySequence(keys), self)
+            shortcut.activated.connect(lambda f=fraction: self.view.scroll_by(f))
+
+    def _set_loaded(self, loaded: bool) -> None:
+        for widget in (
+            self.saveButton,
+            self.editButton,
+            self.deleteButton,
+            self.scrollBar,
+        ):
+            widget.setEnabled(loaded)
+
+    # ----- opening a recording ---------------------------------------------------
+
+    def open_file(self) -> None:
+        if not self._confirm_discard():
+            return
+        prefs = preferences.load_preferences(preferences_path)
+        start_dir = prefs.get("eeg_last_dir") or str(Path.home())
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Open EEG recording", str(start_dir), io.FILE_FILTER
+        )
+        if path:
+            self._load(Path(path))
+
+    def _load(self, path: Path) -> None:
+        try:
+            recording = io.open_recording(path)
+        except (ValueError, OSError, RuntimeError) as exc:
+            self._error("Could not open the recording.", str(exc))
+            return
+        tsv_path, _ = sidecar_paths(path)
+        if tsv_path.is_file():
+            # Resume a previous review. A sidecar that exists but won't parse
+            # aborts the open: it is the reviewer's data, and proceeding would
+            # overwrite it with an empty list on the next save.
+            try:
+                annotations = read_annotations_tsv(tsv_path)
+            except (OSError, ValueError) as exc:
+                self._error(
+                    "Could not read the existing annotations sidecar.",
+                    f"{tsv_path.name}: {exc}\n\nFix or rename the sidecar, "
+                    "then open the recording again.",
+                )
+                return
+        else:
+            # A fresh review starts from the events embedded in the recording
+            # (amp markers, SMACC's own portcodes…), so they end up in the
+            # sidecar alongside the reviewer's marks.
+            annotations = io.embedded_annotations(recording)
+        self._recording = recording
+        self._annotations = annotations
+        self._dirty = False
+        self.view.set_provider(recording)
+        self.view.set_annotations(annotations)
+        self._refresh_list()
+        self._refresh_title()
+        self._configure_scrollbar()
+        self._set_loaded(True)
+        preferences.update_preferences(
+            preferences_path, {"eeg_last_dir": str(path.parent)}
+        )
+        started = wall_time(recording, 0.0)
+        clock = f" · started {started.strftime('%H:%M:%S')}" if started else ""
+        self.fileInfoLabel.setText(
+            f"{path.name} — {len(recording.ch_names)} ch · "
+            f"{recording.sfreq:g} Hz · {recording.duration:.0f} s{clock}"
+        )
+
+    # ----- annotation editing -----------------------------------------------------
+
+    def _on_region_drawn(self, lo: float, hi: float) -> None:
+        result = LabelDialog.get_label(self, self._recent_labels())
+        if result is None:
+            return
+        label, instant = result
+        annotation = Annotation(lo, 0.0 if instant else hi - lo, label)
+        self._annotations = insert(self._annotations, annotation)
+        self._remember_label(label)
+        self._mark_dirty()
+        self._select(self._annotations.index(annotation))
+
+    def edit_selected(self) -> None:
+        index = self.annotationList.currentRow()
+        if not 0 <= index < len(self._annotations):
+            return
+        current = self._annotations[index]
+        result = LabelDialog.get_label(
+            self, self._recent_labels(), current.description, offer_instant=False
+        )
+        if result is None:
+            return
+        label, _ = result
+        edited = Annotation(current.onset, current.duration, label)
+        self._annotations = replace(self._annotations, index, edited)
+        self._remember_label(label)
+        self._mark_dirty()
+        self._select(self._annotations.index(edited))
+
+    def delete_selected(self) -> None:
+        index = self.annotationList.currentRow()
+        if not 0 <= index < len(self._annotations):
+            return
+        self._annotations = remove(self._annotations, index)
+        self._mark_dirty()
+        self._select(-1)
+
+    def go_to_selected(self) -> None:
+        """Jump the view so the selected annotation sits a quarter-window in."""
+        index = self.annotationList.currentRow()
+        if not 0 <= index < len(self._annotations):
+            return
+        onset = self._annotations[index].onset
+        self._jump_to(onset - self.view.window_seconds / 4)
+
+    def save_annotations(self) -> None:
+        if self._recording is None:
+            return
+        tsv_path, json_path = sidecar_paths(self._recording.path)
+        try:
+            write_annotations_tsv(self._annotations, tsv_path)
+            write_annotations_json(
+                json_path,
+                source_name=self._recording.path.name,
+                meas_date=self._recording.meas_date,
+            )
+        except OSError as exc:
+            self._error("Could not save the annotations.", str(exc))
+            return
+        self._dirty = False
+        self._refresh_title()
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.showMessage(
+            f"Saved {len(self._annotations)} annotations to {tsv_path.name}", 5000
+        )
+
+    # ----- annotation bookkeeping ----------------------------------------------------
+
+    def _mark_dirty(self) -> None:
+        self._dirty = True
+        self._refresh_title()
+
+    def _select(self, index: int) -> None:
+        """Sync the list widget and the view to one selected annotation.
+
+        The row is set with signals blocked: letting currentRowChanged fire
+        would rebuild the view's overlay a second time right before the
+        explicit set_annotations below (and that explicit call must stay —
+        deselection never fires currentRowChanged, the row is already -1
+        after the blocked rebuild).
+        """
+        self._refresh_list()
+        self.annotationList.blockSignals(True)
+        self.annotationList.setCurrentRow(index)
+        self.annotationList.blockSignals(False)
+        self.view.set_annotations(self._annotations, index)
+
+    def _refresh_list(self) -> None:
+        self.annotationList.blockSignals(True)  # programmatic fill: not a selection
+        self.annotationList.clear()
+        for a in self._annotations:
+            span = f"{a.onset:.3f}s" + (f" +{a.duration:.3f}s" if a.duration else "")
+            self.annotationList.addItem(f"{span}  {a.description}")
+        self.annotationList.blockSignals(False)
+
+    def _refresh_title(self) -> None:
+        name = f" — {self._recording.path.name}" if self._recording else ""
+        star = " *" if self._dirty else ""
+        self.setWindowTitle(f"SMACC — EEG review{name}{star}")
+
+    def _recent_labels(self) -> list[str]:
+        prefs = preferences.load_preferences(preferences_path)
+        recents = prefs.get("eeg_recent_labels")
+        return [r for r in recents if isinstance(r, str)] if recents else []
+
+    def _remember_label(self, label: str) -> None:
+        recents = preferences.push_recent(
+            self._recent_labels(), label, limit=_MAX_RECENT_LABELS
+        )
+        preferences.update_preferences(preferences_path, {"eeg_recent_labels": recents})
+
+    # ----- selection sync ---------------------------------------------------------
+
+    def _on_view_selection(self, index: int) -> None:
+        self.annotationList.blockSignals(True)
+        self.annotationList.setCurrentRow(index)
+        self.annotationList.blockSignals(False)
+
+    def _on_list_selection(self, row: int) -> None:
+        self.view.set_annotations(self._annotations, row)
+
+    # ----- navigation / display controls ----------------------------------------------
+
+    def _jump_to(self, seconds: float) -> None:
+        self.view.set_window_start(seconds)  # the view clamps
+        self._sync_scrollbar(self.view.window_start)
+
+    def _configure_scrollbar(self) -> None:
+        duration = self._recording.duration if self._recording else 0.0
+        span = max(0.0, duration - self.view.window_seconds)
+        self.scrollBar.blockSignals(True)
+        self.scrollBar.setRange(0, int(span * _SCROLL_TICKS_PER_SECOND))
+        self.scrollBar.setPageStep(
+            int(self.view.window_seconds * _SCROLL_TICKS_PER_SECOND)
+        )
+        self.scrollBar.setValue(int(self.view.window_start * _SCROLL_TICKS_PER_SECOND))
+        self.scrollBar.blockSignals(False)
+
+    def _on_scrollbar(self, value: int) -> None:
+        self.view.set_window_start(value / _SCROLL_TICKS_PER_SECOND)
+
+    def _sync_scrollbar(self, window_start: float) -> None:
+        self.scrollBar.blockSignals(True)
+        self.scrollBar.setValue(int(window_start * _SCROLL_TICKS_PER_SECOND))
+        self.scrollBar.blockSignals(False)
+
+    def _on_window_length_changed(self) -> None:
+        self.view.set_window_seconds(float(self.windowCombo.currentData()))
+        self._configure_scrollbar()
+
+    def _on_filters_changed(self) -> None:
+        highpass = self.highpassSpin.value() or None  # 0.0 displays as "Off"
+        lowpass = self.lowpassSpin.value() or None
+        notch = self.notchCombo.currentData()
+        try:
+            spec = dsp.FilterSpec(highpass=highpass, lowpass=lowpass, notch=notch)
+        except ValueError:
+            # Invalid band (high-pass >= low-pass): keep the previous filter,
+            # say why, and snap the controls back to it — a control left
+            # showing a rejected value would silently apply the moment the
+            # *other* edge moved, a filter the operator never confirmed.
+            status_bar = self.statusBar()
+            assert status_bar is not None
+            status_bar.showMessage(
+                "High-pass must stay below low-pass — filters unchanged.", 4000
+            )
+            applied = self.view._spec
+            for spin, value in (
+                (self.highpassSpin, applied.highpass),
+                (self.lowpassSpin, applied.lowpass),
+            ):
+                spin.blockSignals(True)
+                spin.setValue(value or 0.0)  # 0.0 displays as "Off"
+                spin.blockSignals(False)
+            return
+        self.view.set_spec(spec)
+
+    def _on_cursor_moved(self, seconds: float) -> None:
+        if self._recording is None:
+            return
+        text = f"t = {seconds:.3f} s"
+        clock = wall_time(self._recording, seconds) if seconds >= 0 else None
+        if clock is not None:
+            text += f" · {clock.strftime('%H:%M:%S')}"
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.showMessage(text)
+
+    # ----- helpers / lifecycle -------------------------------------------------------
+
+    def _confirm_discard(self) -> bool:
+        """True when it's safe to drop the current annotations (saved or confirmed)."""
+        if not self._dirty:
+            return True
+        button = QtWidgets.QMessageBox.question(
+            self,
+            "Unsaved annotations",
+            "Save the annotations before closing this recording?",
+            QtWidgets.QMessageBox.StandardButton.Save
+            | QtWidgets.QMessageBox.StandardButton.Discard
+            | QtWidgets.QMessageBox.StandardButton.Cancel,
+        )
+        if button == QtWidgets.QMessageBox.StandardButton.Save:
+            self.save_annotations()
+            return not self._dirty  # a failed save keeps the recording open
+        return button == QtWidgets.QMessageBox.StandardButton.Discard
+
+    def _error(self, short: str, detail: str | None = None) -> None:
+        box = QtWidgets.QMessageBox(self)
+        box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+        box.setWindowTitle("EEG review")
+        box.setText(short)
+        if detail is not None:
+            box.setInformativeText(detail)
+        box.exec()
+
+    def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+        if not self._confirm_discard():
+            if event is not None:
+                event.ignore()
+            return
+        # Remember where this window sat for next launch (best-effort, never raises).
+        preferences.update_window_geometry(
+            preferences_path, _EEG_WINDOW_ID, windowstate.geometry_of(self)
+        )
+        if event is not None:
+            event.accept()

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -45,6 +45,13 @@ DEFAULTS: dict[str, Any] = {
     # first; the log file always keeps everything). Large values cost GUI memory
     # and repaint time over an overnight session.
     "log_preview_max_lines": 1000,
+    # EEG review tool (#136): recently used annotation labels (most-recent
+    # first, seeding the label dialog's dropdown) and the last folder a
+    # recording was opened from. Note loading only round-trips keys present
+    # here, so the EEG window's keys must stay in DEFAULTS even though the
+    # tool is an optional component.
+    "eeg_recent_labels": [],
+    "eeg_last_dir": None,
 }
 
 _logger = logging.getLogger("smacc")

--- a/tests/test_eeg_view.py
+++ b/tests/test_eeg_view.py
@@ -1,0 +1,362 @@
+"""Tests for the EEG trace view (#136) — offscreen, no MNE.
+
+The view draws from the :class:`SliceProvider` protocol, so a small fake with
+known constant data stands in for a recording; channel scaling and lane
+offsets can then be asserted exactly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pyqtgraph as pg
+import pytest
+from PyQt6 import QtCore, QtGui
+
+from smacc.eeg import dsp
+from smacc.eeg.annotations import Annotation
+from smacc.eeg.view import TYPE_GAINS, TraceView
+
+SFREQ = 100.0
+DURATION = 60.0
+# 50 µV everywhere: with the default 100 µV lane scale an EEG channel sits at
+# +0.5 lane units above its offset.
+CONSTANT_VOLTS = 50e-6
+
+
+class FakeProvider:
+    """Constant-valued recording: 2 EEG + EOG + EMG, 100 Hz, 60 s."""
+
+    ch_names = ["C3", "C4", "EOG", "EMG"]
+    ch_types = ["eeg", "eeg", "eog", "emg"]
+    sfreq = SFREQ
+    duration = DURATION
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[float, float]] = []
+
+    def get_slice(self, start_s: float, stop_s: float):
+        self.calls.append((start_s, stop_s))
+        start = max(0, int(round(max(0.0, start_s) * SFREQ)))
+        stop = min(int(DURATION * SFREQ), int(round(min(DURATION, stop_s) * SFREQ)))
+        n = max(0, stop - start)
+        times = (start + np.arange(n)) / SFREQ
+        return times, np.full((4, n), CONSTANT_VOLTS)
+
+
+@pytest.fixture
+def view(qtbot):
+    view = TraceView()
+    qtbot.addWidget(view)
+    view.resize(800, 500)
+    return view
+
+
+@pytest.fixture
+def loaded(view):
+    provider = FakeProvider()
+    view.set_provider(provider)
+    return view, provider
+
+
+# ----- construction and data flow ----------------------------------------------
+
+
+def test_set_provider_builds_one_curve_per_channel(loaded):
+    view, _ = loaded
+    assert len(view._curves) == 4
+
+
+def test_traces_are_scaled_to_microvolt_lanes(loaded):
+    # 50 µV on a 100 µV lane scale → +0.5 above the channel's lane center,
+    # with channel i centered at y = -i and EMG halved by its type gain.
+    view, _ = loaded
+    _, y0 = view._curves[0].getData()
+    assert y0 == pytest.approx(0.0 + 0.5)
+    _, y3 = view._curves[3].getData()
+    emg = 0.5 * TYPE_GAINS["emg"]
+    assert y3 == pytest.approx(-3 + emg)
+
+
+def test_scale_control_changes_trace_amplitude(loaded):
+    view, _ = loaded
+    view.set_scale(50.0)  # half the lane height → double the excursion
+    _, y0 = view._curves[0].getData()
+    assert y0 == pytest.approx(1.0)
+
+
+def test_filter_margin_is_fetched_but_trimmed(loaded):
+    # With a 0.5 Hz high-pass the view fetches pad_seconds of margin on each
+    # side, but the drawn data must stay inside the visible window — the
+    # margin exists exactly so filter edge transients are never shown.
+    view, provider = loaded
+    provider.calls.clear()
+    view.set_spec(dsp.FilterSpec(highpass=0.5))
+    pad = dsp.pad_seconds(dsp.FilterSpec(highpass=0.5))
+    (fetch_start, fetch_stop) = provider.calls[-1]
+    assert fetch_start == pytest.approx(0.0 - pad)
+    assert fetch_stop == pytest.approx(30.0 + pad)
+    x0, _ = view._curves[0].getData()
+    assert x0.min() >= 0.0
+    assert x0.max() <= 30.0
+
+
+# ----- windowing ------------------------------------------------------------------
+
+
+def test_window_start_clamps_to_the_recording(loaded):
+    view, _ = loaded
+    view.set_window_start(-5.0)
+    assert view.window_start == 0.0
+    view.set_window_start(1e9)
+    assert view.window_start == DURATION - view.window_seconds
+
+
+def test_scroll_by_pages_and_reports(loaded):
+    view, _ = loaded
+    moves: list[float] = []
+    view.windowChanged.connect(moves.append)
+    view.scroll_by(0.5)  # half a 30 s window
+    assert view.window_start == 15.0
+    assert moves == [15.0]
+
+
+def test_window_length_change_keeps_the_view_in_range(loaded):
+    view, _ = loaded
+    view.set_window_start(50.0)  # 60 s file, 30 s window → clamps to 30
+    view.set_window_seconds(60.0)  # now the whole file: start must fall to 0
+    assert view.window_start == 0.0
+
+
+def test_view_without_provider_is_inert(view):
+    view.set_window_start(10.0)
+    view.set_annotations([Annotation(1.0, 0.0, "x")])
+    view.scroll_by(1.0)
+    assert view.window_start == 0.0
+    assert view._curves == []
+
+
+# ----- annotations -----------------------------------------------------------------
+
+
+def test_annotations_draw_regions_and_lines_in_window_only(loaded):
+    view, _ = loaded
+    view.set_annotations(
+        [
+            Annotation(5.0, 2.0, "region"),  # in window: LinearRegionItem
+            Annotation(10.0, 0.0, "point"),  # in window: InfiniteLine
+            Annotation(55.0, 1.0, "offscreen"),  # outside the 0-30 s window
+        ]
+    )
+    items = view._annotation_items
+    assert len(items) == 2
+    assert isinstance(items[0], pg.LinearRegionItem)
+    assert isinstance(items[1], pg.InfiniteLine)
+
+
+def test_click_hit_testing_prefers_the_inner_annotation(loaded):
+    view, _ = loaded
+    view.set_annotations(
+        [
+            Annotation(5.0, 20.0, "REM period"),
+            Annotation(10.0, 1.0, "Arousal"),  # nested inside the REM span
+        ]
+    )
+    assert view._annotation_at(10.5) == 1  # the nested one wins
+    assert view._annotation_at(6.0) == 0
+    assert view._annotation_at(29.0) == -1
+
+
+def test_point_annotations_get_click_tolerance(loaded):
+    view, _ = loaded
+    view.set_annotations([Annotation(10.0, 0.0, "mark")])
+    tolerance = view.window_seconds * 0.005
+    assert view._annotation_at(10.0 + tolerance / 2) == 0
+    assert view._annotation_at(10.0 + tolerance * 3) == -1
+
+
+def test_click_selects_and_signals(loaded):
+    view, _ = loaded
+    view.set_annotations([Annotation(5.0, 2.0, "region")])
+    selections: list[int] = []
+    view.annotationSelected.connect(selections.append)
+    view._on_clicked(6.0)
+    assert selections == [0]
+    assert view.selected == 0
+    view._on_clicked(20.0)  # empty space deselects
+    assert selections == [0, -1]
+
+
+def test_drawn_region_is_clamped_and_empty_drags_dropped(loaded):
+    view, _ = loaded
+    drawn: list[tuple[float, float]] = []
+    view.regionDrawn.connect(lambda lo, hi: drawn.append((lo, hi)))
+    view._on_drag_finished(-2.0, 4.0)  # started before the data
+    assert drawn == [(0.0, 4.0)]
+    view._on_drag_finished(70.0, 80.0)  # entirely past the end: nothing
+    assert len(drawn) == 1
+
+
+# ----- non-bioelectric channels ----------------------------------------------------
+
+
+class StimProvider(FakeProvider):
+    """One EEG channel plus a trigger channel carrying integer event codes."""
+
+    ch_names = ["C3", "TRIG"]
+    ch_types = ["eeg", "stim"]
+
+    def get_slice(self, start_s: float, stop_s: float):
+        times, _data = super().get_slice(start_s, stop_s)
+        data = np.vstack(
+            [np.full(times.shape, CONSTANT_VOLTS), np.full(times.shape, 255.0)]
+        )
+        return times, data
+
+
+def test_stim_channels_are_fit_to_their_own_lane(view):
+    # A trigger code of 255 fed through the µV scaling would draw at
+    # -i + 255/100 — straight across every EEG lane above it. Auto-fit must
+    # keep it within its own lane's excursion instead.
+    view.set_provider(StimProvider())
+    _, y_eeg = view._curves[0].getData()
+    assert y_eeg == pytest.approx(0.5)  # unchanged by the stim handling
+    _, y_stim = view._curves[1].getData()
+    assert np.all(np.abs(y_stim - (-1)) <= 0.4 + 1e-9)
+
+
+# ----- the real mouse gesture path --------------------------------------------------
+
+
+class _FakeMouseEvent:
+    """Stands in for pyqtgraph's MouseDragEvent/MouseClickEvent.
+
+    Positions are given in data coordinates and converted to the ViewBox's
+    item coordinates with mapFromView — the frame the real events deliver.
+    """
+
+    def __init__(self, viewbox, down_x: float, x: float, *, finish=True, button=None):
+        self._button = button or QtCore.Qt.MouseButton.LeftButton
+        self._down = viewbox.mapFromView(pg.Point(down_x, 0.0))
+        self._pos = viewbox.mapFromView(pg.Point(x, 0.0))
+        self._finish = finish
+        self.accepted = False
+        self.ignored = False
+
+    def button(self):
+        return self._button
+
+    def buttonDownPos(self):
+        return self._down
+
+    def pos(self):
+        return self._pos
+
+    def isFinish(self):
+        return self._finish
+
+    def accept(self):
+        self.accepted = True
+
+    def ignore(self):
+        self.ignored = True
+
+
+@pytest.fixture
+def exposed(loaded, qtbot):
+    """The loaded view, shown and laid out so ViewBox transforms are valid."""
+    view, provider = loaded
+    view.show()
+    qtbot.waitExposed(view)
+    return view, provider
+
+
+def test_left_drag_emits_the_dragged_span(exposed):
+    view, _ = exposed
+    drawn: list[tuple[float, float]] = []
+    view.regionDrawn.connect(lambda lo, hi: drawn.append((lo, hi)))
+    viewbox = view._viewbox
+    move = _FakeMouseEvent(viewbox, 5.0, 8.0, finish=False)
+    viewbox.mouseDragEvent(move)
+    assert move.accepted
+    assert viewbox._preview is not None  # live rubber-band while dragging
+    finish = _FakeMouseEvent(viewbox, 5.0, 8.0, finish=True)
+    viewbox.mouseDragEvent(finish)
+    assert viewbox._preview is None
+    assert len(drawn) == 1
+    assert drawn[0][0] == pytest.approx(5.0, abs=0.05)
+    assert drawn[0][1] == pytest.approx(8.0, abs=0.05)
+
+
+def test_backwards_drag_is_normalized(exposed):
+    view, _ = exposed
+    drawn: list[tuple[float, float]] = []
+    view.regionDrawn.connect(lambda lo, hi: drawn.append((lo, hi)))
+    view._viewbox.mouseDragEvent(_FakeMouseEvent(view._viewbox, 8.0, 5.0))
+    assert drawn[0][0] < drawn[0][1]
+
+
+def test_non_left_drag_is_ignored(exposed):
+    view, _ = exposed
+    drawn: list[tuple[float, float]] = []
+    view.regionDrawn.connect(lambda lo, hi: drawn.append((lo, hi)))
+    ev = _FakeMouseEvent(
+        view._viewbox, 5.0, 8.0, button=QtCore.Qt.MouseButton.RightButton
+    )
+    view._viewbox.mouseDragEvent(ev)
+    assert ev.ignored
+    assert drawn == []
+
+
+def test_click_event_maps_to_data_seconds(exposed):
+    view, _ = exposed
+    view.set_annotations([Annotation(5.0, 2.0, "region")])
+    selections: list[int] = []
+    view.annotationSelected.connect(selections.append)
+    view._viewbox.mouseClickEvent(_FakeMouseEvent(view._viewbox, 6.0, 6.0))
+    assert selections == [0]
+
+
+# ----- wheel and keyboard navigation -------------------------------------------------
+
+
+def _wheel_event(notches: float) -> QtGui.QWheelEvent:
+    from PyQt6.QtCore import QPoint, QPointF, Qt
+
+    return QtGui.QWheelEvent(
+        QPointF(0, 0),
+        QPointF(0, 0),
+        QPoint(0, 0),
+        QPoint(0, int(notches * 120)),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+
+
+def test_wheel_down_scrolls_forward(loaded):
+    # Wheel-down (negative delta) must move forward in time — a sign flip
+    # here would silently invert scrolling everywhere.
+    view, _ = loaded
+    view.wheelEvent(_wheel_event(-1.0))
+    assert view.window_start == pytest.approx(3.0)  # +0.1 windows of 30 s
+    view.wheelEvent(_wheel_event(1.0))
+    assert view.window_start == pytest.approx(0.0)
+
+
+def _key_event(key) -> QtGui.QKeyEvent:
+    return QtGui.QKeyEvent(
+        QtCore.QEvent.Type.KeyPress, key, QtCore.Qt.KeyboardModifier.NoModifier
+    )
+
+
+def test_arrow_and_home_end_keys_navigate(loaded):
+    view, _ = loaded
+    view.keyPressEvent(_key_event(QtCore.Qt.Key.Key_Right))
+    assert view.window_start == pytest.approx(3.0)
+    view.keyPressEvent(_key_event(QtCore.Qt.Key.Key_Left))
+    assert view.window_start == pytest.approx(0.0)
+    view.keyPressEvent(_key_event(QtCore.Qt.Key.Key_End))
+    assert view.window_start == pytest.approx(DURATION - view.window_seconds)
+    view.keyPressEvent(_key_event(QtCore.Qt.Key.Key_Home))
+    assert view.window_start == pytest.approx(0.0)

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -1,0 +1,485 @@
+"""Tests for the EEG review window (#136) — offscreen, no MNE.
+
+``io.open_recording``/``io.embedded_annotations`` are monkeypatched with a
+fake recording, so the window's whole flow — open, sidecar precedence,
+annotate, edit, delete, save, dirty/close — runs without the eeg extra.
+Preferences are pointed at a temp file (the launcher-test pattern) so no test
+touches the machine's real ``preferences.yaml``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PyQt6 import QtWidgets
+
+from smacc import preferences
+from smacc.config import VERSION
+from smacc.eeg import dsp
+from smacc.eeg import window as window_mod
+from smacc.eeg.__main__ import pick_recording_path
+from smacc.eeg.annotations import (
+    Annotation,
+    read_annotations_tsv,
+    sidecar_paths,
+    write_annotations_tsv,
+)
+from smacc.eeg.window import SEED_LABELS, EegReviewWindow, LabelDialog
+
+SFREQ = 100.0
+DURATION = 600.0
+MEAS_DATE = datetime(2026, 6, 5, 22, 0, 0, tzinfo=UTC)
+
+
+class FakeRecording:
+    """Stands in for io.Recording: metadata plus constant slices."""
+
+    ch_names = ["C3", "C4", "EOG", "EMG"]
+    ch_types = ["eeg", "eeg", "eog", "emg"]
+    sfreq = SFREQ
+    duration = DURATION
+    meas_date = MEAS_DATE
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+
+    def get_slice(self, start_s: float, stop_s: float):
+        start = max(0, int(round(max(0.0, start_s) * SFREQ)))
+        stop = min(int(DURATION * SFREQ), int(round(min(DURATION, stop_s) * SFREQ)))
+        n = max(0, stop - start)
+        return (start + np.arange(n)) / SFREQ, np.zeros((4, n))
+
+
+@pytest.fixture
+def window(qtbot, tmp_path, monkeypatch):
+    """An EegReviewWindow over faked IO, isolated prefs, and silent dialogs."""
+    monkeypatch.setattr(window_mod, "preferences_path", tmp_path / "prefs.yaml")
+    monkeypatch.setattr(window_mod.io, "open_recording", FakeRecording)
+    monkeypatch.setattr(window_mod.io, "embedded_annotations", lambda rec: [])
+    # Tests routinely leave unsaved annotations, and pytest-qt closes added
+    # widgets in its runtest-teardown hook — *before* fixture cleanup could
+    # reset any state — so a dirty close would raise a real (blocking)
+    # Save/Discard/Cancel prompt with no event loop to answer it and hang the
+    # offscreen suite. Default the prompt to Discard; the close-flow tests
+    # re-patch it to exercise the other answers.
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: QtWidgets.QMessageBox.StandardButton.Discard,
+    )
+    win = EegReviewWindow()
+    qtbot.addWidget(win)
+    win.show()
+    win._prefs_path = tmp_path / "prefs.yaml"  # test convenience handle
+    return win
+
+
+@pytest.fixture
+def recording_path(tmp_path):
+    path = tmp_path / "night1.edf"
+    path.write_bytes(b"")  # only the name matters; IO is faked
+    return path
+
+
+def _answer_label(monkeypatch, answer):
+    """Make the label dialog answer without exec()-ing (None = cancelled)."""
+    monkeypatch.setattr(
+        window_mod.LabelDialog, "get_label", staticmethod(lambda *a, **k: answer)
+    )
+
+
+# ----- opening ------------------------------------------------------------------
+
+
+def test_loading_enables_the_window_and_shows_the_file(window, recording_path):
+    assert not window.saveButton.isEnabled()  # nothing loaded yet
+    window._load(recording_path)
+    assert window.saveButton.isEnabled()
+    assert "night1.edf" in window.windowTitle()
+    assert "4 ch" in window.fileInfoLabel.text()
+    assert "22:00:00" in window.fileInfoLabel.text()  # meas_date clock
+    # 600 s file, 30 s window, tenth-of-a-second ticks.
+    assert window.scrollBar.maximum() == int((DURATION - 30) * 10)
+
+
+def test_fresh_review_seeds_from_embedded_events(window, recording_path, monkeypatch):
+    embedded = [Annotation(1.0, 0.0, "Cue started: Piano")]
+    monkeypatch.setattr(window_mod.io, "embedded_annotations", lambda rec: embedded)
+    window._load(recording_path)
+    assert window._annotations == embedded
+    assert not window._dirty  # imported events aren't user edits
+    assert window.annotationList.count() == 1
+
+
+def test_existing_sidecar_wins_over_embedded_events(
+    window, recording_path, monkeypatch
+):
+    # Re-importing embedded events on every open would duplicate them into the
+    # sidecar; once a sidecar exists it is the single source of truth.
+    saved = [Annotation(5.0, 2.0, "REM period")]
+    tsv_path, _ = sidecar_paths(recording_path)
+    write_annotations_tsv(saved, tsv_path)
+    monkeypatch.setattr(
+        window_mod.io,
+        "embedded_annotations",
+        lambda rec: pytest.fail("embedded events must not be imported"),
+    )
+    window._load(recording_path)
+    assert window._annotations == saved
+
+
+def test_corrupt_sidecar_aborts_the_open(window, recording_path, silence_dialogs):
+    # The sidecar is the reviewer's data: loading with an empty list would
+    # overwrite it on the next save, so the open must refuse instead.
+    tsv_path, _ = sidecar_paths(recording_path)
+    tsv_path.write_text("not\ta\tsidecar\n", encoding="utf-8")
+    window._load(recording_path)
+    assert window._recording is None
+    assert not window.saveButton.isEnabled()
+
+
+# ----- annotating -----------------------------------------------------------------
+
+
+def test_drawn_region_becomes_a_labeled_annotation(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    assert window._annotations == [Annotation(10.0, 4.0, "LRLR")]
+    assert window._dirty
+    assert window.windowTitle().endswith("*")
+    # The label lands in the recents that seed the next dialog.
+    prefs = preferences.load_preferences(window._prefs_path)
+    assert prefs["eeg_recent_labels"] == ["LRLR"]
+
+
+def test_instant_checkbox_drops_the_drawn_duration(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", True))
+    window._on_region_drawn(10.0, 14.0)
+    assert window._annotations == [Annotation(10.0, 0.0, "LRLR")]
+
+
+def test_cancelled_label_dialog_adds_nothing(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, None)
+    window._on_region_drawn(10.0, 14.0)
+    assert window._annotations == []
+    assert not window._dirty
+
+
+def test_edit_renames_but_keeps_the_span(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("Arousal", False))
+    window._on_region_drawn(10.0, 14.0)
+    window.annotationList.setCurrentRow(0)
+    _answer_label(monkeypatch, ("Artifact", False))
+    window.edit_selected()
+    assert window._annotations == [Annotation(10.0, 4.0, "Artifact")]
+
+
+def test_delete_removes_the_selected_annotation(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("Arousal", False))
+    window._on_region_drawn(10.0, 14.0)
+    window.annotationList.setCurrentRow(0)
+    window.delete_selected()
+    assert window._annotations == []
+    assert window._dirty
+
+
+def test_go_to_selected_jumps_the_view(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("Arousal", False))
+    window._on_region_drawn(50.0, 51.0)
+    window.annotationList.setCurrentRow(0)
+    window.go_to_selected()
+    # A quarter-window of lead-in before the annotation (30 s window).
+    assert window.view.window_start == pytest.approx(50.0 - 7.5)
+
+
+# ----- saving and closing -----------------------------------------------------------
+
+
+def test_save_writes_both_sidecars_and_clears_dirty(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    window.save_annotations()
+    tsv_path, json_path = sidecar_paths(recording_path)
+    assert read_annotations_tsv(tsv_path) == [Annotation(10.0, 4.0, "LRLR")]
+    assert json_path.is_file()
+    assert not window._dirty
+    assert not window.windowTitle().endswith("*")
+
+
+def test_dirty_close_can_be_cancelled(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: QtWidgets.QMessageBox.StandardButton.Cancel,
+    )
+    assert not window.close()
+    assert window.isVisible()
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: QtWidgets.QMessageBox.StandardButton.Discard,
+    )
+    assert window.close()
+
+
+def test_clean_close_needs_no_prompt(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: pytest.fail("no prompt expected on a clean close"),
+    )
+    assert window.close()
+
+
+# ----- display controls ----------------------------------------------------------------
+
+
+def test_filter_controls_build_the_spec(window, recording_path):
+    window._load(recording_path)
+    window.highpassSpin.setValue(0.3)
+    window.lowpassSpin.setValue(35.0)
+    window.notchCombo.setCurrentIndex(2)  # 60 Hz
+    assert window.view._spec == dsp.FilterSpec(highpass=0.3, lowpass=35.0, notch=60.0)
+
+
+def test_inverted_band_is_rejected_and_filters_kept(window, recording_path):
+    window._load(recording_path)
+    window.highpassSpin.setValue(0.3)
+    window.lowpassSpin.setValue(35.0)
+    window.highpassSpin.setValue(40.0)  # above the low-pass: must not apply
+    assert window.view._spec.highpass == 0.3
+
+
+def test_window_length_change_reconfigures_the_scrollbar(window, recording_path):
+    window._load(recording_path)
+    window.windowCombo.setCurrentIndex(3)  # 120 s
+    assert window.view.window_seconds == 120.0
+    assert window.scrollBar.maximum() == int((DURATION - 120) * 10)
+    assert window.scrollBar.pageStep() == 1200
+
+
+def test_scrollbar_moves_the_view_and_back(window, recording_path):
+    window._load(recording_path)
+    window.scrollBar.setValue(450)  # 45.0 s
+    assert window.view.window_start == pytest.approx(45.0)
+    window.view.scroll_by(1.0)  # keyboard/wheel path reports back
+    assert window.scrollBar.value() == 750
+
+
+def test_cursor_readout_shows_data_and_clock_time(window, recording_path):
+    window._load(recording_path)
+    window._on_cursor_moved(90.0)
+    status_bar = window.statusBar()
+    assert status_bar is not None
+    message = status_bar.currentMessage()
+    assert "t = 90.000 s" in message
+    assert "22:01:30" in message  # 22:00:00 meas_date + 90 s, amp wall clock
+
+
+# ----- label dialog / entry point -----------------------------------------------------
+
+
+def test_failed_save_keeps_the_dirty_flag(
+    window, recording_path, monkeypatch, silence_dialogs
+):
+    # If the sidecar write fails, the annotations are still unsaved — clearing
+    # the flag would let the close prompt silently discard them.
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+
+    def boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(window_mod, "write_annotations_tsv", boom)
+    window.save_annotations()
+    assert window._dirty
+    assert window.windowTitle().endswith("*")
+
+
+def test_open_file_respects_a_cancelled_discard_prompt(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: QtWidgets.QMessageBox.StandardButton.Cancel,
+    )
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getOpenFileName",
+        lambda *a, **k: pytest.fail("the file dialog must not open"),
+    )
+    window.open_file()  # cancelled prompt: no dialog, annotations intact
+    assert window._annotations  # nothing was discarded
+
+
+def test_open_dialog_starts_in_the_last_used_folder(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)  # records eeg_last_dir
+    seen_dirs: list[str] = []
+
+    def fake_dialog(parent, caption, directory, file_filter):
+        seen_dirs.append(directory)
+        return "", ""
+
+    monkeypatch.setattr(QtWidgets.QFileDialog, "getOpenFileName", fake_dialog)
+    window.open_file()
+    assert seen_dirs == [str(recording_path.parent)]
+
+
+def test_trace_click_highlights_the_list_row(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("Arousal", False))
+    window._on_region_drawn(10.0, 14.0)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(30.0, 31.0)
+    window.view._on_clicked(30.5)  # inside the second annotation
+    assert window.annotationList.currentRow() == 1
+    window.view._on_clicked(20.0)  # empty space deselects
+    assert window.annotationList.currentRow() == -1
+
+
+def test_edit_and_delete_without_a_selection_are_no_ops(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)
+    monkeypatch.setattr(
+        window_mod.LabelDialog,
+        "get_label",
+        staticmethod(lambda *a, **k: pytest.fail("no dialog expected")),
+    )
+    window.edit_selected()
+    window.delete_selected()
+    assert window._annotations == []
+    assert not window._dirty
+
+
+def test_double_click_jumps_to_the_annotation(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("Arousal", False))
+    window._on_region_drawn(50.0, 51.0)
+    window.annotationList.setCurrentRow(0)
+    item = window.annotationList.item(0)
+    window.annotationList.itemDoubleClicked.emit(item)
+    assert window.view.window_start == pytest.approx(50.0 - 7.5)
+
+
+def test_geometry_is_persisted_on_close(window, recording_path):
+    # The layout's minimum size may override a small resize request, so pin
+    # the expectation to whatever geometry the window actually had at close.
+    window.resize(1600, 800)
+    expected = {
+        "x": window.x(),
+        "y": window.y(),
+        "w": window.width(),
+        "h": window.height(),
+    }
+    assert window.close()
+    prefs = preferences.load_preferences(window._prefs_path)
+    assert preferences.window_geometry(prefs, "eeg-review") == expected
+
+
+def test_recent_labels_are_capped_and_deduplicated(window):
+    for i in range(14):
+        window._remember_label(f"label-{i}")
+    window._remember_label("label-5")  # an old one used again moves up front
+    recents = window._recent_labels()
+    assert len(recents) == 12
+    assert recents[0] == "label-5"
+    assert recents[1] == "label-13"
+
+
+def test_label_dialog_merges_recents_over_seeds(qtbot):
+    dialog = LabelDialog(None, ["Custom", SEED_LABELS[0]])
+    qtbot.addWidget(dialog)
+    items = [dialog.labelCombo.itemText(i) for i in range(dialog.labelCombo.count())]
+    assert items == ["Custom", *SEED_LABELS]  # deduplicated, recents first
+
+
+def test_pick_recording_path_takes_the_last_non_flag_argument():
+    assert pick_recording_path(["exe"]) is None
+    assert pick_recording_path(["exe", "--debug", "a.edf"]) == "a.edf"
+    assert pick_recording_path(["exe", "a.edf", "b.fif"]) == "b.fif"
+
+
+# ----- wall-clock display ---------------------------------------------------------
+
+
+def test_wall_time_shows_edf_stamps_as_recorded(tmp_path):
+    # EDF start times are the tech's wall-clock stamps (MNE tags them UTC pro
+    # forma); converting them would lie about what the bedside clock said.
+    rec = FakeRecording(tmp_path / "night1.edf")
+    clock = window_mod.wall_time(rec, 90.0)
+    assert clock == MEAS_DATE + timedelta(seconds=90)
+    assert clock.strftime("%H:%M:%S") == "22:01:30"
+
+
+def test_wall_time_converts_fif_instants_to_local(tmp_path):
+    # A FIF meas_date is a true UTC instant; showing it raw would display
+    # UTC, not the wall clock the tech saw. astimezone() is right whenever
+    # the file is reviewed in the timezone it was recorded in.
+    rec = FakeRecording(tmp_path / "night1_raw.fif")
+    clock = window_mod.wall_time(rec, 0.0)
+    assert clock == MEAS_DATE.astimezone()
+
+
+def test_wall_time_without_meas_date_is_none(tmp_path):
+    rec = FakeRecording(tmp_path / "night1.edf")
+    rec.meas_date = None
+    assert window_mod.wall_time(rec, 0.0) is None
+
+
+# ----- process hygiene (subprocess checks) --------------------------------------------
+
+
+def test_eeg_window_never_imports_the_live_session_stack():
+    # The EEG tool runs as its own process and the frozen SMACC-EEG.exe will
+    # not ship the live-session stack — importing it here (e.g. panels.base,
+    # which imports sounddevice and SmaccSession at module scope) would break
+    # the packaged build and the documented process isolation.
+    code = (
+        "import sys; import smacc.eeg.window; "
+        "leaks = [m for m in ('sounddevice', 'smacc.session', 'smacc.devices', "
+        "'smacc.panels.base') if m in sys.modules]; "
+        "sys.exit('leaked: ' + ', '.join(leaks) if leaks else 0)"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=120
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_version_flag_exits_zero_without_a_window():
+    # The release workflow smoke-tests the frozen SMACC-EEG.exe with exactly
+    # this invocation; the import tree resolving and exit code 0 are the test.
+    proc = subprocess.run(
+        [sys.executable, "-m", "smacc.eeg", "--version"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert VERSION in proc.stdout

--- a/tools/bench_eeg_view.py
+++ b/tools/bench_eeg_view.py
@@ -1,0 +1,89 @@
+# Benchmark the EEG TraceView against the #136 performance target:
+# an 8 h x 32 ch x 512 Hz overnight recording must scroll smoothly.
+#
+#   > uv run --extra eeg python tools/bench_eeg_view.py
+#
+# A synthetic provider generates EEG-shaped data on demand (so the bench needs
+# no gigabyte fixture file); each "refresh" is what one scroll step costs:
+# slice fetch -> zero-phase filter -> per-curve setData -> a forced offscreen
+# render. Real-file I/O (MNE's memory-mapped read) is NOT measured here — this
+# isolates the render path, the part the view design controls.
+
+import os
+import sys
+import time
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+from PyQt6 import QtWidgets
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from smacc.eeg import dsp  # noqa: E402
+from smacc.eeg.view import TraceView  # noqa: E402
+
+SFREQ = 512.0
+N_CHANNELS = 32
+DURATION_S = 8 * 3600.0
+REFRESHES = 20
+
+
+class SyntheticProvider:
+    """EEG-shaped noise, generated per slice (deterministic per start sample)."""
+
+    ch_names = [f"CH{i:02d}" for i in range(N_CHANNELS)]
+    ch_types = ["eeg"] * (N_CHANNELS - 2) + ["eog", "emg"]
+    sfreq = SFREQ
+    duration = DURATION_S
+
+    def get_slice(self, start_s: float, stop_s: float):
+        start = max(0, int(round(max(0.0, start_s) * SFREQ)))
+        stop = min(int(DURATION_S * SFREQ), int(round(min(DURATION_S, stop_s) * SFREQ)))
+        n = max(0, stop - start)
+        times = (start + np.arange(n)) / SFREQ
+        rng = np.random.default_rng(start)  # deterministic, cheap
+        data = rng.standard_normal((N_CHANNELS, n)) * 20e-6
+        data += 50e-6 * np.sin(2 * np.pi * 1.0 * times)  # slow-wave-ish
+        return times, data
+
+
+def bench(view: TraceView, window_seconds: float) -> tuple[float, float]:
+    view.set_window_seconds(window_seconds)
+    view.set_window_start(0.0)
+    view.grab()  # warm-up render outside the timed loop
+    laps = []
+    for _ in range(REFRESHES):
+        t0 = time.perf_counter()
+        view.scroll_by(0.5)
+        view.grab()  # force a full offscreen paint
+        laps.append((time.perf_counter() - t0) * 1000)
+    return float(np.mean(laps)), float(np.max(laps))
+
+
+def main() -> int:
+    app = QtWidgets.QApplication(sys.argv)  # noqa: F841 — Qt needs a live app
+    view = TraceView()
+    view.resize(1400, 900)
+    view.set_provider(SyntheticProvider())
+    view.set_spec(dsp.FilterSpec(highpass=0.3, lowpass=35.0, notch=60.0))
+    print(
+        f"{N_CHANNELS} ch x {SFREQ:.0f} Hz x {DURATION_S / 3600:.0f} h, "
+        f"{REFRESHES} scrolled refreshes per row (filter HP 0.3 / LP 35 / notch 60)"
+    )
+    failed = False
+    # 100 ms keeps scrolling comfortably interactive; 120 s windows may be
+    # slower but must stay under a quarter second to feel responsive.
+    for window_seconds, budget_ms in ((10.0, 100.0), (30.0, 100.0), (120.0, 250.0)):
+        mean_ms, max_ms = bench(view, window_seconds)
+        verdict = "ok" if mean_ms <= budget_ms else "TOO SLOW"
+        failed |= mean_ms > budget_ms
+        print(
+            f"  {window_seconds:5.0f} s window: mean {mean_ms:7.1f} ms  "
+            f"max {max_ms:7.1f} ms  (budget {budget_ms:.0f} ms)  {verdict}"
+        )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Second of the #136 stack (on #148); merge in order, squash.

The viewer itself: a pyqtgraph trace view (stacked channels, peak downsampling, drag-to-annotate, click-to-select; stim/misc channels auto-fit to their lane) and the review window around it (display filters with sane rejection handling, 30 s scoring-epoch default window, amplitude scale, annotation list with edit/delete/jump, TSV/JSON sidecar save, dirty tracking, geometry persistence). `python -m smacc.eeg [file]` runs it; `--version` is the future frozen-exe smoke test and eagerly imports the whole tree on purpose.

Notes:
- The window imports nothing from the live-session stack (enforced by a subprocess test) — the frozen SMACC-EEG.exe in PR 4 of the stack depends on that.
- Clock-time readout is format-aware: EDF/BrainVision stamps display as recorded; FIF UTC instants convert to local.
- `tools/bench_eeg_view.py` pins the #136 perf target (8 h × 32 ch × 512 Hz): 30 s window refreshes at ~75 ms, 120 s at ~240 ms, offscreen.
- Recordings open unfiltered by default (deliberate: never silently rewrite amplitudes); the usual sleep view is two clicks (HP 0.3 / LP 35).