### PR TITLE
feat: persistent crash log with faulthandler dumps (#149)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -292,6 +292,19 @@ file's **data directory** (e.g. `~/SMACC/data/`), capturing the events and setti
 for that session. Open one later from the Launcher's **Analyze** to see a
 summary, export its events to BIDS, or recover its settings.
 
+### If SMACC crashes
+
+Separately from the per-run logs, SMACC keeps a permanent crash log at
+`~/SMACC/logs/crash.log`. Uncaught errors, Qt's own fatal messages, and — via
+Python's `faulthandler` — the stack of every thread at a hard crash (such as an
+access violation inside Qt or an audio driver) are appended there, even when no
+session is running. Note that a hard-crash dump shows where the *Python* side
+was at that moment, which is usually enough to identify the failing subsystem.
+Every launch and every session start is also stamped in the file, so a crash
+can be matched to its night and run folder. When reporting a crash, send
+`crash.log` together with the affected run's folder. The file is rotated at
+launch once it grows large (one older `crash.log.1` generation is kept).
+
 ## SMACC files (`.smacc`)
 
 A **SMACC file** captures your study's whole configuration — cue files, volumes,

--- a/src/smacc/__main__.py
+++ b/src/smacc/__main__.py
@@ -1,5 +1,6 @@
 """Run the app."""
 
+import ctypes
 import faulthandler
 import logging
 import os
@@ -149,7 +150,17 @@ def _schedule_crash_test(mode: str | None) -> None:
     if mode is None:
         return
     if mode == "native":
-        QTimer.singleShot(0, faulthandler._sigsegv)
+
+        def _segv() -> None:
+            # Keep Windows from raising its error-report popup: this crash is
+            # deliberate, and a modal popup would hang an unattended run (the
+            # release smoke test) waiting for a click. 0x8007 =
+            # SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX |
+            # SEM_NOALIGNMENTFAULTEXCEPT | SEM_NOOPENFILEERRORBOX.
+            ctypes.windll.kernel32.SetErrorMode(0x8007)
+            faulthandler._sigsegv()
+
+        QTimer.singleShot(0, _segv)
         return
 
     def _boom() -> None:

--- a/src/smacc/__main__.py
+++ b/src/smacc/__main__.py
@@ -1,5 +1,6 @@
 """Run the app."""
 
+import faulthandler
 import logging
 import os
 import sys
@@ -8,16 +9,17 @@ import traceback
 from pathlib import Path
 from types import TracebackType
 
-from PyQt6.QtCore import Qt
+from PyQt6.QtCore import Qt, QTimer
 from PyQt6.QtGui import QIcon
 from PyQt6.QtWidgets import QApplication, QMessageBox
 
-from . import preferences
+from . import crashlog, preferences
 from .config import VERSION
 from .launcher import LauncherWindow, resolve_initial_settings
 from .paths import (
     BUNDLED_CUES_DIR,
     BUNDLED_DEFAULT_SETTINGS,
+    CRASH_LOG_PATH,
     DEFAULT_DATA_DIR,
     DEFAULT_SETTINGS_PATH,
     LOGO_PATH,
@@ -64,22 +66,26 @@ def pick_settings_path(args: list[str]) -> str | None:
 
 
 def _install_excepthook() -> None:
-    """Capture uncaught exceptions in the log file (and a dialog on the GUI thread).
+    """Capture uncaught exceptions in the crash log, the run log, and a dialog.
 
     The packaged app is built with PyInstaller ``--noconsole``, so without this an
-    unhandled exception would be lost entirely (no terminal to print to). We log
-    the full traceback to the smacc log file and still chain to the default hook
-    so a dev terminal keeps printing tracebacks. Background-thread exceptions
-    (e.g. the audio callback) are logged only — never touch widgets off the GUI
-    thread.
+    unhandled exception would be lost entirely (no terminal to print to). The
+    traceback goes to the persistent crash log first (a direct file write that
+    depends on nothing), then to the smacc logger (the run log, when a session
+    is live), then a dialog — shown only once a QApplication exists, so the
+    hook can be installed before Qt starts and still cover the whole launch.
+    Background-thread exceptions (e.g. the audio callback) are logged only —
+    never touch widgets off the GUI thread.
     """
     logger = logging.getLogger("smacc")
 
     def log_file_hint() -> str:
+        # Prefer the run log (the crash in context); outside a live session the
+        # crash log is the only file, and it always has the traceback.
         for handler in logger.handlers:
             if isinstance(handler, logging.FileHandler):
                 return f"\n\nDetails were written to:\n{handler.baseFilename}"
-        return ""
+        return f"\n\nDetails were written to:\n{CRASH_LOG_PATH}"
 
     def handle_main(
         exc_type: type[BaseException],
@@ -89,13 +95,15 @@ def _install_excepthook() -> None:
         if issubclass(exc_type, KeyboardInterrupt):
             sys.__excepthook__(exc_type, exc_value, exc_tb)
             return
+        crashlog.record_exception("Uncaught exception", exc_type, exc_value, exc_tb)
         logger.critical("Uncaught exception", exc_info=(exc_type, exc_value, exc_tb))
         summary = "".join(traceback.format_exception_only(exc_type, exc_value)).strip()
-        QMessageBox.critical(
-            None,
-            "SMACC error",
-            f"An unexpected error occurred:\n\n{summary}{log_file_hint()}",
-        )
+        if QApplication.instance() is not None:
+            QMessageBox.critical(
+                None,
+                "SMACC error",
+                f"An unexpected error occurred:\n\n{summary}{log_file_hint()}",
+            )
         # Keep default behaviour too, so a dev terminal still shows the traceback.
         sys.__excepthook__(exc_type, exc_value, exc_tb)
 
@@ -104,6 +112,12 @@ def _install_excepthook() -> None:
             return
         name = args.thread.name if args.thread is not None else "?"
         exc_value = args.exc_value if args.exc_value is not None else args.exc_type()
+        crashlog.record_exception(
+            f"Uncaught exception in thread {name}",
+            args.exc_type,
+            exc_value,
+            args.exc_traceback,
+        )
         logger.critical(
             "Uncaught exception in thread %s",
             name,
@@ -112,6 +126,36 @@ def _install_excepthook() -> None:
 
     sys.excepthook = handle_main
     threading.excepthook = handle_thread
+
+
+def pick_crash_test(args: list[str]) -> str | None:
+    """Return the hidden ``--crash-test`` mode from CLI args, or ``None``.
+
+    ``--crash-test`` (or ``=python``) raises a RuntimeError once the event loop
+    runs, exercising the excepthook → crash log → dialog path; ``=native``
+    segfaults the process, exercising the faulthandler dump. This is the only
+    way to verify the crash pipeline on the frozen ``--noconsole`` exe, where
+    no console or debugger is attached. Deliberately undocumented in the UI.
+    """
+    for arg in args:
+        if arg == "--crash-test" or arg.startswith("--crash-test="):
+            mode = arg.partition("=")[2]
+            return mode or "python"
+    return None
+
+
+def _schedule_crash_test(mode: str | None) -> None:
+    """Arm the deliberate ``--crash-test`` crash to fire once the loop starts."""
+    if mode is None:
+        return
+    if mode == "native":
+        QTimer.singleShot(0, faulthandler._sigsegv)
+        return
+
+    def _boom() -> None:
+        raise RuntimeError("SMACC crash test (--crash-test)")
+
+    QTimer.singleShot(0, _boom)
 
 
 def main() -> None:
@@ -133,9 +177,14 @@ def main() -> None:
         if sys.stdout is not None:  # absent in a --noconsole build
             print(f"SMACC {VERSION}")
         return
+    # Crash capture first, before any Qt: a native crash during Qt startup is
+    # exactly what the persistent crash log exists to record (#149). The
+    # excepthook's dialog arms itself once the QApplication below exists.
+    crashlog.install(VERSION)
+    crashlog.install_qt_message_handler()
+    _install_excepthook()
     _quiet_qt_multimedia_logging()  # before QApplication: Qt reads the rule at startup
     app = QApplication(sys.argv)
-    _install_excepthook()
     # Fusion honors the full QPalette consistently across platforms, which the
     # native Windows style does not — required for the lights-off dark theme.
     app.setStyle("Fusion")
@@ -168,6 +217,8 @@ def main() -> None:
         prefs = preferences.load_preferences(preferences_path)
         launcher = LauncherWindow(resolve_initial_settings(prefs))
         launcher.show()
+    # Hidden QA hook: crash on purpose right after startup (see pick_crash_test).
+    _schedule_crash_test(pick_crash_test(sys.argv[1:]))
     # `launcher` stays referenced for the life of main() (until app.exec returns),
     # so Qt won't garbage-collect the root window.
     sys.exit(app.exec())

--- a/src/smacc/__main__.py
+++ b/src/smacc/__main__.py
@@ -157,8 +157,10 @@ def _schedule_crash_test(mode: str | None) -> None:
             # release smoke test) waiting for a click. 0x8007 =
             # SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX |
             # SEM_NOALIGNMENTFAULTEXCEPT | SEM_NOOPENFILEERRORBOX.
-            ctypes.windll.kernel32.SetErrorMode(0x8007)
-            faulthandler._sigsegv()
+            # type-ignores: CI's mypy runs on Linux, whose stubs lack windll;
+            # _sigsegv is faulthandler's private (unstubbed) test helper.
+            ctypes.windll.kernel32.SetErrorMode(0x8007)  # type: ignore[attr-defined]
+            faulthandler._sigsegv()  # type: ignore[attr-defined]
 
         QTimer.singleShot(0, _segv)
         return

--- a/src/smacc/crashlog.py
+++ b/src/smacc/crashlog.py
@@ -1,0 +1,185 @@
+"""The persistent crash log: the one file that survives any kind of crash.
+
+A live run already writes a detailed per-run log (see :mod:`smacc.session`),
+and ``__main__`` hooks uncaught Python exceptions into it. That still loses the
+crashes this module exists for:
+
+* **Native crashes** — an access violation inside Qt, PortAudio, or liblsl
+  kills the process below Python, so no excepthook ever runs. ``faulthandler``
+  is enabled on this file, so the Python stack of every thread is dumped at
+  that moment.
+* **Crashes outside a live session** — the launcher, editor, and analyzer have
+  no run log, and the frozen exe is built ``--noconsole`` (``sys.stderr`` is
+  ``None``), so a traceback printed by the default hook goes nowhere.
+* **Qt's own diagnostics** — the qCritical/qFatal lines that precede many
+  aborts are printed to the (absent) stderr unless a message handler captures
+  them.
+
+Everything lands in one append-only file, ``~/SMACC/logs/crash.log``, rotated
+at launch once it grows large (one older ``crash.log.1`` generation is kept) —
+so "send in crash.log plus the night's run folder" is the complete debug kit.
+A faulthandler dump carries no timestamps, which is why every launch and every
+session start is stamped here: those breadcrumbs are what tie a dump to its
+night. Writes here never raise — this module must not be able to take down a
+live night.
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import logging
+import os
+import traceback
+from datetime import datetime
+from pathlib import Path
+from types import TracebackType
+from typing import TextIO
+
+from PyQt6 import QtCore
+
+from .paths import CRASH_LOG_PATH
+
+# Rotate past this size at launch (before faulthandler pins the file open).
+_MAX_BYTES = 512_000
+
+# The append handle everything writes to, opened by install() and kept for the
+# life of the process: faulthandler holds its fd, so it must never be closed
+# while enabled (on Windows it also keeps the file locked against deletion).
+_crash_file: TextIO | None = None
+
+
+def _timestamp() -> str:
+    return datetime.now().isoformat(sep=" ", timespec="seconds")
+
+
+def _write(text: str) -> None:
+    """Append ``text`` to the crash log; a failed write is silently dropped."""
+    if _crash_file is None:
+        return
+    try:
+        _crash_file.write(text)
+        _crash_file.flush()
+    except Exception:
+        pass
+
+
+def rotate_if_large(path: Path, max_bytes: int = _MAX_BYTES) -> None:
+    """Rename ``path`` to ``<name>.1`` when it exceeds ``max_bytes``.
+
+    One older generation is kept (an existing ``.1`` is replaced). Failures are
+    ignored: another SMACC instance may hold the file open (faulthandler pins
+    it), and appending to an oversized log beats failing the launch.
+    """
+    try:
+        if not path.exists() or path.stat().st_size <= max_bytes:
+            return
+        backup = path.with_name(path.name + ".1")
+        backup.unlink(missing_ok=True)
+        path.rename(backup)
+    except OSError:
+        pass
+
+
+def install(version: str, path: Path = CRASH_LOG_PATH) -> None:
+    """Open the crash log and enable faulthandler on it. Call first in main().
+
+    Must run before ``QApplication`` exists: a native crash during Qt startup
+    is exactly the kind of death this file is for. Never raises — an unwritable
+    disk must not stop SMACC from launching (that run simply has no crash log).
+    """
+    global _crash_file
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        rotate_if_large(path)
+        handle = open(path, "a", encoding="utf-8")
+    except Exception:
+        return
+    previous = _crash_file
+    _crash_file = handle
+    # One banner per launch: with it (and the session breadcrumbs) an undated
+    # faulthandler dump can be matched to its night.
+    _write(f"\n=== SMACC v{version} (pid {os.getpid()}) launched {_timestamp()} ===\n")
+    try:
+        faulthandler.enable(file=handle, all_threads=True)
+    except Exception:
+        pass
+    if previous is not None:
+        # Reinstalled (tests): release the old handle only after faulthandler
+        # has been pointed at the new one.
+        try:
+            previous.close()
+        except Exception:
+            pass
+
+
+def uninstall() -> None:
+    """Disable faulthandler and close the crash-log handle (for tests)."""
+    global _crash_file
+    faulthandler.disable()
+    if _crash_file is not None:
+        try:
+            _crash_file.close()
+        except Exception:
+            pass
+        _crash_file = None
+
+
+def note(message: str) -> None:
+    """Append a timestamped one-liner (e.g. the session-start breadcrumb)."""
+    _write(f"{_timestamp()} {message}\n")
+
+
+def record_exception(
+    prefix: str,
+    exc_type: type[BaseException],
+    exc_value: BaseException,
+    exc_tb: TracebackType | None,
+) -> None:
+    """Append an uncaught exception's full traceback under a timestamped header.
+
+    A direct file write with no dependency on the logging tree, so it works in
+    every phase: at the launcher (no run log yet), in the editor (NullHandler),
+    and mid-session alike.
+    """
+    try:
+        text = "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
+    except Exception:
+        text = f"{exc_type.__name__}: {exc_value!r} (traceback unavailable)\n"
+    _write(f"{_timestamp()} {prefix}\n{text}")
+
+
+def qt_message_handler(
+    mode: QtCore.QtMsgType, context: QtCore.QMessageLogContext, message: str | None
+) -> None:
+    """Route one Qt diagnostic message (installed by install_qt_message_handler).
+
+    Fatal/critical messages go to the crash log *and* the smacc logger — a
+    qFatal line ("QThread: Destroyed while thread is still running", …) is
+    often the only clue to a native abort. Plain warnings and chatter go only
+    to the smacc logger at DEBUG: the run log file records every level, while
+    the live preview's gate starts at INFO, so they never bother the operator.
+    Never raises — a logging failure must not break Qt's message delivery.
+    """
+    try:
+        logger = logging.getLogger("smacc")
+        if mode == QtCore.QtMsgType.QtFatalMsg:
+            note(f"Qt fatal: {message}")
+            logger.critical(f"Qt fatal: {message}")
+        elif mode == QtCore.QtMsgType.QtCriticalMsg:
+            note(f"Qt critical: {message}")
+            logger.error(f"Qt critical: {message}")
+        else:
+            logger.debug(f"Qt: {message}")
+    except Exception:
+        pass
+
+
+def install_qt_message_handler() -> None:
+    """Capture Qt's own diagnostics instead of losing them to a missing stderr.
+
+    The frozen exe is windowed (``--noconsole``), so without this the
+    qWarning/qCritical/qFatal lines Qt prints right before many aborts vanish.
+    The ``QT_LOGGING_RULES`` category filters (see ``__main__``) still apply
+    upstream of the handler.
+    """
+    QtCore.qInstallMessageHandler(qt_message_handler)

--- a/src/smacc/paths.py
+++ b/src/smacc/paths.py
@@ -37,6 +37,11 @@ preferences_path = smacc_directory / "preferences.yaml"
 DEFAULT_SETTINGS_PATH = smacc_directory / "default.smacc"
 # Where runs go when a settings file doesn't name its own data directory.
 DEFAULT_DATA_DIR = smacc_directory / "data"
+# App-level logs, global to this machine (run logs live in per-run folders).
+LOGS_DIR = smacc_directory / "logs"
+# The persistent crash log: faulthandler dumps, uncaught-exception tracebacks,
+# and Qt fatal messages land here even when no run log exists (see smacc.crashlog).
+CRASH_LOG_PATH = LOGS_DIR / "crash.log"
 # Biocal voice recordings (#78). The standard set is read straight from the
 # bundle (so it tracks the app on upgrade, #122); this folder is an optional
 # *override* — a lab drops a same-named WAV here to replace one — and is not

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from pylsl import StreamInfo, StreamOutlet, local_clock
 from PyQt6 import QtWidgets
 
-from . import bids, devices, events, hue, settings, triggers
+from . import bids, crashlog, devices, events, hue, settings, triggers
 from .config import VERSION
 
 
@@ -134,6 +134,10 @@ class SmaccSession:
             log_path = session_dir / f"{session_dir.name}.log"
             self.log_path = log_path
             self.init_logger(log_path)
+            # Breadcrumb in the persistent crash log: a faulthandler dump has
+            # no timestamps, so this line is what ties a crash to its night
+            # and points at the run folder with the detailed log (#149).
+            crashlog.note(f"Session started: {session_dir}")
             self.init_lsl_stream()
 
     def init_logger(self, log_path: Path) -> None:

--- a/tests/test_crashlog.py
+++ b/tests/test_crashlog.py
@@ -190,9 +190,15 @@ def test_faulthandler_dump_survives_a_real_segfault(tmp_path):
     """
     path = tmp_path / "crash.log"
     code = (
+        "import ctypes\n"
         "import faulthandler\n"
         "from pathlib import Path\n"
         "from smacc import crashlog\n"
+        # Keep Windows from raising its error-report popup for this deliberate
+        # crash — it would surface on the developer's desktop on every local
+        # test run (0x8007 = SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX |
+        # SEM_NOALIGNMENTFAULTEXCEPT | SEM_NOOPENFILEERRORBOX).
+        "ctypes.windll.kernel32.SetErrorMode(0x8007)\n"
         f"crashlog.install('0.0-test', Path({str(path)!r}))\n"
         "faulthandler._sigsegv()\n"
     )

--- a/tests/test_crashlog.py
+++ b/tests/test_crashlog.py
@@ -1,0 +1,206 @@
+"""Tests for the persistent crash log (~/SMACC/logs/crash.log)."""
+
+import faulthandler
+import logging
+import subprocess
+import sys
+import threading
+
+import pytest
+from PyQt6 import QtCore
+
+from smacc import crashlog
+from smacc.__main__ import _install_excepthook, pick_crash_test
+
+
+@pytest.fixture
+def crash_log(tmp_path):
+    """Install the crash log at a temp path; restore process state after."""
+    path = tmp_path / "logs" / "crash.log"
+    crashlog.install("9.9-test", path)
+    yield path
+    crashlog.uninstall()
+    if sys.stderr is not None:
+        # Give pytest back its default hang-dump handler on the real stderr.
+        faulthandler.enable()
+
+
+@pytest.fixture
+def smacc_records():
+    """Capture records reaching the shared 'smacc' logger."""
+    records: list[logging.LogRecord] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            records.append(record)
+
+    logger = logging.getLogger("smacc")
+    handler = _Capture(level=logging.DEBUG)
+    old_level = logger.level
+    logger.addHandler(handler)
+    logger.setLevel(logging.DEBUG)
+    yield records
+    logger.removeHandler(handler)
+    logger.setLevel(old_level)
+
+
+# ----- install / banner / breadcrumbs ----------------------------------------
+
+
+def test_install_writes_launch_banner_and_enables_faulthandler(crash_log):
+    content = crash_log.read_text(encoding="utf-8")
+    assert "SMACC v9.9-test" in content
+    assert "launched" in content
+    assert faulthandler.is_enabled()
+
+
+def test_note_appends_timestamped_line(crash_log):
+    crashlog.note("Session started: somewhere")
+    last = crash_log.read_text(encoding="utf-8").splitlines()[-1]
+    assert last.endswith("Session started: somewhere")
+    assert last[:4].isdigit()  # leads with the ISO date
+
+
+def test_install_on_unwritable_path_is_silent(tmp_path):
+    blocker = tmp_path / "file"
+    blocker.write_text("not a directory")
+    crashlog.install("9.9-test", blocker / "logs" / "crash.log")  # must not raise
+    crashlog.note("dropped")  # and later writes stay no-ops
+
+
+def test_record_exception_writes_full_traceback(crash_log):
+    try:
+        raise RuntimeError("boom at 3am")
+    except RuntimeError as exc:
+        crashlog.record_exception(
+            "Uncaught exception", type(exc), exc, exc.__traceback__
+        )
+    content = crash_log.read_text(encoding="utf-8")
+    assert "Uncaught exception" in content
+    assert "Traceback (most recent call last)" in content
+    assert "RuntimeError: boom at 3am" in content
+
+
+# ----- rotation ---------------------------------------------------------------
+
+
+def test_rotate_replaces_one_older_generation(tmp_path):
+    path = tmp_path / "crash.log"
+    backup = tmp_path / "crash.log.1"
+    path.write_text("x" * 200)
+    backup.write_text("old generation")
+    crashlog.rotate_if_large(path, max_bytes=100)
+    assert not path.exists()
+    assert backup.read_text() == "x" * 200
+
+
+def test_rotate_leaves_small_file_alone(tmp_path):
+    path = tmp_path / "crash.log"
+    path.write_text("tiny")
+    crashlog.rotate_if_large(path, max_bytes=100)
+    assert path.read_text() == "tiny"
+    assert not (tmp_path / "crash.log.1").exists()
+
+
+def test_install_rotates_an_oversized_log(tmp_path):
+    path = tmp_path / "crash.log"
+    path.write_text("x" * (crashlog._MAX_BYTES + 1))
+    crashlog.install("9.9-test", path)
+    try:
+        assert (tmp_path / "crash.log.1").exists()
+        assert "launched" in path.read_text(encoding="utf-8")
+    finally:
+        crashlog.uninstall()
+        if sys.stderr is not None:
+            faulthandler.enable()
+
+
+# ----- excepthook integration (__main__) --------------------------------------
+
+
+def test_excepthook_lands_in_crash_log_without_any_session(
+    crash_log, monkeypatch, silence_dialogs, capsys
+):
+    # The launcher-phase gap (#149): no run log exists, the 'smacc' logger has
+    # no file handler, yet the traceback must still be captured somewhere.
+    monkeypatch.setattr(sys, "excepthook", sys.excepthook)
+    monkeypatch.setattr(threading, "excepthook", threading.excepthook)
+    _install_excepthook()
+    try:
+        raise RuntimeError("launcher-phase crash")
+    except RuntimeError as exc:
+        sys.excepthook(type(exc), exc, exc.__traceback__)
+    content = crash_log.read_text(encoding="utf-8")
+    assert "Uncaught exception" in content
+    assert "RuntimeError: launcher-phase crash" in content
+
+
+def test_thread_excepthook_lands_in_crash_log(crash_log, monkeypatch):
+    monkeypatch.setattr(sys, "excepthook", sys.excepthook)
+    monkeypatch.setattr(threading, "excepthook", threading.excepthook)
+    _install_excepthook()
+    exc = RuntimeError("audio thread crash")
+    threading.excepthook(threading.ExceptHookArgs([RuntimeError, exc, None, None]))
+    content = crash_log.read_text(encoding="utf-8")
+    assert "Uncaught exception in thread ?" in content
+    assert "RuntimeError: audio thread crash" in content
+
+
+# ----- Qt message routing ------------------------------------------------------
+
+
+def test_qt_fatal_and_critical_reach_crash_log(crash_log, smacc_records):
+    crashlog.qt_message_handler(QtCore.QtMsgType.QtFatalMsg, None, "qFatal last words")
+    crashlog.qt_message_handler(QtCore.QtMsgType.QtCriticalMsg, None, "qCritical line")
+    content = crash_log.read_text(encoding="utf-8")
+    assert "Qt fatal: qFatal last words" in content
+    assert "Qt critical: qCritical line" in content
+    levels = [(r.levelno, r.getMessage()) for r in smacc_records]
+    assert (logging.CRITICAL, "Qt fatal: qFatal last words") in levels
+    assert (logging.ERROR, "Qt critical: qCritical line") in levels
+
+
+def test_qt_warnings_stay_out_of_crash_log(crash_log, smacc_records):
+    before = crash_log.read_text(encoding="utf-8")
+    crashlog.qt_message_handler(QtCore.QtMsgType.QtWarningMsg, None, "connect spam")
+    assert crash_log.read_text(encoding="utf-8") == before
+    levels = [(r.levelno, r.getMessage()) for r in smacc_records]
+    assert (logging.DEBUG, "Qt: connect spam") in levels
+
+
+# ----- the hidden --crash-test flag --------------------------------------------
+
+
+def test_pick_crash_test_modes():
+    assert pick_crash_test([]) is None
+    assert pick_crash_test(["study.smacc"]) is None
+    assert pick_crash_test(["--crash-test"]) == "python"
+    assert pick_crash_test(["--crash-test=python"]) == "python"
+    assert pick_crash_test(["--crash-test=native"]) == "native"
+
+
+# ----- the real thing: a native crash ------------------------------------------
+
+
+def test_faulthandler_dump_survives_a_real_segfault(tmp_path):
+    """Segfault a child process and confirm the thread dump lands in crash.log.
+
+    This is the crash class #149 is about: the process dies below Python, no
+    excepthook runs, and only the pre-armed faulthandler fd gets a word in.
+    """
+    path = tmp_path / "crash.log"
+    code = (
+        "import faulthandler\n"
+        "from pathlib import Path\n"
+        "from smacc import crashlog\n"
+        f"crashlog.install('0.0-test', Path({str(path)!r}))\n"
+        "faulthandler._sigsegv()\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=120
+    )
+    assert proc.returncode != 0  # the child really died
+    content = path.read_text(encoding="utf-8", errors="replace")
+    assert "SMACC v0.0-test" in content  # the launch banner dates the dump
+    assert "Windows fatal exception" in content or "Fatal Python error" in content
+    assert "File " in content  # the Python stack made it out


### PR DESCRIPTION
Closes #149.

A permanent, append-only crash log at `~/SMACC/logs/crash.log` that survives every kind of crash, even when no session is running:

- **faulthandler** is enabled on it first thing in `main()`, so a native crash (access violation in Qt/PortAudio/liblsl) dumps every thread's Python stack — the crash class that previously left no trace in the `--noconsole` build.
- The **excepthooks** now also append tracebacks here by direct file write, covering launcher/editor-phase crashes where the `smacc` logger has no file handler; the error dialog falls back to naming `crash.log` when there is no run log.
- A **Qt message handler** captures qFatal/qCritical lines (often Qt's last words before an abort) into the crash log + session logger; qWarnings go to the run log at DEBUG.
- Each launch writes a version/pid **banner** and each session start a breadcrumb naming its run folder — faulthandler dumps carry no timestamps, so these tie a dump to its night.
- Rotated at launch past ~512 KB (one `crash.log.1` generation kept).
- Hidden `--crash-test[=native]` flag arms a deliberate crash after startup, for verifying the pipeline on the frozen exe.

Verified end-to-end: `python -m smacc --crash-test=native` segfaults the real app and the banner + full thread dump land in crash.log. Docs: "If SMACC crashes" section in usage.md.