### PR TITLE
feat: launch the EEG review tool from the launcher

### DIFF
--- a/src/smacc/eeg/__init__.py
+++ b/src/smacc/eeg/__init__.py
@@ -16,5 +16,55 @@ Layout keeps the heavy dependency at the edges: :mod:`~smacc.eeg.annotations`
 (the model and sidecar I/O) and :mod:`~smacc.eeg.dsp` (display filtering) are
 pure Python over numpy/scipy and import no MNE; :mod:`~smacc.eeg.io` is the
 only module that touches MNE, and imports it lazily. This module itself stays
-import-light so the base app can probe for the component without paying for it.
+import-light so the base app can probe for the component without paying for it:
+:func:`available` and :func:`launch` below are everything the launcher uses.
 """
+
+# NO `from __future__ import annotations` here, on purpose: in a package
+# __init__ it would bind the name "annotations" to the __future__ feature and
+# shadow the smacc.eeg.annotations submodule for `from smacc.eeg import
+# annotations` (the runtime annotations below don't need the future import).
+import sys
+from importlib.util import find_spec
+from pathlib import Path
+
+# The frozen EEG component, installed beside SMACC.exe by the installer's
+# optional "EEG Review Tools" component (see tools/smacc.iss).
+EXE_NAME = "SMACC-EEG.exe"
+
+
+def component_exe() -> Path:
+    """Where the packaged build expects the frozen EEG exe (beside SMACC.exe)."""
+    return Path(sys.executable).resolve().parent / EXE_NAME
+
+
+def available() -> bool:
+    """True when the EEG review tool can be launched from this install.
+
+    Packaged build: the installer component dropped ``SMACC-EEG.exe`` next to
+    ``SMACC.exe``. Development: the ``eeg`` extra (mne + pyqtgraph) is in the
+    environment. Checked via ``find_spec`` so probing costs no imports —
+    the launcher calls this at startup.
+    """
+    if getattr(sys, "frozen", False):
+        return component_exe().is_file()
+    return find_spec("mne") is not None and find_spec("pyqtgraph") is not None
+
+
+def launch() -> bool:
+    """Start the EEG review tool as its own detached process; True if started.
+
+    Detached on purpose: the viewer outlives the launcher (or a session) and
+    never shares a process with them — see the isolation rationale above. The
+    development path runs ``python -m smacc.eeg`` with the current
+    interpreter, the packaged path runs the installed exe.
+    """
+    from PyQt6 import QtCore  # deferred: keep this module import-light
+
+    if getattr(sys, "frozen", False):
+        started, _pid = QtCore.QProcess.startDetached(str(component_exe()), [])
+    else:
+        started, _pid = QtCore.QProcess.startDetached(
+            sys.executable, ["-m", "smacc.eeg"]
+        )
+    return started

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from . import preferences, settings, updates, winassoc, windowstate
+from . import eeg, preferences, settings, updates, winassoc, windowstate
 from .analyze import AnalyzeWindow
 from .config import VERSION
 from .cuedesigner import CueDesignerWindow
@@ -118,6 +118,29 @@ class LauncherWindow(QtWidgets.QMainWindow):
         )
         analyzeButton.clicked.connect(self.analyze_session)
         layout.addWidget(analyzeButton)
+
+        # The optional EEG review component (#136). Shown disabled (not
+        # hidden) when absent, so a lab knows the tool exists and how to get
+        # it — the same surface-don't-hide approach as missing trigger
+        # hardware (#147). Availability is probed once, here: installing the
+        # component mid-run requires closing SMACC anyway (the installer
+        # replaces the locked exe), and a stale True is already handled by
+        # the launch-failure dialog.
+        reviewEegButton = QtWidgets.QPushButton("Review EEG", self)
+        reviewEegButton.setMinimumHeight(40)
+        if eeg.available():
+            reviewEegButton.setStatusTip(
+                "Open the EEG review tool in its own window (annotate a recording)."
+            )
+        else:
+            reviewEegButton.setEnabled(False)
+            reviewEegButton.setStatusTip(
+                "EEG Review Tools are not installed — re-run the SMACC "
+                "installer and select the component."
+            )
+        reviewEegButton.clicked.connect(self.review_eeg)
+        self.reviewEegButton = reviewEegButton
+        layout.addWidget(reviewEegButton)
 
         layout.addStretch(1)
         # Link to the documentation site (not the repo), hyperlinked. Rich text +
@@ -334,6 +357,27 @@ class LauncherWindow(QtWidgets.QMainWindow):
     def analyze_session(self) -> None:
         """Open the analyze window over the current settings' data directory."""
         self._open_tool(AnalyzeWindow(self._data_dir()))
+
+    def review_eeg(self) -> None:
+        """Launch the EEG review tool as its own detached process.
+
+        Unlike the launcher-managed tools this never hides the launcher: the
+        viewer is a sibling app in a separate process (the frozen build can't
+        run it in-process — MNE isn't bundled in SMACC.exe), so there is no
+        ``closed`` signal to bring the launcher back.
+        """
+        if eeg.launch():
+            bar = self.statusBar()
+            if bar is not None:
+                bar.showMessage("EEG review opened in its own window.", 5000)
+            return
+        QtWidgets.QMessageBox.warning(
+            self,
+            "Review EEG",
+            "Could not start the EEG review tool.\n\n"
+            "Re-running the SMACC installer and selecting the EEG Review "
+            "Tools component may repair it.",
+        )
 
     def associate_files(self) -> None:
         """Register SMACC as the Windows handler for .smacc files (packaged build)."""

--- a/tests/test_eeg_launch.py
+++ b/tests/test_eeg_launch.py
@@ -1,0 +1,125 @@
+"""Tests for launching the optional EEG component from the launcher (#136).
+
+Covers the availability probe (dev extra vs. frozen exe-beside-exe), the
+detached-process launch, and the launcher's Review EEG button — which is shown
+disabled (never hidden) when the component is absent, the same
+surface-don't-hide approach as missing trigger hardware (#147).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from PyQt6 import QtCore, QtWidgets
+
+import smacc.eeg as eeg
+from smacc import launcher
+from smacc.launcher import LauncherWindow
+
+# ----- availability ----------------------------------------------------------
+
+
+def test_available_in_development_needs_the_eeg_extra():
+    # This test env has the extra installed, so the probe must say yes.
+    assert eeg.available()
+
+
+def test_available_in_development_without_the_extra(monkeypatch):
+    monkeypatch.setattr(eeg, "find_spec", lambda name: None)
+    assert not eeg.available()
+
+
+def test_available_frozen_checks_for_the_exe(tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "SMACC.exe"))
+    assert not eeg.available()  # component not installed
+    (tmp_path / eeg.EXE_NAME).write_bytes(b"")
+    assert eeg.available()
+
+
+def test_component_exe_sits_beside_the_main_exe(tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "SMACC.exe"))
+    assert eeg.component_exe() == tmp_path / eeg.EXE_NAME
+
+
+# ----- launching ----------------------------------------------------------------
+
+
+@pytest.fixture
+def spawned(monkeypatch):
+    """Capture detached-process launches instead of spawning anything."""
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_start(program, arguments=(), *args):
+        calls.append((program, list(arguments)))
+        return True, 4242
+
+    monkeypatch.setattr(QtCore.QProcess, "startDetached", staticmethod(fake_start))
+    return calls
+
+
+def test_launch_in_development_runs_the_module(spawned):
+    assert eeg.launch()
+    assert spawned == [(sys.executable, ["-m", "smacc.eeg"])]
+
+
+def test_launch_frozen_runs_the_component_exe(spawned, tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "SMACC.exe"))
+    assert eeg.launch()
+    assert spawned == [(str(tmp_path / eeg.EXE_NAME), [])]
+
+
+# ----- the launcher button ----------------------------------------------------------
+
+
+@pytest.fixture
+def make_launcher(qtbot, tmp_path, monkeypatch):
+    """Build a LauncherWindow with isolated prefs (the test_launcher pattern)."""
+    monkeypatch.setattr(launcher, "preferences_path", tmp_path / "preferences.yaml")
+
+    def build() -> LauncherWindow:
+        win = LauncherWindow(settings_path=None)
+        qtbot.addWidget(win)
+        win.show()
+        return win
+
+    return build
+
+
+def test_button_launches_and_keeps_the_launcher_visible(
+    make_launcher, monkeypatch, spawned
+):
+    monkeypatch.setattr(eeg, "available", lambda: True)
+    win = make_launcher()
+    assert win.reviewEegButton.isEnabled()
+    win.reviewEegButton.click()
+    assert len(spawned) == 1
+    # Unlike launcher-managed tools, the viewer is a sibling process: the
+    # launcher must stay up (there is no closed signal to bring it back).
+    assert win.isVisible()
+
+
+def test_button_is_disabled_with_an_install_hint_when_absent(
+    make_launcher, monkeypatch
+):
+    monkeypatch.setattr(eeg, "available", lambda: False)
+    win = make_launcher()
+    assert not win.reviewEegButton.isEnabled()
+    assert "installer" in win.reviewEegButton.statusTip()
+
+
+def test_failed_launch_shows_a_warning(make_launcher, monkeypatch):
+    monkeypatch.setattr(eeg, "available", lambda: True)
+    monkeypatch.setattr(eeg, "launch", lambda: False)
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "warning",
+        lambda parent, title, text: warnings.append(text),
+    )
+    win = make_launcher()
+    win.review_eeg()
+    assert len(warnings) == 1
+    assert "EEG Review Tools" in warnings[0]


### PR DESCRIPTION
Third of the #136 stack (on #150); merge in order, squash.

Adds `smacc.eeg.available()`/`launch()` (dev: the `eeg` extra is importable; packaged: `SMACC-EEG.exe` sits beside `SMACC.exe`) and a **Review EEG** launcher button. Absent component → button disabled with an install hint (surface-don't-hide, like #147's trigger hardware). The viewer launches as a detached sibling process and the launcher stays visible — there is no cross-process closed signal, and review work must never share a process with a session.

The installer component the frozen path expects lands in the next PR of the stack.