### PR TITLE
feat: add the EEG review tool (#136)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,9 @@ jobs:
         run: uv run --extra dev ruff check .
       - name: Ruff format check
         run: uv run --extra dev ruff format --check .
+      # mypy doesn't need the eeg extra: neither mne nor pyqtgraph ships
+      # py.typed, so installing them adds no type information (and
+      # ignore_missing_imports already covers their absence).
       - name: Type check
         run: uv run --extra dev mypy
 
@@ -46,8 +49,10 @@ jobs:
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
+      # --extra eeg pulls mne/pyqtgraph so the optional EEG review tests run
+      # too (#136); they importorskip, so a base env still passes without it.
       - name: Run tests
-        run: uv run --extra dev pytest --cov=smacc --cov-report=xml --cov-report=term-missing
+        run: uv run --extra dev --extra eeg pytest --cov=smacc --cov-report=xml --cov-report=term-missing
       - name: Upload coverage to Codecov
         # Upload only from the release-mirror runner, and only when the tests passed
         # (`success()` — an explicit `if:` otherwise overrides the implicit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,12 +14,21 @@ jobs:
     # Windows runner, maximizing compatibility for labs on older Windows. CI's
     # test job (ci.yaml) uses the same runner so it validates this exact env.
     runs-on: windows-2022
+    # A crashed --noconsole exe shows PyInstaller's "Failed to execute script"
+    # MessageBox, which Start-Process -Wait sits behind forever — exactly the
+    # failure the smoke tests exist to catch would otherwise hang the job for
+    # GitHub's default 6 hours instead of failing fast.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
-      - run: uv sync --extra dev
+      # --extra eeg supplies mne/pyqtgraph for the SMACC-EEG.exe build (#136).
+      # It cannot leak into SMACC.exe: PyInstaller traces entry.py's imports,
+      # and nothing reachable from the base app imports the MNE-touching eeg
+      # modules (smacc.eeg's __init__ is import-light by design).
+      - run: uv sync --extra dev --extra eeg
       # The tag is the release's public version; smacc.__version__ is what the app
       # reports (About dialog, --version) and what the installer is stamped with.
       # A mismatch would ship an installer that misidentifies itself, so fail fast.
@@ -32,17 +41,43 @@ jobs:
           "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append
       # Embeds product name/version/publisher in the exe's Properties dialog —
       # metadata IT departments look at when vetting or whitelisting a binary.
-      - name: Generate the exe version-info resource
-        run: uv run python tools/make_versionfile.py version_info.txt
+      # Each call is checked: the step's result otherwise reflects only the
+      # last command, and a failed first write would surface one step late
+      # (at the SMACC.exe build) misattributed to PyInstaller.
+      - name: Generate the exe version-info resources
+        run: |
+          uv run python tools/make_versionfile.py version_info.txt
+          if ($LASTEXITCODE -ne 0) { throw "make_versionfile (SMACC) exited with code $LASTEXITCODE" }
+          uv run python tools/make_versionfile.py version_info_eeg.txt --product SMACC-EEG --description "SMACC EEG review tool"
+          if ($LASTEXITCODE -ne 0) { throw "make_versionfile (SMACC-EEG) exited with code $LASTEXITCODE" }
       - name: Build SMACC.exe
         run: uv run pyinstaller entry.py --name SMACC --onefile --noconsole --icon src/smacc/assets/icon.ico --version-file version_info.txt --add-data "src/smacc/assets/icon.png;smacc/assets" --add-data "src/smacc/assets/default.smacc;smacc/assets" --add-data "src/smacc/assets/cues;smacc/assets/cues" --add-data "src/smacc/assets/biocals;smacc/assets/biocals" --add-data "src/smacc/assets/surveys;smacc/assets/surveys"
+      # The optional EEG review component (#136): a second frozen exe carrying
+      # the MNE/pyqtgraph stack the base exe deliberately doesn't. MNE uses
+      # lazy_loader, which imports submodules by name at runtime and reads the
+      # package's .pyi stubs — both invisible to PyInstaller's static analysis —
+      # so MNE's submodules and data must be collected explicitly (without them
+      # the exe builds fine and dies on first MNE use). matplotlib must ship
+      # even though the viewer renders with pyqtgraph: MNE's IO layer
+      # transitively imports mne.viz.ui_events (-> matplotlib) at import time,
+      # so excluding it kills read_raw_*. The --selftest smoke below proves
+      # all of this end to end.
+      - name: Build SMACC-EEG.exe
+        run: uv run pyinstaller entry_eeg.py --name SMACC-EEG --onefile --noconsole --icon src/smacc/assets/icon.ico --version-file version_info_eeg.txt --add-data "src/smacc/assets/icon.png;smacc/assets" --collect-submodules mne --collect-data mne
       # A broken bundle (missing data file, import error) otherwise ships silently:
-      # the exe is windowed (--noconsole), so PowerShell won't wait for it on its
-      # own and there is no stdout — Start-Process -Wait + the exit code is the test.
-      - name: Smoke-test the exe
+      # the exes are windowed (--noconsole), so PowerShell won't wait for them on
+      # their own and there is no stdout — Start-Process -Wait + the exit code is
+      # the test. For the EEG exe, --version only proves the import tree (MNE is
+      # imported lazily), so --selftest additionally round-trips a synthetic
+      # recording through MNE, the filters, and the annotation sidecar.
+      - name: Smoke-test the exes
         run: |
           $p = Start-Process -FilePath dist/SMACC.exe -ArgumentList '--version' -Wait -PassThru
           if ($p.ExitCode -ne 0) { throw "SMACC.exe --version exited with code $($p.ExitCode)" }
+          $p = Start-Process -FilePath dist/SMACC-EEG.exe -ArgumentList '--version' -Wait -PassThru
+          if ($p.ExitCode -ne 0) { throw "SMACC-EEG.exe --version exited with code $($p.ExitCode)" }
+          $p = Start-Process -FilePath dist/SMACC-EEG.exe -ArgumentList '--selftest' -Wait -PassThru
+          if ($p.ExitCode -ne 0) { throw "SMACC-EEG.exe --selftest exited with code $($p.ExitCode)" }
       # The crash-log pipeline (#149) matters most in exactly this windowed build,
       # where nothing else can capture a crash — and it's the one build the test
       # suite can't cover. Crash the exe on purpose (the hidden --crash-test flag,
@@ -70,12 +105,13 @@ jobs:
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAppVersion=$env:VERSION tools\smacc.iss
           if ($LASTEXITCODE -ne 0) { throw "ISCC exited with code $LASTEXITCODE" }
       # Same idea as the exe smoke test, one level up: a broken installer (bad
-      # source path, registry section typo) would otherwise ship silently. Install
-      # per-user, run the *installed* exe, and confirm the .smacc association the
-      # [Registry] section is responsible for actually landed.
-      - name: Smoke-test the installer
+      # source path, registry section typo) would otherwise ship silently. Both
+      # component configurations are exercised: the default (standard) install
+      # must NOT drop the EEG exe, then an explicit core+eeg install (the same
+      # in-place upgrade path a lab uses to add the component later) must.
+      - name: Smoke-test the installer (default - no EEG component)
         run: |
-          $p = Start-Process -FilePath dist/SMACC-Setup.exe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/CURRENTUSER' -Wait -PassThru
+          $p = Start-Process -FilePath dist/SMACC-Setup.exe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/CURRENTUSER' -Wait -PassThru
           if ($p.ExitCode -ne 0) { throw "SMACC-Setup.exe exited with code $($p.ExitCode)" }
           $exe = "$env:LOCALAPPDATA\Programs\SMACC\SMACC.exe"
           if (-not (Test-Path $exe)) { throw "Installed exe not found at $exe" }
@@ -83,9 +119,19 @@ jobs:
           if ($p.ExitCode -ne 0) { throw "Installed SMACC.exe --version exited with code $($p.ExitCode)" }
           $progid = (Get-ItemProperty -Path 'HKCU:\Software\Classes\.smacc').'(default)'
           if ($progid -ne 'SMACC.Study') { throw ".smacc association not registered (got '$progid')" }
-      - name: Attach exe and installer to release
+          if (Test-Path "$env:LOCALAPPDATA\Programs\SMACC\SMACC-EEG.exe") { throw "Default install must not include SMACC-EEG.exe" }
+      - name: Smoke-test the installer (adding the EEG component)
+        run: |
+          $p = Start-Process -FilePath dist/SMACC-Setup.exe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/CURRENTUSER','/COMPONENTS="core,eeg"' -Wait -PassThru
+          if ($p.ExitCode -ne 0) { throw "SMACC-Setup.exe (core,eeg) exited with code $($p.ExitCode)" }
+          $eeg = "$env:LOCALAPPDATA\Programs\SMACC\SMACC-EEG.exe"
+          if (-not (Test-Path $eeg)) { throw "Installed EEG exe not found at $eeg" }
+          $p = Start-Process -FilePath $eeg -ArgumentList '--selftest' -Wait -PassThru
+          if ($p.ExitCode -ne 0) { throw "Installed SMACC-EEG.exe --selftest exited with code $($p.ExitCode)" }
+      - name: Attach exes and installer to release
         uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/SMACC.exe
+            dist/SMACC-EEG.exe
             dist/SMACC-Setup.exe

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -113,6 +113,30 @@ PyYAML (settings export/import) is pure Python and is picked up automatically by
 PyInstaller; if a frozen build ever fails to import `yaml`, add
 `--hidden-import yaml`.
 
+The optional EEG review component (#136) is a second frozen exe with its own
+entry point — it carries the MNE/pyqtgraph stack the base exe deliberately
+doesn't (requires `uv sync --extra dev --extra eeg`):
+
+```sh
+uv run pyinstaller entry_eeg.py --name SMACC-EEG --onefile --noconsole \
+  --icon src/smacc/assets/icon.ico \
+  --add-data "src/smacc/assets/icon.png:smacc/assets" \
+  --collect-submodules mne --collect-data mne
+```
+
+The `--collect-*` flags matter: MNE uses `lazy_loader`, which imports
+submodules by name at runtime and reads the package's `.pyi` stubs — both
+invisible to PyInstaller's static analysis. Without them the exe builds
+cleanly and dies on first MNE use. Don't try `--exclude-module matplotlib`
+to slim the bundle: the viewer never plots with it, but MNE's IO layer
+transitively imports `mne.viz.ui_events` (→ matplotlib) at import time, so
+the exclusion breaks `read_raw_*`.
+
+Verify a built `SMACC-EEG.exe` with `--selftest` (the check is exit code 0):
+it round-trips a synthetic recording through MNE, the display filters, and the
+annotation sidecar. `--version` alone would not catch a broken MNE bundling —
+MNE is imported lazily, so it only loads when a recording is actually touched.
+
 The `blinkstick` driver (BlinkStick visual cues) and its Windows backend
 `pywinusb` are pure Python and bundle the same way. PyInstaller may warn that
 `usb.core` is missing — that is BlinkStick's non-Windows backend, which SMACC
@@ -121,10 +145,13 @@ the driver, add `--hidden-import pywinusb`.
 
 Releases are built automatically: pushing a `v*` tag (e.g. `v0.0.7`) triggers the
 [release workflow](https://github.com/remrama/smacc/blob/main/.github/workflows/release.yaml),
-which checks the tag against `smacc.__version__`, builds `SMACC.exe` (stamped with
-version metadata from `tools/make_versionfile.py`), wraps it in an Inno Setup
-installer (`tools/smacc.iss` → `SMACC-Setup.exe`), smoke-tests both, and attaches
-the two artifacts to the GitHub Release. The installer's asset name is a stable
+which checks the tag against `smacc.__version__`, builds `SMACC.exe` and
+`SMACC-EEG.exe` (each stamped with version metadata from
+`tools/make_versionfile.py`), wraps them in an Inno Setup installer
+(`tools/smacc.iss` → `SMACC-Setup.exe`, with the EEG exe as the optional
+component), smoke-tests the exes (`--version`, and `--selftest` for the EEG
+one) and both installer component configurations, and attaches the three
+artifacts to the GitHub Release. The installer's asset name is a stable
 contract — the docs' download button links
 `releases/latest/download/SMACC-Setup.exe` — so don't rename it. The installer's
 `[Registry]` section must mirror `winassoc.association_entries()` exactly (so an

--- a/docs/eeg-review.md
+++ b/docs/eeg-review.md
@@ -1,0 +1,76 @@
+# EEG review
+
+SMACC's **EEG review tool** is a post-hoc viewer for recorded EEG: open a
+file, scroll through the night, apply display filters, and place named
+annotations — saved as a small sidecar file next to the recording, which is
+**never modified**. It is a review tool, not a real-time display; nothing
+about it runs during a live session.
+
+It opens from the Launcher's **Review EEG** button, from its own Start-menu
+entry (**SMACC EEG review**), and always runs as its own window and process —
+you can keep reviewing last night's file while tonight's session runs.
+
+!!! note "An optional component"
+    The viewer ships as the installer's **EEG Review Tools** component, off by
+    default (it carries the MNE library, which would triple the install for
+    labs that only run sessions). To add it later, re-run the
+    [installer](installation.md) and pick **Full installation** — the existing
+    install is upgraded in place. When the component is missing, the
+    Launcher's button is shown disabled with a hint, so you always know the
+    tool exists.
+
+## Supported recordings
+
+| Format | Open via |
+|---|---|
+| European Data Format | `.edf` |
+| BrainVision | `.vhdr` (of the `.vhdr`/`.eeg`/`.vmrk` triplet) |
+| FIF (MNE / Elekta) | `.fif` |
+
+Recordings are memory-mapped, never loaded whole: an 8-hour high-density
+night opens in seconds and scrolling stays smooth regardless of file size.
+
+## Viewing
+
+- **Window length** — 10/30/60/120 s pages; **30 s** (one scoring epoch) is
+  the default. PageUp/PageDown page; the mouse wheel and scrollbar scroll;
+  click the traces and the arrow keys nudge, Home/End jump.
+- **Filters** — high-pass, low-pass, and a 50/60 Hz notch, applied to the
+  *display only* (zero-phase, so nothing shifts in time). Recordings open
+  **unfiltered** — the usual sleep view is two clicks away (HP 0.3 Hz, LP
+  35 Hz).
+- **Scale** — microvolts per channel lane; smaller numbers mean bigger
+  traces. Trigger/stim channels are auto-fit to their lane.
+- The status bar shows the cursor's time from recording start **and the
+  wall-clock time**, so events line up with the night's session log.
+
+## Annotating
+
+1. **Drag** across the traces to mark a span (drag never pans — the time
+   axis only moves when you ask it to).
+2. Name it in the label dialog — recent labels and common marks (LRLR,
+   arousal, artifact, cue response) are one click; free text always works.
+   Tick **instantaneous** to keep just the moment instead of the dragged span.
+3. **Click** an annotation to select it; use the side list to rename,
+   delete, or jump to one (double-click).
+4. **Save annotations** writes the sidecar next to the recording:
+   `night1.edf` → `night1.annotations.tsv` (+ a small `.json` describing it).
+   Unsaved changes star the title and prompt before closing.
+
+Events already stored **inside** the recording — amp markers, SMACC's own
+trigger codes — are imported automatically the *first* time a file is
+reviewed, so your cues appear on the traces alongside your new marks. Once a
+sidecar exists it is the single source of truth (nothing is re-imported or
+duplicated).
+
+The sidecar format is documented in the
+[annotations file reference](reference/annotations-file.md).
+
+## For developers
+
+Run it from a source checkout with the `eeg` extra:
+
+```sh
+uv sync --extra dev --extra eeg
+uv run python -m smacc.eeg [recording.edf]
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,11 +9,16 @@ double-click `SMACC-Setup.exe` and click through. The installer:
 - adds a **Start menu** entry (and, if you opt in, a desktop shortcut);
 - associates **`.smacc` files**, so double-clicking a SMACC file opens a session
   with it;
+- optionally installs the **EEG Review Tools** — the post-hoc
+  [EEG viewer/annotator](eeg-review.md). Off by default (it carries the
+  heavyweight MNE library); choose **Full installation** to include it, or
+  re-run the installer later to add it;
 - registers an uninstaller — remove SMACC from **Settings › Apps** like any other
   program. Uninstalling never touches your data: SMACC files, recordings, and
   logs under `~/SMACC` (or your data directories) all stay put.
 
-Installing a newer version over an existing one upgrades it in place.
+Installing a newer version over an existing one upgrades it in place, keeping
+whichever components you had chosen.
 
 To get an older or specific version, browse the
 [releases page](https://github.com/remrama/smacc/releases): pick the release you
@@ -44,7 +49,10 @@ Every release also ships the same app as a single portable `SMACC.exe` — downl
 it, double-click it, no installation. This suits USB-stick deployment, machines
 where nothing may be installed, and quick tests. The portable build skips the
 installer's conveniences (Start menu entry, uninstaller); it offers to associate
-`.smacc` files itself the first time it runs (see below).
+`.smacc` files itself the first time it runs (see below). The
+[EEG review tool](eeg-review.md) is likewise available portable as
+`SMACC-EEG.exe` — put it **next to** `SMACC.exe` and the Launcher's *Review
+EEG* button lights up (it also runs standalone).
 
 !!! note "For IT departments"
     The default install is per-user (under `%LOCALAPPDATA%\Programs\SMACC`, no

--- a/docs/reference/annotations-file.md
+++ b/docs/reference/annotations-file.md
@@ -1,0 +1,67 @@
+# Annotations sidecar
+
+The [EEG review tool](../eeg-review.md) saves annotations as a **TSV + JSON
+sidecar pair** next to the source recording, which is never modified:
+
+```
+night1.edf
+night1.annotations.tsv    ← the annotations
+night1.annotations.json   ← column documentation + provenance
+```
+
+The pair is named by replacing the recording's extension with
+`.annotations.tsv` / `.annotations.json`. It is deliberately **not** BIDS's
+`_events.tsv` name: opening a recording that lives inside a BIDS dataset must
+never clobber the dataset's own events file. The columns themselves follow the
+BIDS/MNE convention, so downstream tooling reads them with no surprises.
+
+## The TSV
+
+Tab-separated, UTF-8, one header row, sorted by onset:
+
+```
+onset	duration	description
+12.345	0.000	LRLR
+80.500	22.000	Arousal
+```
+
+| Column | Meaning |
+|---|---|
+| `onset` | Seconds from the start of the recording's **data** (not clock time), millisecond precision |
+| `duration` | Seconds; `0.000` marks an instantaneous event |
+| `description` | The label as entered by the reviewer |
+
+Overlapping annotations are allowed (an arousal inside a REM period is two
+rows). A label containing a double quote is csv-quoted (`"saw a ""light"""`);
+tabs/newlines never appear inside fields — labels are whitespace-normalized
+when created.
+
+The file is hand-editable: the reader accepts Windows line endings and a
+UTF-8 BOM (e.g. a Notepad re-save), but it is strict about the header and the
+column count, so a corrupted file is reported instead of silently losing rows.
+
+## The JSON
+
+Documents each column (BIDS-style) and records provenance:
+
+```json
+{
+  "onset": {"Description": "Annotation onset relative to the start of the recording's data.", "Units": "second"},
+  "duration": {"Description": "Annotation duration; 0 for an instantaneous mark.", "Units": "second"},
+  "description": {"Description": "Annotation label as entered by the reviewer."},
+  "SourceFile": "night1.edf",
+  "MeasurementDate": "2026-06-05T22:00:00+00:00",
+  "GeneratedBy": {"Name": "SMACC", "Version": "1.0.0"}
+}
+```
+
+`MeasurementDate` is the recording's start as stored in the file — combined
+with the data-relative onsets it reconstructs clock time. It is `null` when
+the format or anonymization dropped it.
+
+## Precedence
+
+When a recording is opened, an existing sidecar **wins**: it is loaded as-is,
+and the events embedded inside the recording are *not* (re)imported — they
+were already captured the first time the file was reviewed. Delete or rename
+the sidecar to start a review from scratch.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -12,6 +12,7 @@ from the task-oriented [Usage](../usage.md) guide.
 | [BIDS export](bids-export.md) | `events.tsv` + JSON sidecar | TSV / JSON | follows BIDS |
 | [Survey definition](../surveys.md) | An in-app survey (built-in or custom) | YAML | `schema_version: 1` |
 | [Survey response](../surveys.md#response-files) | One administration's answers | JSON | — |
+| [Annotations sidecar](annotations-file.md) | EEG review marks (`*.annotations.tsv`) | TSV / JSON | follows BIDS columns |
 
 ## Where each file lives
 

--- a/entry_eeg.py
+++ b/entry_eeg.py
@@ -1,0 +1,9 @@
+# PyInstaller bootstrap for the optional EEG review component (#136):
+#   > pyinstaller entry_eeg.py --name SMACC-EEG --onefile --noconsole
+# Same absolute-import requirement as entry.py: PyInstaller runs its target as
+# the top-level __main__, where smacc/eeg/__main__.py's relative imports would
+# fail. For normal runs use `python -m smacc.eeg`.
+from smacc.eeg.__main__ import main
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,10 +54,12 @@ nav:
   - Devices: devices.md
   - Surveys: surveys.md
   - Triggers & port codes: triggers.md
+  - EEG review: eeg-review.md
   - Reference:
     - File formats: reference/index.md
     - SMACC file (.smacc): reference/settings-file.md
     - Preferences file: reference/preferences-file.md
     - Session log: reference/session-log.md
     - BIDS export: reference/bids-export.md
+    - Annotations sidecar: reference/annotations-file.md
   - Contributing: contributing.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,14 @@ docs = [
     "mkdocs-material",
     "mike",
 ]
+# The optional EEG review tool (#136). MNE is far too heavy for the base install,
+# so the viewer ships as a separate frozen exe / installer component; this extra
+# is its dev/CI environment. MNE is I/O and annotation conversion only — rendering
+# is pyqtgraph and display filtering is scipy (a core dependency).
+eeg = [
+    "mne>=1.6",
+    "pyqtgraph>=0.13",
+]
 dev = [
     "pytest",
     # GUI tests run headless via the Qt "offscreen" platform (set in

--- a/src/smacc/eeg/__init__.py
+++ b/src/smacc/eeg/__init__.py
@@ -16,5 +16,55 @@ Layout keeps the heavy dependency at the edges: :mod:`~smacc.eeg.annotations`
 (the model and sidecar I/O) and :mod:`~smacc.eeg.dsp` (display filtering) are
 pure Python over numpy/scipy and import no MNE; :mod:`~smacc.eeg.io` is the
 only module that touches MNE, and imports it lazily. This module itself stays
-import-light so the base app can probe for the component without paying for it.
+import-light so the base app can probe for the component without paying for it:
+:func:`available` and :func:`launch` below are everything the launcher uses.
 """
+
+# NO `from __future__ import annotations` here, on purpose: in a package
+# __init__ it would bind the name "annotations" to the __future__ feature and
+# shadow the smacc.eeg.annotations submodule for `from smacc.eeg import
+# annotations` (the runtime annotations below don't need the future import).
+import sys
+from importlib.util import find_spec
+from pathlib import Path
+
+# The frozen EEG component, installed beside SMACC.exe by the installer's
+# optional "EEG Review Tools" component (see tools/smacc.iss).
+EXE_NAME = "SMACC-EEG.exe"
+
+
+def component_exe() -> Path:
+    """Where the packaged build expects the frozen EEG exe (beside SMACC.exe)."""
+    return Path(sys.executable).resolve().parent / EXE_NAME
+
+
+def available() -> bool:
+    """True when the EEG review tool can be launched from this install.
+
+    Packaged build: the installer component dropped ``SMACC-EEG.exe`` next to
+    ``SMACC.exe``. Development: the ``eeg`` extra (mne + pyqtgraph) is in the
+    environment. Checked via ``find_spec`` so probing costs no imports —
+    the launcher calls this at startup.
+    """
+    if getattr(sys, "frozen", False):
+        return component_exe().is_file()
+    return find_spec("mne") is not None and find_spec("pyqtgraph") is not None
+
+
+def launch() -> bool:
+    """Start the EEG review tool as its own detached process; True if started.
+
+    Detached on purpose: the viewer outlives the launcher (or a session) and
+    never shares a process with them — see the isolation rationale above. The
+    development path runs ``python -m smacc.eeg`` with the current
+    interpreter, the packaged path runs the installed exe.
+    """
+    from PyQt6 import QtCore  # deferred: keep this module import-light
+
+    if getattr(sys, "frozen", False):
+        started, _pid = QtCore.QProcess.startDetached(str(component_exe()), [])
+    else:
+        started, _pid = QtCore.QProcess.startDetached(
+            sys.executable, ["-m", "smacc.eeg"]
+        )
+    return started

--- a/src/smacc/eeg/__init__.py
+++ b/src/smacc/eeg/__init__.py
@@ -1,0 +1,20 @@
+"""The EEG review tool: post-hoc trace viewing and annotation (#136).
+
+This subpackage is SMACC's *optional* EEG component. It opens a recorded EEG
+file (EDF, BrainVision, FIF), scrolls its traces, applies display-only filters,
+and saves named annotations to a TSV sidecar — the source file is never
+modified. It is a review tool, not a real-time display: nothing here runs
+during a live session, and nothing in the live-session path imports from here.
+
+The component always runs as its own process with its own ``QApplication``.
+The base ``SMACC.exe`` does not bundle MNE, so an in-process viewer is
+impossible in the packaged app; keeping development behavior identical gives
+one code path and isolates the heavy MNE/pyqtgraph process from the
+lab-critical session app.
+
+Layout keeps the heavy dependency at the edges: :mod:`~smacc.eeg.annotations`
+(the model and sidecar I/O) and :mod:`~smacc.eeg.dsp` (display filtering) are
+pure Python over numpy/scipy and import no MNE; :mod:`~smacc.eeg.io` is the
+only module that touches MNE, and imports it lazily. This module itself stays
+import-light so the base app can probe for the component without paying for it.
+"""

--- a/src/smacc/eeg/__main__.py
+++ b/src/smacc/eeg/__main__.py
@@ -5,10 +5,14 @@ sharing one with a live session (see the package docstring). The frozen
 ``SMACC-EEG.exe`` targets the same :func:`main` via ``entry_eeg.py``.
 
 ``--version`` exits immediately (code 0) without opening any window, mirroring
-the base app: the release workflow smoke-tests the frozen exe with it, and
-reaching that point proves the bundle unpacks and every import — including the
-MNE/pyqtgraph tree — resolves. The exe is built ``--noconsole`` (no stdout),
-so the check is the exit code, not the output.
+the base app: reaching that point proves the bundle unpacks and every import —
+including the pyqtgraph tree — resolves. It does *not* prove MNE works: MNE is
+imported lazily inside :mod:`smacc.eeg.io`, so a bundle missing half of it
+would still print a version. That is what ``--selftest`` is for — it
+round-trips a synthetic recording through MNE, the slice filters, and the
+annotation sidecar, headless, and is what the release workflow runs against
+the frozen ``SMACC-EEG.exe``. The exe is built ``--noconsole`` (no stdout), so
+the check is the exit code, not the output.
 """
 
 from __future__ import annotations
@@ -36,10 +40,54 @@ def pick_recording_path(args: list[str]) -> str | None:
     return candidates[-1] if candidates else None
 
 
+def selftest() -> int:
+    """Exercise the full non-GUI stack on a synthetic recording; 0 on success.
+
+    The frozen bundle's real smoke test: a broken MNE bundling (a missed
+    lazy_loader submodule, a dropped data file) only surfaces when MNE
+    actually runs, which ``--version`` never makes it do. Builds a recording
+    in memory, saves it as FIF, reopens it through :mod:`smacc.eeg.io`,
+    filters a slice, and round-trips an annotation sidecar — every layer the
+    viewer sits on, no window needed.
+    """
+    import tempfile
+    from pathlib import Path
+
+    import mne
+    import numpy as np
+
+    from . import dsp
+    from .annotations import Annotation, read_annotations_tsv, write_annotations_tsv
+    from .io import embedded_annotations, open_recording
+
+    info = mne.create_info(["C3", "C4"], sfreq=100.0, ch_types="eeg", verbose="error")
+    raw = mne.io.RawArray(np.zeros((2, 1000)), info, verbose="error")
+    raw.set_annotations(
+        mne.Annotations(onset=[1.0], duration=[0.5], description=["selftest"])
+    )
+    with tempfile.TemporaryDirectory(prefix="smacc-eeg-selftest-") as tmp:
+        fif = Path(tmp) / "selftest_raw.fif"
+        raw.save(fif, verbose="error")
+        recording = open_recording(fif)
+        _times, data = recording.get_slice(2.0, 8.0)
+        assert data.shape == (2, 600), data.shape
+        filtered = dsp.apply(data, 100.0, dsp.FilterSpec(highpass=0.3, lowpass=35.0))
+        assert filtered.shape == data.shape
+        found = embedded_annotations(recording)
+        assert [a.description for a in found] == ["selftest"], found
+        tsv = Path(tmp) / "selftest.annotations.tsv"
+        write_annotations_tsv([Annotation(1.0, 0.5, "selftest")], tsv)
+        assert read_annotations_tsv(tsv) == [Annotation(1.0, 0.5, "selftest")]
+    print("selftest ok")
+    return 0
+
+
 def main() -> None:
     if "--version" in sys.argv:
         print(f"SMACC EEG review v{VERSION}")
         sys.exit(0)
+    if "--selftest" in sys.argv:
+        sys.exit(selftest())
     app = QApplication(sys.argv)
     app.setApplicationName("SMACC EEG review")
     window = EegReviewWindow(pick_recording_path(sys.argv))

--- a/src/smacc/eeg/__main__.py
+++ b/src/smacc/eeg/__main__.py
@@ -1,0 +1,51 @@
+"""Run the EEG review tool: ``python -m smacc.eeg [recording]``.
+
+The component's own entry point — its own process and ``QApplication``, never
+sharing one with a live session (see the package docstring). The frozen
+``SMACC-EEG.exe`` targets the same :func:`main` via ``entry_eeg.py``.
+
+``--version`` exits immediately (code 0) without opening any window, mirroring
+the base app: the release workflow smoke-tests the frozen exe with it, and
+reaching that point proves the bundle unpacks and every import — including the
+MNE/pyqtgraph tree — resolves. The exe is built ``--noconsole`` (no stdout),
+so the check is the exit code, not the output.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from PyQt6.QtWidgets import QApplication
+
+from ..config import VERSION
+
+# Imported eagerly, on purpose: --version must prove the whole MNE/pyqtgraph
+# import tree resolves in the frozen bundle (that is the point of the smoke
+# test — a lazy import would make it pass on a bundle that can't open a file).
+from .window import EegReviewWindow
+
+
+def pick_recording_path(args: list[str]) -> str | None:
+    """Return the recording to open from CLI args, or ``None``.
+
+    The last non-flag argument wins, mirroring the base app's settings-file
+    handling; existence and format errors are left to the window so the user
+    sees a dialog, not a vanishing process.
+    """
+    candidates = [arg for arg in args[1:] if not arg.startswith("-")]
+    return candidates[-1] if candidates else None
+
+
+def main() -> None:
+    if "--version" in sys.argv:
+        print(f"SMACC EEG review v{VERSION}")
+        sys.exit(0)
+    app = QApplication(sys.argv)
+    app.setApplicationName("SMACC EEG review")
+    window = EegReviewWindow(pick_recording_path(sys.argv))
+    window.show()
+    sys.exit(app.exec())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/smacc/eeg/annotations.py
+++ b/src/smacc/eeg/annotations.py
@@ -1,0 +1,193 @@
+"""The annotation model and its TSV/JSON sidecar files (#136).
+
+An annotation is a labeled span of recording time: ``onset`` and ``duration``
+in seconds from the start of the *data* (not clock time), plus a free-text
+``description``. Overlapping annotations are simply allowed — BIDS events
+permit them and a reviewer marking an arousal inside a REM period needs them —
+so the only collection invariant is sort order.
+
+Annotations save to a sidecar next to the source recording — ``night1.edf`` →
+``night1.annotations.tsv`` + ``night1.annotations.json`` — and the source file
+is never touched. The columns (``onset``/``duration``/``description``) follow
+MNE-BIDS conventions, but the name is deliberately *not* BIDS's ``_events.tsv``:
+opening a file inside a real BIDS dataset must never clobber the dataset's own
+events file. The JSON sidecar documents the columns and records provenance
+(source file, measurement date, app version).
+
+Pure functions and frozen dataclasses, no GUI and no MNE — directly
+unit-testable, mirroring :mod:`smacc.bids`.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from ..config import VERSION
+
+ANNOTATION_COLUMNS = ["onset", "duration", "description"]
+
+# Sidecar suffixes appended to the source's stem (via Path.with_suffix, so
+# "night1.edf" maps to "night1.annotations.tsv" — see sidecar_paths).
+TSV_SUFFIX = ".annotations.tsv"
+JSON_SUFFIX = ".annotations.json"
+
+# Onsets/durations are written with millisecond precision: finer than any human
+# click on a plot, and exact for every sample at the rates sleep labs record.
+_SECONDS_DECIMALS = 3
+
+
+@dataclass(frozen=True, order=True)
+class Annotation:
+    """One labeled span: seconds from data start, seconds long, and its label.
+
+    Field order gives the natural sort (onset, then duration, then label) via
+    ``order=True``. Construction normalizes the description's whitespace —
+    tabs/newlines would corrupt the TSV, and there is no BIDS escaping
+    convention to hide behind — and rejects an empty label outright (an
+    unlabeled span is meaningless to the next reader of the sidecar).
+    """
+
+    onset: float
+    duration: float
+    description: str
+
+    def __post_init__(self) -> None:
+        if self.onset < 0:
+            raise ValueError(f"Annotation onset must be >= 0 (got {self.onset})")
+        if self.duration < 0:
+            raise ValueError(f"Annotation duration must be >= 0 (got {self.duration})")
+        # Frozen dataclass: normalized fields go through object.__setattr__.
+        normalized = " ".join(self.description.split())
+        if not normalized:
+            raise ValueError("Annotation description must not be empty")
+        object.__setattr__(self, "description", normalized)
+        object.__setattr__(self, "onset", round(self.onset, _SECONDS_DECIMALS))
+        object.__setattr__(self, "duration", round(self.duration, _SECONDS_DECIMALS))
+
+
+def insert(annotations: list[Annotation], annotation: Annotation) -> list[Annotation]:
+    """Return a new sorted list with ``annotation`` added (input left untouched)."""
+    return sorted([*annotations, annotation])
+
+
+def remove(annotations: list[Annotation], index: int) -> list[Annotation]:
+    """Return a new list without the annotation at ``index`` (of the sorted list)."""
+    out = list(annotations)
+    del out[index]
+    return out
+
+
+def replace(
+    annotations: list[Annotation], index: int, annotation: Annotation
+) -> list[Annotation]:
+    """Return a new sorted list with ``index`` swapped for ``annotation``.
+
+    Re-sorts because an edited onset may move the entry — the caller should
+    re-locate the annotation by value, not assume it kept its row.
+    """
+    out = list(annotations)
+    del out[index]
+    return insert(out, annotation)
+
+
+def sidecar_paths(source: str | Path) -> tuple[Path, Path]:
+    """Return the (TSV, JSON) sidecar paths for a source recording.
+
+    The source's final suffix is replaced (``night1.edf`` →
+    ``night1.annotations.tsv``), so a BrainVision triplet opened via its
+    ``.vhdr`` gets one obvious sidecar pair. The JSON's ``SourceFile`` field
+    records which recording the pair belongs to.
+    """
+    src = Path(source)
+    return src.with_suffix(TSV_SUFFIX), src.with_suffix(JSON_SUFFIX)
+
+
+def write_annotations_tsv(annotations: list[Annotation], path: str | Path) -> None:
+    """Write ``annotations`` (sorted) to ``path`` as a tab-separated values file."""
+    with Path(path).open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.writer(stream, delimiter="\t", lineterminator="\n")
+        writer.writerow(ANNOTATION_COLUMNS)
+        for ann in sorted(annotations):
+            writer.writerow(
+                [
+                    f"{ann.onset:.{_SECONDS_DECIMALS}f}",
+                    f"{ann.duration:.{_SECONDS_DECIMALS}f}",
+                    ann.description,
+                ]
+            )
+
+
+def read_annotations_tsv(path: str | Path) -> list[Annotation]:
+    """Read a sidecar TSV back into a sorted list of annotations.
+
+    Strict on shape so a half-clobbered or hand-mangled file surfaces as an
+    error instead of silently losing rows: the header must match
+    :data:`ANNOTATION_COLUMNS` exactly and every row must parse.
+
+    Raises:
+        OSError: if the file can't be read.
+        ValueError: on a wrong header or an unparseable row (with its line number).
+    """
+    # utf-8-sig: a sidecar tweaked in Notepad comes back with a BOM, which
+    # plain utf-8 would smuggle into the first header cell and fail the strict
+    # header check. Writing stays plain utf-8 (no BOM).
+    with Path(path).open("r", encoding="utf-8-sig", newline="") as stream:
+        reader = csv.reader(stream, delimiter="\t")
+        header = next(reader, None)
+        if header != ANNOTATION_COLUMNS:
+            raise ValueError(
+                f"Not an annotations TSV (header {header!r}, "
+                f"expected {ANNOTATION_COLUMNS!r})"
+            )
+        annotations: list[Annotation] = []
+        for line_number, row in enumerate(reader, start=2):
+            if not row:  # a trailing blank line is not an error
+                continue
+            if len(row) != len(ANNOTATION_COLUMNS):
+                raise ValueError(
+                    f"Line {line_number}: expected {len(ANNOTATION_COLUMNS)} "
+                    f"columns, got {len(row)}"
+                )
+            try:
+                annotation = Annotation(float(row[0]), float(row[1]), row[2])
+            except ValueError as exc:
+                raise ValueError(f"Line {line_number}: {exc}") from exc
+            annotations.append(annotation)
+    return sorted(annotations)
+
+
+def annotations_sidecar(source_name: str, meas_date: datetime | None) -> dict[str, Any]:
+    """Return the JSON sidecar payload documenting the TSV columns and provenance.
+
+    ``MeasurementDate`` (the recording's absolute start, when the file carries
+    one) is what lets a reader reconstruct clock time from the data-relative
+    onsets; ``null`` when the format/anonymization dropped it.
+    """
+    return {
+        "onset": {
+            "Description": "Annotation onset relative to the start of the "
+            "recording's data.",
+            "Units": "second",
+        },
+        "duration": {
+            "Description": "Annotation duration; 0 for an instantaneous mark.",
+            "Units": "second",
+        },
+        "description": {"Description": "Annotation label as entered by the reviewer."},
+        "SourceFile": source_name,
+        "MeasurementDate": meas_date.isoformat() if meas_date else None,
+        "GeneratedBy": {"Name": "SMACC", "Version": VERSION},
+    }
+
+
+def write_annotations_json(
+    path: str | Path, *, source_name: str, meas_date: datetime | None
+) -> None:
+    """Write the JSON sidecar to ``path``."""
+    payload = annotations_sidecar(source_name, meas_date)
+    Path(path).write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/src/smacc/eeg/dsp.py
+++ b/src/smacc/eeg/dsp.py
@@ -1,0 +1,164 @@
+"""Display filtering for the EEG review tool (#136).
+
+The viewer filters only the *visible slice* of the recording, never the whole
+file. ``mne.io.Raw.filter`` requires preloading the entire recording — an
+overnight high-density file is gigabytes as float64 — while filtering the
+fetched slice keeps memory flat regardless of file size (the approach EDF
+browsers have used for decades). The trade-off is an edge transient at the
+slice boundaries, handled by fetching a margin around the visible window
+(:func:`pad_seconds`) that the view trims after filtering.
+
+Zero-phase IIR (Butterworth via ``sosfiltfilt``) rather than MNE's default FIR:
+zero phase means a filtered feature stays at its true time — annotations placed
+on filtered traces must land where the event is in the raw data — and a 4th-
+order IIR over a few seconds of slice is microseconds of work. This is a
+*display* filter; it feeds nothing downstream, so publication-grade filter
+choice is out of scope.
+
+Pure numpy/scipy (already core dependencies), no MNE, no GUI.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from functools import lru_cache
+
+import numpy as np
+from scipy import signal
+
+# 4th-order Butterworth: the conventional review-display filter — steep enough
+# to clean a trace, gentle enough to never ring on K-complexes or slow waves.
+_BUTTER_ORDER = 4
+# iirnotch quality factor: ~2 Hz wide at 60 Hz, the usual mains-notch shape.
+_NOTCH_Q = 30.0
+# Filter edges at/above this fraction of Nyquist are dropped rather than
+# designed: scipy raises on >= Nyquist, and a 70 Hz lowpass on a 128 Hz file
+# should simply mean "no lowpass", not a crash (see effective_spec).
+_NYQUIST_FRACTION = 0.99
+
+
+@dataclass(frozen=True)
+class FilterSpec:
+    """The viewer's display-filter settings: band edges and mains notch, in Hz.
+
+    ``highpass`` is the low *cut* (drop slow drift below it), ``lowpass`` the
+    high cut — named for what they pass, the convention on every EEG review
+    screen ("HP 0.3 Hz, LP 35 Hz"). ``None`` disables that stage; all three
+    ``None`` (:data:`UNFILTERED`) bypasses filtering entirely.
+    """
+
+    highpass: float | None = None
+    lowpass: float | None = None
+    notch: float | None = None
+
+    def __post_init__(self) -> None:
+        for name in ("highpass", "lowpass", "notch"):
+            value = getattr(self, name)
+            if value is not None and value <= 0:
+                raise ValueError(f"{name} must be positive (got {value})")
+        if (
+            self.highpass is not None
+            and self.lowpass is not None
+            and self.highpass >= self.lowpass
+        ):
+            raise ValueError(
+                f"highpass ({self.highpass} Hz) must be below "
+                f"lowpass ({self.lowpass} Hz)"
+            )
+
+    @property
+    def is_identity(self) -> bool:
+        """True when no filtering is requested at all."""
+        return self.highpass is None and self.lowpass is None and self.notch is None
+
+
+UNFILTERED = FilterSpec()
+
+
+def effective_spec(spec: FilterSpec, sfreq: float) -> FilterSpec:
+    """Return ``spec`` with stages the sampling rate can't support dropped.
+
+    A stage whose edge sits at/above (a hair under) Nyquist is undesignable;
+    treating it as disabled keeps one filter setting usable across files with
+    different rates (the viewer remembers settings, files vary by amp).
+    """
+    limit = sfreq / 2 * _NYQUIST_FRACTION
+    out = spec
+    if out.lowpass is not None and out.lowpass >= limit:
+        out = replace(out, lowpass=None)
+    if out.notch is not None and out.notch >= limit:
+        out = replace(out, notch=None)
+    if out.highpass is not None and out.highpass >= limit:
+        out = replace(out, highpass=None)
+    return out
+
+
+@lru_cache(maxsize=8)
+def _design(spec: FilterSpec, sfreq: float) -> np.ndarray:
+    """Design the cascaded SOS for ``spec`` at ``sfreq`` (cached per pair).
+
+    The cache means scrolling re-filters with an already-designed filter; only
+    changing the settings or opening a differently-rated file designs anew.
+    Callers pass a spec already reduced by :func:`effective_spec` and not
+    identity (there must be at least one stage to design).
+    """
+    sections: list[np.ndarray] = []
+    if spec.highpass is not None and spec.lowpass is not None:
+        sections.append(
+            signal.butter(
+                _BUTTER_ORDER,
+                [spec.highpass, spec.lowpass],
+                btype="bandpass",
+                fs=sfreq,
+                output="sos",
+            )
+        )
+    elif spec.highpass is not None:
+        sections.append(
+            signal.butter(
+                _BUTTER_ORDER, spec.highpass, btype="highpass", fs=sfreq, output="sos"
+            )
+        )
+    elif spec.lowpass is not None:
+        sections.append(
+            signal.butter(
+                _BUTTER_ORDER, spec.lowpass, btype="lowpass", fs=sfreq, output="sos"
+            )
+        )
+    if spec.notch is not None:
+        b, a = signal.iirnotch(spec.notch, _NOTCH_Q, fs=sfreq)
+        sections.append(signal.tf2sos(b, a))
+    return np.vstack(sections)
+
+
+def apply(data: np.ndarray, sfreq: float, spec: FilterSpec) -> np.ndarray:
+    """Zero-phase filter ``data`` (``(n_channels, n_samples)``) per ``spec``.
+
+    Identity specs (including specs reduced to identity by the sampling rate)
+    return ``data`` unchanged — same array, no copy. Slices too short to pad
+    (a sliver at the end of a file) also pass through unfiltered rather than
+    raising; a few unfilterable samples aren't worth crashing the view over.
+    """
+    spec = effective_spec(spec, sfreq)
+    if spec.is_identity or data.size == 0:
+        return data
+    sos = _design(spec, sfreq)
+    # sosfiltfilt's default pad length; inputs shorter than it can't be padded.
+    padlen = 3 * (2 * len(sos) + 1)
+    if data.shape[-1] <= padlen:
+        return data
+    return signal.sosfiltfilt(sos, data, axis=-1)
+
+
+def pad_seconds(spec: FilterSpec) -> float:
+    """The margin to fetch around the visible window before filtering.
+
+    Filter transients are longest for the highpass (its time constant scales
+    with 1/frequency: a 0.3 Hz cut rings for seconds), so the margin tracks it;
+    a flat minimum covers the lowpass/notch. The view fetches this much extra
+    on both sides and trims it after :func:`apply`, so edge artifacts never
+    reach the screen.
+    """
+    if spec.highpass is None:
+        return 1.0
+    return max(1.0, 2.0 / spec.highpass)

--- a/src/smacc/eeg/io.py
+++ b/src/smacc/eeg/io.py
@@ -1,0 +1,153 @@
+"""Recording access for the EEG review tool — the only module that touches MNE (#136).
+
+MNE is strictly a *backend* here: it reads the formats (EDF, BrainVision, FIF —
+the formats sleep-lab amps actually produce) and exposes their metadata;
+rendering is pyqtgraph and filtering is :mod:`smacc.eeg.dsp`. The review tool
+itself only ever *writes* the TSV/JSON sidecar (:mod:`smacc.eeg.annotations`) —
+the source recording is never modified. The import is lazy so probing
+this package costs nothing, and recordings are opened with ``preload=False`` so
+an overnight file is memory-mapped and fetched slice-by-slice — never loaded
+whole (see the dsp module docstring for why).
+
+:class:`Recording` is the thin contract the viewer draws from (names, types,
+rate, duration, ``get_slice``); tests fake it without MNE.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from .annotations import Annotation
+
+if TYPE_CHECKING:  # only for annotations; mne itself is imported lazily
+    import mne
+
+# Suffix → the mne.io reader that opens it. BrainVision recordings are a
+# triplet (.vhdr/.eeg/.vmrk) opened via the header file.
+_READERS = {
+    ".edf": "read_raw_edf",
+    ".vhdr": "read_raw_brainvision",
+    ".fif": "read_raw_fif",
+}
+
+# Qt file-dialog filter for the open dialog.
+FILE_FILTER = "EEG recordings (*.edf *.vhdr *.fif);;All files (*)"
+
+# Label for embedded events that arrive without one (rare, but EDF+ allows it);
+# the Annotation model rejects empty descriptions, and inventing nothing is
+# worse than naming the gap.
+_UNLABELED = "unlabeled"
+
+
+class Recording:
+    """An open recording: its metadata, and data fetched per visible slice."""
+
+    def __init__(self, raw: mne.io.BaseRaw, path: Path) -> None:
+        self._raw = raw
+        self.path = path
+
+    @property
+    def ch_names(self) -> list[str]:
+        return list(self._raw.ch_names)
+
+    @property
+    def ch_types(self) -> list[str]:
+        """Per-channel kind ("eeg", "eog", "emg", …) as MNE classified them."""
+        return list(self._raw.get_channel_types())
+
+    @property
+    def sfreq(self) -> float:
+        return float(self._raw.info["sfreq"])
+
+    @property
+    def duration(self) -> float:
+        """Total data span in seconds (the valid range for slices and annotations)."""
+        return self._raw.n_times / self.sfreq
+
+    @property
+    def meas_date(self) -> datetime | None:
+        """The recording's absolute start time, when the file carries one.
+
+        Lets the viewer show clock time — how sleep techs think ("the arousal
+        at 03:12"), and how a night's SMACC log is cross-referenced — alongside
+        seconds-from-start. ``None`` when the format or anonymization dropped it.
+        """
+        return self._raw.info["meas_date"]
+
+    def get_slice(self, start_s: float, stop_s: float) -> tuple[Any, Any]:
+        """Return ``(times, data)`` for the span, clamped to the recording.
+
+        ``times`` is seconds from data start (the annotation timebase); ``data``
+        is ``(n_channels, n_samples)`` float64 in the file's units (SI — volts
+        for bioelectric channels; display scaling is the view's job). A span
+        entirely outside the recording yields empty arrays rather than raising,
+        so a scrolled-past-the-end view simply draws nothing.
+        """
+        sfreq = self.sfreq
+        start = max(0, int(round(max(0.0, start_s) * sfreq)))
+        stop = min(self._raw.n_times, int(round(min(self.duration, stop_s) * sfreq)))
+        if stop <= start:
+            return np.empty(0), np.empty((len(self._raw.ch_names), 0))
+        data, times = self._raw.get_data(start=start, stop=stop, return_times=True)
+        return times, data
+
+
+def open_recording(path: str | Path) -> Recording:
+    """Open ``path`` (dispatched on suffix) without preloading its data.
+
+    Raises:
+        ValueError: for a suffix no reader claims.
+        OSError, RuntimeError: from MNE, for a file that exists but won't parse
+            (the window shows these verbatim — amp-specific corruption messages
+            are more useful than a generic wrapper).
+    """
+    import mne
+
+    src = Path(path)
+    reader_name = _READERS.get(src.suffix.lower())
+    if reader_name is None:
+        supported = " ".join(sorted(_READERS))
+        raise ValueError(
+            f"Unsupported recording type {src.suffix!r} (supported: {supported})"
+        )
+    reader = getattr(mne.io, reader_name)
+    raw = reader(src, preload=False, verbose="error")
+    return Recording(raw, src)
+
+
+def embedded_annotations(recording: Recording) -> list[Annotation]:
+    """Return events already stored in the file as data-relative annotations.
+
+    Files from amp software routinely carry event markers — including SMACC's
+    own portcode triggers — and a reviewer expects to see them alongside their
+    new marks. Converted to this package's model so they save into the sidecar
+    like any other annotation.
+
+    MNE's onsets are relative to ``orig_time`` when one is set (so the data
+    offset ``first_time`` must come off) and data-relative when it is ``None``
+    — the documented ``mne.Annotations`` semantics. Events that land outside
+    the data span after correction (possible on cropped files) are dropped.
+    """
+    raw = recording._raw
+    duration = recording.duration
+    shift = raw.first_time if raw.annotations.orig_time is not None else 0.0
+    out: list[Annotation] = []
+    for onset, length, description in zip(
+        raw.annotations.onset,
+        raw.annotations.duration,
+        raw.annotations.description,
+        strict=True,
+    ):
+        data_onset = float(onset) - shift
+        if data_onset < 0 or data_onset > duration:
+            continue
+        # Normalize the same way the model will, so a whitespace-only label
+        # falls back to _UNLABELED instead of tripping the model's own
+        # empty-description check and aborting the whole conversion.
+        label = " ".join(str(description).split()) or _UNLABELED
+        out.append(Annotation(data_onset, float(length), label))
+    return sorted(out)

--- a/src/smacc/eeg/view.py
+++ b/src/smacc/eeg/view.py
@@ -1,0 +1,407 @@
+"""The multichannel trace view for the EEG review tool (#136).
+
+One pyqtgraph ``PlotWidget``, all channels stacked in a single ViewBox by
+vertical offset (channel *i* centered at ``y = -i``), channel names as y-axis
+ticks — not one ViewBox per channel, which is slow to sync and slow to draw.
+Performance comes from rendering only the visible window (fetched per scroll,
+filtered by :mod:`smacc.eeg.dsp`, never the whole file) and from pyqtgraph's
+min/max *peak* downsampling on each curve, which keeps extremes — a spindle or
+artifact stays visible no matter how far the trace is decimated. Deliberately
+no OpenGL: pyqtgraph's raster path plus downsampling is the proven approach
+(it is what mne-qt-browser ships with; the GL option is off by default there
+for Windows driver reasons).
+
+Interaction is built for annotation, not navigation: a left-drag *draws* a
+region (it never pans), a click selects the annotation under the cursor, and
+the wheel scrolls time. Paging/zoom shortcuts and every other control live in
+:mod:`smacc.eeg.window`, which owns this widget.
+
+The view draws from any :class:`SliceProvider` — :class:`smacc.eeg.io.Recording`
+in the app, a synthetic fake in tests and benchmarks — so this module imports
+no MNE and nothing from the wider app.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+import numpy as np
+import pyqtgraph as pg
+from PyQt6 import QtCore, QtGui
+
+from . import dsp
+from .annotations import Annotation
+
+# Bioelectric channels are recorded in volts and displayed in microvolts.
+# Other kinds (stim/misc/…) carry arbitrary units — a trigger channel holds
+# integer event codes like 255, which on a 100 µV lane scale would paint
+# straight across every EEG lane — so they are auto-fit into their own lane
+# per visible slice instead (see _refresh_data).
+_MICROVOLT_TYPES = {"eeg", "eog", "emg", "ecg", "seeg", "ecog", "dbs", "bio"}
+_VOLTS_TO_MICROVOLTS = 1e6
+# Lane-units excursion an auto-fit (non-bioelectric) channel is normalized to.
+_AUTOFIT_EXCURSION = 0.4
+
+# Per-channel-type display gain applied on top of the global scale. EMG rides
+# hotter than EEG on most montages; halving it keeps the trace inside its lane
+# without a per-channel scaling UI (cut deliberately — see issue #136).
+TYPE_GAINS = {"emg": 0.5}
+
+# Clicking selects the annotation under the cursor; a zero-duration mark gets
+# this much slack on each side, as a fraction of the visible window.
+_CLICK_TOLERANCE_FRACTION = 0.005
+
+# Annotation paint: translucent fills so traces stay readable through them.
+_REGION_BRUSH = (70, 130, 180, 50)  # steel blue wash
+_REGION_BRUSH_SELECTED = (70, 130, 180, 110)
+_REGION_PEN = (70, 130, 180, 160)
+_LINE_PEN = (178, 34, 34, 160)  # firebrick for instantaneous marks
+_LINE_PEN_SELECTED = (178, 34, 34, 255)
+
+
+class SliceProvider(Protocol):
+    """What the view needs from a recording (satisfied by ``io.Recording``)."""
+
+    @property
+    def ch_names(self) -> list[str]: ...
+
+    @property
+    def ch_types(self) -> list[str]: ...
+
+    @property
+    def sfreq(self) -> float: ...
+
+    @property
+    def duration(self) -> float: ...
+
+    def get_slice(self, start_s: float, stop_s: float) -> tuple[Any, Any]: ...
+
+
+class _AnnotateViewBox(pg.ViewBox):
+    """A ViewBox where the left mouse annotates instead of panning.
+
+    Pan/zoom-by-mouse is disabled outright: a misdrag that silently shifts the
+    time axis would make the operator distrust where their annotations landed.
+    Dragging rubber-bands a span (live region preview, then ``dragFinished``);
+    a plain click reports its time so the view can select/deselect.
+    """
+
+    dragFinished = QtCore.pyqtSignal(float, float)  # span in data seconds
+    clicked = QtCore.pyqtSignal(float)  # click time in data seconds
+
+    def __init__(self) -> None:
+        super().__init__(enableMouse=False, enableMenu=False)
+        self._preview: pg.LinearRegionItem | None = None
+
+    def mouseDragEvent(self, ev: Any, axis: int | None = None) -> None:
+        if ev.button() != QtCore.Qt.MouseButton.LeftButton:
+            ev.ignore()
+            return
+        ev.accept()
+        start = float(self.mapToView(ev.buttonDownPos()).x())
+        current = float(self.mapToView(ev.pos()).x())
+        lo, hi = sorted((start, current))
+        if self._preview is None:
+            self._preview = pg.LinearRegionItem(
+                values=(lo, hi), movable=False, brush=_REGION_BRUSH
+            )
+            self._preview.setZValue(20)
+            self.addItem(self._preview)
+        self._preview.setRegion((lo, hi))
+        if ev.isFinish():
+            self.removeItem(self._preview)
+            self._preview = None
+            self.dragFinished.emit(lo, hi)
+
+    def mouseClickEvent(self, ev: Any) -> None:
+        if ev.button() != QtCore.Qt.MouseButton.LeftButton:
+            ev.ignore()
+            return
+        ev.accept()
+        self.clicked.emit(float(self.mapToView(ev.pos()).x()))
+
+
+class TraceView(pg.PlotWidget):
+    """Stacked-channel trace display with drag-to-annotate.
+
+    Owns the display state (window position/length, filter spec, amplitude
+    scale, the annotation list and selection) and emits user intent upward:
+
+    * ``regionDrawn(start, stop)`` — a drag finished; the window asks for a label.
+    * ``annotationSelected(index)`` — click selected an annotation (-1: none).
+    * ``windowChanged(start)`` — the view scrolled itself (mouse wheel), so the
+      window can sync its scrollbar.
+    * ``cursorMoved(seconds)`` — mouse position, for the status-bar clock.
+    """
+
+    regionDrawn = QtCore.pyqtSignal(float, float)
+    annotationSelected = QtCore.pyqtSignal(int)
+    windowChanged = QtCore.pyqtSignal(float)
+    cursorMoved = QtCore.pyqtSignal(float)
+
+    def __init__(self) -> None:
+        self._viewbox = _AnnotateViewBox()
+        super().__init__(viewBox=self._viewbox, background=None)
+        self._provider: SliceProvider | None = None
+        self._spec = dsp.UNFILTERED
+        self._window_start = 0.0
+        self._window_seconds = 30.0  # the standard sleep-scoring epoch
+        self._scale_uv = 100.0  # microvolts per channel lane
+        self._annotations: list[Annotation] = []
+        self._selected = -1
+        self._annotation_items: list[pg.LinearRegionItem | pg.InfiniteLine] = []
+        self._curves: list[pg.PlotDataItem] = []
+
+        self._viewbox.dragFinished.connect(self._on_drag_finished)
+        self._viewbox.clicked.connect(self._on_clicked)
+        # Click-to-focus so the arrow-key navigation in keyPressEvent reaches
+        # the traces after the operator clicks them.
+        self.setFocusPolicy(QtCore.Qt.FocusPolicy.ClickFocus)
+        self.setAntialiasing(False)  # measurably faster, invisible at 1 px pens
+        plot_item = self.getPlotItem()
+        assert plot_item is not None
+        plot_item.hideButtons()  # the autoscale "A" makes no sense here
+        plot_item.setMenuEnabled(False)
+        left_axis = plot_item.getAxis("left")
+        left_axis.setStyle(tickLength=0)
+        bottom_axis = plot_item.getAxis("bottom")
+        bottom_axis.setLabel("time (s)")
+        # Track the mouse for the status-bar clock readout.
+        self.scene().sigMouseMoved.connect(self._on_mouse_moved)
+
+    # ----- display state ----------------------------------------------------
+
+    @property
+    def window_start(self) -> float:
+        return self._window_start
+
+    @property
+    def window_seconds(self) -> float:
+        return self._window_seconds
+
+    @property
+    def annotations(self) -> list[Annotation]:
+        return list(self._annotations)
+
+    @property
+    def selected(self) -> int:
+        return self._selected
+
+    def set_provider(self, provider: SliceProvider | None) -> None:
+        """Show a (new) recording from its start; ``None`` clears the view."""
+        self._provider = provider
+        self._window_start = 0.0
+        self._build_curves()
+        self._refresh_data()
+        self._refresh_annotations()
+
+    def set_spec(self, spec: dsp.FilterSpec) -> None:
+        self._spec = spec
+        self._refresh_data()
+
+    def set_scale(self, microvolts: float) -> None:
+        """Set the lane height in µV (smaller value → visually bigger traces)."""
+        self._scale_uv = max(1e-9, microvolts)
+        self._refresh_data()
+
+    def set_window_seconds(self, seconds: float) -> None:
+        self._window_seconds = max(1.0, seconds)
+        self._clamp_window_start()
+        self._refresh_data()
+        self._refresh_annotations()
+
+    def set_window_start(self, seconds: float) -> None:
+        self._window_start = seconds
+        self._clamp_window_start()
+        self._refresh_data()
+        self._refresh_annotations()
+
+    def scroll_by(self, fraction: float) -> None:
+        """Scroll by a fraction of the window (±1.0 is a full page)."""
+        self.set_window_start(self._window_start + fraction * self._window_seconds)
+        self.windowChanged.emit(self._window_start)
+
+    def set_annotations(
+        self, annotations: list[Annotation], selected: int = -1
+    ) -> None:
+        """Replace the displayed annotations (and selection) — no refilter."""
+        self._annotations = list(annotations)
+        self._selected = selected
+        self._refresh_annotations()
+
+    # ----- interaction ---------------------------------------------------------
+
+    def _on_drag_finished(self, lo: float, hi: float) -> None:
+        if self._provider is None:
+            return
+        # Clamp to the recording so a drag past an edge yields a valid span.
+        lo = max(0.0, lo)
+        hi = min(self._provider.duration, hi)
+        if hi > lo:
+            self.regionDrawn.emit(lo, hi)
+
+    def _on_clicked(self, seconds: float) -> None:
+        index = self._annotation_at(seconds)
+        self._selected = index
+        self._refresh_annotations()
+        self.annotationSelected.emit(index)
+
+    def _annotation_at(self, seconds: float) -> int:
+        """The index of the annotation under ``seconds``, or -1.
+
+        Prefers the latest-starting (typically narrowest/topmost) hit so a
+        point mark inside a long region is still clickable. Zero-duration
+        marks get a small symmetric tolerance.
+        """
+        tolerance = self._window_seconds * _CLICK_TOLERANCE_FRACTION
+        hit = -1
+        for index, a in enumerate(self._annotations):
+            lo, hi = a.onset, a.onset + a.duration
+            if a.duration == 0:
+                lo, hi = lo - tolerance, hi + tolerance
+            if lo <= seconds <= hi:
+                hit = index
+        return hit
+
+    def _on_mouse_moved(self, scene_pos: Any) -> None:
+        plot_item = self.getPlotItem()
+        # sceneBoundingRect lives on the PlotItem (a QGraphicsWidget) — the
+        # PlotWidget itself is the QGraphicsView and has no scene rect.
+        if plot_item is not None and plot_item.sceneBoundingRect().contains(scene_pos):
+            self.cursorMoved.emit(float(self._viewbox.mapSceneToView(scene_pos).x()))
+
+    def wheelEvent(self, ev: QtGui.QWheelEvent | None) -> None:
+        """Wheel scrolls time (a tenth of a window per notch), never zooms."""
+        if ev is None:
+            return
+        notches = ev.angleDelta().y() / 120.0
+        self.scroll_by(-0.1 * notches)
+        ev.accept()
+
+    def keyPressEvent(self, ev: QtGui.QKeyEvent | None) -> None:
+        """Arrow/Home/End navigation while the traces have focus.
+
+        These live here (with click-to-focus) rather than as window shortcuts
+        because a focused spin box consumes cursor keys via ShortcutOverride —
+        a window-level Left/Right would silently die right after the operator
+        adjusts a filter. Clicking the traces focuses them, and from there the
+        arrows always work. PageUp/PageDown are window shortcuts (no text
+        widget steals them), so paging works regardless of focus.
+        """
+        if ev is None:
+            return
+        key = ev.key()
+        if key == QtCore.Qt.Key.Key_Right:
+            self.scroll_by(0.1)
+        elif key == QtCore.Qt.Key.Key_Left:
+            self.scroll_by(-0.1)
+        elif key == QtCore.Qt.Key.Key_Home:
+            self.set_window_start(0.0)
+            self.windowChanged.emit(self._window_start)
+        elif key == QtCore.Qt.Key.Key_End:
+            self.set_window_start(float("inf"))
+            self.windowChanged.emit(self._window_start)
+        else:
+            super().keyPressEvent(ev)
+            return
+        ev.accept()
+
+    # ----- drawing ---------------------------------------------------------------
+
+    def _clamp_window_start(self) -> None:
+        if self._provider is None:
+            self._window_start = 0.0
+            return
+        latest = max(0.0, self._provider.duration - self._window_seconds)
+        self._window_start = min(max(0.0, self._window_start), latest)
+
+    def _build_curves(self) -> None:
+        """Recreate one curve per channel (on open/clear), tuned for speed."""
+        plot_item = self.getPlotItem()
+        assert plot_item is not None
+        for curve in self._curves:
+            plot_item.removeItem(curve)
+        self._curves = []
+        if self._provider is None:
+            plot_item.getAxis("left").setTicks([[]])
+            return
+        pen = pg.mkPen(self.palette().color(QtGui.QPalette.ColorRole.Text), width=1)
+        names = self._provider.ch_names
+        for _ in names:
+            curve = pg.PlotDataItem(pen=pen)
+            # Peak (min/max) downsampling keeps extremes visible at any zoom;
+            # clip-to-view skips offscreen points when a margin is set.
+            curve.setDownsampling(auto=True, method="peak")
+            curve.setClipToView(True)
+            plot_item.addItem(curve)
+            self._curves.append(curve)
+        plot_item.getAxis("left").setTicks(
+            [[(-i, name) for i, name in enumerate(names)]]
+        )
+        self.setYRange(-len(names) + 0.4, 0.6, padding=0)
+
+    def _refresh_data(self) -> None:
+        """Fetch, filter, scale, and draw the visible slice of every channel."""
+        if self._provider is None:
+            return
+        pad = dsp.pad_seconds(self._spec)
+        lo = self._window_start
+        hi = self._window_start + self._window_seconds
+        times, data = self._provider.get_slice(lo - pad, hi + pad)
+        data = dsp.apply(np.asarray(data), self._provider.sfreq, self._spec)
+        times = np.asarray(times)
+        # Trim the filter margin so its edge transients never reach the screen.
+        keep = (times >= lo) & (times <= hi)
+        times, data = times[keep], data[:, keep]
+        ch_types = self._provider.ch_types
+        for i, curve in enumerate(self._curves):
+            trace = data[i]
+            if ch_types[i] in _MICROVOLT_TYPES:
+                gain = TYPE_GAINS.get(ch_types[i], 1.0)
+                scaled = trace * _VOLTS_TO_MICROVOLTS * (gain / self._scale_uv)
+            else:
+                # Unit-less channel (stim/misc/…): fit it to its own lane per
+                # visible slice. Absolute amplitude is meaningless for these;
+                # the edges (a trigger firing) are what a reviewer looks for.
+                peak = float(np.max(np.abs(trace))) if trace.size else 0.0
+                scaled = trace * (_AUTOFIT_EXCURSION / peak) if peak else trace
+            curve.setData(times, -i + scaled)
+        self.setXRange(lo, hi, padding=0)
+
+    def _refresh_annotations(self) -> None:
+        """Redraw the annotation overlay for the visible window (cheap)."""
+        plot_item = self.getPlotItem()
+        assert plot_item is not None
+        for old in self._annotation_items:
+            plot_item.removeItem(old)
+        self._annotation_items = []
+        if self._provider is None:
+            return
+        lo = self._window_start
+        hi = self._window_start + self._window_seconds
+        for index, a in enumerate(self._annotations):
+            if a.onset + a.duration < lo or a.onset > hi:
+                continue
+            selected = index == self._selected
+            item: pg.LinearRegionItem | pg.InfiniteLine
+            if a.duration > 0:
+                item = pg.LinearRegionItem(
+                    values=(a.onset, a.onset + a.duration),
+                    movable=False,
+                    brush=_REGION_BRUSH_SELECTED if selected else _REGION_BRUSH,
+                    pen=_REGION_PEN,
+                )
+            else:
+                item = pg.InfiniteLine(
+                    pos=a.onset,
+                    angle=90,
+                    movable=False,
+                    pen=pg.mkPen(
+                        _LINE_PEN_SELECTED if selected else _LINE_PEN,
+                        width=2 if selected else 1,
+                    ),
+                )
+            item.setToolTip(a.description)
+            item.setZValue(10)
+            plot_item.addItem(item)
+            self._annotation_items.append(item)

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -1,0 +1,630 @@
+"""The EEG review window: open a recording, scroll it, annotate it (#136).
+
+A standalone top-level window with its own process and ``QApplication`` (see
+the package docstring) — not a launcher-managed :class:`~smacc.toolwindow
+.ToolWindow`, since the launcher can't signal across processes. It owns a
+:class:`~smacc.eeg.view.TraceView` plus the controls around it: open/save,
+display filters, window length, amplitude scale, a scrollbar, and the
+annotation list.
+
+Annotation flow: a drag on the traces draws a span, the label dialog asks what
+it was (seeded with sleep-research vocabulary and the operator's recent
+labels), and Save writes the TSV/JSON sidecar next to the source recording.
+Opening a file that already has a sidecar resumes from it; only a *fresh*
+review imports the events embedded in the recording itself (re-importing on
+every open would duplicate them into the saved sidecar). Unsaved changes mark
+the title and prompt on close.
+
+This is a *daytime* analysis tool: unlike the session windows there is no dark
+theme, no always-on-top, and nothing here may import from the live-session
+modules (the frozen ``SMACC-EEG.exe`` doesn't ship them all — and review work
+must never share a process with a running night).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from .. import preferences, windowstate
+from ..paths import LOGO_PATH, preferences_path
+from . import dsp, io
+from .annotations import (
+    Annotation,
+    insert,
+    read_annotations_tsv,
+    remove,
+    replace,
+    sidecar_paths,
+    write_annotations_json,
+    write_annotations_tsv,
+)
+from .view import TraceView
+
+# Stable id for this window's geometry entry in the per-window prefs map.
+_EEG_WINDOW_ID = "eeg-review"
+
+# Starting points for the label dropdown before an operator has any recents:
+# the marks dream-engineering reviewers actually place (see the
+# dream-engineering skill / docs). Free text is always allowed on top.
+SEED_LABELS = ["LRLR", "Arousal", "Artifact", "Cue response"]
+_MAX_RECENT_LABELS = 12
+
+# Selectable page lengths, seconds. 30 s — the sleep-scoring epoch — is the
+# default; the rest bracket it for fine inspection and context.
+WINDOW_LENGTHS = (10, 30, 60, 120)
+DEFAULT_WINDOW_LENGTH = 30
+
+# The scrollbar works in tenths of a second: fine enough to land anywhere,
+# coarse enough that an 8 h night stays within QScrollBar's int range.
+_SCROLL_TICKS_PER_SECOND = 10
+
+
+def _section_title(text: str) -> QtWidgets.QLabel:
+    """A centered 18pt section header (QFont, not stylesheet, so it follows
+    the palette).
+
+    Deliberately duplicated from ``panels.base.make_section_title``: importing
+    ``panels.base`` executes ``import sounddevice`` and pulls in the whole
+    live-session stack, which this process must never load (see the module
+    docstring) and the frozen ``SMACC-EEG.exe`` will not ship.
+    """
+    label = QtWidgets.QLabel(text)
+    label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+    font = QtGui.QFont()
+    font.setPointSize(18)
+    label.setFont(font)
+    return label
+
+
+def wall_time(recording: io.Recording, seconds: float) -> datetime | None:
+    """The wall-clock time at ``seconds`` into ``recording``, or ``None``.
+
+    Format-aware on purpose: EDF/BrainVision start times are the tech's
+    wall-clock stamps that MNE only tags UTC pro forma, so they display as-is;
+    a FIF ``meas_date`` is a true UTC instant, so it converts to this
+    machine's local zone (the right answer whenever the file is reviewed in
+    the timezone it was recorded in — the overwhelmingly common case).
+    """
+    start = recording.meas_date
+    if start is None:
+        return None
+    if recording.path.suffix.lower() == ".fif":
+        start = start.astimezone()
+    return start + timedelta(seconds=seconds)
+
+
+class LabelDialog(QtWidgets.QDialog):
+    """Ask for an annotation's label: editable dropdown of recents + free text.
+
+    The "instant" checkbox turns a drawn span into a zero-duration mark — the
+    natural unit for events like an LRLR signal, where the moment matters and
+    the drawn width was just the drag.
+    """
+
+    def __init__(
+        self, parent: QtWidgets.QWidget | None, recents: list[str], initial: str = ""
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Annotation label")
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(QtWidgets.QLabel("Label for this annotation:", self))
+        self.labelCombo = QtWidgets.QComboBox(self)
+        self.labelCombo.setEditable(True)
+        seen: list[str] = []
+        for label in [*recents, *SEED_LABELS]:
+            if label not in seen:
+                seen.append(label)
+        self.labelCombo.addItems(seen)
+        self.labelCombo.setCurrentText(initial)
+        layout.addWidget(self.labelCombo)
+        self.instantCheck = QtWidgets.QCheckBox(
+            "Instantaneous mark (drop the drawn duration)", self
+        )
+        layout.addWidget(self.instantCheck)
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    @staticmethod
+    def get_label(
+        parent: QtWidgets.QWidget | None,
+        recents: list[str],
+        initial: str = "",
+        *,
+        offer_instant: bool = True,
+    ) -> tuple[str, bool] | None:
+        """Run the dialog; return ``(label, instant)`` or ``None`` on cancel.
+
+        Cancel includes confirming an empty label — there is nothing useful to
+        do with an unnamed span, so it reads as "never mind".
+        """
+        dialog = LabelDialog(parent, recents, initial)
+        dialog.instantCheck.setVisible(offer_instant)
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return None
+        label = " ".join(dialog.labelCombo.currentText().split())
+        if not label:
+            return None
+        return label, offer_instant and dialog.instantCheck.isChecked()
+
+
+class EegReviewWindow(QtWidgets.QMainWindow):
+    """Review and annotate one recording; the EEG component's main window."""
+
+    def __init__(self, file_path: str | Path | None = None) -> None:
+        super().__init__()
+        self._recording: io.Recording | None = None
+        self._annotations: list[Annotation] = []
+        self._dirty = False
+        self.setWindowTitle("SMACC — EEG review")
+        if LOGO_PATH.is_file():
+            self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
+        self._build()
+        self._set_loaded(False)
+        if file_path is not None:
+            # After the event loop starts, so the window is up before any
+            # open-error dialog (and a long load doesn't block the first paint).
+            QtCore.QTimer.singleShot(0, lambda: self._load(Path(file_path)))
+
+    # ----- UI construction ----------------------------------------------------
+
+    def _build(self) -> None:
+        central = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(central)
+        layout.setContentsMargins(12, 8, 12, 8)
+        layout.setSpacing(8)
+        layout.addWidget(_section_title("EEG review"))
+        layout.addLayout(self._build_controls_row())
+
+        body = QtWidgets.QHBoxLayout()
+        viewColumn = QtWidgets.QVBoxLayout()
+        self.view = TraceView()
+        self.view.regionDrawn.connect(self._on_region_drawn)
+        self.view.annotationSelected.connect(self._on_view_selection)
+        self.view.windowChanged.connect(self._sync_scrollbar)
+        self.view.cursorMoved.connect(self._on_cursor_moved)
+        viewColumn.addWidget(self.view, 1)
+        self.scrollBar = QtWidgets.QScrollBar(QtCore.Qt.Orientation.Horizontal, self)
+        self.scrollBar.setStatusTip("Scroll through the recording.")
+        self.scrollBar.valueChanged.connect(self._on_scrollbar)
+        viewColumn.addWidget(self.scrollBar)
+        body.addLayout(viewColumn, 1)
+        body.addLayout(self._build_annotation_panel())
+        layout.addLayout(body, 1)
+
+        self.statusBar()
+        # Permanent (right-aligned) recording summary; transient messages and
+        # the cursor clock use the normal message area.
+        self.fileInfoLabel = QtWidgets.QLabel("", self)
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.addPermanentWidget(self.fileInfoLabel)
+
+        self._build_shortcuts()
+        self.setCentralWidget(central)
+        prefs = preferences.load_preferences(preferences_path)
+        geometry = preferences.window_geometry(prefs, _EEG_WINDOW_ID)
+        windowstate.restore_geometry(self, geometry, default_size=(1150, 700))
+
+    def _build_controls_row(self) -> QtWidgets.QLayout:
+        row = QtWidgets.QHBoxLayout()
+        openButton = QtWidgets.QPushButton("Open recording…", self)
+        openButton.setStatusTip("Open an EEG recording (EDF, BrainVision, or FIF).")
+        openButton.clicked.connect(self.open_file)
+        row.addWidget(openButton)
+        row.addSpacing(12)
+
+        # Display filters. 0 reads as "Off" (special value text): the viewer
+        # opens unfiltered — silently rewriting amplitudes before the operator
+        # asked would misrepresent the recording.
+        row.addWidget(QtWidgets.QLabel("High-pass:", self))
+        self.highpassSpin = QtWidgets.QDoubleSpinBox(self)
+        self.highpassSpin.setRange(0.0, 100.0)
+        self.highpassSpin.setDecimals(2)
+        self.highpassSpin.setSingleStep(0.1)
+        self.highpassSpin.setSuffix(" Hz")
+        self.highpassSpin.setSpecialValueText("Off")
+        self.highpassSpin.setStatusTip(
+            "Drop slow drift below this frequency (0.3 Hz is the usual sleep view)."
+        )
+        row.addWidget(self.highpassSpin)
+        row.addWidget(QtWidgets.QLabel("Low-pass:", self))
+        self.lowpassSpin = QtWidgets.QDoubleSpinBox(self)
+        self.lowpassSpin.setRange(0.0, 500.0)
+        self.lowpassSpin.setDecimals(1)
+        self.lowpassSpin.setSingleStep(5.0)
+        self.lowpassSpin.setSuffix(" Hz")
+        self.lowpassSpin.setSpecialValueText("Off")
+        self.lowpassSpin.setStatusTip(
+            "Drop fast noise above this frequency (35 Hz is the usual sleep view)."
+        )
+        row.addWidget(self.lowpassSpin)
+        row.addWidget(QtWidgets.QLabel("Notch:", self))
+        self.notchCombo = QtWidgets.QComboBox(self)
+        self.notchCombo.addItem("Off", None)
+        self.notchCombo.addItem("50 Hz", 50.0)
+        self.notchCombo.addItem("60 Hz", 60.0)
+        self.notchCombo.setStatusTip("Remove mains interference (50 Hz EU, 60 Hz US).")
+        row.addWidget(self.notchCombo)
+        for widget in (self.highpassSpin, self.lowpassSpin):
+            widget.valueChanged.connect(self._on_filters_changed)
+        self.notchCombo.currentIndexChanged.connect(self._on_filters_changed)
+        row.addSpacing(12)
+
+        row.addWidget(QtWidgets.QLabel("Window:", self))
+        self.windowCombo = QtWidgets.QComboBox(self)
+        for seconds in WINDOW_LENGTHS:
+            self.windowCombo.addItem(f"{seconds} s", float(seconds))
+        self.windowCombo.setCurrentIndex(WINDOW_LENGTHS.index(DEFAULT_WINDOW_LENGTH))
+        self.windowCombo.setStatusTip(
+            "How many seconds are on screen (30 s is one scoring epoch)."
+        )
+        self.windowCombo.currentIndexChanged.connect(self._on_window_length_changed)
+        row.addWidget(self.windowCombo)
+
+        row.addWidget(QtWidgets.QLabel("Scale:", self))
+        self.scaleSpin = QtWidgets.QDoubleSpinBox(self)
+        self.scaleSpin.setRange(1.0, 10000.0)
+        self.scaleSpin.setDecimals(0)
+        self.scaleSpin.setValue(100.0)
+        self.scaleSpin.setSuffix(" µV")
+        self.scaleSpin.setStatusTip(
+            "Microvolts per channel lane — smaller means visually bigger traces."
+        )
+        self.scaleSpin.valueChanged.connect(
+            lambda value: self.view.set_scale(float(value))
+        )
+        row.addWidget(self.scaleSpin)
+
+        row.addStretch(1)
+        self.saveButton = QtWidgets.QPushButton("Save annotations", self)
+        self.saveButton.setStatusTip(
+            "Write the annotations TSV/JSON sidecar next to the recording."
+        )
+        self.saveButton.clicked.connect(self.save_annotations)
+        row.addWidget(self.saveButton)
+        return row
+
+    def _build_annotation_panel(self) -> QtWidgets.QLayout:
+        panel = QtWidgets.QVBoxLayout()
+        panel.addWidget(QtWidgets.QLabel("Annotations:", self))
+        self.annotationList = QtWidgets.QListWidget(self)
+        self.annotationList.setMinimumWidth(230)
+        self.annotationList.setStatusTip(
+            "Click to highlight; double-click to jump the view there."
+        )
+        self.annotationList.currentRowChanged.connect(self._on_list_selection)
+        self.annotationList.itemDoubleClicked.connect(
+            lambda _item: self.go_to_selected()
+        )
+        panel.addWidget(self.annotationList, 1)
+        buttons = QtWidgets.QHBoxLayout()
+        self.editButton = QtWidgets.QPushButton("Edit…", self)
+        self.editButton.setStatusTip("Rename the selected annotation.")
+        self.editButton.clicked.connect(self.edit_selected)
+        self.deleteButton = QtWidgets.QPushButton("Delete", self)
+        self.deleteButton.setStatusTip("Delete the selected annotation.")
+        self.deleteButton.clicked.connect(self.delete_selected)
+        buttons.addWidget(self.editButton)
+        buttons.addWidget(self.deleteButton)
+        panel.addLayout(buttons)
+        return panel
+
+    def _build_shortcuts(self) -> None:
+        """Window-wide paging on PageUp/PageDown only.
+
+        Arrows and Home/End live on the TraceView itself (click the traces,
+        then navigate): as window shortcuts they would be consumed by whichever
+        spin box or list last had focus. No text widget steals PageUp/Down, so
+        paging works from anywhere.
+        """
+        for keys, fraction in (
+            (QtCore.Qt.Key.Key_PageDown, 1.0),
+            (QtCore.Qt.Key.Key_PageUp, -1.0),
+        ):
+            shortcut = QtGui.QShortcut(QtGui.QKeySequence(keys), self)
+            shortcut.activated.connect(lambda f=fraction: self.view.scroll_by(f))
+
+    def _set_loaded(self, loaded: bool) -> None:
+        for widget in (
+            self.saveButton,
+            self.editButton,
+            self.deleteButton,
+            self.scrollBar,
+        ):
+            widget.setEnabled(loaded)
+
+    # ----- opening a recording ---------------------------------------------------
+
+    def open_file(self) -> None:
+        if not self._confirm_discard():
+            return
+        prefs = preferences.load_preferences(preferences_path)
+        start_dir = prefs.get("eeg_last_dir") or str(Path.home())
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Open EEG recording", str(start_dir), io.FILE_FILTER
+        )
+        if path:
+            self._load(Path(path))
+
+    def _load(self, path: Path) -> None:
+        try:
+            recording = io.open_recording(path)
+        except (ValueError, OSError, RuntimeError) as exc:
+            self._error("Could not open the recording.", str(exc))
+            return
+        tsv_path, _ = sidecar_paths(path)
+        if tsv_path.is_file():
+            # Resume a previous review. A sidecar that exists but won't parse
+            # aborts the open: it is the reviewer's data, and proceeding would
+            # overwrite it with an empty list on the next save.
+            try:
+                annotations = read_annotations_tsv(tsv_path)
+            except (OSError, ValueError) as exc:
+                self._error(
+                    "Could not read the existing annotations sidecar.",
+                    f"{tsv_path.name}: {exc}\n\nFix or rename the sidecar, "
+                    "then open the recording again.",
+                )
+                return
+        else:
+            # A fresh review starts from the events embedded in the recording
+            # (amp markers, SMACC's own portcodes…), so they end up in the
+            # sidecar alongside the reviewer's marks.
+            annotations = io.embedded_annotations(recording)
+        self._recording = recording
+        self._annotations = annotations
+        self._dirty = False
+        self.view.set_provider(recording)
+        self.view.set_annotations(annotations)
+        self._refresh_list()
+        self._refresh_title()
+        self._configure_scrollbar()
+        self._set_loaded(True)
+        preferences.update_preferences(
+            preferences_path, {"eeg_last_dir": str(path.parent)}
+        )
+        started = wall_time(recording, 0.0)
+        clock = f" · started {started.strftime('%H:%M:%S')}" if started else ""
+        self.fileInfoLabel.setText(
+            f"{path.name} — {len(recording.ch_names)} ch · "
+            f"{recording.sfreq:g} Hz · {recording.duration:.0f} s{clock}"
+        )
+
+    # ----- annotation editing -----------------------------------------------------
+
+    def _on_region_drawn(self, lo: float, hi: float) -> None:
+        result = LabelDialog.get_label(self, self._recent_labels())
+        if result is None:
+            return
+        label, instant = result
+        annotation = Annotation(lo, 0.0 if instant else hi - lo, label)
+        self._annotations = insert(self._annotations, annotation)
+        self._remember_label(label)
+        self._mark_dirty()
+        self._select(self._annotations.index(annotation))
+
+    def edit_selected(self) -> None:
+        index = self.annotationList.currentRow()
+        if not 0 <= index < len(self._annotations):
+            return
+        current = self._annotations[index]
+        result = LabelDialog.get_label(
+            self, self._recent_labels(), current.description, offer_instant=False
+        )
+        if result is None:
+            return
+        label, _ = result
+        edited = Annotation(current.onset, current.duration, label)
+        self._annotations = replace(self._annotations, index, edited)
+        self._remember_label(label)
+        self._mark_dirty()
+        self._select(self._annotations.index(edited))
+
+    def delete_selected(self) -> None:
+        index = self.annotationList.currentRow()
+        if not 0 <= index < len(self._annotations):
+            return
+        self._annotations = remove(self._annotations, index)
+        self._mark_dirty()
+        self._select(-1)
+
+    def go_to_selected(self) -> None:
+        """Jump the view so the selected annotation sits a quarter-window in."""
+        index = self.annotationList.currentRow()
+        if not 0 <= index < len(self._annotations):
+            return
+        onset = self._annotations[index].onset
+        self._jump_to(onset - self.view.window_seconds / 4)
+
+    def save_annotations(self) -> None:
+        if self._recording is None:
+            return
+        tsv_path, json_path = sidecar_paths(self._recording.path)
+        try:
+            write_annotations_tsv(self._annotations, tsv_path)
+            write_annotations_json(
+                json_path,
+                source_name=self._recording.path.name,
+                meas_date=self._recording.meas_date,
+            )
+        except OSError as exc:
+            self._error("Could not save the annotations.", str(exc))
+            return
+        self._dirty = False
+        self._refresh_title()
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.showMessage(
+            f"Saved {len(self._annotations)} annotations to {tsv_path.name}", 5000
+        )
+
+    # ----- annotation bookkeeping ----------------------------------------------------
+
+    def _mark_dirty(self) -> None:
+        self._dirty = True
+        self._refresh_title()
+
+    def _select(self, index: int) -> None:
+        """Sync the list widget and the view to one selected annotation.
+
+        The row is set with signals blocked: letting currentRowChanged fire
+        would rebuild the view's overlay a second time right before the
+        explicit set_annotations below (and that explicit call must stay —
+        deselection never fires currentRowChanged, the row is already -1
+        after the blocked rebuild).
+        """
+        self._refresh_list()
+        self.annotationList.blockSignals(True)
+        self.annotationList.setCurrentRow(index)
+        self.annotationList.blockSignals(False)
+        self.view.set_annotations(self._annotations, index)
+
+    def _refresh_list(self) -> None:
+        self.annotationList.blockSignals(True)  # programmatic fill: not a selection
+        self.annotationList.clear()
+        for a in self._annotations:
+            span = f"{a.onset:.3f}s" + (f" +{a.duration:.3f}s" if a.duration else "")
+            self.annotationList.addItem(f"{span}  {a.description}")
+        self.annotationList.blockSignals(False)
+
+    def _refresh_title(self) -> None:
+        name = f" — {self._recording.path.name}" if self._recording else ""
+        star = " *" if self._dirty else ""
+        self.setWindowTitle(f"SMACC — EEG review{name}{star}")
+
+    def _recent_labels(self) -> list[str]:
+        prefs = preferences.load_preferences(preferences_path)
+        recents = prefs.get("eeg_recent_labels")
+        return [r for r in recents if isinstance(r, str)] if recents else []
+
+    def _remember_label(self, label: str) -> None:
+        recents = preferences.push_recent(
+            self._recent_labels(), label, limit=_MAX_RECENT_LABELS
+        )
+        preferences.update_preferences(preferences_path, {"eeg_recent_labels": recents})
+
+    # ----- selection sync ---------------------------------------------------------
+
+    def _on_view_selection(self, index: int) -> None:
+        self.annotationList.blockSignals(True)
+        self.annotationList.setCurrentRow(index)
+        self.annotationList.blockSignals(False)
+
+    def _on_list_selection(self, row: int) -> None:
+        self.view.set_annotations(self._annotations, row)
+
+    # ----- navigation / display controls ----------------------------------------------
+
+    def _jump_to(self, seconds: float) -> None:
+        self.view.set_window_start(seconds)  # the view clamps
+        self._sync_scrollbar(self.view.window_start)
+
+    def _configure_scrollbar(self) -> None:
+        duration = self._recording.duration if self._recording else 0.0
+        span = max(0.0, duration - self.view.window_seconds)
+        self.scrollBar.blockSignals(True)
+        self.scrollBar.setRange(0, int(span * _SCROLL_TICKS_PER_SECOND))
+        self.scrollBar.setPageStep(
+            int(self.view.window_seconds * _SCROLL_TICKS_PER_SECOND)
+        )
+        self.scrollBar.setValue(int(self.view.window_start * _SCROLL_TICKS_PER_SECOND))
+        self.scrollBar.blockSignals(False)
+
+    def _on_scrollbar(self, value: int) -> None:
+        self.view.set_window_start(value / _SCROLL_TICKS_PER_SECOND)
+
+    def _sync_scrollbar(self, window_start: float) -> None:
+        self.scrollBar.blockSignals(True)
+        self.scrollBar.setValue(int(window_start * _SCROLL_TICKS_PER_SECOND))
+        self.scrollBar.blockSignals(False)
+
+    def _on_window_length_changed(self) -> None:
+        self.view.set_window_seconds(float(self.windowCombo.currentData()))
+        self._configure_scrollbar()
+
+    def _on_filters_changed(self) -> None:
+        highpass = self.highpassSpin.value() or None  # 0.0 displays as "Off"
+        lowpass = self.lowpassSpin.value() or None
+        notch = self.notchCombo.currentData()
+        try:
+            spec = dsp.FilterSpec(highpass=highpass, lowpass=lowpass, notch=notch)
+        except ValueError:
+            # Invalid band (high-pass >= low-pass): keep the previous filter,
+            # say why, and snap the controls back to it — a control left
+            # showing a rejected value would silently apply the moment the
+            # *other* edge moved, a filter the operator never confirmed.
+            status_bar = self.statusBar()
+            assert status_bar is not None
+            status_bar.showMessage(
+                "High-pass must stay below low-pass — filters unchanged.", 4000
+            )
+            applied = self.view._spec
+            for spin, value in (
+                (self.highpassSpin, applied.highpass),
+                (self.lowpassSpin, applied.lowpass),
+            ):
+                spin.blockSignals(True)
+                spin.setValue(value or 0.0)  # 0.0 displays as "Off"
+                spin.blockSignals(False)
+            return
+        self.view.set_spec(spec)
+
+    def _on_cursor_moved(self, seconds: float) -> None:
+        if self._recording is None:
+            return
+        text = f"t = {seconds:.3f} s"
+        clock = wall_time(self._recording, seconds) if seconds >= 0 else None
+        if clock is not None:
+            text += f" · {clock.strftime('%H:%M:%S')}"
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.showMessage(text)
+
+    # ----- helpers / lifecycle -------------------------------------------------------
+
+    def _confirm_discard(self) -> bool:
+        """True when it's safe to drop the current annotations (saved or confirmed)."""
+        if not self._dirty:
+            return True
+        button = QtWidgets.QMessageBox.question(
+            self,
+            "Unsaved annotations",
+            "Save the annotations before closing this recording?",
+            QtWidgets.QMessageBox.StandardButton.Save
+            | QtWidgets.QMessageBox.StandardButton.Discard
+            | QtWidgets.QMessageBox.StandardButton.Cancel,
+        )
+        if button == QtWidgets.QMessageBox.StandardButton.Save:
+            self.save_annotations()
+            return not self._dirty  # a failed save keeps the recording open
+        return button == QtWidgets.QMessageBox.StandardButton.Discard
+
+    def _error(self, short: str, detail: str | None = None) -> None:
+        box = QtWidgets.QMessageBox(self)
+        box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+        box.setWindowTitle("EEG review")
+        box.setText(short)
+        if detail is not None:
+            box.setInformativeText(detail)
+        box.exec()
+
+    def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+        if not self._confirm_discard():
+            if event is not None:
+                event.ignore()
+            return
+        # Remember where this window sat for next launch (best-effort, never raises).
+        preferences.update_window_geometry(
+            preferences_path, _EEG_WINDOW_ID, windowstate.geometry_of(self)
+        )
+        if event is not None:
+            event.accept()

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from . import preferences, settings, updates, winassoc, windowstate
+from . import eeg, preferences, settings, updates, winassoc, windowstate
 from .analyze import AnalyzeWindow
 from .config import VERSION
 from .cuedesigner import CueDesignerWindow
@@ -118,6 +118,29 @@ class LauncherWindow(QtWidgets.QMainWindow):
         )
         analyzeButton.clicked.connect(self.analyze_session)
         layout.addWidget(analyzeButton)
+
+        # The optional EEG review component (#136). Shown disabled (not
+        # hidden) when absent, so a lab knows the tool exists and how to get
+        # it — the same surface-don't-hide approach as missing trigger
+        # hardware (#147). Availability is probed once, here: installing the
+        # component mid-run requires closing SMACC anyway (the installer
+        # replaces the locked exe), and a stale True is already handled by
+        # the launch-failure dialog.
+        reviewEegButton = QtWidgets.QPushButton("Review EEG", self)
+        reviewEegButton.setMinimumHeight(40)
+        if eeg.available():
+            reviewEegButton.setStatusTip(
+                "Open the EEG review tool in its own window (annotate a recording)."
+            )
+        else:
+            reviewEegButton.setEnabled(False)
+            reviewEegButton.setStatusTip(
+                "EEG Review Tools are not installed — re-run the SMACC "
+                "installer and select the component."
+            )
+        reviewEegButton.clicked.connect(self.review_eeg)
+        self.reviewEegButton = reviewEegButton
+        layout.addWidget(reviewEegButton)
 
         layout.addStretch(1)
         # Link to the documentation site (not the repo), hyperlinked. Rich text +
@@ -334,6 +357,27 @@ class LauncherWindow(QtWidgets.QMainWindow):
     def analyze_session(self) -> None:
         """Open the analyze window over the current settings' data directory."""
         self._open_tool(AnalyzeWindow(self._data_dir()))
+
+    def review_eeg(self) -> None:
+        """Launch the EEG review tool as its own detached process.
+
+        Unlike the launcher-managed tools this never hides the launcher: the
+        viewer is a sibling app in a separate process (the frozen build can't
+        run it in-process — MNE isn't bundled in SMACC.exe), so there is no
+        ``closed`` signal to bring the launcher back.
+        """
+        if eeg.launch():
+            bar = self.statusBar()
+            if bar is not None:
+                bar.showMessage("EEG review opened in its own window.", 5000)
+            return
+        QtWidgets.QMessageBox.warning(
+            self,
+            "Review EEG",
+            "Could not start the EEG review tool.\n\n"
+            "Re-running the SMACC installer and selecting the EEG Review "
+            "Tools component may repair it.",
+        )
 
     def associate_files(self) -> None:
         """Register SMACC as the Windows handler for .smacc files (packaged build)."""

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -45,6 +45,13 @@ DEFAULTS: dict[str, Any] = {
     # first; the log file always keeps everything). Large values cost GUI memory
     # and repaint time over an overnight session.
     "log_preview_max_lines": 1000,
+    # EEG review tool (#136): recently used annotation labels (most-recent
+    # first, seeding the label dialog's dropdown) and the last folder a
+    # recording was opened from. Note loading only round-trips keys present
+    # here, so the EEG window's keys must stay in DEFAULTS even though the
+    # tool is an optional component.
+    "eeg_recent_labels": [],
+    "eeg_last_dir": None,
 }
 
 _logger = logging.getLogger("smacc")

--- a/tests/test_eeg_annotations.py
+++ b/tests/test_eeg_annotations.py
@@ -1,0 +1,188 @@
+"""Tests for the EEG annotation model and its TSV/JSON sidecars (#136, no GUI)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from smacc.config import VERSION
+from smacc.eeg import annotations as ann
+
+# ----- the model ------------------------------------------------------------
+
+
+def test_annotation_normalizes_whitespace_in_description():
+    # Tabs/newlines would corrupt the TSV (no escaping convention exists), so
+    # construction collapses them rather than letting the writer corrupt a file.
+    a = ann.Annotation(1.0, 0.5, "  saw\ta\nlight \r\n twice  ")
+    assert a.description == "saw a light twice"
+
+
+def test_annotation_rejects_empty_description():
+    with pytest.raises(ValueError, match="empty"):
+        ann.Annotation(1.0, 0.5, "   \t\n ")
+
+
+def test_annotation_rejects_negative_onset_and_duration():
+    with pytest.raises(ValueError, match="onset"):
+        ann.Annotation(-0.001, 0.0, "x")
+    with pytest.raises(ValueError, match="duration"):
+        ann.Annotation(0.0, -1.0, "x")
+
+
+def test_annotation_rounds_to_millisecond_precision():
+    a = ann.Annotation(1.23456789, 0.0005, "x")
+    assert a.onset == 1.235
+    assert a.duration == 0.001  # rounds, not truncates
+
+
+def test_insert_keeps_sort_order_and_leaves_input_untouched():
+    first = ann.Annotation(5.0, 1.0, "later")
+    existing = [first]
+    out = ann.insert(existing, ann.Annotation(2.0, 0.0, "earlier"))
+    assert [a.description for a in out] == ["earlier", "later"]
+    assert existing == [first]  # pure: caller's list unchanged
+
+
+def test_replace_resorts_when_an_edit_moves_the_onset():
+    items = [ann.Annotation(1.0, 0.0, "a"), ann.Annotation(2.0, 0.0, "b")]
+    out = ann.replace(items, 0, ann.Annotation(9.0, 0.0, "a-moved"))
+    assert [a.description for a in out] == ["b", "a-moved"]
+
+
+def test_remove_drops_by_index():
+    items = [ann.Annotation(1.0, 0.0, "a"), ann.Annotation(2.0, 0.0, "b")]
+    assert [a.description for a in ann.remove(items, 0)] == ["b"]
+
+
+def test_overlapping_annotations_are_allowed():
+    # An arousal marked inside a REM period must coexist; only order matters.
+    items = ann.insert(
+        [ann.Annotation(10.0, 300.0, "REM period")],
+        ann.Annotation(20.0, 5.0, "Arousal"),
+    )
+    assert len(items) == 2
+
+
+# ----- sidecar paths --------------------------------------------------------
+
+
+def test_sidecar_paths_replace_the_recording_suffix():
+    tsv, js = ann.sidecar_paths(Path("C:/data/night1.edf"))
+    assert tsv.name == "night1.annotations.tsv"
+    assert js.name == "night1.annotations.json"
+
+
+def test_sidecar_paths_keep_bids_style_stems_intact():
+    # Deliberately NOT *_events.tsv: opening a file inside a real BIDS dataset
+    # must never clobber the dataset's own events sidecar.
+    tsv, _ = ann.sidecar_paths(Path("sub-01_task-sleep_eeg.vhdr"))
+    assert tsv.name == "sub-01_task-sleep_eeg.annotations.tsv"
+
+
+# ----- TSV round-trip -------------------------------------------------------
+
+
+def test_tsv_round_trip_preserves_annotations(tmp_path):
+    items = [
+        ann.Annotation(0.0, 0.0, "Lights off"),
+        ann.Annotation(12.345, 4.0, "LRLR"),
+        ann.Annotation(12.345, 0.5, "Arousal"),  # same onset, shorter: sorts first
+    ]
+    path = tmp_path / "night1.annotations.tsv"
+    ann.write_annotations_tsv(items, path)
+    assert ann.read_annotations_tsv(path) == sorted(items)
+
+
+def test_tsv_is_tab_separated_with_header(tmp_path):
+    path = tmp_path / "x.tsv"
+    ann.write_annotations_tsv([ann.Annotation(1.5, 0.0, "mark")], path)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "onset\tduration\tdescription"
+    assert lines[1] == "1.500\t0.000\tmark"
+
+
+def test_read_rejects_a_foreign_header(tmp_path):
+    path = tmp_path / "x.tsv"
+    path.write_text("onset\tduration\ttrial_type\n1.0\t0.0\tmark\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="header"):
+        ann.read_annotations_tsv(path)
+
+
+def test_read_reports_the_bad_line_number(tmp_path):
+    path = tmp_path / "x.tsv"
+    path.write_text(
+        "onset\tduration\tdescription\n1.0\t0.0\tok\noops\t0.0\tbad\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="Line 3"):
+        ann.read_annotations_tsv(path)
+
+
+def test_read_rejects_a_short_row(tmp_path):
+    path = tmp_path / "x.tsv"
+    path.write_text("onset\tduration\tdescription\n1.0\t0.0\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Line 2"):
+        ann.read_annotations_tsv(path)
+
+
+def test_read_tolerates_a_trailing_blank_line(tmp_path):
+    path = tmp_path / "x.tsv"
+    path.write_text(
+        "onset\tduration\tdescription\n1.0\t0.0\tmark\n\n", encoding="utf-8"
+    )
+    assert len(ann.read_annotations_tsv(path)) == 1
+
+
+def test_read_missing_file_raises_oserror(tmp_path):
+    with pytest.raises(OSError):
+        ann.read_annotations_tsv(tmp_path / "absent.tsv")
+
+
+def test_round_trip_preserves_double_quotes(tmp_path):
+    # The one real escaping case: csv.writer wraps a quoted label and doubles
+    # the quotes, and only csv.reader undoes it — a "simplification" to manual
+    # tab-joining would silently corrupt every label with a quote in it.
+    quoted = ann.Annotation(1.0, 0.5, 'saw a "light" twice')
+    path = tmp_path / "x.tsv"
+    ann.write_annotations_tsv([quoted], path)
+    assert '"saw a ""light"" twice"' in path.read_text(encoding="utf-8")
+    assert ann.read_annotations_tsv(path) == [quoted]
+
+
+def test_round_trip_preserves_unicode(tmp_path):
+    item = ann.Annotation(1.0, 0.0, "señal lúcida — ασπίδα")
+    path = tmp_path / "x.tsv"
+    ann.write_annotations_tsv([item], path)
+    assert ann.read_annotations_tsv(path) == [item]
+
+
+def test_read_accepts_a_hand_edited_windows_file(tmp_path):
+    # A sidecar opened and resaved in Notepad gains CRLF endings and a UTF-8
+    # BOM; a reviewer's hand-tweaked label must not brick the file.
+    path = tmp_path / "x.tsv"
+    path.write_bytes(b"\xef\xbb\xbfonset\tduration\tdescription\r\n1.0\t0.0\tmark\r\n")
+    assert ann.read_annotations_tsv(path) == [ann.Annotation(1.0, 0.0, "mark")]
+
+
+# ----- JSON sidecar ---------------------------------------------------------
+
+
+def test_json_sidecar_documents_columns_and_provenance(tmp_path):
+    path = tmp_path / "night1.annotations.json"
+    when = datetime(2026, 6, 5, 22, 0, 0, tzinfo=UTC)
+    ann.write_annotations_json(path, source_name="night1.edf", meas_date=when)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert set(ann.ANNOTATION_COLUMNS) <= set(payload)
+    assert payload["SourceFile"] == "night1.edf"
+    assert payload["MeasurementDate"] == when.isoformat()
+    assert payload["GeneratedBy"] == {"Name": "SMACC", "Version": VERSION}
+
+
+def test_json_sidecar_handles_a_missing_meas_date(tmp_path):
+    path = tmp_path / "x.json"
+    ann.write_annotations_json(path, source_name="x.fif", meas_date=None)
+    assert json.loads(path.read_text(encoding="utf-8"))["MeasurementDate"] is None

--- a/tests/test_eeg_dsp.py
+++ b/tests/test_eeg_dsp.py
@@ -1,0 +1,149 @@
+"""Tests for the EEG display-filter math in :mod:`smacc.eeg.dsp` (#136, no GUI)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from smacc.eeg import dsp
+
+SFREQ = 256.0
+
+
+def _sine(freq: float, seconds: float = 20.0, sfreq: float = SFREQ) -> np.ndarray:
+    t = np.arange(int(seconds * sfreq)) / sfreq
+    return np.sin(2 * np.pi * freq * t)
+
+
+def _amplitude_at(x: np.ndarray, freq: float, sfreq: float = SFREQ) -> float:
+    """Single-bin amplitude of ``freq`` in ``x`` (test signals sit on exact bins)."""
+    spectrum = np.abs(np.fft.rfft(x)) / (len(x) / 2)
+    bin_hz = np.fft.rfftfreq(len(x), 1.0 / sfreq)
+    return float(spectrum[int(np.argmin(np.abs(bin_hz - freq)))])
+
+
+# ----- FilterSpec validation ------------------------------------------------
+
+
+def test_spec_rejects_nonpositive_edges():
+    with pytest.raises(ValueError, match="highpass"):
+        dsp.FilterSpec(highpass=0)
+    with pytest.raises(ValueError, match="lowpass"):
+        dsp.FilterSpec(lowpass=-35)
+    with pytest.raises(ValueError, match="notch"):
+        dsp.FilterSpec(notch=0)
+
+
+def test_spec_rejects_an_inverted_band():
+    with pytest.raises(ValueError, match="below"):
+        dsp.FilterSpec(highpass=35, lowpass=0.3)
+
+
+def test_unfiltered_is_identity():
+    assert dsp.UNFILTERED.is_identity
+    assert not dsp.FilterSpec(notch=60).is_identity
+
+
+# ----- effective_spec: rate-dependent reduction ------------------------------
+
+
+def test_effective_spec_drops_edges_the_rate_cannot_support():
+    # A 70 Hz lowpass on a 128 Hz file means "no lowpass", not a crash.
+    spec = dsp.FilterSpec(highpass=0.3, lowpass=70.0, notch=60.0)
+    eff = dsp.effective_spec(spec, 128.0)
+    assert eff.lowpass is None
+    assert eff.highpass == 0.3
+    assert eff.notch == 60.0  # 60 < 0.99 * 64: still designable
+
+
+def test_effective_spec_can_reduce_to_identity():
+    assert dsp.effective_spec(dsp.FilterSpec(notch=60.0), 100.0).is_identity
+
+
+def test_effective_spec_drops_an_unsupportable_highpass():
+    # Absurd but possible: a 30 Hz highpass on a 50 Hz file. The pair survives
+    # FilterSpec validation (30 < 35) yet neither edge is designable at fs=50.
+    eff = dsp.effective_spec(dsp.FilterSpec(highpass=30.0, lowpass=35.0), 50.0)
+    assert eff.is_identity
+
+
+# ----- apply: the actual filtering -------------------------------------------
+
+
+def test_identity_spec_returns_the_same_array():
+    data = _sine(10.0)[np.newaxis, :]
+    assert dsp.apply(data, SFREQ, dsp.UNFILTERED) is data
+
+
+def test_bandpass_keeps_the_band_and_removes_drift():
+    # 10 Hz signal riding on a big slow drift: the standard sleep display
+    # (HP 0.3 / LP 35) must keep the signal and flatten the drift.
+    x = _sine(10.0) + 5.0 * _sine(0.05)
+    out = dsp.apply(x[np.newaxis, :], SFREQ, dsp.FilterSpec(highpass=0.3, lowpass=35.0))
+    assert _amplitude_at(out[0], 10.0) == pytest.approx(1.0, abs=0.05)
+    assert _amplitude_at(out[0], 0.05) < 0.25  # was 5.0
+
+
+def test_highpass_alone_removes_drift_and_keeps_the_signal():
+    x = _sine(10.0) + 5.0 * _sine(0.05)
+    out = dsp.apply(x[np.newaxis, :], SFREQ, dsp.FilterSpec(highpass=0.5))
+    assert _amplitude_at(out[0], 10.0) == pytest.approx(1.0, abs=0.05)
+    assert _amplitude_at(out[0], 0.05) < 0.25  # was 5.0
+
+
+def test_lowpass_removes_high_frequency_noise():
+    x = _sine(10.0) + _sine(80.0)
+    out = dsp.apply(x[np.newaxis, :], SFREQ, dsp.FilterSpec(lowpass=35.0))
+    assert _amplitude_at(out[0], 10.0) == pytest.approx(1.0, abs=0.05)
+    assert _amplitude_at(out[0], 80.0) < 0.01
+
+
+def test_notch_removes_mains_and_little_else():
+    x = _sine(10.0) + _sine(60.0)
+    out = dsp.apply(x[np.newaxis, :], SFREQ, dsp.FilterSpec(notch=60.0))
+    assert _amplitude_at(out[0], 60.0) < 0.05
+    assert _amplitude_at(out[0], 10.0) == pytest.approx(1.0, abs=0.05)
+
+
+def test_filtering_is_zero_phase():
+    # Annotations are placed on the filtered trace but must land where the
+    # event is in the raw data — a filtered transient may not move in time.
+    # (A single Gaussian bump has one unambiguous peak; a sine's many equal
+    # peaks would make argmax arbitrary.)
+    t = np.arange(int(20.0 * SFREQ)) / SFREQ
+    x = np.exp(-((t - 10.0) ** 2) / (2 * 0.5**2))  # bump centered at 10 s
+    out = dsp.apply(x[np.newaxis, :], SFREQ, dsp.FilterSpec(lowpass=30.0))[0]
+    assert abs(int(np.argmax(out)) - int(np.argmax(x))) <= 1
+
+
+def test_multichannel_filtering_treats_channels_independently():
+    data = np.vstack([_sine(10.0), _sine(60.0)])
+    out = dsp.apply(data, SFREQ, dsp.FilterSpec(notch=60.0))
+    assert out.shape == data.shape
+    assert _amplitude_at(out[0], 10.0) == pytest.approx(1.0, abs=0.05)  # untouched
+    assert _amplitude_at(out[1], 60.0) < 0.05  # notched
+
+
+def test_a_sliver_too_short_to_pad_passes_through():
+    data = np.ones((2, 5))
+    out = dsp.apply(data, SFREQ, dsp.FilterSpec(lowpass=35.0))
+    assert out is data
+
+
+def test_empty_slice_passes_through():
+    data = np.empty((4, 0))
+    assert dsp.apply(data, SFREQ, dsp.FilterSpec(lowpass=35.0)) is data
+
+
+def test_filter_design_is_cached_per_spec_and_rate():
+    spec = dsp.FilterSpec(highpass=0.3, lowpass=35.0)
+    assert dsp._design(spec, SFREQ) is dsp._design(dsp.FilterSpec(0.3, 35.0), SFREQ)
+
+
+# ----- pad_seconds ------------------------------------------------------------
+
+
+def test_pad_scales_with_the_highpass_time_constant():
+    assert dsp.pad_seconds(dsp.FilterSpec(highpass=0.3)) == pytest.approx(2.0 / 0.3)
+    assert dsp.pad_seconds(dsp.FilterSpec(highpass=10.0)) == 1.0  # floor
+    assert dsp.pad_seconds(dsp.UNFILTERED) == 1.0

--- a/tests/test_eeg_io.py
+++ b/tests/test_eeg_io.py
@@ -1,0 +1,166 @@
+"""Tests for the MNE-backed recording access in :mod:`smacc.eeg.io` (#136).
+
+These need MNE (the ``eeg`` extra), so the module skips without it — the rest
+of the eeg tests (model, dsp) stay runnable in a base dev environment.
+Recordings are synthesized as FIF (the one format MNE writes natively, so no
+extra dependency); the suffix dispatch for EDF/BrainVision is asserted against
+the reader table since their writers aren't available to round-trip.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import numpy as np
+import pytest
+
+mne = pytest.importorskip("mne")
+
+from smacc.eeg import io  # noqa: E402
+
+SFREQ = 100.0
+MEAS_DATE = datetime(2026, 6, 5, 22, 0, 0, tzinfo=UTC)
+
+
+def _make_raw(seconds: float = 30.0) -> mne.io.RawArray:
+    """A small in-memory recording: 2 EEG + EOG + EMG at 100 Hz."""
+    rng = np.random.default_rng(0)
+    data = rng.standard_normal((4, int(seconds * SFREQ))) * 1e-5
+    info = mne.create_info(
+        ch_names=["C3", "C4", "EOG", "EMG"],
+        sfreq=SFREQ,
+        ch_types=["eeg", "eeg", "eog", "emg"],
+        verbose="error",
+    )
+    raw = mne.io.RawArray(data, info, verbose="error")
+    raw.set_meas_date(MEAS_DATE)
+    return raw
+
+
+@pytest.fixture
+def fif_path(tmp_path):
+    """A 30 s FIF on disk with one embedded annotation at 1.5 s."""
+    raw = _make_raw()
+    raw.set_annotations(
+        mne.Annotations(onset=[1.5], duration=[0.5], description=["Arousal"])
+    )
+    path = tmp_path / "night1_raw.fif"
+    raw.save(path, verbose="error")
+    return path
+
+
+# ----- opening ----------------------------------------------------------------
+
+
+def test_open_recording_exposes_the_metadata(fif_path):
+    rec = io.open_recording(fif_path)
+    assert rec.ch_names == ["C3", "C4", "EOG", "EMG"]
+    assert rec.ch_types == ["eeg", "eeg", "eog", "emg"]
+    assert rec.sfreq == SFREQ
+    assert rec.duration == pytest.approx(30.0)
+    assert rec.meas_date == MEAS_DATE
+    assert rec.path == fif_path
+
+
+def test_open_recording_rejects_unknown_suffixes(tmp_path):
+    bogus = tmp_path / "night1.xyz"
+    bogus.write_text("not eeg")
+    with pytest.raises(ValueError, match="Unsupported"):
+        io.open_recording(bogus)
+
+
+def test_reader_table_matches_real_mne_readers():
+    # The EDF/BrainVision branches can't be round-tripped without their writers;
+    # at minimum every name in the dispatch table must be a real mne.io reader.
+    assert set(io._READERS) == {".edf", ".vhdr", ".fif"}
+    for reader_name in io._READERS.values():
+        assert callable(getattr(mne.io, reader_name))
+
+
+# ----- slicing ------------------------------------------------------------------
+
+
+def test_get_slice_returns_data_relative_times(fif_path):
+    rec = io.open_recording(fif_path)
+    times, data = rec.get_slice(5.0, 10.0)
+    assert data.shape == (4, 500)
+    assert times[0] == pytest.approx(5.0)
+    assert times[-1] == pytest.approx(10.0 - 1 / SFREQ)
+
+
+def test_get_slice_clamps_to_the_recording(fif_path):
+    rec = io.open_recording(fif_path)
+    times, data = rec.get_slice(-3.0, 9_999.0)
+    assert data.shape == (4, 3000)
+    assert times[0] == pytest.approx(0.0)
+
+
+def test_get_slice_past_the_end_is_empty_not_an_error(fif_path):
+    rec = io.open_recording(fif_path)
+    times, data = rec.get_slice(100.0, 200.0)
+    assert times.size == 0
+    assert data.shape == (4, 0)
+
+
+# ----- embedded annotations ------------------------------------------------------
+
+
+def test_embedded_annotations_convert_to_the_model(fif_path):
+    rec = io.open_recording(fif_path)
+    found = io.embedded_annotations(rec)
+    assert len(found) == 1
+    assert found[0].onset == pytest.approx(1.5)
+    assert found[0].duration == pytest.approx(0.5)
+    assert found[0].description == "Arousal"
+
+
+def test_embedded_annotations_correct_for_first_time(tmp_path):
+    # A cropped-then-saved FIF starts mid-stream (first_time > 0) while its
+    # annotation onsets stay absolute; the conversion must shift them back to
+    # the data-relative timebase annotations are displayed and saved in.
+    raw = _make_raw()
+    raw.set_annotations(
+        mne.Annotations(onset=[3.0], duration=[0.0], description=["mark"])
+    )
+    cropped = raw.copy().crop(tmin=2.0)
+    path = tmp_path / "cropped_raw.fif"
+    cropped.save(path, verbose="error")
+    rec = io.open_recording(path)
+    assert rec._raw.first_time > 0  # the premise of this test
+    found = io.embedded_annotations(rec)
+    assert len(found) == 1
+    assert found[0].onset == pytest.approx(1.0)  # 3.0 absolute - 2.0 crop
+
+
+def test_embedded_annotations_name_blank_labels_instead_of_crashing(tmp_path):
+    # EDF+ allows label-less events, and whitespace-only labels survive an MNE
+    # round-trip verbatim; both must fall back to "unlabeled" — one odd label
+    # must never abort the whole conversion (the valid ones would be lost too).
+    raw = _make_raw()
+    raw.set_annotations(
+        mne.Annotations(
+            onset=[1.0, 2.0, 3.0],
+            duration=[0.0, 0.0, 0.0],
+            description=["", "   ", "real"],
+        )
+    )
+    rec = io.Recording(raw, tmp_path / "in-memory.fif")
+    found = io.embedded_annotations(rec)
+    assert [a.description for a in found] == ["unlabeled", "unlabeled", "real"]
+
+
+def test_embedded_annotations_never_surface_out_of_range_events(tmp_path):
+    # Crop away the start: the annotation before the new start must vanish
+    # (whether MNE drops it on crop or our range check does), never appear
+    # clamped at 0 as a lie.
+    raw = _make_raw()
+    raw.set_annotations(
+        mne.Annotations(
+            onset=[1.0, 5.0], duration=[0.0, 0.0], description=["gone", "kept"]
+        )
+    )
+    cropped = raw.copy().crop(tmin=2.0)
+    path = tmp_path / "cropped2_raw.fif"
+    cropped.save(path, verbose="error")
+    found = io.embedded_annotations(io.open_recording(path))
+    assert [a.description for a in found] == ["kept"]

--- a/tests/test_eeg_launch.py
+++ b/tests/test_eeg_launch.py
@@ -1,0 +1,125 @@
+"""Tests for launching the optional EEG component from the launcher (#136).
+
+Covers the availability probe (dev extra vs. frozen exe-beside-exe), the
+detached-process launch, and the launcher's Review EEG button — which is shown
+disabled (never hidden) when the component is absent, the same
+surface-don't-hide approach as missing trigger hardware (#147).
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from PyQt6 import QtCore, QtWidgets
+
+import smacc.eeg as eeg
+from smacc import launcher
+from smacc.launcher import LauncherWindow
+
+# ----- availability ----------------------------------------------------------
+
+
+def test_available_in_development_needs_the_eeg_extra():
+    # This test env has the extra installed, so the probe must say yes.
+    assert eeg.available()
+
+
+def test_available_in_development_without_the_extra(monkeypatch):
+    monkeypatch.setattr(eeg, "find_spec", lambda name: None)
+    assert not eeg.available()
+
+
+def test_available_frozen_checks_for_the_exe(tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "SMACC.exe"))
+    assert not eeg.available()  # component not installed
+    (tmp_path / eeg.EXE_NAME).write_bytes(b"")
+    assert eeg.available()
+
+
+def test_component_exe_sits_beside_the_main_exe(tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "SMACC.exe"))
+    assert eeg.component_exe() == tmp_path / eeg.EXE_NAME
+
+
+# ----- launching ----------------------------------------------------------------
+
+
+@pytest.fixture
+def spawned(monkeypatch):
+    """Capture detached-process launches instead of spawning anything."""
+    calls: list[tuple[str, list[str]]] = []
+
+    def fake_start(program, arguments=(), *args):
+        calls.append((program, list(arguments)))
+        return True, 4242
+
+    monkeypatch.setattr(QtCore.QProcess, "startDetached", staticmethod(fake_start))
+    return calls
+
+
+def test_launch_in_development_runs_the_module(spawned):
+    assert eeg.launch()
+    assert spawned == [(sys.executable, ["-m", "smacc.eeg"])]
+
+
+def test_launch_frozen_runs_the_component_exe(spawned, tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "SMACC.exe"))
+    assert eeg.launch()
+    assert spawned == [(str(tmp_path / eeg.EXE_NAME), [])]
+
+
+# ----- the launcher button ----------------------------------------------------------
+
+
+@pytest.fixture
+def make_launcher(qtbot, tmp_path, monkeypatch):
+    """Build a LauncherWindow with isolated prefs (the test_launcher pattern)."""
+    monkeypatch.setattr(launcher, "preferences_path", tmp_path / "preferences.yaml")
+
+    def build() -> LauncherWindow:
+        win = LauncherWindow(settings_path=None)
+        qtbot.addWidget(win)
+        win.show()
+        return win
+
+    return build
+
+
+def test_button_launches_and_keeps_the_launcher_visible(
+    make_launcher, monkeypatch, spawned
+):
+    monkeypatch.setattr(eeg, "available", lambda: True)
+    win = make_launcher()
+    assert win.reviewEegButton.isEnabled()
+    win.reviewEegButton.click()
+    assert len(spawned) == 1
+    # Unlike launcher-managed tools, the viewer is a sibling process: the
+    # launcher must stay up (there is no closed signal to bring it back).
+    assert win.isVisible()
+
+
+def test_button_is_disabled_with_an_install_hint_when_absent(
+    make_launcher, monkeypatch
+):
+    monkeypatch.setattr(eeg, "available", lambda: False)
+    win = make_launcher()
+    assert not win.reviewEegButton.isEnabled()
+    assert "installer" in win.reviewEegButton.statusTip()
+
+
+def test_failed_launch_shows_a_warning(make_launcher, monkeypatch):
+    monkeypatch.setattr(eeg, "available", lambda: True)
+    monkeypatch.setattr(eeg, "launch", lambda: False)
+    warnings: list[str] = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "warning",
+        lambda parent, title, text: warnings.append(text),
+    )
+    win = make_launcher()
+    win.review_eeg()
+    assert len(warnings) == 1
+    assert "EEG Review Tools" in warnings[0]

--- a/tests/test_eeg_view.py
+++ b/tests/test_eeg_view.py
@@ -1,0 +1,362 @@
+"""Tests for the EEG trace view (#136) — offscreen, no MNE.
+
+The view draws from the :class:`SliceProvider` protocol, so a small fake with
+known constant data stands in for a recording; channel scaling and lane
+offsets can then be asserted exactly.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pyqtgraph as pg
+import pytest
+from PyQt6 import QtCore, QtGui
+
+from smacc.eeg import dsp
+from smacc.eeg.annotations import Annotation
+from smacc.eeg.view import TYPE_GAINS, TraceView
+
+SFREQ = 100.0
+DURATION = 60.0
+# 50 µV everywhere: with the default 100 µV lane scale an EEG channel sits at
+# +0.5 lane units above its offset.
+CONSTANT_VOLTS = 50e-6
+
+
+class FakeProvider:
+    """Constant-valued recording: 2 EEG + EOG + EMG, 100 Hz, 60 s."""
+
+    ch_names = ["C3", "C4", "EOG", "EMG"]
+    ch_types = ["eeg", "eeg", "eog", "emg"]
+    sfreq = SFREQ
+    duration = DURATION
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[float, float]] = []
+
+    def get_slice(self, start_s: float, stop_s: float):
+        self.calls.append((start_s, stop_s))
+        start = max(0, int(round(max(0.0, start_s) * SFREQ)))
+        stop = min(int(DURATION * SFREQ), int(round(min(DURATION, stop_s) * SFREQ)))
+        n = max(0, stop - start)
+        times = (start + np.arange(n)) / SFREQ
+        return times, np.full((4, n), CONSTANT_VOLTS)
+
+
+@pytest.fixture
+def view(qtbot):
+    view = TraceView()
+    qtbot.addWidget(view)
+    view.resize(800, 500)
+    return view
+
+
+@pytest.fixture
+def loaded(view):
+    provider = FakeProvider()
+    view.set_provider(provider)
+    return view, provider
+
+
+# ----- construction and data flow ----------------------------------------------
+
+
+def test_set_provider_builds_one_curve_per_channel(loaded):
+    view, _ = loaded
+    assert len(view._curves) == 4
+
+
+def test_traces_are_scaled_to_microvolt_lanes(loaded):
+    # 50 µV on a 100 µV lane scale → +0.5 above the channel's lane center,
+    # with channel i centered at y = -i and EMG halved by its type gain.
+    view, _ = loaded
+    _, y0 = view._curves[0].getData()
+    assert y0 == pytest.approx(0.0 + 0.5)
+    _, y3 = view._curves[3].getData()
+    emg = 0.5 * TYPE_GAINS["emg"]
+    assert y3 == pytest.approx(-3 + emg)
+
+
+def test_scale_control_changes_trace_amplitude(loaded):
+    view, _ = loaded
+    view.set_scale(50.0)  # half the lane height → double the excursion
+    _, y0 = view._curves[0].getData()
+    assert y0 == pytest.approx(1.0)
+
+
+def test_filter_margin_is_fetched_but_trimmed(loaded):
+    # With a 0.5 Hz high-pass the view fetches pad_seconds of margin on each
+    # side, but the drawn data must stay inside the visible window — the
+    # margin exists exactly so filter edge transients are never shown.
+    view, provider = loaded
+    provider.calls.clear()
+    view.set_spec(dsp.FilterSpec(highpass=0.5))
+    pad = dsp.pad_seconds(dsp.FilterSpec(highpass=0.5))
+    (fetch_start, fetch_stop) = provider.calls[-1]
+    assert fetch_start == pytest.approx(0.0 - pad)
+    assert fetch_stop == pytest.approx(30.0 + pad)
+    x0, _ = view._curves[0].getData()
+    assert x0.min() >= 0.0
+    assert x0.max() <= 30.0
+
+
+# ----- windowing ------------------------------------------------------------------
+
+
+def test_window_start_clamps_to_the_recording(loaded):
+    view, _ = loaded
+    view.set_window_start(-5.0)
+    assert view.window_start == 0.0
+    view.set_window_start(1e9)
+    assert view.window_start == DURATION - view.window_seconds
+
+
+def test_scroll_by_pages_and_reports(loaded):
+    view, _ = loaded
+    moves: list[float] = []
+    view.windowChanged.connect(moves.append)
+    view.scroll_by(0.5)  # half a 30 s window
+    assert view.window_start == 15.0
+    assert moves == [15.0]
+
+
+def test_window_length_change_keeps_the_view_in_range(loaded):
+    view, _ = loaded
+    view.set_window_start(50.0)  # 60 s file, 30 s window → clamps to 30
+    view.set_window_seconds(60.0)  # now the whole file: start must fall to 0
+    assert view.window_start == 0.0
+
+
+def test_view_without_provider_is_inert(view):
+    view.set_window_start(10.0)
+    view.set_annotations([Annotation(1.0, 0.0, "x")])
+    view.scroll_by(1.0)
+    assert view.window_start == 0.0
+    assert view._curves == []
+
+
+# ----- annotations -----------------------------------------------------------------
+
+
+def test_annotations_draw_regions_and_lines_in_window_only(loaded):
+    view, _ = loaded
+    view.set_annotations(
+        [
+            Annotation(5.0, 2.0, "region"),  # in window: LinearRegionItem
+            Annotation(10.0, 0.0, "point"),  # in window: InfiniteLine
+            Annotation(55.0, 1.0, "offscreen"),  # outside the 0-30 s window
+        ]
+    )
+    items = view._annotation_items
+    assert len(items) == 2
+    assert isinstance(items[0], pg.LinearRegionItem)
+    assert isinstance(items[1], pg.InfiniteLine)
+
+
+def test_click_hit_testing_prefers_the_inner_annotation(loaded):
+    view, _ = loaded
+    view.set_annotations(
+        [
+            Annotation(5.0, 20.0, "REM period"),
+            Annotation(10.0, 1.0, "Arousal"),  # nested inside the REM span
+        ]
+    )
+    assert view._annotation_at(10.5) == 1  # the nested one wins
+    assert view._annotation_at(6.0) == 0
+    assert view._annotation_at(29.0) == -1
+
+
+def test_point_annotations_get_click_tolerance(loaded):
+    view, _ = loaded
+    view.set_annotations([Annotation(10.0, 0.0, "mark")])
+    tolerance = view.window_seconds * 0.005
+    assert view._annotation_at(10.0 + tolerance / 2) == 0
+    assert view._annotation_at(10.0 + tolerance * 3) == -1
+
+
+def test_click_selects_and_signals(loaded):
+    view, _ = loaded
+    view.set_annotations([Annotation(5.0, 2.0, "region")])
+    selections: list[int] = []
+    view.annotationSelected.connect(selections.append)
+    view._on_clicked(6.0)
+    assert selections == [0]
+    assert view.selected == 0
+    view._on_clicked(20.0)  # empty space deselects
+    assert selections == [0, -1]
+
+
+def test_drawn_region_is_clamped_and_empty_drags_dropped(loaded):
+    view, _ = loaded
+    drawn: list[tuple[float, float]] = []
+    view.regionDrawn.connect(lambda lo, hi: drawn.append((lo, hi)))
+    view._on_drag_finished(-2.0, 4.0)  # started before the data
+    assert drawn == [(0.0, 4.0)]
+    view._on_drag_finished(70.0, 80.0)  # entirely past the end: nothing
+    assert len(drawn) == 1
+
+
+# ----- non-bioelectric channels ----------------------------------------------------
+
+
+class StimProvider(FakeProvider):
+    """One EEG channel plus a trigger channel carrying integer event codes."""
+
+    ch_names = ["C3", "TRIG"]
+    ch_types = ["eeg", "stim"]
+
+    def get_slice(self, start_s: float, stop_s: float):
+        times, _data = super().get_slice(start_s, stop_s)
+        data = np.vstack(
+            [np.full(times.shape, CONSTANT_VOLTS), np.full(times.shape, 255.0)]
+        )
+        return times, data
+
+
+def test_stim_channels_are_fit_to_their_own_lane(view):
+    # A trigger code of 255 fed through the µV scaling would draw at
+    # -i + 255/100 — straight across every EEG lane above it. Auto-fit must
+    # keep it within its own lane's excursion instead.
+    view.set_provider(StimProvider())
+    _, y_eeg = view._curves[0].getData()
+    assert y_eeg == pytest.approx(0.5)  # unchanged by the stim handling
+    _, y_stim = view._curves[1].getData()
+    assert np.all(np.abs(y_stim - (-1)) <= 0.4 + 1e-9)
+
+
+# ----- the real mouse gesture path --------------------------------------------------
+
+
+class _FakeMouseEvent:
+    """Stands in for pyqtgraph's MouseDragEvent/MouseClickEvent.
+
+    Positions are given in data coordinates and converted to the ViewBox's
+    item coordinates with mapFromView — the frame the real events deliver.
+    """
+
+    def __init__(self, viewbox, down_x: float, x: float, *, finish=True, button=None):
+        self._button = button or QtCore.Qt.MouseButton.LeftButton
+        self._down = viewbox.mapFromView(pg.Point(down_x, 0.0))
+        self._pos = viewbox.mapFromView(pg.Point(x, 0.0))
+        self._finish = finish
+        self.accepted = False
+        self.ignored = False
+
+    def button(self):
+        return self._button
+
+    def buttonDownPos(self):
+        return self._down
+
+    def pos(self):
+        return self._pos
+
+    def isFinish(self):
+        return self._finish
+
+    def accept(self):
+        self.accepted = True
+
+    def ignore(self):
+        self.ignored = True
+
+
+@pytest.fixture
+def exposed(loaded, qtbot):
+    """The loaded view, shown and laid out so ViewBox transforms are valid."""
+    view, provider = loaded
+    view.show()
+    qtbot.waitExposed(view)
+    return view, provider
+
+
+def test_left_drag_emits_the_dragged_span(exposed):
+    view, _ = exposed
+    drawn: list[tuple[float, float]] = []
+    view.regionDrawn.connect(lambda lo, hi: drawn.append((lo, hi)))
+    viewbox = view._viewbox
+    move = _FakeMouseEvent(viewbox, 5.0, 8.0, finish=False)
+    viewbox.mouseDragEvent(move)
+    assert move.accepted
+    assert viewbox._preview is not None  # live rubber-band while dragging
+    finish = _FakeMouseEvent(viewbox, 5.0, 8.0, finish=True)
+    viewbox.mouseDragEvent(finish)
+    assert viewbox._preview is None
+    assert len(drawn) == 1
+    assert drawn[0][0] == pytest.approx(5.0, abs=0.05)
+    assert drawn[0][1] == pytest.approx(8.0, abs=0.05)
+
+
+def test_backwards_drag_is_normalized(exposed):
+    view, _ = exposed
+    drawn: list[tuple[float, float]] = []
+    view.regionDrawn.connect(lambda lo, hi: drawn.append((lo, hi)))
+    view._viewbox.mouseDragEvent(_FakeMouseEvent(view._viewbox, 8.0, 5.0))
+    assert drawn[0][0] < drawn[0][1]
+
+
+def test_non_left_drag_is_ignored(exposed):
+    view, _ = exposed
+    drawn: list[tuple[float, float]] = []
+    view.regionDrawn.connect(lambda lo, hi: drawn.append((lo, hi)))
+    ev = _FakeMouseEvent(
+        view._viewbox, 5.0, 8.0, button=QtCore.Qt.MouseButton.RightButton
+    )
+    view._viewbox.mouseDragEvent(ev)
+    assert ev.ignored
+    assert drawn == []
+
+
+def test_click_event_maps_to_data_seconds(exposed):
+    view, _ = exposed
+    view.set_annotations([Annotation(5.0, 2.0, "region")])
+    selections: list[int] = []
+    view.annotationSelected.connect(selections.append)
+    view._viewbox.mouseClickEvent(_FakeMouseEvent(view._viewbox, 6.0, 6.0))
+    assert selections == [0]
+
+
+# ----- wheel and keyboard navigation -------------------------------------------------
+
+
+def _wheel_event(notches: float) -> QtGui.QWheelEvent:
+    from PyQt6.QtCore import QPoint, QPointF, Qt
+
+    return QtGui.QWheelEvent(
+        QPointF(0, 0),
+        QPointF(0, 0),
+        QPoint(0, 0),
+        QPoint(0, int(notches * 120)),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+
+
+def test_wheel_down_scrolls_forward(loaded):
+    # Wheel-down (negative delta) must move forward in time — a sign flip
+    # here would silently invert scrolling everywhere.
+    view, _ = loaded
+    view.wheelEvent(_wheel_event(-1.0))
+    assert view.window_start == pytest.approx(3.0)  # +0.1 windows of 30 s
+    view.wheelEvent(_wheel_event(1.0))
+    assert view.window_start == pytest.approx(0.0)
+
+
+def _key_event(key) -> QtGui.QKeyEvent:
+    return QtGui.QKeyEvent(
+        QtCore.QEvent.Type.KeyPress, key, QtCore.Qt.KeyboardModifier.NoModifier
+    )
+
+
+def test_arrow_and_home_end_keys_navigate(loaded):
+    view, _ = loaded
+    view.keyPressEvent(_key_event(QtCore.Qt.Key.Key_Right))
+    assert view.window_start == pytest.approx(3.0)
+    view.keyPressEvent(_key_event(QtCore.Qt.Key.Key_Left))
+    assert view.window_start == pytest.approx(0.0)
+    view.keyPressEvent(_key_event(QtCore.Qt.Key.Key_End))
+    assert view.window_start == pytest.approx(DURATION - view.window_seconds)
+    view.keyPressEvent(_key_event(QtCore.Qt.Key.Key_Home))
+    assert view.window_start == pytest.approx(0.0)

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
+from importlib.util import find_spec
 from pathlib import Path
 
 import numpy as np
@@ -483,3 +484,19 @@ def test_version_flag_exits_zero_without_a_window():
     )
     assert proc.returncode == 0, proc.stderr
     assert VERSION in proc.stdout
+
+
+def test_selftest_round_trips_through_mne():
+    # The stronger frozen-bundle smoke test (MNE is lazy, so --version alone
+    # can't catch a broken MNE bundling). Exercised here on the dev install so
+    # a selftest regression is caught before a release build trips on it.
+    if find_spec("mne") is None:
+        pytest.skip("needs the eeg extra (mne)")
+    proc = subprocess.run(
+        [sys.executable, "-m", "smacc.eeg", "--selftest"],
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "selftest ok" in proc.stdout

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -1,0 +1,485 @@
+"""Tests for the EEG review window (#136) — offscreen, no MNE.
+
+``io.open_recording``/``io.embedded_annotations`` are monkeypatched with a
+fake recording, so the window's whole flow — open, sidecar precedence,
+annotate, edit, delete, save, dirty/close — runs without the eeg extra.
+Preferences are pointed at a temp file (the launcher-test pattern) so no test
+touches the machine's real ``preferences.yaml``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PyQt6 import QtWidgets
+
+from smacc import preferences
+from smacc.config import VERSION
+from smacc.eeg import dsp
+from smacc.eeg import window as window_mod
+from smacc.eeg.__main__ import pick_recording_path
+from smacc.eeg.annotations import (
+    Annotation,
+    read_annotations_tsv,
+    sidecar_paths,
+    write_annotations_tsv,
+)
+from smacc.eeg.window import SEED_LABELS, EegReviewWindow, LabelDialog
+
+SFREQ = 100.0
+DURATION = 600.0
+MEAS_DATE = datetime(2026, 6, 5, 22, 0, 0, tzinfo=UTC)
+
+
+class FakeRecording:
+    """Stands in for io.Recording: metadata plus constant slices."""
+
+    ch_names = ["C3", "C4", "EOG", "EMG"]
+    ch_types = ["eeg", "eeg", "eog", "emg"]
+    sfreq = SFREQ
+    duration = DURATION
+    meas_date = MEAS_DATE
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+
+    def get_slice(self, start_s: float, stop_s: float):
+        start = max(0, int(round(max(0.0, start_s) * SFREQ)))
+        stop = min(int(DURATION * SFREQ), int(round(min(DURATION, stop_s) * SFREQ)))
+        n = max(0, stop - start)
+        return (start + np.arange(n)) / SFREQ, np.zeros((4, n))
+
+
+@pytest.fixture
+def window(qtbot, tmp_path, monkeypatch):
+    """An EegReviewWindow over faked IO, isolated prefs, and silent dialogs."""
+    monkeypatch.setattr(window_mod, "preferences_path", tmp_path / "prefs.yaml")
+    monkeypatch.setattr(window_mod.io, "open_recording", FakeRecording)
+    monkeypatch.setattr(window_mod.io, "embedded_annotations", lambda rec: [])
+    # Tests routinely leave unsaved annotations, and pytest-qt closes added
+    # widgets in its runtest-teardown hook — *before* fixture cleanup could
+    # reset any state — so a dirty close would raise a real (blocking)
+    # Save/Discard/Cancel prompt with no event loop to answer it and hang the
+    # offscreen suite. Default the prompt to Discard; the close-flow tests
+    # re-patch it to exercise the other answers.
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: QtWidgets.QMessageBox.StandardButton.Discard,
+    )
+    win = EegReviewWindow()
+    qtbot.addWidget(win)
+    win.show()
+    win._prefs_path = tmp_path / "prefs.yaml"  # test convenience handle
+    return win
+
+
+@pytest.fixture
+def recording_path(tmp_path):
+    path = tmp_path / "night1.edf"
+    path.write_bytes(b"")  # only the name matters; IO is faked
+    return path
+
+
+def _answer_label(monkeypatch, answer):
+    """Make the label dialog answer without exec()-ing (None = cancelled)."""
+    monkeypatch.setattr(
+        window_mod.LabelDialog, "get_label", staticmethod(lambda *a, **k: answer)
+    )
+
+
+# ----- opening ------------------------------------------------------------------
+
+
+def test_loading_enables_the_window_and_shows_the_file(window, recording_path):
+    assert not window.saveButton.isEnabled()  # nothing loaded yet
+    window._load(recording_path)
+    assert window.saveButton.isEnabled()
+    assert "night1.edf" in window.windowTitle()
+    assert "4 ch" in window.fileInfoLabel.text()
+    assert "22:00:00" in window.fileInfoLabel.text()  # meas_date clock
+    # 600 s file, 30 s window, tenth-of-a-second ticks.
+    assert window.scrollBar.maximum() == int((DURATION - 30) * 10)
+
+
+def test_fresh_review_seeds_from_embedded_events(window, recording_path, monkeypatch):
+    embedded = [Annotation(1.0, 0.0, "Cue started: Piano")]
+    monkeypatch.setattr(window_mod.io, "embedded_annotations", lambda rec: embedded)
+    window._load(recording_path)
+    assert window._annotations == embedded
+    assert not window._dirty  # imported events aren't user edits
+    assert window.annotationList.count() == 1
+
+
+def test_existing_sidecar_wins_over_embedded_events(
+    window, recording_path, monkeypatch
+):
+    # Re-importing embedded events on every open would duplicate them into the
+    # sidecar; once a sidecar exists it is the single source of truth.
+    saved = [Annotation(5.0, 2.0, "REM period")]
+    tsv_path, _ = sidecar_paths(recording_path)
+    write_annotations_tsv(saved, tsv_path)
+    monkeypatch.setattr(
+        window_mod.io,
+        "embedded_annotations",
+        lambda rec: pytest.fail("embedded events must not be imported"),
+    )
+    window._load(recording_path)
+    assert window._annotations == saved
+
+
+def test_corrupt_sidecar_aborts_the_open(window, recording_path, silence_dialogs):
+    # The sidecar is the reviewer's data: loading with an empty list would
+    # overwrite it on the next save, so the open must refuse instead.
+    tsv_path, _ = sidecar_paths(recording_path)
+    tsv_path.write_text("not\ta\tsidecar\n", encoding="utf-8")
+    window._load(recording_path)
+    assert window._recording is None
+    assert not window.saveButton.isEnabled()
+
+
+# ----- annotating -----------------------------------------------------------------
+
+
+def test_drawn_region_becomes_a_labeled_annotation(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    assert window._annotations == [Annotation(10.0, 4.0, "LRLR")]
+    assert window._dirty
+    assert window.windowTitle().endswith("*")
+    # The label lands in the recents that seed the next dialog.
+    prefs = preferences.load_preferences(window._prefs_path)
+    assert prefs["eeg_recent_labels"] == ["LRLR"]
+
+
+def test_instant_checkbox_drops_the_drawn_duration(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", True))
+    window._on_region_drawn(10.0, 14.0)
+    assert window._annotations == [Annotation(10.0, 0.0, "LRLR")]
+
+
+def test_cancelled_label_dialog_adds_nothing(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, None)
+    window._on_region_drawn(10.0, 14.0)
+    assert window._annotations == []
+    assert not window._dirty
+
+
+def test_edit_renames_but_keeps_the_span(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("Arousal", False))
+    window._on_region_drawn(10.0, 14.0)
+    window.annotationList.setCurrentRow(0)
+    _answer_label(monkeypatch, ("Artifact", False))
+    window.edit_selected()
+    assert window._annotations == [Annotation(10.0, 4.0, "Artifact")]
+
+
+def test_delete_removes_the_selected_annotation(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("Arousal", False))
+    window._on_region_drawn(10.0, 14.0)
+    window.annotationList.setCurrentRow(0)
+    window.delete_selected()
+    assert window._annotations == []
+    assert window._dirty
+
+
+def test_go_to_selected_jumps_the_view(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("Arousal", False))
+    window._on_region_drawn(50.0, 51.0)
+    window.annotationList.setCurrentRow(0)
+    window.go_to_selected()
+    # A quarter-window of lead-in before the annotation (30 s window).
+    assert window.view.window_start == pytest.approx(50.0 - 7.5)
+
+
+# ----- saving and closing -----------------------------------------------------------
+
+
+def test_save_writes_both_sidecars_and_clears_dirty(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    window.save_annotations()
+    tsv_path, json_path = sidecar_paths(recording_path)
+    assert read_annotations_tsv(tsv_path) == [Annotation(10.0, 4.0, "LRLR")]
+    assert json_path.is_file()
+    assert not window._dirty
+    assert not window.windowTitle().endswith("*")
+
+
+def test_dirty_close_can_be_cancelled(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: QtWidgets.QMessageBox.StandardButton.Cancel,
+    )
+    assert not window.close()
+    assert window.isVisible()
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: QtWidgets.QMessageBox.StandardButton.Discard,
+    )
+    assert window.close()
+
+
+def test_clean_close_needs_no_prompt(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: pytest.fail("no prompt expected on a clean close"),
+    )
+    assert window.close()
+
+
+# ----- display controls ----------------------------------------------------------------
+
+
+def test_filter_controls_build_the_spec(window, recording_path):
+    window._load(recording_path)
+    window.highpassSpin.setValue(0.3)
+    window.lowpassSpin.setValue(35.0)
+    window.notchCombo.setCurrentIndex(2)  # 60 Hz
+    assert window.view._spec == dsp.FilterSpec(highpass=0.3, lowpass=35.0, notch=60.0)
+
+
+def test_inverted_band_is_rejected_and_filters_kept(window, recording_path):
+    window._load(recording_path)
+    window.highpassSpin.setValue(0.3)
+    window.lowpassSpin.setValue(35.0)
+    window.highpassSpin.setValue(40.0)  # above the low-pass: must not apply
+    assert window.view._spec.highpass == 0.3
+
+
+def test_window_length_change_reconfigures_the_scrollbar(window, recording_path):
+    window._load(recording_path)
+    window.windowCombo.setCurrentIndex(3)  # 120 s
+    assert window.view.window_seconds == 120.0
+    assert window.scrollBar.maximum() == int((DURATION - 120) * 10)
+    assert window.scrollBar.pageStep() == 1200
+
+
+def test_scrollbar_moves_the_view_and_back(window, recording_path):
+    window._load(recording_path)
+    window.scrollBar.setValue(450)  # 45.0 s
+    assert window.view.window_start == pytest.approx(45.0)
+    window.view.scroll_by(1.0)  # keyboard/wheel path reports back
+    assert window.scrollBar.value() == 750
+
+
+def test_cursor_readout_shows_data_and_clock_time(window, recording_path):
+    window._load(recording_path)
+    window._on_cursor_moved(90.0)
+    status_bar = window.statusBar()
+    assert status_bar is not None
+    message = status_bar.currentMessage()
+    assert "t = 90.000 s" in message
+    assert "22:01:30" in message  # 22:00:00 meas_date + 90 s, amp wall clock
+
+
+# ----- label dialog / entry point -----------------------------------------------------
+
+
+def test_failed_save_keeps_the_dirty_flag(
+    window, recording_path, monkeypatch, silence_dialogs
+):
+    # If the sidecar write fails, the annotations are still unsaved — clearing
+    # the flag would let the close prompt silently discard them.
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+
+    def boom(*args, **kwargs):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(window_mod, "write_annotations_tsv", boom)
+    window.save_annotations()
+    assert window._dirty
+    assert window.windowTitle().endswith("*")
+
+
+def test_open_file_respects_a_cancelled_discard_prompt(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: QtWidgets.QMessageBox.StandardButton.Cancel,
+    )
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog,
+        "getOpenFileName",
+        lambda *a, **k: pytest.fail("the file dialog must not open"),
+    )
+    window.open_file()  # cancelled prompt: no dialog, annotations intact
+    assert window._annotations  # nothing was discarded
+
+
+def test_open_dialog_starts_in_the_last_used_folder(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)  # records eeg_last_dir
+    seen_dirs: list[str] = []
+
+    def fake_dialog(parent, caption, directory, file_filter):
+        seen_dirs.append(directory)
+        return "", ""
+
+    monkeypatch.setattr(QtWidgets.QFileDialog, "getOpenFileName", fake_dialog)
+    window.open_file()
+    assert seen_dirs == [str(recording_path.parent)]
+
+
+def test_trace_click_highlights_the_list_row(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("Arousal", False))
+    window._on_region_drawn(10.0, 14.0)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(30.0, 31.0)
+    window.view._on_clicked(30.5)  # inside the second annotation
+    assert window.annotationList.currentRow() == 1
+    window.view._on_clicked(20.0)  # empty space deselects
+    assert window.annotationList.currentRow() == -1
+
+
+def test_edit_and_delete_without_a_selection_are_no_ops(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)
+    monkeypatch.setattr(
+        window_mod.LabelDialog,
+        "get_label",
+        staticmethod(lambda *a, **k: pytest.fail("no dialog expected")),
+    )
+    window.edit_selected()
+    window.delete_selected()
+    assert window._annotations == []
+    assert not window._dirty
+
+
+def test_double_click_jumps_to_the_annotation(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("Arousal", False))
+    window._on_region_drawn(50.0, 51.0)
+    window.annotationList.setCurrentRow(0)
+    item = window.annotationList.item(0)
+    window.annotationList.itemDoubleClicked.emit(item)
+    assert window.view.window_start == pytest.approx(50.0 - 7.5)
+
+
+def test_geometry_is_persisted_on_close(window, recording_path):
+    # The layout's minimum size may override a small resize request, so pin
+    # the expectation to whatever geometry the window actually had at close.
+    window.resize(1600, 800)
+    expected = {
+        "x": window.x(),
+        "y": window.y(),
+        "w": window.width(),
+        "h": window.height(),
+    }
+    assert window.close()
+    prefs = preferences.load_preferences(window._prefs_path)
+    assert preferences.window_geometry(prefs, "eeg-review") == expected
+
+
+def test_recent_labels_are_capped_and_deduplicated(window):
+    for i in range(14):
+        window._remember_label(f"label-{i}")
+    window._remember_label("label-5")  # an old one used again moves up front
+    recents = window._recent_labels()
+    assert len(recents) == 12
+    assert recents[0] == "label-5"
+    assert recents[1] == "label-13"
+
+
+def test_label_dialog_merges_recents_over_seeds(qtbot):
+    dialog = LabelDialog(None, ["Custom", SEED_LABELS[0]])
+    qtbot.addWidget(dialog)
+    items = [dialog.labelCombo.itemText(i) for i in range(dialog.labelCombo.count())]
+    assert items == ["Custom", *SEED_LABELS]  # deduplicated, recents first
+
+
+def test_pick_recording_path_takes_the_last_non_flag_argument():
+    assert pick_recording_path(["exe"]) is None
+    assert pick_recording_path(["exe", "--debug", "a.edf"]) == "a.edf"
+    assert pick_recording_path(["exe", "a.edf", "b.fif"]) == "b.fif"
+
+
+# ----- wall-clock display ---------------------------------------------------------
+
+
+def test_wall_time_shows_edf_stamps_as_recorded(tmp_path):
+    # EDF start times are the tech's wall-clock stamps (MNE tags them UTC pro
+    # forma); converting them would lie about what the bedside clock said.
+    rec = FakeRecording(tmp_path / "night1.edf")
+    clock = window_mod.wall_time(rec, 90.0)
+    assert clock == MEAS_DATE + timedelta(seconds=90)
+    assert clock.strftime("%H:%M:%S") == "22:01:30"
+
+
+def test_wall_time_converts_fif_instants_to_local(tmp_path):
+    # A FIF meas_date is a true UTC instant; showing it raw would display
+    # UTC, not the wall clock the tech saw. astimezone() is right whenever
+    # the file is reviewed in the timezone it was recorded in.
+    rec = FakeRecording(tmp_path / "night1_raw.fif")
+    clock = window_mod.wall_time(rec, 0.0)
+    assert clock == MEAS_DATE.astimezone()
+
+
+def test_wall_time_without_meas_date_is_none(tmp_path):
+    rec = FakeRecording(tmp_path / "night1.edf")
+    rec.meas_date = None
+    assert window_mod.wall_time(rec, 0.0) is None
+
+
+# ----- process hygiene (subprocess checks) --------------------------------------------
+
+
+def test_eeg_window_never_imports_the_live_session_stack():
+    # The EEG tool runs as its own process and the frozen SMACC-EEG.exe will
+    # not ship the live-session stack — importing it here (e.g. panels.base,
+    # which imports sounddevice and SmaccSession at module scope) would break
+    # the packaged build and the documented process isolation.
+    code = (
+        "import sys; import smacc.eeg.window; "
+        "leaks = [m for m in ('sounddevice', 'smacc.session', 'smacc.devices', "
+        "'smacc.panels.base') if m in sys.modules]; "
+        "sys.exit('leaked: ' + ', '.join(leaks) if leaks else 0)"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=120
+    )
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_version_flag_exits_zero_without_a_window():
+    # The release workflow smoke-tests the frozen SMACC-EEG.exe with exactly
+    # this invocation; the import tree resolving and exit code 0 are the test.
+    proc = subprocess.run(
+        [sys.executable, "-m", "smacc.eeg", "--version"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert VERSION in proc.stdout

--- a/tools/bench_eeg_view.py
+++ b/tools/bench_eeg_view.py
@@ -1,0 +1,89 @@
+# Benchmark the EEG TraceView against the #136 performance target:
+# an 8 h x 32 ch x 512 Hz overnight recording must scroll smoothly.
+#
+#   > uv run --extra eeg python tools/bench_eeg_view.py
+#
+# A synthetic provider generates EEG-shaped data on demand (so the bench needs
+# no gigabyte fixture file); each "refresh" is what one scroll step costs:
+# slice fetch -> zero-phase filter -> per-curve setData -> a forced offscreen
+# render. Real-file I/O (MNE's memory-mapped read) is NOT measured here — this
+# isolates the render path, the part the view design controls.
+
+import os
+import sys
+import time
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+from PyQt6 import QtWidgets
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from smacc.eeg import dsp  # noqa: E402
+from smacc.eeg.view import TraceView  # noqa: E402
+
+SFREQ = 512.0
+N_CHANNELS = 32
+DURATION_S = 8 * 3600.0
+REFRESHES = 20
+
+
+class SyntheticProvider:
+    """EEG-shaped noise, generated per slice (deterministic per start sample)."""
+
+    ch_names = [f"CH{i:02d}" for i in range(N_CHANNELS)]
+    ch_types = ["eeg"] * (N_CHANNELS - 2) + ["eog", "emg"]
+    sfreq = SFREQ
+    duration = DURATION_S
+
+    def get_slice(self, start_s: float, stop_s: float):
+        start = max(0, int(round(max(0.0, start_s) * SFREQ)))
+        stop = min(int(DURATION_S * SFREQ), int(round(min(DURATION_S, stop_s) * SFREQ)))
+        n = max(0, stop - start)
+        times = (start + np.arange(n)) / SFREQ
+        rng = np.random.default_rng(start)  # deterministic, cheap
+        data = rng.standard_normal((N_CHANNELS, n)) * 20e-6
+        data += 50e-6 * np.sin(2 * np.pi * 1.0 * times)  # slow-wave-ish
+        return times, data
+
+
+def bench(view: TraceView, window_seconds: float) -> tuple[float, float]:
+    view.set_window_seconds(window_seconds)
+    view.set_window_start(0.0)
+    view.grab()  # warm-up render outside the timed loop
+    laps = []
+    for _ in range(REFRESHES):
+        t0 = time.perf_counter()
+        view.scroll_by(0.5)
+        view.grab()  # force a full offscreen paint
+        laps.append((time.perf_counter() - t0) * 1000)
+    return float(np.mean(laps)), float(np.max(laps))
+
+
+def main() -> int:
+    app = QtWidgets.QApplication(sys.argv)  # noqa: F841 — Qt needs a live app
+    view = TraceView()
+    view.resize(1400, 900)
+    view.set_provider(SyntheticProvider())
+    view.set_spec(dsp.FilterSpec(highpass=0.3, lowpass=35.0, notch=60.0))
+    print(
+        f"{N_CHANNELS} ch x {SFREQ:.0f} Hz x {DURATION_S / 3600:.0f} h, "
+        f"{REFRESHES} scrolled refreshes per row (filter HP 0.3 / LP 35 / notch 60)"
+    )
+    failed = False
+    # 100 ms keeps scrolling comfortably interactive; 120 s windows may be
+    # slower but must stay under a quarter second to feel responsive.
+    for window_seconds, budget_ms in ((10.0, 100.0), (30.0, 100.0), (120.0, 250.0)):
+        mean_ms, max_ms = bench(view, window_seconds)
+        verdict = "ok" if mean_ms <= budget_ms else "TOO SLOW"
+        failed |= mean_ms > budget_ms
+        print(
+            f"  {window_seconds:5.0f} s window: mean {mean_ms:7.1f} ms  "
+            f"max {max_ms:7.1f} ms  (budget {budget_ms:.0f} ms)  {verdict}"
+        )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/make_versionfile.py
+++ b/tools/make_versionfile.py
@@ -1,13 +1,16 @@
-"""Generate the PyInstaller version-info file for the frozen SMACC.exe (#116).
+"""Generate a PyInstaller version-info file for a frozen SMACC exe (#116).
 
 Writes the ``VSVersionInfo`` resource PyInstaller embeds via ``--version-file``,
 so the exe's Properties dialog (and tools IT departments use to vet binaries)
 show the product name, version, and publisher instead of nothing. The version is
 read from ``smacc.__version__`` — the single source of truth — so the resource
 can never drift from the release tag (the release workflow checks the tag against
-the same attribute). Run by the release workflow before PyInstaller::
+the same attribute). Run by the release workflow before PyInstaller, once per
+exe (the optional EEG component, #136, is a second frozen exe)::
 
     uv run python tools/make_versionfile.py version_info.txt
+    uv run python tools/make_versionfile.py version_info_eeg.txt \\
+        --product SMACC-EEG --description "SMACC EEG review tool"
 """
 
 from __future__ import annotations
@@ -30,14 +33,11 @@ VSVersionInfo(
                     "040904B0",
                     [
                         StringStruct("CompanyName", "Remington Mallett"),
-                        StringStruct(
-                            "FileDescription",
-                            "Sleep Manipulation and Communication Clickything",
-                        ),
+                        StringStruct("FileDescription", "{description}"),
                         StringStruct("FileVersion", "{version}"),
-                        StringStruct("ProductName", "SMACC"),
+                        StringStruct("ProductName", "{product}"),
                         StringStruct("ProductVersion", "{version}"),
-                        StringStruct("OriginalFilename", "SMACC.exe"),
+                        StringStruct("OriginalFilename", "{product}.exe"),
                         StringStruct(
                             "LegalCopyright", "Remington Mallett, GPL-3.0-or-later"
                         ),
@@ -50,6 +50,8 @@ VSVersionInfo(
 )
 """
 
+_DEFAULT_DESCRIPTION = "Sleep Manipulation and Communication Clickything"
+
 
 def version_tuple(version: str) -> tuple[int, int, int, int]:
     """``"0.1.0"`` → ``(0, 1, 0, 0)`` — the four-part numeric form VS_FIXEDFILEINFO needs."""
@@ -57,9 +59,18 @@ def version_tuple(version: str) -> tuple[int, int, int, int]:
     return tuple(parts + [0] * (4 - len(parts)))[:4]  # type: ignore[return-value]
 
 
-def render(version: str) -> str:
-    """The version-file text for ``version`` (pure, for tests)."""
-    return _TEMPLATE.format(version=version, vers_tuple=version_tuple(version))
+def render(
+    version: str,
+    product: str = "SMACC",
+    description: str = _DEFAULT_DESCRIPTION,
+) -> str:
+    """The version-file text for one exe (pure, for tests)."""
+    return _TEMPLATE.format(
+        version=version,
+        vers_tuple=version_tuple(version),
+        product=product,
+        description=description,
+    )
 
 
 def main() -> None:
@@ -67,9 +78,21 @@ def main() -> None:
     parser.add_argument(
         "output", type=Path, help="path to write (e.g. version_info.txt)"
     )
+    parser.add_argument(
+        "--product",
+        default="SMACC",
+        help="ProductName / OriginalFilename stem (e.g. SMACC-EEG)",
+    )
+    parser.add_argument(
+        "--description",
+        default=_DEFAULT_DESCRIPTION,
+        help="FileDescription shown in the exe's Properties dialog",
+    )
     args = parser.parse_args()
-    args.output.write_text(render(__version__), encoding="utf-8")
-    print(f"Wrote VSVersionInfo for SMACC {__version__} to {args.output}")
+    args.output.write_text(
+        render(__version__, args.product, args.description), encoding="utf-8"
+    )
+    print(f"Wrote VSVersionInfo for {args.product} {__version__} to {args.output}")
 
 
 if __name__ == "__main__":

--- a/tools/smacc.iss
+++ b/tools/smacc.iss
@@ -47,11 +47,38 @@ SolidCompression=yes
 ; Desktop shortcut is opt-in (unchecked by default); the Start menu entry is always created.
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
+; The EEG Review Tools (#136) are an optional component: the SMACC-EEG.exe
+; bundle carries the full MNE/pyqtgraph stack, so labs that only run sessions
+; skip it. The first [Types] entry ("standard", without it) is the default for
+; a fresh install; on upgrades Inno preselects whatever was chosen before, so
+; the pair stays in sync. A silent install adds it with /COMPONENTS="core,eeg",
+; and re-running the installer later can add it to an existing install.
+[Types]
+Name: "standard"; Description: "Standard installation"
+Name: "full"; Description: "Full installation (with EEG Review Tools)"
+Name: "custom"; Description: "Custom installation"; Flags: iscustom
+
+[Components]
+Name: "core"; Description: "SMACC"; Types: standard full custom; Flags: fixed
+Name: "eeg"; Description: "EEG Review Tools (view and annotate recordings)"; Types: full
+
 [Files]
-Source: "..\dist\SMACC.exe"; DestDir: "{app}"; Flags: ignoreversion
+Source: "..\dist\SMACC.exe"; DestDir: "{app}"; Components: core; Flags: ignoreversion
+Source: "..\dist\SMACC-EEG.exe"; DestDir: "{app}"; Components: eeg; Flags: ignoreversion
+
+[InstallDelete]
+; Inno never removes a *deselected* component's files on an upgrade — without
+; this, dropping the EEG component would leave a stale, never-again-updated
+; SMACC-EEG.exe behind, which the launcher's availability probe would still
+; detect and happily run.
+Type: files; Name: "{app}\SMACC-EEG.exe"; Components: not eeg
+Type: files; Name: "{autoprograms}\SMACC EEG review.lnk"; Components: not eeg
 
 [Icons]
 Name: "{autoprograms}\SMACC"; Filename: "{app}\SMACC.exe"
+; The EEG viewer is also launchable from inside SMACC, but a reviewer doing
+; daytime analysis shouldn't have to open the session app to get there.
+Name: "{autoprograms}\SMACC EEG review"; Filename: "{app}\SMACC-EEG.exe"; Components: eeg
 Name: "{autodesktop}\SMACC"; Filename: "{app}\SMACC.exe"; Tasks: desktopicon
 
 [Registry]

--- a/uv.lock
+++ b/uv.lock
@@ -268,6 +268,72 @@ wheels = [
 ]
 
 [[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/45/adfee365d9ea3d853550b2e735f9d66366701c65db7855cd07621732ccfc/contourpy-1.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b08a32ea2f8e42cf1d4be3169a98dd4be32bafe4f22b6c4cb4ba810fa9e5d2cb", size = 293419, upload-time = "2025-07-26T12:01:21.16Z" },
+    { url = "https://files.pythonhosted.org/packages/53/3e/405b59cfa13021a56bba395a6b3aca8cec012b45bf177b0eaf7a202cde2c/contourpy-1.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:556dba8fb6f5d8742f2923fe9457dbdd51e1049c4a43fd3986a0b14a1d815fc6", size = 273979, upload-time = "2025-07-26T12:01:22.448Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/a12359b9b2ca3a845e8f7f9ac08bdf776114eb931392fcad91743e2ea17b/contourpy-1.3.3-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92d9abc807cf7d0e047b95ca5d957cf4792fcd04e920ca70d48add15c1a90ea7", size = 332653, upload-time = "2025-07-26T12:01:24.155Z" },
+    { url = "https://files.pythonhosted.org/packages/63/12/897aeebfb475b7748ea67b61e045accdfcf0d971f8a588b67108ed7f5512/contourpy-1.3.3-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b2e8faa0ed68cb29af51edd8e24798bb661eac3bd9f65420c1887b6ca89987c8", size = 379536, upload-time = "2025-07-26T12:01:25.91Z" },
+    { url = "https://files.pythonhosted.org/packages/43/8a/a8c584b82deb248930ce069e71576fc09bd7174bbd35183b7943fb1064fd/contourpy-1.3.3-cp312-cp312-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:626d60935cf668e70a5ce6ff184fd713e9683fb458898e4249b63be9e28286ea", size = 384397, upload-time = "2025-07-26T12:01:27.152Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/8f/ec6289987824b29529d0dfda0d74a07cec60e54b9c92f3c9da4c0ac732de/contourpy-1.3.3-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4d00e655fcef08aba35ec9610536bfe90267d7ab5ba944f7032549c55a146da1", size = 362601, upload-time = "2025-07-26T12:01:28.808Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0a/a3fe3be3ee2dceb3e615ebb4df97ae6f3828aa915d3e10549ce016302bd1/contourpy-1.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:451e71b5a7d597379ef572de31eeb909a87246974d960049a9848c3bc6c41bf7", size = 1331288, upload-time = "2025-07-26T12:01:31.198Z" },
+    { url = "https://files.pythonhosted.org/packages/33/1d/acad9bd4e97f13f3e2b18a3977fe1b4a37ecf3d38d815333980c6c72e963/contourpy-1.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:459c1f020cd59fcfe6650180678a9993932d80d44ccde1fa1868977438f0b411", size = 1403386, upload-time = "2025-07-26T12:01:33.947Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8f/5847f44a7fddf859704217a99a23a4f6417b10e5ab1256a179264561540e/contourpy-1.3.3-cp312-cp312-win32.whl", hash = "sha256:023b44101dfe49d7d53932be418477dba359649246075c996866106da069af69", size = 185018, upload-time = "2025-07-26T12:01:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:8153b8bfc11e1e4d75bcb0bff1db232f9e10b274e0929de9d608027e0d34ff8b", size = 226567, upload-time = "2025-07-26T12:01:36.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/e2/f05240d2c39a1ed228d8328a78b6f44cd695f7ef47beb3e684cf93604f86/contourpy-1.3.3-cp312-cp312-win_arm64.whl", hash = "sha256:07ce5ed73ecdc4a03ffe3e1b3e3c1166db35ae7584be76f65dbbe28a7791b0cc", size = 193655, upload-time = "2025-07-26T12:01:37.999Z" },
+    { url = "https://files.pythonhosted.org/packages/68/35/0167aad910bbdb9599272bd96d01a9ec6852f36b9455cf2ca67bd4cc2d23/contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:177fb367556747a686509d6fef71d221a4b198a3905fe824430e5ea0fda54eb5", size = 293257, upload-time = "2025-07-26T12:01:39.367Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e4/7adcd9c8362745b2210728f209bfbcf7d91ba868a2c5f40d8b58f54c509b/contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d002b6f00d73d69333dac9d0b8d5e84d9724ff9ef044fd63c5986e62b7c9e1b1", size = 274034, upload-time = "2025-07-26T12:01:40.645Z" },
+    { url = "https://files.pythonhosted.org/packages/73/23/90e31ceeed1de63058a02cb04b12f2de4b40e3bef5e082a7c18d9c8ae281/contourpy-1.3.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:348ac1f5d4f1d66d3322420f01d42e43122f43616e0f194fc1c9f5d830c5b286", size = 334672, upload-time = "2025-07-26T12:01:41.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/93/b43d8acbe67392e659e1d984700e79eb67e2acb2bd7f62012b583a7f1b55/contourpy-1.3.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655456777ff65c2c548b7c454af9c6f33f16c8884f11083244b5819cc214f1b5", size = 381234, upload-time = "2025-07-26T12:01:43.499Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3b/bec82a3ea06f66711520f75a40c8fc0b113b2a75edb36aa633eb11c4f50f/contourpy-1.3.3-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:644a6853d15b2512d67881586bd03f462c7ab755db95f16f14d7e238f2852c67", size = 385169, upload-time = "2025-07-26T12:01:45.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4debd64f124ca62069f313a9cb86656ff087786016d76927ae2cf37846b006c9", size = 362859, upload-time = "2025-07-26T12:01:46.519Z" },
+    { url = "https://files.pythonhosted.org/packages/33/71/e2a7945b7de4e58af42d708a219f3b2f4cff7386e6b6ab0a0fa0033c49a9/contourpy-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a15459b0f4615b00bbd1e91f1b9e19b7e63aea7483d03d804186f278c0af2659", size = 1332062, upload-time = "2025-07-26T12:01:48.964Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fc/4e87ac754220ccc0e807284f88e943d6d43b43843614f0a8afa469801db0/contourpy-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca0fdcd73925568ca027e0b17ab07aad764be4706d0a925b89227e447d9737b7", size = 1403932, upload-time = "2025-07-26T12:01:51.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/2e/adc197a37443f934594112222ac1aa7dc9a98faf9c3842884df9a9d8751d/contourpy-1.3.3-cp313-cp313-win32.whl", hash = "sha256:b20c7c9a3bf701366556e1b1984ed2d0cedf999903c51311417cf5f591d8c78d", size = 185024, upload-time = "2025-07-26T12:01:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/18/0b/0098c214843213759692cc638fce7de5c289200a830e5035d1791d7a2338/contourpy-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:1cadd8b8969f060ba45ed7c1b714fe69185812ab43bd6b86a9123fe8f99c3263", size = 226578, upload-time = "2025-07-26T12:01:54.422Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9a/2f6024a0c5995243cd63afdeb3651c984f0d2bc727fd98066d40e141ad73/contourpy-1.3.3-cp313-cp313-win_arm64.whl", hash = "sha256:fd914713266421b7536de2bfa8181aa8c699432b6763a0ea64195ebe28bff6a9", size = 193524, upload-time = "2025-07-26T12:01:55.73Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b3/f8a1a86bd3298513f500e5b1f5fd92b69896449f6cab6a146a5d52715479/contourpy-1.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:88df9880d507169449d434c293467418b9f6cbe82edd19284aa0409e7fdb933d", size = 306730, upload-time = "2025-07-26T12:01:57.051Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/11/4780db94ae62fc0c2053909b65dc3246bd7cecfc4f8a20d957ad43aa4ad8/contourpy-1.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d06bb1f751ba5d417047db62bca3c8fde202b8c11fb50742ab3ab962c81e8216", size = 287897, upload-time = "2025-07-26T12:01:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/15/e59f5f3ffdd6f3d4daa3e47114c53daabcb18574a26c21f03dc9e4e42ff0/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4e6b05a45525357e382909a4c1600444e2a45b4795163d3b22669285591c1ae", size = 326751, upload-time = "2025-07-26T12:02:00.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/81/03b45cfad088e4770b1dcf72ea78d3802d04200009fb364d18a493857210/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab3074b48c4e2cf1a960e6bbeb7f04566bf36b1861d5c9d4d8ac04b82e38ba20", size = 375486, upload-time = "2025-07-26T12:02:02.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ba/49923366492ffbdd4486e970d421b289a670ae8cf539c1ea9a09822b371a/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c3d53c796f8647d6deb1abe867daeb66dcc8a97e8455efa729516b997b8ed99", size = 388106, upload-time = "2025-07-26T12:02:03.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/52/5b00ea89525f8f143651f9f03a0df371d3cbd2fccd21ca9b768c7a6500c2/contourpy-1.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50ed930df7289ff2a8d7afeb9603f8289e5704755c7e5c3bbd929c90c817164b", size = 352548, upload-time = "2025-07-26T12:02:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1d/a209ec1a3a3452d490f6b14dd92e72280c99ae3d1e73da74f8277d4ee08f/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4feffb6537d64b84877da813a5c30f1422ea5739566abf0bd18065ac040e120a", size = 1322297, upload-time = "2025-07-26T12:02:07.379Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/9e/46f0e8ebdd884ca0e8877e46a3f4e633f6c9c8c4f3f6e72be3fe075994aa/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2b7e9480ffe2b0cd2e787e4df64270e3a0440d9db8dc823312e2c940c167df7e", size = 1391023, upload-time = "2025-07-26T12:02:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/70/f308384a3ae9cd2209e0849f33c913f658d3326900d0ff5d378d6a1422d2/contourpy-1.3.3-cp313-cp313t-win32.whl", hash = "sha256:283edd842a01e3dcd435b1c5116798d661378d83d36d337b8dde1d16a5fc9ba3", size = 196157, upload-time = "2025-07-26T12:02:11.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dd/880f890a6663b84d9e34a6f88cded89d78f0091e0045a284427cb6b18521/contourpy-1.3.3-cp313-cp313t-win_amd64.whl", hash = "sha256:87acf5963fc2b34825e5b6b048f40e3635dd547f590b04d2ab317c2619ef7ae8", size = 240570, upload-time = "2025-07-26T12:02:12.754Z" },
+    { url = "https://files.pythonhosted.org/packages/80/99/2adc7d8ffead633234817ef8e9a87115c8a11927a94478f6bb3d3f4d4f7d/contourpy-1.3.3-cp313-cp313t-win_arm64.whl", hash = "sha256:3c30273eb2a55024ff31ba7d052dde990d7d8e5450f4bbb6e913558b3d6c2301", size = 199713, upload-time = "2025-07-26T12:02:14.4Z" },
+    { url = "https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fde6c716d51c04b1c25d0b90364d0be954624a0ee9d60e23e850e8d48353d07a", size = 292189, upload-time = "2025-07-26T12:02:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cbedb772ed74ff5be440fa8eee9bd49f64f6e3fc09436d9c7d8f1c287b121d77", size = 273251, upload-time = "2025-07-26T12:02:17.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22e9b1bd7a9b1d652cd77388465dc358dafcd2e217d35552424aa4f996f524f5", size = 335810, upload-time = "2025-07-26T12:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f9/e35f4c1c93f9275d4e38681a80506b5510e9327350c51f8d4a5a724d178c/contourpy-1.3.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a22738912262aa3e254e4f3cb079a95a67132fc5a063890e224393596902f5a4", size = 382871, upload-time = "2025-07-26T12:02:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/71/47b512f936f66a0a900d81c396a7e60d73419868fba959c61efed7a8ab46/contourpy-1.3.3-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:afe5a512f31ee6bd7d0dda52ec9864c984ca3d66664444f2d72e0dc4eb832e36", size = 386264, upload-time = "2025-07-26T12:02:21.916Z" },
+    { url = "https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f64836de09927cba6f79dcd00fdd7d5329f3fccc633468507079c829ca4db4e3", size = 363819, upload-time = "2025-07-26T12:02:23.759Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/a6/0b185d4cc480ee494945cde102cb0149ae830b5fa17bf855b95f2e70ad13/contourpy-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1fd43c3be4c8e5fd6e4f2baeae35ae18176cf2e5cced681cca908addf1cdd53b", size = 1333650, upload-time = "2025-07-26T12:02:26.181Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d7/afdc95580ca56f30fbcd3060250f66cedbde69b4547028863abd8aa3b47e/contourpy-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6afc576f7b33cf00996e5c1102dc2a8f7cc89e39c0b55df93a0b78c1bd992b36", size = 1404833, upload-time = "2025-07-26T12:02:28.782Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e2/366af18a6d386f41132a48f033cbd2102e9b0cf6345d35ff0826cd984566/contourpy-1.3.3-cp314-cp314-win32.whl", hash = "sha256:66c8a43a4f7b8df8b71ee1840e4211a3c8d93b214b213f590e18a1beca458f7d", size = 189692, upload-time = "2025-07-26T12:02:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:cf9022ef053f2694e31d630feaacb21ea24224be1c3ad0520b13d844274614fd", size = 232424, upload-time = "2025-07-26T12:02:31.395Z" },
+    { url = "https://files.pythonhosted.org/packages/18/79/a9416650df9b525737ab521aa181ccc42d56016d2123ddcb7b58e926a42c/contourpy-1.3.3-cp314-cp314-win_arm64.whl", hash = "sha256:95b181891b4c71de4bb404c6621e7e2390745f887f2a026b2d99e92c17892339", size = 198300, upload-time = "2025-07-26T12:02:32.956Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/42/38c159a7d0f2b7b9c04c64ab317042bb6952b713ba875c1681529a2932fe/contourpy-1.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:33c82d0138c0a062380332c861387650c82e4cf1747aaa6938b9b6516762e772", size = 306769, upload-time = "2025-07-26T12:02:34.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6c/26a8205f24bca10974e77460de68d3d7c63e282e23782f1239f226fcae6f/contourpy-1.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ea37e7b45949df430fe649e5de8351c423430046a2af20b1c1961cae3afcda77", size = 287892, upload-time = "2025-07-26T12:02:35.807Z" },
+    { url = "https://files.pythonhosted.org/packages/66/06/8a475c8ab718ebfd7925661747dbb3c3ee9c82ac834ccb3570be49d129f4/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d304906ecc71672e9c89e87c4675dc5c2645e1f4269a5063b99b0bb29f232d13", size = 326748, upload-time = "2025-07-26T12:02:37.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a3/c5ca9f010a44c223f098fccd8b158bb1cb287378a31ac141f04730dc49be/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca658cd1a680a5c9ea96dc61cdbae1e85c8f25849843aa799dfd3cb370ad4fbe", size = 375554, upload-time = "2025-07-26T12:02:38.894Z" },
+    { url = "https://files.pythonhosted.org/packages/80/5b/68bd33ae63fac658a4145088c1e894405e07584a316738710b636c6d0333/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ab2fd90904c503739a75b7c8c5c01160130ba67944a7b77bbf36ef8054576e7f", size = 388118, upload-time = "2025-07-26T12:02:40.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/52/4c285a6435940ae25d7410a6c36bda5145839bc3f0beb20c707cda18b9d2/contourpy-1.3.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7301b89040075c30e5768810bc96a8e8d78085b47d8be6e4c3f5a0b4ed478a0", size = 352555, upload-time = "2025-07-26T12:02:42.25Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ee/3e81e1dd174f5c7fefe50e85d0892de05ca4e26ef1c9a59c2a57e43b865a/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2a2a8b627d5cc6b7c41a4beff6c5ad5eb848c88255fda4a8745f7e901b32d8e4", size = 1322295, upload-time = "2025-07-26T12:02:44.668Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/6d913d4d04e14379de429057cd169e5e00f6c2af3bb13e1710bcbdb5da12/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fd6ec6be509c787f1caf6b247f0b1ca598bef13f4ddeaa126b7658215529ba0f", size = 1391027, upload-time = "2025-07-26T12:02:47.09Z" },
+    { url = "https://files.pythonhosted.org/packages/93/8a/68a4ec5c55a2971213d29a9374913f7e9f18581945a7a31d1a39b5d2dfe5/contourpy-1.3.3-cp314-cp314t-win32.whl", hash = "sha256:e74a9a0f5e3fff48fb5a7f2fd2b9b70a3fe014a67522f79b7cca4c0c7e43c9ae", size = 202428, upload-time = "2025-07-26T12:02:48.691Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/96/fd9f641ffedc4fa3ace923af73b9d07e869496c9cc7a459103e6e978992f/contourpy-1.3.3-cp314-cp314t-win_amd64.whl", hash = "sha256:13b68d6a62db8eafaebb8039218921399baf6e47bf85006fd8529f2a08ef33fc", size = 250331, upload-time = "2025-07-26T12:02:50.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/469afb6465b853afff216f9528ffda78a915ff880ed58813ba4faf4ba0b6/contourpy-1.3.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b7448cb5a725bb1e35ce88771b86fba35ef418952474492cf7c764059933ff8b", size = 203831, upload-time = "2025-07-26T12:02:51.449Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.14.1"
 source = { registry = "https://pypi.org/simple" }
@@ -352,6 +418,24 @@ wheels = [
 ]
 
 [[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -367,6 +451,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/f9/f38573ed5844586db374d085911740a501ccfa373b455fc9413f09f85237/filelock-3.29.1.tar.gz", hash = "sha256:d97e6b1b9757569626c58caa07dc4beb1613f4a2938b1e8cc81afca398906c9e", size = 59335, upload-time = "2026-06-03T15:19:04.053Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4c/a0/614c5fe402fd88951df45f4dda2fa3b4e17a99ecd92340771929169b3b95/filelock-3.29.1-py3-none-any.whl", hash = "sha256:85199dfd706869641b72b2e8955d5416a4b2b7dc4b0e8e6d97b4cc1299a6983b", size = 40750, upload-time = "2026-06-03T15:19:02.959Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.63.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/ef/b3c6b9b5be2f82416d73fe2ed2e96e2793cd80e7510bd6a17ca79cdd88ec/fonttools-4.63.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:37dd23e621e3b0aef1baa70a303b80aaf38449632cfc8fd2a55fb285bbccfc02", size = 2881131, upload-time = "2026-05-14T12:03:13.386Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/c815bea63117fa63e4e1c01f8a1110d2112fa003f838e6467094ec2432ce/fonttools-4.63.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:a9faff9e0c1f76f9fd55899d2ce785832efebab37eb8ae13995853aef178bef0", size = 2426704, upload-time = "2026-05-14T12:03:15.801Z" },
+    { url = "https://files.pythonhosted.org/packages/44/04/0b91d8e916e92ad1fac9e4624760baf0fd5ff2ead614c2f68fb21373f03f/fonttools-4.63.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef3048ef05dbb552b89817713d9cac912e00d0fde4a3105c00d29e52e10c89af", size = 5044298, upload-time = "2026-05-14T12:03:18.085Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c7/2342da9830e3e9d4870305ca5d2091d2a83284f2953079b7bdd3b5e029d8/fonttools-4.63.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:58dc6bb86a78d782f00f9190ca02c119cf5bbe2807536e361e18d42019f877d8", size = 4999800, upload-time = "2026-05-14T12:03:20.161Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/6d/67fe16c48d7ce050979b33f47e0d28a318f02da030602e944c34f7a16ef3/fonttools-4.63.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ee08ebfa58f6e1aeff5697ab9582105bb620008c1caafb681e4c557e7483027b", size = 4982666, upload-time = "2026-05-14T12:03:22.87Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/00/3bbab338c07c71fa56269953845e92c951a61457bbbb0f1022551ea266d9/fonttools-4.63.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:27fdc65af8da6f88b9c6121c47a464cbe359fcfff7ff6fc2d37a1f395d755b78", size = 5133598, upload-time = "2026-05-14T12:03:25.168Z" },
+    { url = "https://files.pythonhosted.org/packages/62/f2/aa27c7f98db5b064883dadcc5283947e81e034de42e22a33675878d98b54/fonttools-4.63.0-cp312-cp312-win32.whl", hash = "sha256:af2fd1664d00a397d75f806985ddb36282091c2131a73a6485c23b4a34722263", size = 2292575, upload-time = "2026-05-14T12:03:27.496Z" },
+    { url = "https://files.pythonhosted.org/packages/87/36/cccb9bc2a6ab63d1b2980374f0dca72ce95ae267c9b4cfe77455bb70d0d4/fonttools-4.63.0-cp312-cp312-win_amd64.whl", hash = "sha256:59ac449f8cca9b4ffa08d2e7bbadad87ce710d69d1eda5c3c1ce579baa987272", size = 2343211, upload-time = "2026-05-14T12:03:30.057Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/8d/d8fec3dcde2963f8c908fb315e5ff2cd0ac34f82394bbbf73a2aa5145ce3/fonttools-4.63.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd7e9857e5e63738b9d9fd707bc1f59c8b09e5177726d23664db393c59bb08bd", size = 2876062, upload-time = "2026-05-14T12:03:32.554Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/71/d935dc54e4ff121bfdd11e08702db63a7e6f25af21d8a3d7b7212df53641/fonttools-4.63.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2a2a42198b696a6f48fad91709afb55176e66a5e566131219dba372fb7f8c59", size = 2424594, upload-time = "2026-05-14T12:03:34.86Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/40/e76320afa1df918e146155ef239b1719ee266092e96f5423bfd075affba1/fonttools-4.63.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e874792a8212b44583ea02189d9e693906b2f78b261f372f95d6c563210ac1d", size = 5024840, upload-time = "2026-05-14T12:03:36.745Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/36/0b805d8c485f872f65a509cbe3b58a5d0d17bee855333b54a150c79d3061/fonttools-4.63.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22135da48a348785c5e2d5d2d9d6bec5ed44adacbaeb9db12d9493bf6c6bfa68", size = 4975801, upload-time = "2026-05-14T12:03:38.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/26/2cee03d0aa083ab022da5c07aff9ed3f689da1defb81ad6917c9627896da/fonttools-4.63.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ccf41f2efdf56994d22d73bef4ced1052161958169428d06ba9724ea9e9a64be", size = 4965009, upload-time = "2026-05-14T12:03:41.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/48/cc4b66d9058c0d0982c833fad10127c4b0e9324606aafa41382295ca4102/fonttools-4.63.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9ced0bd02ac751dd6319b0da88aaef24414e3b0dbc32bb4f24944821a3741a27", size = 5105892, upload-time = "2026-05-14T12:03:43.525Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1f/a98a30a814b9ddef3a2e706025f90b9e0bc94890e6cb15254bc86547d11a/fonttools-4.63.0-cp313-cp313-win32.whl", hash = "sha256:85be818f5506e8a7753153def2c9550178f0ecae6a47b5e0e8dbb23f7cc90380", size = 2291313, upload-time = "2026-05-14T12:03:45.594Z" },
+    { url = "https://files.pythonhosted.org/packages/92/46/5177b01f3b4abfdd4409f31cca4ab279c9343a26efbe9ec78c97fc612e02/fonttools-4.63.0-cp313-cp313-win_amd64.whl", hash = "sha256:ba04cb5891d4c0c21b6da95eda8d7b090021508a294fff33464fc7d241e0856b", size = 2342299, upload-time = "2026-05-14T12:03:47.414Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d2/23d25e3f247b328be58d04a4c9f894178a0d1eda7d42867cfb388adaf416/fonttools-4.63.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd1e3094f42d806d3d7c79162fc59e5910fcbe3a7360c385b8da969bc4493745", size = 2875338, upload-time = "2026-05-14T12:03:50.052Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/58/7dfa0c761cb3b2964e2a84c4dc986c926a87de0cb9fb60d5b28ded3f2914/fonttools-4.63.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6e528da43bc3791085f8cb6141b1d13e459226790240340fcbb4625649238b03", size = 2422661, upload-time = "2026-05-14T12:03:52.154Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/87/64cfa18a7a1621d17b7f4502b2b0ed8a135a90c3db51ea590ee99043e76b/fonttools-4.63.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b2248c5decb223562f7902ff6325077a073f608ee8e33e88ad88db734eb9f49", size = 5010526, upload-time = "2026-05-14T12:03:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e1/a8933a72c45a87177fbde2696e0d0755c8c9062f8c077a961c6215fa27b1/fonttools-4.63.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:308f957cdeaf8abe4e5f2f124902ef405448af92c90f80e302a3b771c2e6116b", size = 4923946, upload-time = "2026-05-14T12:03:56.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/872e6e233b8c5e8b41413796ff18b7fe479661bd40147e071b450dfad7a1/fonttools-4.63.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bf00f21eb5fb721dbaf73d1e9da6d02a1af7768f2ebcf9798be98beab8ba90f6", size = 4962489, upload-time = "2026-05-14T12:03:59.443Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c4/83c24f2ec38b90cfda84bf4b1a1f49df80e84a1db4e7ac6e0d41bf23bc39/fonttools-4.63.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c1aaa4b9c75798400ac043ce04d74e7830376c85095a5a6ed7cba2f17a266bf4", size = 5071870, upload-time = "2026-05-14T12:04:02.122Z" },
+    { url = "https://files.pythonhosted.org/packages/de/40/3ae22b60ff1d41ce0bd044b31238cdc72cef99f28b976f1e128ebd618c9b/fonttools-4.63.0-cp314-cp314-win32.whl", hash = "sha256:22693918177bd9ceabec4736d338045f357769416fc6b0b2508eefef75b08616", size = 2295026, upload-time = "2026-05-14T12:04:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d4/98078064ccc76b45cb0f6c002452011e93c4bd26f6850344f0951cc1fe89/fonttools-4.63.0-cp314-cp314-win_amd64.whl", hash = "sha256:7d782fac32985914c351556f68ac0855391572bcd87de50e05970d3cd4c96fc5", size = 2347454, upload-time = "2026-05-14T12:04:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4e/652d1580c5f4e39f7d103b0c793e4773129ad633dce4addd0cf4dfebde02/fonttools-4.63.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6db5140a60a5d731d21ec076745b40a310607731b0a565b50776393188649001", size = 2958152, upload-time = "2026-05-14T12:04:08.706Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/55/ad864c9a9b219f552eb46b32cd7906c466e5a578ba0c3abfcc0fe7413eb6/fonttools-4.63.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d76edbff9014094dbf03bd2d074709dfa6ec7aba13d838c937a2b33d2d6a86e", size = 2460809, upload-time = "2026-05-14T12:04:10.783Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2b/0aa8db70f18cf52e49b4ed5ecec68547f981160bf5ded3b5aed6faa0a6f9/fonttools-4.63.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0eac00b9118c3c2f87d272e45341871c5b3066baa3c86897fa634a7c3fb59096", size = 5148649, upload-time = "2026-05-14T12:04:12.747Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/63/18e4369c25043096f1048e0c9915951adc4f842bd81c6b18155824d6fa99/fonttools-4.63.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51394295f1a51de8b5f30bdb1e1b9a4231536c7064ef5c6e211eec19fa36036f", size = 4932147, upload-time = "2026-05-14T12:04:14.806Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/3f/67f3eac2ffd8a98446c5022f8ed3864eac878a5ff7af8df4c8286dba16cc/fonttools-4.63.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9e12f105d2b6342c559c298afb674006bb2893afc7102dcf8a1b55b0486b4e40", size = 5027237, upload-time = "2026-05-14T12:04:17.675Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ba/4e6214cb38a7b04779e97bb7636de9a5c7f20af7018d03dee0b64c08510a/fonttools-4.63.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:796f27556dbe094c4824f75ca85267e4df776c79036c8441469a4df37038c196", size = 5053933, upload-time = "2026-05-14T12:04:20.818Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3b/214dcc19ee31d3d38fb5ad2755c11ef0514e5dc300bbaf41c0b69f393799/fonttools-4.63.0-cp314-cp314t-win32.whl", hash = "sha256:948428a275741f0b64b113c955425a953314f4b9ab9997f73a72c83e68e569c8", size = 2359326, upload-time = "2026-05-14T12:04:24.22Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1e/3ff1a9b523058c2eeb6a9d50f5574e2a738200d0d94107d5bc4105e8da3f/fonttools-4.63.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d4741eb179121cab9eea4cb2393d24492373a260d7945006358c08cfbf45419", size = 2425829, upload-time = "2026-05-14T12:04:26.829Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
 ]
 
 [[package]]
@@ -418,6 +543,104 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/b2/818b74ebea34dabe6d0c51cb1c572e046730e64844da6ed646d5298c40ce/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:4e9750bc21b886308024f8a54ccb9a2cc38ac9fa813bf4348434e3d54f337ff9", size = 123158, upload-time = "2026-03-09T13:13:23.127Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d9/405320f8077e8e1c5c4bd6adc45e1e6edf6d727b6da7f2e2533cf58bff71/kiwisolver-1.5.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:72ec46b7eba5b395e0a7b63025490d3214c11013f4aacb4f5e8d6c3041829588", size = 66388, upload-time = "2026-03-09T13:13:24.765Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9f/795fedf35634f746151ca8839d05681ceb6287fbed6cc1c9bf235f7887c2/kiwisolver-1.5.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ed3a984b31da7481b103f68776f7128a89ef26ed40f4dc41a2223cda7fb24819", size = 64068, upload-time = "2026-03-09T13:13:25.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/13/680c54afe3e65767bed7ec1a15571e1a2f1257128733851ade24abcefbcc/kiwisolver-1.5.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bb5136fb5352d3f422df33f0c879a1b0c204004324150cc3b5e3c4f310c9049f", size = 1477934, upload-time = "2026-03-09T13:13:27.166Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/2f/cebfcdb60fd6a9b0f6b47a9337198bcbad6fbe15e68189b7011fd914911f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2af221f268f5af85e776a73d62b0845fc8baf8ef0abfae79d29c77d0e776aaf", size = 1278537, upload-time = "2026-03-09T13:13:28.707Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/0d/9b782923aada3fafb1d6b84e13121954515c669b18af0c26e7d21f579855/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b0f172dc8ffaccb8522d7c5d899de00133f2f1ca7b0a49b7da98e901de87bf2d", size = 1296685, upload-time = "2026-03-09T13:13:30.528Z" },
+    { url = "https://files.pythonhosted.org/packages/27/70/83241b6634b04fe44e892688d5208332bde130f38e610c0418f9ede47ded/kiwisolver-1.5.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6ab8ba9152203feec73758dad83af9a0bbe05001eb4639e547207c40cfb52083", size = 1346024, upload-time = "2026-03-09T13:13:32.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/db/30ed226fb271ae1a6431fc0fe0edffb2efe23cadb01e798caeb9f2ceae8f/kiwisolver-1.5.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:cdee07c4d7f6d72008d3f73b9bf027f4e11550224c7c50d8df1ae4a37c1402a6", size = 987241, upload-time = "2026-03-09T13:13:34.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bd/c314595208e4c9587652d50959ead9e461995389664e490f4dce7ff0f782/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7c60d3c9b06fb23bd9c6139281ccbdc384297579ae037f08ae90c69f6845c0b1", size = 2227742, upload-time = "2026-03-09T13:13:36.4Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/43/0499cec932d935229b5543d073c2b87c9c22846aab48881e9d8d6e742a2d/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:e315e5ec90d88e140f57696ff85b484ff68bb311e36f2c414aa4286293e6dee0", size = 2323966, upload-time = "2026-03-09T13:13:38.204Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/79b0d760907965acfd9d61826a3d41f8f093c538f55cd2633d3f0db269f6/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1465387ac63576c3e125e5337a6892b9e99e0627d52317f3ca79e6930d889d15", size = 1977417, upload-time = "2026-03-09T13:13:39.966Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/01d0537c41cb75a551a438c3c7a80d0c60d60b81f694dac83dd436aec0d0/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:530a3fd64c87cffa844d4b6b9768774763d9caa299e9b75d8eca6a4423b31314", size = 2491238, upload-time = "2026-03-09T13:13:41.698Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/34/8aefdd0be9cfd00a44509251ba864f5caf2991e36772e61c408007e7f417/kiwisolver-1.5.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1d9daea4ea6b9be74fe2f01f7fbade8d6ffab263e781274cffca0dba9be9eec9", size = 2294947, upload-time = "2026-03-09T13:13:43.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cf/0348374369ca588f8fe9c338fae49fa4e16eeb10ffb3d012f23a54578a9e/kiwisolver-1.5.0-cp312-cp312-win_amd64.whl", hash = "sha256:f18c2d9782259a6dc132fdc7a63c168cbc74b35284b6d75c673958982a378384", size = 73569, upload-time = "2026-03-09T13:13:45.792Z" },
+    { url = "https://files.pythonhosted.org/packages/28/26/192b26196e2316e2bd29deef67e37cdf9870d9af8e085e521afff0fed526/kiwisolver-1.5.0-cp312-cp312-win_arm64.whl", hash = "sha256:f7c7553b13f69c1b29a5bde08ddc6d9d0c8bfb84f9ed01c30db25944aeb852a7", size = 64997, upload-time = "2026-03-09T13:13:46.878Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/69/024d6711d5ba575aa65d5538042e99964104e97fa153a9f10bc369182bc2/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd40bb9cd0891c4c3cb1ddf83f8bbfa15731a248fdc8162669405451e2724b09", size = 123166, upload-time = "2026-03-09T13:13:48.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/adbb40df306f587054a348831220812b9b1d787aff714cfbc8556e38fccd/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0e1403fd7c26d77c1f03e096dc58a5c726503fa0db0456678b8668f76f521e3", size = 66395, upload-time = "2026-03-09T13:13:49.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/d0a972b34e1c63e2409413104216cd1caa02c5a37cb668d1687d466c1c45/kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dda366d548e89a90d88a86c692377d18d8bd64b39c1fb2b92cb31370e2896bbd", size = 64065, upload-time = "2026-03-09T13:13:50.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0a/7b98e1e119878a27ba8618ca1e18b14f992ff1eda40f47bccccf4de44121/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3", size = 1477903, upload-time = "2026-03-09T13:13:52.084Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d8/55638d89ffd27799d5cc3d8aa28e12f4ce7a64d67b285114dbedc8ea4136/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c50b89ffd3e1a911c69a1dd3de7173c0cd10b130f56222e57898683841e4f96", size = 1278751, upload-time = "2026-03-09T13:13:54.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/97/b4c8d0d18421ecceba20ad8701358453b88e32414e6f6950b5a4bad54e65/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4db576bb8c3ef9365f8b40fe0f671644de6736ae2c27a2c62d7d8a1b4329f099", size = 1296793, upload-time = "2026-03-09T13:13:56.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/f862f94b6389d8957448ec9df59450b81bec4abb318805375c401a1e6892/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0b85aad90cea8ac6797a53b5d5f2e967334fa4d1149f031c4537569972596cb8", size = 1346041, upload-time = "2026-03-09T13:13:58.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6a/f1650af35821eaf09de398ec0bc2aefc8f211f0cda50204c9f1673741ba9/kiwisolver-1.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:d36ca54cb4c6c4686f7cbb7b817f66f5911c12ddb519450bbe86707155028f87", size = 987292, upload-time = "2026-03-09T13:13:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/de/19/d7fb82984b9238115fe629c915007be608ebd23dc8629703d917dbfaffd4/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:38f4a703656f493b0ad185211ccfca7f0386120f022066b018eb5296d8613e23", size = 2227865, upload-time = "2026-03-09T13:14:01.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/46b7f386589fd222dac9e9de9c956ce5bcefe2ee73b4e79891381dda8654/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ac2360e93cb41be81121755c6462cff3beaa9967188c866e5fce5cf13170859", size = 2324369, upload-time = "2026-03-09T13:14:02.972Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8b/95e237cf3d9c642960153c769ddcbe278f182c8affb20cecc1cc983e7cc5/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c95cab08d1965db3d84a121f1c7ce7479bdd4072c9b3dafd8fecce48a2e6b902", size = 1977989, upload-time = "2026-03-09T13:14:04.503Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/95/980c9df53501892784997820136c01f62bc1865e31b82b9560f980c0e649/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc20894c3d21194d8041a28b65622d5b86db786da6e3cfe73f0c762951a61167", size = 2491645, upload-time = "2026-03-09T13:14:06.106Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/900647fd0840abebe1561792c6b31e6a7c0e278fc3973d30572a965ca14c/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a32f72973f0f950c1920475d5c5ea3d971b81b6f0ec53b8d0a956cc965f22e0", size = 2295237, upload-time = "2026-03-09T13:14:08.891Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8a/be60e3bbcf513cc5a50f4a3e88e1dcecebb79c1ad607a7222877becaa101/kiwisolver-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bf3acf1419fa93064a4c2189ac0b58e3be7872bf6ee6177b0d4c63dc4cea276", size = 73573, upload-time = "2026-03-09T13:14:12.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d2/64be2e429eb4fca7f7e1c52a91b12663aeaf25de3895e5cca0f47ef2a8d0/kiwisolver-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa8eb9ecdb7efb0b226acec134e0d709e87a909fa4971a54c0c4f6e88635484c", size = 64998, upload-time = "2026-03-09T13:14:13.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/69/ce68dd0c85755ae2de490bf015b62f2cea5f6b14ff00a463f9d0774449ff/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db485b3847d182b908b483b2ed133c66d88d49cacf98fd278fadafe11b4478d1", size = 125700, upload-time = "2026-03-09T13:14:14.636Z" },
+    { url = "https://files.pythonhosted.org/packages/74/aa/937aac021cf9d4349990d47eb319309a51355ed1dbdc9c077cdc9224cb11/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:be12f931839a3bdfe28b584db0e640a65a8bcbc24560ae3fdb025a449b3d754e", size = 67537, upload-time = "2026-03-09T13:14:15.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/20/3a87fbece2c40ad0f6f0aefa93542559159c5f99831d596050e8afae7a9f/kiwisolver-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:16b85d37c2cbb3253226d26e64663f755d88a03439a9c47df6246b35defbdfb7", size = 65514, upload-time = "2026-03-09T13:14:18.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7f/f943879cda9007c45e1f7dba216d705c3a18d6b35830e488b6c6a4e7cdf0/kiwisolver-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4432b835675f0ea7414aab3d37d119f7226d24869b7a829caeab49ebda407b0c", size = 1584848, upload-time = "2026-03-09T13:14:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f8/4d4f85cc1870c127c88d950913370dd76138482161cd07eabbc450deff01/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b0feb50971481a2cc44d94e88bdb02cdd497618252ae226b8eb1201b957e368", size = 1391542, upload-time = "2026-03-09T13:14:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/04/0b/65dd2916c84d252b244bd405303220f729e7c17c9d7d33dca6feeff9ffc4/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56fa888f10d0f367155e76ce849fa1166fc9730d13bd2d65a2aa13b6f5424489", size = 1404447, upload-time = "2026-03-09T13:14:23.205Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5c/2606a373247babce9b1d056c03a04b65f3cf5290a8eac5d7bdead0a17e21/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:940dda65d5e764406b9fb92761cbf462e4e63f712ab60ed98f70552e496f3bf1", size = 1455918, upload-time = "2026-03-09T13:14:24.74Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d1/c6078b5756670658e9192a2ef11e939c92918833d2745f85cd14a6004bdf/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:89fc958c702ee9a745e4700378f5d23fddbc46ff89e8fdbf5395c24d5c1452a3", size = 1072856, upload-time = "2026-03-09T13:14:26.597Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c8/7def6ddf16eb2b3741d8b172bdaa9af882b03c78e9b0772975408801fa63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9027d773c4ff81487181a925945743413f6069634d0b122d0b37684ccf4f1e18", size = 2333580, upload-time = "2026-03-09T13:14:28.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/87/2ac1fce0eb1e616fcd3c35caa23e665e9b1948bb984f4764790924594128/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5b233ea3e165e43e35dba1d2b8ecc21cf070b45b65ae17dd2747d2713d942021", size = 2423018, upload-time = "2026-03-09T13:14:30.018Z" },
+    { url = "https://files.pythonhosted.org/packages/67/13/c6700ccc6cc218716bfcda4935e4b2997039869b4ad8a94f364c5a3b8e63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ce9bf03dad3b46408c08649c6fbd6ca28a9fce0eb32fdfffa6775a13103b5310", size = 2062804, upload-time = "2026-03-09T13:14:32.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/877056304626943ff0f1f44c08f584300c199b887cb3176cd7e34f1515f1/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3", size = 2597482, upload-time = "2026-03-09T13:14:34.971Z" },
+    { url = "https://files.pythonhosted.org/packages/75/19/c60626c47bf0f8ac5dcf72c6c98e266d714f2fbbfd50cf6dab5ede3aaa50/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2", size = 2394328, upload-time = "2026-03-09T13:14:36.816Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/6a6d5e5bb8273756c27b7d810d47f7ef2f1f9b9fd23c9ee9a3f8c75c9cef/kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53", size = 68410, upload-time = "2026-03-09T13:14:38.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/060f45052f2a01ad5762c8fdecd6d7a752b43400dc29ff75cd47225a40fd/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8df31fe574b8b3993cc61764f40941111b25c2d9fea13d3ce24a49907cd2d615", size = 123231, upload-time = "2026-03-09T13:14:41.323Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a7/78da680eadd06ff35edef6ef68a1ad273bad3e2a0936c9a885103230aece/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1d49a49ac4cbfb7c1375301cd1ec90169dfeae55ff84710d782260ce77a75a02", size = 66489, upload-time = "2026-03-09T13:14:42.534Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b2/97980f3ad4fae37dd7fe31626e2bf75fbf8bdf5d303950ec1fab39a12da8/kiwisolver-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0cbe94b69b819209a62cb27bdfa5dc2a8977d8de2f89dfd97ba4f53ed3af754e", size = 64063, upload-time = "2026-03-09T13:14:44.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/b06c934a6aa8bc91f566bd2a214fd04c30506c2d9e2b6b171953216a65b6/kiwisolver-1.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80aa065ffd378ff784822a6d7c3212f2d5f5e9c3589614b5c228b311fd3063ac", size = 1475913, upload-time = "2026-03-09T13:14:46.247Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f0/f768ae564a710135630672981231320bc403cf9152b5596ec5289de0f106/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e7f886f47ab881692f278ae901039a234e4025a68e6dfab514263a0b1c4ae05", size = 1282782, upload-time = "2026-03-09T13:14:48.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/1de7aad00697325f05238a5f2eafbd487fb637cc27a558b5367a5f37fb7f/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5060731cc3ed12ca3a8b57acd4aeca5bbc2f49216dd0bec1650a1acd89486bcd", size = 1300815, upload-time = "2026-03-09T13:14:50.721Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c2/297f25141d2e468e0ce7f7a7b92e0cf8918143a0cbd3422c1ad627e85a06/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7a4aa69609f40fce3cbc3f87b2061f042eee32f94b8f11db707b66a26461591a", size = 1347925, upload-time = "2026-03-09T13:14:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d3/f4c73a02eb41520c47610207b21afa8cdd18fdbf64ffd94674ae21c4812d/kiwisolver-1.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:d168fda2dbff7b9b5f38e693182d792a938c31db4dac3a80a4888de603c99554", size = 991322, upload-time = "2026-03-09T13:14:54.637Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/46/d3f2efef7732fcda98d22bf4ad5d3d71d545167a852ca710a494f4c15343/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:413b820229730d358efd838ecbab79902fe97094565fdc80ddb6b0a18c18a581", size = 2232857, upload-time = "2026-03-09T13:14:56.471Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ec/2d9756bf2b6d26ae4349b8d3662fb3993f16d80c1f971c179ce862b9dbae/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5124d1ea754509b09e53738ec185584cc609aae4a3b510aaf4ed6aa047ef9303", size = 2329376, upload-time = "2026-03-09T13:14:58.072Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/9f/876a0a0f2260f1bde92e002b3019a5fabc35e0939c7d945e0fa66185eb20/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e4415a8db000bf49a6dd1c478bf70062eaacff0f462b92b0ba68791a905861f9", size = 1982549, upload-time = "2026-03-09T13:14:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4f/ba3624dfac23a64d54ac4179832860cb537c1b0af06024936e82ca4154a0/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d618fd27420381a4f6044faa71f46d8bfd911bd077c555f7138ed88729bfbe79", size = 2494680, upload-time = "2026-03-09T13:15:01.364Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b7/97716b190ab98911b20d10bf92eca469121ec483b8ce0edd314f51bc85af/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5092eb5b1172947f57d6ea7d89b2f29650414e4293c47707eb499ec07a0ac796", size = 2297905, upload-time = "2026-03-09T13:15:03.925Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/36/4e551e8aa55c9188bca9abb5096805edbf7431072b76e2298e34fd3a3008/kiwisolver-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:d76e2d8c75051d58177e762164d2e9ab92886534e3a12e795f103524f221dd8e", size = 75086, upload-time = "2026-03-09T13:15:07.775Z" },
+    { url = "https://files.pythonhosted.org/packages/70/15/9b90f7df0e31a003c71649cf66ef61c3c1b862f48c81007fa2383c8bd8d7/kiwisolver-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:fa6248cd194edff41d7ea9425ced8ca3a6f838bfb295f6f1d6e6bb694a8518df", size = 66577, upload-time = "2026-03-09T13:15:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/17/01/7dc8c5443ff42b38e72731643ed7cf1ed9bf01691ae5cdca98501999ed83/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d1ffeb80b5676463d7a7d56acbe8e37a20ce725570e09549fe738e02ca6b7e1e", size = 125794, upload-time = "2026-03-09T13:15:10.525Z" },
+    { url = "https://files.pythonhosted.org/packages/46/8a/b4ebe46ebaac6a303417fab10c2e165c557ddaff558f9699d302b256bc53/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc4d8e252f532ab46a1de9349e2d27b91fce46736a9eedaa37beaca66f574ed4", size = 67646, upload-time = "2026-03-09T13:15:12.016Z" },
+    { url = "https://files.pythonhosted.org/packages/60/35/10a844afc5f19d6f567359bf4789e26661755a2f36200d5d1ed8ad0126e5/kiwisolver-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6783e069732715ad0c3ce96dbf21dbc2235ab0593f2baf6338101f70371f4028", size = 65511, upload-time = "2026-03-09T13:15:13.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8a/685b297052dd041dcebce8e8787b58923b6e78acc6115a0dc9189011c44b/kiwisolver-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7c4c09a490dc4d4a7f8cbee56c606a320f9dc28cf92a7157a39d1ce7676a657", size = 1584858, upload-time = "2026-03-09T13:15:15.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/80/04865e3d4638ac5bddec28908916df4a3075b8c6cc101786a96803188b96/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a075bd7bd19c70cf67c8badfa36cf7c5d8de3c9ddb8420c51e10d9c50e94920", size = 1392539, upload-time = "2026-03-09T13:15:16.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/01/77a19cacc0893fa13fafa46d1bba06fb4dc2360b3292baf4b56d8e067b24/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bdd3e53429ff02aa319ba59dfe4ceeec345bf46cf180ec2cf6fd5b942e7975e9", size = 1405310, upload-time = "2026-03-09T13:15:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/53/39/bcaf5d0cca50e604cfa9b4e3ae1d64b50ca1ae5b754122396084599ef903/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cdcb35dc9d807259c981a85531048ede628eabcffb3239adf3d17463518992d", size = 1456244, upload-time = "2026-03-09T13:15:20.444Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7a/72c187abc6975f6978c3e39b7cf67aeb8b3c0a8f9790aa7fd412855e9e1f/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:70d593af6a6ca332d1df73d519fddb5148edb15cd90d5f0155e3746a6d4fcc65", size = 1073154, upload-time = "2026-03-09T13:15:22.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ca/cf5b25783ebbd59143b4371ed0c8428a278abe68d6d0104b01865b1bbd0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:377815a8616074cabbf3f53354e1d040c35815a134e01d7614b7692e4bf8acfa", size = 2334377, upload-time = "2026-03-09T13:15:23.741Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e5/b1f492adc516796e88751282276745340e2a72dcd0d36cf7173e0daf3210/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0255a027391d52944eae1dbb5d4cc5903f57092f3674e8e544cdd2622826b3f0", size = 2425288, upload-time = "2026-03-09T13:15:25.789Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e5/9b21fbe91a61b8f409d74a26498706e97a48008bfcd1864373d32a6ba31c/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:012b1eb16e28718fa782b5e61dc6f2da1f0792ca73bd05d54de6cb9561665fc9", size = 2063158, upload-time = "2026-03-09T13:15:27.63Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/02/83f47986138310f95ea95531f851b2a62227c11cbc3e690ae1374fe49f0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e3aafb33aed7479377e5e9a82e9d4bf87063741fc99fc7ae48b0f16e32bdd6f", size = 2597260, upload-time = "2026-03-09T13:15:29.421Z" },
+    { url = "https://files.pythonhosted.org/packages/07/18/43a5f24608d8c313dd189cf838c8e68d75b115567c6279de7796197cfb6a/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646", size = 2394403, upload-time = "2026-03-09T13:15:31.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b5/98222136d839b8afabcaa943b09bd05888c2d36355b7e448550211d1fca4/kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681", size = 79687, upload-time = "2026-03-09T13:15:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a2/ca7dc962848040befed12732dff6acae7fb3c4f6fc4272b3f6c9a30b8713/kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57", size = 70032, upload-time = "2026-03-09T13:15:34.411Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fa/2910df836372d8761bb6eff7d8bdcb1613b5c2e03f260efe7abe34d388a7/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_10_13_x86_64.whl", hash = "sha256:5ae8e62c147495b01a0f4765c878e9bfdf843412446a247e28df59936e99e797", size = 130262, upload-time = "2026-03-09T13:15:35.629Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/41/c5f71f9f00aabcc71fee8b7475e3f64747282580c2fe748961ba29b18385/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f6764a4ccab3078db14a632420930f6186058750df066b8ea2a7106df91d3203", size = 138036, upload-time = "2026-03-09T13:15:36.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/7399a607f434119c6e1fdc8ec89a8d51ccccadf3341dee4ead6bd14caaf5/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c31c13da98624f957b0fb1b5bae5383b2333c2c3f6793d9825dd5ce79b525cb7", size = 194295, upload-time = "2026-03-09T13:15:38.22Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/91/53255615acd2a1eaca307ede3c90eb550bae9c94581f8c00081b6b1c8f44/kiwisolver-1.5.0-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:1f1489f769582498610e015a8ef2d36f28f505ab3096d0e16b4858a9ec214f57", size = 75987, upload-time = "2026-03-09T13:15:39.65Z" },
+]
+
+[[package]]
+name = "lazy-loader"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/ac/21a1f8aa3777f5658576777ea76bfb124b702c520bbe90edf4ae9915eafa/lazy_loader-0.5.tar.gz", hash = "sha256:717f9179a0dbed357012ddad50a5ad3d5e4d9a0b8712680d4e687f5e6e6ed9b3", size = 15294, upload-time = "2026-03-06T15:45:09.054Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/a1/8d812e53a5da1687abb10445275d41a8b13adb781bbf7196ddbcf8d88505/lazy_loader-0.5-py3-none-any.whl", hash = "sha256:ab0ea149e9c554d4ffeeb21105ac60bed7f3b4fd69b1d2360a4add51b170b005", size = 8044, upload-time = "2026-03-06T15:45:07.668Z" },
 ]
 
 [[package]]
@@ -565,6 +788,60 @@ wheels = [
 ]
 
 [[package]]
+name = "matplotlib"
+version = "3.10.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/c6/5581e26c72233ebb2a2a6fed2d24fb7c66b4700120b813f51b0555acf0b6/matplotlib-3.10.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0c3c28d9fbcc1fe7a03be236d73430cf6409c41fb2383a7ac52fe932b072cb1", size = 8319908, upload-time = "2026-04-24T00:12:21.323Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/18/4880dd762e40cd360c1bf06e890c5a97b997e91cb324602b1a19950ad5ce/matplotlib-3.10.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:41cb28c2bd769aa3e98322c6ab09854cbcc52ab69d2759d681bba3e327b2b320", size = 8216016, upload-time = "2026-04-24T00:12:23.4Z" },
+    { url = "https://files.pythonhosted.org/packages/32/91/d024616abdba99e83120e07a20658976f6a343646710760c4a51df126029/matplotlib-3.10.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ae20801130378b82d647ff5047c07316295b68dc054ca6b3c13519d0ea624285", size = 8789336, upload-time = "2026-04-24T00:12:26.096Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/04/030a2f61ef2158f5e4c259487a92ac877732499fb33d871585d89e03c42d/matplotlib-3.10.9-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c63ebcd8b4b169eb2f5c200552ae6b8be8999a005b6b507ed76fb8d7d674fe2", size = 9604602, upload-time = "2026-04-24T00:12:29.052Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c2/541e4d09d87bb6b5830fc28b4c887a9a8cf4e1c6cee698a8c05552ae2003/matplotlib-3.10.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d75d11c949914165976c621b2324f9ef162af7ebf4b057ddf95dd1dba7e5edcf", size = 9670966, upload-time = "2026-04-24T00:12:32.131Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a1/4571fc46e7702de8d0c2dc54ad1b2f8e29328dea3ee90831181f7353d93c/matplotlib-3.10.9-cp312-cp312-win_amd64.whl", hash = "sha256:d091f9d758b34aaaaa6331d13574bf01891d903b3dec59bfff458ef7551de5d6", size = 8217462, upload-time = "2026-04-24T00:12:35.226Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d0/2269edb12aa30c13c8bcc9382892e39943ce1d28aab4ec296e0381798e81/matplotlib-3.10.9-cp312-cp312-win_arm64.whl", hash = "sha256:10cc5ce06d10231c36f40e875f3c7e8050362a4ee8f0ee5d29a6b3277d57bb42", size = 8136688, upload-time = "2026-04-24T00:12:37.442Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/d3/8d4f6afbecb49fc04e060a57c0fce39ea51cc163a6bd87303ccd698e4fa6/matplotlib-3.10.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b580440f1ff81a0e34122051a3dfabb7e4b7f9e380629929bde0eff9af72165f", size = 8320331, upload-time = "2026-04-24T00:12:39.688Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d9/9e14bc7564bf92d5ffa801ae5fac819ce74b925dfb55e3ebde61a3bbad3e/matplotlib-3.10.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b1b745c489cd1a77a0dc1120a05dc87af9798faebc913601feb8c73d89bf2d1e", size = 8216461, upload-time = "2026-04-24T00:12:42.494Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/4402d0d14ccf1dfc70932600b68097fbbf9c898a4871d2cbbe79c7801a32/matplotlib-3.10.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8f3bcac1ca5ed000a6f4337d47ba67dfddf37ed6a46c15fd7f014997f7bf865f", size = 8790091, upload-time = "2026-04-24T00:12:44.789Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0b/322aeec06dd9b91411f92028b37d447342770a24392aa4813e317064dad5/matplotlib-3.10.9-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a8d66a55def891c33147ba3ba9bfcabf0b526a43764c818acbb4525e5ed0838", size = 9605027, upload-time = "2026-04-24T00:12:47.583Z" },
+    { url = "https://files.pythonhosted.org/packages/74/88/5f13482f55e7b00bcfc09838b093c2456e1379978d2a146844aae05350ad/matplotlib-3.10.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d843374407c4017a6403b59c6c81606773d136f3259d5b6da3131bc814542cc2", size = 9671269, upload-time = "2026-04-24T00:12:50.878Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e0/0840fd2f93da988ec660b8ad1984abe9f25d2aed22a5e394ff1c68c88307/matplotlib-3.10.9-cp313-cp313-win_amd64.whl", hash = "sha256:f4399f64b3e94cd500195490972ae1ee81170df1636fa15364d157d5bdd7b921", size = 8217588, upload-time = "2026-04-24T00:12:53.784Z" },
+    { url = "https://files.pythonhosted.org/packages/47/b9/d706d06dd605c49b9f83a2aed8c13e3e5db70697d7a80b7e3d7915de6b17/matplotlib-3.10.9-cp313-cp313-win_arm64.whl", hash = "sha256:ba7b3b8ef09eab7df0e86e9ae086faa433efbfbdb46afcb3aa16aabf779469a8", size = 8136913, upload-time = "2026-04-24T00:12:56.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/45/6e32d96978264c8ca8c4b1010adb955a1a49cfaf314e212bbc8908f04a61/matplotlib-3.10.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:09218df8a93712bd6ea133e83a153c755448cf7868316c531cffcc43f69d1cc9", size = 8368019, upload-time = "2026-04-24T00:12:58.896Z" },
+    { url = "https://files.pythonhosted.org/packages/86/0a/c8e3d3bba245f0f7fc424937f8ff7ef77291a36af3edb97ccd78aa93d84f/matplotlib-3.10.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:82368699727bfb7b0182e1aa13082e3c08e092fa1a25d3e1fd92405bff96f6d4", size = 8264645, upload-time = "2026-04-24T00:13:01.406Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/aa/5bf5a14fe4fed73a4209a155606f8096ff797aad89c6c35179026571133e/matplotlib-3.10.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3225f4e1edcb8c86c884ddf79ebe20ecd0a67d30188f279897554ccd8fded4dc", size = 8802194, upload-time = "2026-04-24T00:13:03.702Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5e/b4be852d6bba6fd15893fadf91ff26ae49cb91aac789e95dde9d342e664f/matplotlib-3.10.9-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:de2445a0c6690d21b7eb6ce071cebad6d40a2e9bdf10d039074a96ba19797b99", size = 9622684, upload-time = "2026-04-24T00:13:06.647Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/ed428c971139112ef730f62770654d609467346d09d4b62617e1afd68a5a/matplotlib-3.10.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:b2b9516251cb89ff618d757daec0e2ed1bf21248013844a853d87ef85ab3081d", size = 9680790, upload-time = "2026-04-24T00:13:10.009Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/09/052e884aaf2b985c63cb79f715f1d5b6a3eaa7de78f6a52b9dbc077d5b53/matplotlib-3.10.9-cp313-cp313t-win_amd64.whl", hash = "sha256:e9fae004b941b23ff2edcf1567a857ed77bafc8086ffa258190462328434faf8", size = 8287571, upload-time = "2026-04-24T00:13:13.087Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/38/ae27288e788c35a4250491422f3db7750366fc8c97d6f36fbdecfc1f5518/matplotlib-3.10.9-cp313-cp313t-win_arm64.whl", hash = "sha256:6b63d9c7c769b88ab81e10dc86e4e0607cf56817b9f9e6cf24b2a5f1693b8e38", size = 8188292, upload-time = "2026-04-24T00:13:15.546Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/e6/3bd8afd04949f02eabc1c17115ea5255e19cacd4d06fc5abdde4eeb0052c/matplotlib-3.10.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:172db52c9e683f5d12eaf57f0f54834190e12581fe1cc2a19595a8f5acb4e77d", size = 8321276, upload-time = "2026-04-24T00:13:18.318Z" },
+    { url = "https://files.pythonhosted.org/packages/41/86/86231232fff41c9f8e4a1a7d7a597d349a02527109c3af7d618366122139/matplotlib-3.10.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97e35e8d39ccc85859095e01a53847432ba9a53ddf7986f7a54a11b73d0e143f", size = 8218218, upload-time = "2026-04-24T00:13:20.974Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8f/becc9722cafc64f5d2eb0b7c1bf5f585271c618a45dbd8fabeb021f898b6/matplotlib-3.10.9-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aba1615dabe83188e19d4f75a253c6a08423e04c1425e64039f800050a69de6b", size = 9608145, upload-time = "2026-04-24T00:13:23.228Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5d/f7e914f7d9325abff4057cee62c0fa70263683189f774473cbfb534cd13b/matplotlib-3.10.9-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:34cf8167e023ad956c15f36302911d5406bd99a9862c1a8499ea6f7c0e015dc2", size = 9885085, upload-time = "2026-04-24T00:13:25.849Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/fd/fa69f2221534e80cc5772ac2b7d222011a2acafc2ec7216d5dd174c864ae/matplotlib-3.10.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:59476c6d29d612b8e9bb6ce8c5b631be6ba8f9e3a2421f22a02b192c7dd28716", size = 9672358, upload-time = "2026-04-24T00:13:28.906Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/1a/5a4f747a8b271cbb024946d2dd3c913ab5032ba430626f8c3528ada96b4b/matplotlib-3.10.9-cp314-cp314-win_amd64.whl", hash = "sha256:336b9acc64d309063126edcdaca00db9373af3c476bb94388fe9c5a53ad13e6f", size = 8349970, upload-time = "2026-04-24T00:13:31.904Z" },
+    { url = "https://files.pythonhosted.org/packages/64/dc/95d60ecaefe30680a154b52ea96ab4b0dab547f1fd6aa12f5fb655e89cae/matplotlib-3.10.9-cp314-cp314-win_arm64.whl", hash = "sha256:2dc9477819ffd78ad12a20df1d9d6a6bd4fec6aaa9072681465fddca052f1456", size = 8272785, upload-time = "2026-04-24T00:13:34.511Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a0/005d68bc8b8418300ce6591f18586910a8526806e2ab663933d9f20a41e9/matplotlib-3.10.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:da4e09638420548f31c354032a6250e473c68e5a4e96899b4844cf39ddea23fe", size = 8367999, upload-time = "2026-04-24T00:13:36.962Z" },
+    { url = "https://files.pythonhosted.org/packages/22/05/1236cc9290be70b2498af20ca348add76e3fffe7f67b477db5133a84f3ea/matplotlib-3.10.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:345f6f68ecc8da0ca56fad2ea08fde1a115eda530079eca185d50a7bc3e146c6", size = 8264543, upload-time = "2026-04-24T00:13:39.851Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/c2/071f5a5ff6c5bd63aaaf2f45c811d9bf2ced94bde188d9e1a519e21d0cba/matplotlib-3.10.9-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4edcfbd8565339aa62f1cd4012f7180926fdbe71850f7b0d3c379c175cd6b66c", size = 9622800, upload-time = "2026-04-24T00:13:42.296Z" },
+    { url = "https://files.pythonhosted.org/packages/95/57/da7d1f10a85624b9e7db68e069dd94e58dc41dbf9463c5921632ecbe3661/matplotlib-3.10.9-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6be157fe17fc37cb95ac1d7374cf717ce9259616edec911a78d9d26dae8522d4", size = 9888561, upload-time = "2026-04-24T00:13:45.026Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b2/ef8d6bb59b0edb6c16c968b70f548aa13b54348972def5aa6ac85df67145/matplotlib-3.10.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4e42042d54db34fda4e95a7bd3e5789c2a995d2dad3eb8850232ee534092fbbf", size = 9680884, upload-time = "2026-04-24T00:13:48.066Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1c/d21bfeb9931881ebe96bcfcff27c7ae4b160ae0ec291a714c42641a56d75/matplotlib-3.10.9-cp314-cp314t-win_amd64.whl", hash = "sha256:c27df8b3848f32a83d1767566595e43cfaa4460380974da06f4279a7ec143c39", size = 8432333, upload-time = "2026-04-24T00:13:51.008Z" },
+    { url = "https://files.pythonhosted.org/packages/78/23/92493c3e6e1b635ccfff146f7b99e674808787915420373ac399283764c2/matplotlib-3.10.9-cp314-cp314t-win_arm64.whl", hash = "sha256:a49f1eadc84ca85fd72fa4e89e70e61bf86452df6f971af04b12c60761a0772c", size = 8324785, upload-time = "2026-04-24T00:13:53.633Z" },
+]
+
+[[package]]
 name = "mergedeep"
 version = "1.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -657,6 +934,26 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mne"
+version = "1.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "decorator" },
+    { name = "jinja2" },
+    { name = "lazy-loader" },
+    { name = "matplotlib" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pooch" },
+    { name = "scipy" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/72/24cd8137df5a185fe0856ff9b6f8a8f9d387d6783c51961a1c6300a4efe8/mne-1.12.1.tar.gz", hash = "sha256:244f844057f28a4da2509039dba637832ffb65f678ca76fc667312c493b12044", size = 7211821, upload-time = "2026-04-20T17:16:57.295Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/da/a3280dbd8f0024b287b625ef97f8ef79ae853ed852e7732641d0ec3c2160/mne-1.12.1-py3-none-any.whl", hash = "sha256:7823bd276d570e9bed2e63e8d86fdbe74d5ee7817b6d01a8e4dc9510ef9e3a91", size = 7509566, upload-time = "2026-04-20T17:16:54.447Z" },
 ]
 
 [[package]]
@@ -819,6 +1116,75 @@ wheels = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -834,6 +1200,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pooch"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/43/85ef45e8b36c6a48546af7b266592dc32d7f67837a6514d111bced6d7d75/pooch-1.9.0.tar.gz", hash = "sha256:de46729579b9857ffd3e741987a2f6d5e0e03219892c167c6578c0091fb511ed", size = 61788, upload-time = "2026-01-30T19:15:09.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl", hash = "sha256:f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b", size = 67175, upload-time = "2026-01-30T19:15:08.36Z" },
 ]
 
 [[package]]
@@ -1027,6 +1407,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/f4/886f901f1e04da717a11e180ba19a9c7fc62da170966d57206006f173bda/pyqt6_sip-13.11.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fcadd68e09ee24cdda8f8bfcba52e59c9b297055d2c450f0eb89afa61a8dc31a", size = 321846, upload-time = "2026-03-09T13:01:29.817Z" },
     { url = "https://files.pythonhosted.org/packages/96/f2/b68fd566f7f86dbb53d933489e70487cabaea0e0161690e4899653bbc7fb/pyqt6_sip-13.11.1-cp314-cp314-win_amd64.whl", hash = "sha256:581e287bf42587593b88b30d9db06ed0fccbf40f345a5bd3ec3f00a5692e2430", size = 55055, upload-time = "2026-03-09T13:01:33.467Z" },
     { url = "https://files.pythonhosted.org/packages/8d/42/efb7ced69f7d1d31eb8f19b2d778aeb182be7e070569d02b9057ac478e3e/pyqt6_sip-13.11.1-cp314-cp314-win_arm64.whl", hash = "sha256:42b62530a9b6a9c6e29c2941b8ab78258652da0aeae4eb1fc9a0631d19a7a7b2", size = 49597, upload-time = "2026-03-09T13:01:34.49Z" },
+]
+
+[[package]]
+name = "pyqtgraph"
+version = "0.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/36/4c242f81fdcbfa4fb62a5645f6af79191f4097a0577bd5460c24f19cc4ef/pyqtgraph-0.14.0-py3-none-any.whl", hash = "sha256:7abb7c3e17362add64f8711b474dffac5e7b0e9245abdf992e9a44119b7aa4f5", size = 1924755, upload-time = "2025-11-16T19:43:22.251Z" },
 ]
 
 [[package]]
@@ -1330,12 +1722,17 @@ docs = [
     { name = "mike" },
     { name = "mkdocs-material" },
 ]
+eeg = [
+    { name = "mne" },
+    { name = "pyqtgraph" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "blinkstick", marker = "sys_platform == 'win32'" },
     { name = "mike", marker = "extra == 'docs'" },
     { name = "mkdocs-material", marker = "extra == 'docs'" },
+    { name = "mne", marker = "extra == 'eeg'", specifier = ">=1.6" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "numpy" },
     { name = "pre-commit", marker = "extra == 'dev'" },
@@ -1343,6 +1740,7 @@ requires-dist = [
     { name = "pyinstaller", marker = "extra == 'dev'" },
     { name = "pylsl" },
     { name = "pyqt6" },
+    { name = "pyqtgraph", marker = "extra == 'eeg'", specifier = ">=0.13" },
     { name = "pyserial" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
@@ -1354,7 +1752,7 @@ requires-dist = [
     { name = "soundfile", specifier = ">=0.12" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
 ]
-provides-extras = ["docs", "dev"]
+provides-extras = ["docs", "eeg", "dev"]
 
 [[package]]
 name = "sounddevice"
@@ -1391,6 +1789,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/34/c9e80783d83eab739a9531fdee03675d53e0bf1b2ccb4bb3af5844675046/soundfile-0.14.0-py2.py3-none-win32.whl", hash = "sha256:0a6ae43c50c71b4e020cc55382925cb89451c1ed1a0c3d0f5d802da269226849", size = 902199, upload-time = "2026-06-06T08:58:43.289Z" },
     { url = "https://files.pythonhosted.org/packages/ed/97/b39c18ac1df45e755ca22b8b00e872929da5d107998a207a5e4ac831bfda/soundfile-0.14.0-py2.py3-none-win_amd64.whl", hash = "sha256:299491d3499460fb1b74bb4bd78b57ffc2d243a5fafa7b6ec1b264875c78453e", size = 1021480, upload-time = "2026-06-06T08:58:45.016Z" },
     { url = "https://files.pythonhosted.org/packages/f4/83/55c65e61cf457805ce2ec157c1c6ae17715d0851aa2374422de0538838ca/soundfile-0.14.0-py2.py3-none-win_arm64.whl", hash = "sha256:e090704718e124e7c844695236f1fce8d18a5e761eaf7c82dfcd124620805f98", size = 888858, upload-time = "2026-06-06T08:58:46.593Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.68.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/05/0d5260f1f1ca784f4a4a0def9cbe6affe587f5b4025328d446c3d67765f4/tqdm-4.68.2.tar.gz", hash = "sha256:89c230e8dbc67c7615c142487111222f878c77427ea09549960f62389e258add", size = 171923, upload-time = "2026-06-09T13:26:42.539Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/75/1a0392bcc21c44dcdf87b3cf2d137e7829be2c083a1e38d44efca3d57a16/tqdm-4.68.2-py3-none-any.whl", hash = "sha256:d4240441fb5353290b87d6a85968c9decc131a99b8c7faa28269d829de669ede", size = 78578, upload-time = "2026-06-09T13:26:40.731Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds SMACC's optional **EEG review tool** (issue #136): open a recorded EEG file, scroll the traces, apply display filters, and place named annotations saved as a TSV/JSON sidecar — the source recording is never modified. Reviewed and merged as one PR (the four pieces are one atomic feature; none is useful alone), but kept as four reviewable commits:

1. **core** — annotation model + TSV/JSON sidecars (`night1.edf` → `night1.annotations.tsv`, deliberately not BIDS `_events.tsv`), zero-phase display-only slice filtering (the whole file is never preloaded), and the lazy-MNE `Recording` wrapper with embedded-event import. New `[eeg]` extra (mne, pyqtgraph); CI runs with it.
2. **viewer** — pyqtgraph stacked-channel trace view (peak downsampling, drag-to-annotate, click-select, auto-fit for stim channels) and the review window (filters, 30 s scoring-epoch default, annotation list, sidecar save with dirty tracking, format-aware clock time). `python -m smacc.eeg [file]` runs it; the benchmark pins the perf target (8 h × 32 ch × 512 Hz scrolls at ~75 ms/refresh).
3. **launcher** — a *Review EEG* button (disabled with an install hint when the component is absent), launching the viewer as a detached sibling process.
4. **packaging** — `SMACC-EEG.exe` (MNE needs `--collect-submodules/--collect-data mne`; matplotlib must ship — MNE's IO imports `mne.viz.ui_events`), the installer's opt-out *EEG Review Tools* component (with a stale-exe cleanup on deselect), release smoke tests for both component configs (incl. a new `--selftest` that round-trips a recording through MNE), and docs.

Rebased onto current main (merges cleanly with the #149 crash-log and #159 device-role work); 787 tests green, lint/format/mypy clean. Each layer went through an adversarial multi-agent review; confirmed findings are folded in.

Supersedes #148, #150, #151 (closed in favour of this single PR).