### PR TITLE
feat: open-logs-folder button on the crash dialog (#154)

### DIFF
--- a/src/smacc/__main__.py
+++ b/src/smacc/__main__.py
@@ -10,9 +10,9 @@ import traceback
 from pathlib import Path
 from types import TracebackType
 
-from PyQt6.QtCore import Qt, QTimer
-from PyQt6.QtGui import QIcon
-from PyQt6.QtWidgets import QApplication, QMessageBox
+from PyQt6.QtCore import Qt, QTimer, QUrl
+from PyQt6.QtGui import QDesktopServices, QIcon
+from PyQt6.QtWidgets import QApplication, QMessageBox, QPushButton
 
 from . import crashlog, preferences
 from .config import VERSION
@@ -80,14 +80,6 @@ def _install_excepthook() -> None:
     """
     logger = logging.getLogger("smacc")
 
-    def log_file_hint() -> str:
-        # Prefer the run log (the crash in context); outside a live session the
-        # crash log is the only file, and it always has the traceback.
-        for handler in logger.handlers:
-            if isinstance(handler, logging.FileHandler):
-                return f"\n\nDetails were written to:\n{handler.baseFilename}"
-        return f"\n\nDetails were written to:\n{CRASH_LOG_PATH}"
-
     def handle_main(
         exc_type: type[BaseException],
         exc_value: BaseException,
@@ -100,11 +92,7 @@ def _install_excepthook() -> None:
         logger.critical("Uncaught exception", exc_info=(exc_type, exc_value, exc_tb))
         summary = "".join(traceback.format_exception_only(exc_type, exc_value)).strip()
         if QApplication.instance() is not None:
-            QMessageBox.critical(
-                None,
-                "SMACC error",
-                f"An unexpected error occurred:\n\n{summary}{log_file_hint()}",
-            )
+            _show_crash_dialog(summary)
         # Keep default behaviour too, so a dev terminal still shows the traceback.
         sys.__excepthook__(exc_type, exc_value, exc_tb)
 
@@ -127,6 +115,53 @@ def _install_excepthook() -> None:
 
     sys.excepthook = handle_main
     threading.excepthook = handle_thread
+
+
+def _crash_details_path() -> Path:
+    """The file that captured the crash for the dialog to point at.
+
+    Prefers the run log (the crash in context) when a session is live; outside
+    a live session the persistent crash log is the only file, and it always
+    has the traceback.
+    """
+    for handler in logging.getLogger("smacc").handlers:
+        if isinstance(handler, logging.FileHandler):
+            return Path(handler.baseFilename)
+    return CRASH_LOG_PATH
+
+
+def _crash_dialog(summary: str, details_path: Path) -> tuple[QMessageBox, QPushButton]:
+    """Build the uncaught-exception dialog; returns it unshown with its extra button.
+
+    Besides Close, the dialog offers **Open logs folder** so a (likely groggy)
+    operator can jump straight to the log named in the message instead of
+    retyping a path off a dialog at 3 a.m. (#154). Close stays the default
+    button so a reflexive Enter doesn't launch Explorer.
+    """
+    box = QMessageBox(
+        QMessageBox.Icon.Critical,
+        "SMACC error",
+        f"An unexpected error occurred:\n\n{summary}"
+        f"\n\nDetails were written to:\n{details_path}",
+    )
+    open_button = box.addButton("Open logs folder", QMessageBox.ButtonRole.ActionRole)
+    assert open_button is not None  # a valid role always yields a button
+    box.addButton(QMessageBox.StandardButton.Close)
+    box.setDefaultButton(QMessageBox.StandardButton.Close)
+    return box, open_button
+
+
+def _show_crash_dialog(summary: str) -> None:
+    """Show the crash dialog; open the log's folder if that button was chosen.
+
+    The folder open is fire-and-forget: Explorer is its own process, so it
+    survives the abort PyQt performs once the excepthook returns.
+    """
+    details_path = _crash_details_path()
+    box, open_button = _crash_dialog(summary, details_path)
+    box.exec()
+    if box.clickedButton() is open_button:
+        QDesktopServices.openUrl(QUrl.fromLocalFile(str(details_path.parent)))
 
 
 def pick_crash_test(args: list[str]) -> str | None:

--- a/tests/test_crashlog.py
+++ b/tests/test_crashlog.py
@@ -7,10 +7,17 @@ import sys
 import threading
 
 import pytest
-from PyQt6 import QtCore
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 from smacc import crashlog
-from smacc.__main__ import _install_excepthook, pick_crash_test
+from smacc.__main__ import (
+    _crash_details_path,
+    _crash_dialog,
+    _install_excepthook,
+    _show_crash_dialog,
+    pick_crash_test,
+)
+from smacc.paths import CRASH_LOG_PATH
 
 
 @pytest.fixture
@@ -166,6 +173,70 @@ def test_qt_warnings_stay_out_of_crash_log(crash_log, smacc_records):
     assert crash_log.read_text(encoding="utf-8") == before
     levels = [(r.levelno, r.getMessage()) for r in smacc_records]
     assert (logging.DEBUG, "Qt: connect spam") in levels
+
+
+# ----- the crash dialog (#154) --------------------------------------------------
+
+
+def test_crash_details_path_prefers_run_log_then_crash_log(tmp_path):
+    logger = logging.getLogger("smacc")
+    # Recreate the launcher phase: the shared logger holds no run-log handler
+    # (other suite tests may have left one; strip them for this check).
+    file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+    for handler in file_handlers:
+        logger.removeHandler(handler)
+    try:
+        assert _crash_details_path() == CRASH_LOG_PATH
+        run_handler = logging.FileHandler(tmp_path / "run.log", encoding="utf-8")
+        logger.addHandler(run_handler)
+        try:
+            assert _crash_details_path() == tmp_path / "run.log"
+        finally:
+            logger.removeHandler(run_handler)
+            run_handler.close()
+    finally:
+        for handler in file_handlers:
+            logger.addHandler(handler)
+
+
+def test_crash_dialog_names_the_log_and_offers_open_button(qapp, tmp_path):
+    details = tmp_path / "logs" / "crash.log"
+    box, open_button = _crash_dialog("RuntimeError: boom", details)
+    assert str(details) in box.text()
+    assert "RuntimeError: boom" in box.text()
+    assert open_button.text() == "Open logs folder"
+    assert box.buttonRole(open_button) == box.ButtonRole.ActionRole
+
+
+def test_show_crash_dialog_opens_the_logs_folder(qapp, monkeypatch):
+    opened = []
+    monkeypatch.setattr(
+        QtGui.QDesktopServices, "openUrl", lambda url: opened.append(url) or True
+    )
+    # Simulate the operator clicking "Open logs folder" (the ActionRole button).
+    monkeypatch.setattr(QtWidgets.QMessageBox, "exec", lambda self: 0)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "clickedButton",
+        lambda self: next(
+            b
+            for b in self.buttons()
+            if self.buttonRole(b) == self.ButtonRole.ActionRole
+        ),
+    )
+    _show_crash_dialog("RuntimeError: boom")
+    assert [url.toLocalFile() for url in opened] == [CRASH_LOG_PATH.parent.as_posix()]
+
+
+def test_show_crash_dialog_close_does_not_open_anything(qapp, monkeypatch):
+    opened = []
+    monkeypatch.setattr(
+        QtGui.QDesktopServices, "openUrl", lambda url: opened.append(url) or True
+    )
+    monkeypatch.setattr(QtWidgets.QMessageBox, "exec", lambda self: 0)
+    monkeypatch.setattr(QtWidgets.QMessageBox, "clickedButton", lambda self: None)
+    _show_crash_dialog("RuntimeError: boom")
+    assert opened == []
 
 
 # ----- the hidden --crash-test flag --------------------------------------------


### PR DESCRIPTION
Closes #154. Stacked on #152 (merge that first).

The uncaught-exception dialog now offers **Open logs folder** next to Close, opening the folder of the log it names in Explorer — the run folder during a live session, else `~/SMACC/logs`. Close stays the default button so a reflexive Enter doesn't launch Explorer. The folder open is fire-and-forget, so it survives the abort PyQt performs after the excepthook returns.