### PR TITLE
ci: bump actions to Node 24 majors before the June 16 cutover

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,8 +13,8 @@ jobs:
   quality:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
       - name: Ruff lint
@@ -42,8 +42,8 @@ jobs:
       # holds even if a future test imports Qt before conftest runs.
       QT_QPA_PLATFORM: offscreen
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
       - name: Run tests
@@ -55,7 +55,7 @@ jobs:
         # (see codecov.yaml) stable rather than double-counting across matrix legs.
         # Strict: an upload error fails the build rather than passing silently.
         if: success() && matrix.os == 'windows-2022'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,10 +18,10 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,8 @@ jobs:
     # test job (ci.yaml) uses the same runner so it validates this exact env.
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
       - run: uv sync --extra dev
@@ -84,7 +84,7 @@ jobs:
           $progid = (Get-ItemProperty -Path 'HKCU:\Software\Classes\.smacc').'(default)'
           if ($progid -ne 'SMACC.Study') { throw ".smacc association not registered (got '$progid')" }
       - name: Attach exe and installer to release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             dist/SMACC.exe


### PR DESCRIPTION
GitHub forces Node 24 for JavaScript actions on June 16, 2026 (the deprecation warning at the end of every current run). Bump each action to its current major, all Node 24-native: `actions/checkout` v4→v6, `astral-sh/setup-uv` v5→v8, `codecov/codecov-action` v5→v7, `softprops/action-gh-release` v2→v3. No input changes needed — `enable-cache`, `files`, and `fail_ci_if_error` are unchanged in the new majors.

CI and docs validate themselves on this PR; the release workflow's bumps get exercised at the next tag.