### PR TITLE
feat: pin device roles to explicit devices, drop system default (#139)

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -40,6 +40,27 @@ The whole assignment is saved in your SMACC file, so a rig travels with
 its study. If a bound device isn't connected when a study loads, SMACC keeps going
 and reports which one is missing instead of silently falling back.
 
+### No "system default"
+
+SMACC never routes audio to "whatever the system default is". Windows reassigns
+its default device on its own — plugging in an HDMI monitor or a Bluetooth headset
+is enough — and an overnight study must not follow it. Instead:
+
+* When a session starts (or loads a study) with nothing bound to **Bedroom
+  speakers** or **Bedroom mic**, SMACC binds the device that is *currently* the
+  Windows default — explicitly, by name — and logs which one it picked. From then
+  on the binding is pinned: changing the Windows default never re-routes a study.
+* A role with nothing bound reads **(none)**, and anything routed to it reports a
+  clear error instead of quietly playing somewhere else.
+* If no device is connected at all, the dropdown says so (e.g. **No output device
+  found**) rather than offering an empty choice.
+* A bound device that isn't currently connected shows as **(not connected)** and
+  is kept — never silently swapped — until you pick another device or plug it back
+  in (then **Refresh devices (F5)**).
+
+The study editor never auto-binds: a study built on an office machine arrives at
+the rig with its roles unbound, and the rig pins its own defaults on first load.
+
 ### Monitoring routes
 
 Three optional routes cover the things you reach for mid-study:

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -178,7 +178,10 @@ and [Devices](../devices.md)).
 | `routing` | mapping | Target key → role key (`""` = off). Targets: `cue_out`, `cue_monitor`, `noise_out`, `intercom_talk`, `intercom_listen`, `report_in`, `monitor_in`, `visual_out`. |
 
 A missing `devices` block loads the defaults (each target on its default role, with
-no devices bound).
+no devices bound). When a live session starts (or loads a study) with `bedroom_out`
+or `bedroom_mic` unbound, SMACC binds the current Windows default device explicitly,
+by name, and logs the choice — there is no "system default" pseudo-selection (see
+[Audio & routing](../audio.md#no-system-default)).
 
 ### `trigger_output`
 

--- a/src/smacc/devices.py
+++ b/src/smacc/devices.py
@@ -90,6 +90,19 @@ TARGETS_BY_KEY: dict[str, Target] = {t.key: t for t in TARGETS}
 # any other input monitor: the same mic the dream report uses.
 LISTEN_SOURCE_ROLE = "bedroom_mic"
 
+# Roles SMACC binds automatically when left unbound (live sessions only): the
+# default role of every required audio target, so a fresh study has a definite
+# device for the paths that play/record out of the box. Roles only optional
+# routes point at (control-room speakers, the dedicated monitor mic) imply
+# hardware a rig may not have, so they are never auto-bound.
+AUTOBIND_ROLES: tuple[str, ...] = tuple(
+    dict.fromkeys(
+        t.default_role
+        for t in TARGETS
+        if not t.optional and t.kind in (OUTPUT, INPUT) and t.default_role
+    )
+)
+
 
 @dataclass
 class DeviceConfig:
@@ -152,3 +165,25 @@ def load(settings: dict) -> DeviceConfig:
     no devices bound); :func:`from_dict` tolerates a malformed block the same way.
     """
     return from_dict(settings.get("devices"))
+
+
+def autobind(cfg: DeviceConfig, defaults: dict[str, str]) -> list[tuple[Role, str]]:
+    """Bind each unbound role in :data:`AUTOBIND_ROLES` to its kind's default device.
+
+    ``defaults`` maps a role kind (:data:`OUTPUT`/:data:`INPUT`) to the device that
+    is currently the Windows default ("" when there is none). There is deliberately
+    no "system default" pseudo-selection (#139): the current default is written into
+    the binding *by name*, so a later change of the Windows default never re-routes
+    a study. Existing bindings — including ones whose device is unplugged — are
+    never overwritten. Returns the (role, device) pairs filled, for logging.
+    """
+    filled: list[tuple[Role, str]] = []
+    for role_key in AUTOBIND_ROLES:
+        if cfg.bindings.get(role_key):
+            continue
+        role = ROLES_BY_KEY[role_key]
+        device = defaults.get(role.kind, "")
+        if device:
+            cfg.bindings[role_key] = device
+            filled.append((role, device))
+    return filled

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -141,6 +141,11 @@ class SmaccWindow(ToolWindow):
         self._hotplug_timer.timeout.connect(self._on_devices_hotplug)
         self._media_devices.audioOutputsChanged.connect(self._hotplug_timer.start)
         self._media_devices.audioInputsChanged.connect(self._hotplug_timer.start)
+        # Pin any unbound required role to the current Windows default, explicitly
+        # by name (#139), so a session always knows which physical device it will
+        # use. No-op in the editor; a study loaded below re-runs it on its own
+        # (freshly loaded) config via apply_settings.
+        self.devices_window.autobind_defaults()
 
         self.init_main_window()  # builds the menu + log handler (does not show yet)
         self._apply_preferences(self._prefs)
@@ -751,6 +756,10 @@ class SmaccWindow(ToolWindow):
             # enumerates from the (newly loaded) bridge, so a bound light matches.
             self.session.hue_config = hue.load(state)
             self.devices_window.refresh_device_lists()
+            # A study with unbound required roles (e.g. one authored in the
+            # editor on another machine) gets *this* rig's current defaults
+            # pinned, by name (#139).
+            self.devices_window.autobind_defaults()
             self._refresh_registry_views()  # a loaded study may add/remove buttons
             self.devices_window.reload_from_config()  # sync widgets + flag missing
             self._refresh_device_indicators()

--- a/src/smacc/panels/audio.py
+++ b/src/smacc/panels/audio.py
@@ -27,6 +27,7 @@ from .base import (
     ModalityWindow,
     describe_target,
     make_section_title,
+    require_device,
     resolve_device,
     restore_spin_value,
 )
@@ -406,9 +407,15 @@ class AudioCueWindow(ModalityWindow):
         # *different* cue is replaced (re-playing the same slot is just a restart).
         if self._active_slot is not None:
             self._finish_active(mark=self._active_slot is not slot)
-        device = resolve_device(
-            self.session.devices.device_for("cue_out"), devices.OUTPUT
+        device = require_device(
+            self.session,
+            "cue_out",
+            devices.OUTPUT,
+            failure="Could not play the cue.",
+            parent=self,
         )
+        if device is None:
+            return
         primary = self._open_output(slot, device)
         if primary is None:
             return  # primary failed (error already shown)
@@ -569,9 +576,16 @@ class AudioCueWindow(ModalityWindow):
         """Start/stop the bedroom monitor-mic meter (the objective acoustic check)."""
         self.session.log_interaction(f"Cue room monitor {'on' if enabled else 'off'}")
         if enabled:
-            device = resolve_device(
-                self.session.devices.device_for("monitor_in"), devices.INPUT
+            device = require_device(
+                self.session,
+                "monitor_in",
+                devices.INPUT,
+                failure="Could not open the room monitor.",
+                parent=self,
             )
+            if device is None:
+                self.monitorCheckBox.setChecked(False)
+                return
             try:
                 self.roomMeter.start(device)
             except Exception as exc:  # PortAudio errors, no device, busy, etc.

--- a/src/smacc/panels/base.py
+++ b/src/smacc/panels/base.py
@@ -22,9 +22,12 @@ def resolve_device(device: str | None, kind: str) -> int | str | None:
     :func:`smacc.panels.devices.wasapi_devices`).
 
     ``kind`` is :data:`smacc.devices.OUTPUT` or :data:`smacc.devices.INPUT`.
-    ``None``/"" (system default) stays ``None``; a name with no current WASAPI
-    match is returned unchanged, so opening it fails with sounddevice's usual
-    "no device matching" error rather than silently using another device.
+    ``None``/"" (nothing bound) stays ``None`` — callers must not open a stream
+    on it, or PortAudio would fall back to its default device (#139); use
+    :func:`require_device` to refuse with a pointer at the Devices window
+    instead. A name with no current WASAPI match is returned unchanged, so
+    opening it fails with sounddevice's usual "no device matching" error rather
+    than silently using another device.
     """
     if not device:
         return None
@@ -47,9 +50,10 @@ def resolve_device(device: str | None, kind: str) -> int | str | None:
 def describe_target(session: SmaccSession, target_key: str) -> str:
     """A short 'Role → device' description of where a modality target resolves.
 
-    Shown read-only on each modality panel; the actual device is chosen once in the
-    Devices window. An unbound audio role reads as the system default; an unbound
-    BlinkStick reads as not set; an off (optional) route reads as off.
+    Shown read-only on each modality panel; the actual device is chosen once in
+    the Devices window. An off (optional) route reads as off; a role with no
+    device bound reads as not set — there is no silent system-default fallback
+    (#139).
     """
     cfg = session.devices
     role_key = cfg.role_for(target_key)
@@ -60,9 +64,63 @@ def describe_target(session: SmaccSession, target_key: str) -> str:
     device = cfg.device_for(target_key)
     if device:
         return f"{role_label} → {device}"
-    if role is not None and role.kind == devices.VISUAL:
-        return f"{role_label} (not set)"
-    return f"{role_label} (system default)"
+    return f"{role_label} (not set)"
+
+
+def require_role_device(
+    session: SmaccSession,
+    role_key: str,
+    kind: str,
+    *,
+    failure: str,
+    parent: QtWidgets.QWidget | None,
+) -> int | str | None:
+    """Resolve a role's bound device, or show ``failure`` and return ``None``.
+
+    The unbound case used to fall through to PortAudio's default device; after
+    #139 nothing opens implicitly — the operator is pointed at the Devices
+    window instead. A bound-but-disconnected device still resolves (to its
+    name), so opening it fails with the usual "no device matching" error rather
+    than being silently re-routed.
+    """
+    role = devices.ROLES_BY_KEY[role_key]
+    device = session.devices.device_for_role(role_key)
+    if not device:
+        session.show_error_popup(
+            failure,
+            f"No device is bound to the {role.label} role. Bind one in the "
+            "Devices window.",
+            parent=parent,
+        )
+        return None
+    return resolve_device(device, kind)
+
+
+def require_device(
+    session: SmaccSession,
+    target_key: str,
+    kind: str,
+    *,
+    failure: str,
+    parent: QtWidgets.QWidget | None,
+) -> int | str | None:
+    """Resolve a target's device via its route, or show ``failure`` and return ``None``.
+
+    Covers both ways a target can have no device: its route is off (no role), or
+    its role has nothing bound. Each error names the missing piece and points at
+    the Devices window.
+    """
+    target = devices.TARGETS_BY_KEY[target_key]
+    role_key = session.devices.role_for(target_key)
+    if not role_key:
+        session.show_error_popup(
+            failure,
+            f"'{target.label}' is not routed to a role. Route it in the "
+            "Devices window.",
+            parent=parent,
+        )
+        return None
+    return require_role_device(session, role_key, kind, failure=failure, parent=parent)
 
 
 def current_device_key(combo: QtWidgets.QComboBox) -> str:

--- a/src/smacc/panels/biocals.py
+++ b/src/smacc/panels/biocals.py
@@ -33,7 +33,13 @@ from ..paths import resolve_biocal_voice
 from ..session import SmaccSession
 from ..utils import format_elapsed
 from .audio import CueOutput
-from .base import ModalityWindow, describe_target, make_section_title, resolve_device
+from .base import (
+    ModalityWindow,
+    describe_target,
+    make_section_title,
+    require_device,
+    resolve_device,
+)
 
 # Rows are instances, not definitions, so a stack can repeat biocals freely; the
 # cap just keeps the window and a played sequence manageable.
@@ -610,9 +616,15 @@ class BiocalsWindow(ModalityWindow):
             return False
         data, rate = loaded
         self._stop_voice()  # safety: never two announcements at once
-        device = resolve_device(
-            self.session.devices.device_for("cue_out"), devices.OUTPUT
+        device = require_device(
+            self.session,
+            "cue_out",
+            devices.OUTPUT,
+            failure="Could not start the biocal voice output",
+            parent=self,
         )
+        if device is None:
+            return False
         primary = self._open_output(data, rate, device)
         if primary is None:
             return False

--- a/src/smacc/panels/devices.py
+++ b/src/smacc/panels/devices.py
@@ -21,13 +21,25 @@ from ..dialogs import HueBridgeDialog
 from ..session import SmaccSession
 from .base import (
     ModalityWindow,
-    current_device_key,
     make_section_title,
     select_saved_device,
 )
 
-_DEFAULT_LABEL = "(system default)"
 _NONE_LABEL = "(none)"
+# Sole-row placeholders when enumeration finds nothing (#139): say so, instead of
+# an ambiguous "(none)" (or the old "(system default)", which implied an output
+# exists when none does). The Hue role distinguishes "no bridge paired yet" (the
+# Set up… button is the path forward) from a paired bridge with nothing to list.
+_EMPTY_LABELS = {
+    devices.OUTPUT: "No output device found",
+    devices.INPUT: "No input device found",
+    devices.VISUAL: "No BlinkStick found",
+}
+_NO_BRIDGE_LABEL = "No bridge paired"
+_NO_LIGHTS_LABEL = "No lights found"
+# Item-data marker for a "(not connected)" row (a bound device with no live row),
+# so a reload can tell it apart from a real match and flag the miss.
+_MISSING_ROLE = QtCore.Qt.ItemDataRole.UserRole + 1
 
 
 def wasapi_devices(kind: str) -> list[str]:
@@ -59,6 +71,26 @@ def wasapi_devices(kind: str) -> list[str]:
         return []
 
 
+def default_wasapi_device(kind: str) -> str:
+    """The name of the device that is currently the WASAPI default ("" when none).
+
+    PortAudio reports each host API's default device as of its last
+    initialization, so this is fresh exactly when SMACC reads it (right after
+    launch or a rescan). Used only to *auto-bind* an unbound role to a concrete
+    device name (#139) — never consulted at stream-open time, so a later change
+    of the Windows default cannot re-route a study.
+    """
+    key = "default_output_device" if kind == devices.OUTPUT else "default_input_device"
+    try:
+        for api in sd.query_hostapis():
+            if api["name"] == devices.WASAPI_HOST_API:
+                index = api[key]
+                return sd.query_devices(index)["name"] if index >= 0 else ""
+    except Exception:
+        pass
+    return ""
+
+
 def blinkstick_devices() -> list[tuple[str, str]]:
     """Return ``(label, serial)`` for each connected BlinkStick (best effort)."""
     try:
@@ -77,8 +109,9 @@ def blinkstick_devices() -> list[tuple[str, str]]:
 def hue_devices(cfg: hue.HueConfig) -> list[tuple[str, str]]:
     """Return ``(label, key)`` for each Hue light/group (best effort).
 
-    Empty when the bridge isn't set up or can't be reached — the combo then only
-    offers "(none)", and the Set up button is the path forward.
+    Empty when the bridge isn't set up or can't be reached — the combo then says
+    so ("No bridge paired" / "No lights found"), and the Set up button is the
+    path forward.
     """
     try:
         return hue.targets(cfg)
@@ -183,39 +216,68 @@ class DevicesWindow(ModalityWindow):
     # ----- enumeration -------------------------------------------------------
 
     def _populate_role_combos(self) -> None:
-        """(Re)fill each role's device dropdown, preserving the current selection."""
+        """(Re)fill each role's device dropdown from a fresh enumeration.
+
+        The selection is re-derived from ``session.devices`` (every user edit
+        writes through to it, so the combo can never hold anything newer): the
+        bound device's row, or the index-0 placeholder when the role is unbound.
+        Index 0 reads "(none)" when there are devices to choose from and a
+        kind-specific "No … found" when there are none (#139).
+        """
         for role in devices.ROLES:
             combo = self._role_combos[role.key]
-            previous = current_device_key(combo)
             combo.blockSignals(True)
             combo.clear()
             if role.key == "hue":
-                combo.addItem(_NONE_LABEL, "")
-                for label, key in hue_devices(self.session.hue_config):
-                    combo.addItem(label, key)
+                entries = hue_devices(self.session.hue_config)
+                empty = (
+                    _NO_LIGHTS_LABEL
+                    if self.session.hue_config.configured
+                    else _NO_BRIDGE_LABEL
+                )
             elif role.kind == devices.VISUAL:
-                combo.addItem(_NONE_LABEL, "")
-                for label, serial in blinkstick_devices():
-                    combo.addItem(label, serial)
+                entries = blinkstick_devices()
+                empty = _EMPTY_LABELS[devices.VISUAL]
             else:
-                combo.addItem(_DEFAULT_LABEL, "")
-                for device_str in wasapi_devices(role.kind):
-                    combo.addItem(device_str, device_str)
-            # Restore the prior selection (after a refresh) or the bound device.
-            target_key = previous or self.session.devices.device_for_role(role.key)
-            if not select_saved_device(combo, target_key):
-                combo.setCurrentIndex(0)  # default / none
+                entries = [(name, name) for name in wasapi_devices(role.kind)]
+                empty = _EMPTY_LABELS[role.kind]
+            combo.addItem(_NONE_LABEL if entries else empty, "")
+            for label, key in entries:
+                combo.addItem(label, key)
+            bound = self.session.devices.device_for_role(role.key)
+            self._select_device_row(combo, bound)
             combo.blockSignals(False)
+
+    def _select_device_row(self, combo: QtWidgets.QComboBox, key: str) -> bool:
+        """Select the row for device ``key``; index 0 (the placeholder) when blank.
+
+        A bound device with no row (not currently connected) is added as an
+        explicit "(not connected)" row carrying ``key`` as its data and selected,
+        so the combo shows the truth instead of displaying the placeholder while
+        the binding — which is kept (flag, don't swap) — still targets the
+        missing device. Returns False in exactly that case so
+        :meth:`reload_from_config` can flag it. A rescan rebuilds the list, so
+        the row disappears once the device is back (or another is picked).
+        """
+        if not key:
+            combo.setCurrentIndex(0)
+            return True
+        if select_saved_device(combo, key):
+            return not combo.itemData(combo.currentIndex(), _MISSING_ROLE)
+        combo.addItem(f"{key} (not connected)", key)
+        index = combo.count() - 1
+        combo.setItemData(index, True, _MISSING_ROLE)
+        combo.setCurrentIndex(index)
+        return False
 
     # ----- editing -> session.devices ----------------------------------------
 
     def _set_binding(self, role_key: str) -> None:
         """A role's device dropdown changed: write just that role's binding."""
-        combo = self._role_combos[role_key]
-        key = current_device_key(combo)
-        if key and combo.currentIndex() > 0:  # index 0 is the default/none entry
+        key = self._role_combos[role_key].currentData()
+        if key:
             self.session.devices.bindings[role_key] = key
-        else:
+        else:  # the "(none)" / "No … found" placeholder rows carry no device key
             self.session.devices.bindings.pop(role_key, None)
         self.session.log_interaction(
             f"{devices.ROLES_BY_KEY[role_key].label} device set"
@@ -238,17 +300,16 @@ class DevicesWindow(ModalityWindow):
         """Sync every dropdown to ``session.devices`` (after a study load).
 
         Flags any bound device that isn't currently connected so the operator is
-        told (the same consolidated notice the other panels use).
+        told (the same consolidated notice the other panels use); the binding is
+        kept and shown as a "(not connected)" row, never silently swapped.
         """
         cfg = self.session.devices
         for role_key, combo in self._role_combos.items():
             combo.blockSignals(True)
             bound = cfg.device_for_role(role_key)
-            if not select_saved_device(combo, bound):
-                combo.setCurrentIndex(0)
-                if bound:  # a saved device that isn't plugged in
-                    role = devices.ROLES_BY_KEY[role_key]
-                    self.session.note_missing_device(role.label, bound)
+            if not self._select_device_row(combo, bound):
+                role = devices.ROLES_BY_KEY[role_key]
+                self.session.note_missing_device(role.label, bound)
             combo.blockSignals(False)
         for target_key, combo in self._route_combos.items():
             combo.blockSignals(True)
@@ -259,6 +320,36 @@ class DevicesWindow(ModalityWindow):
     def refresh_device_lists(self) -> None:
         """Re-enumerate the role device dropdowns (the Refresh devices hook)."""
         self._populate_role_combos()
+
+    def autobind_defaults(self) -> None:
+        """Bind unbound required roles to the current Windows default, by name (#139).
+
+        Live sessions only: the editor usually runs on a different machine than
+        the rig, so baking *its* devices into a study would be wrong — the rig
+        pins its own defaults the first time the study loads there. Called at
+        session construction and after a study load, deliberately not on rescans,
+        so an explicit "(none)" never snaps back on a hot-plug. Once bound, the
+        device is pinned: a later change of the Windows default re-routes
+        nothing. Each fill is logged ungated — which physical device a night
+        actually used is provenance, not chatter.
+        """
+        if self.session.design:
+            return
+        defaults = {
+            kind: default_wasapi_device(kind)
+            for kind in (devices.OUTPUT, devices.INPUT)
+        }
+        filled = devices.autobind(self.session.devices, defaults)
+        for role, device in filled:
+            combo = self._role_combos[role.key]
+            combo.blockSignals(True)
+            self._select_device_row(combo, device)
+            combo.blockSignals(False)
+            self.session.log_info_msg(
+                f"{role.label} auto-selected: {device} (the current Windows default)"
+            )
+        if filled:
+            self.changed.emit()
 
     def setup_hue_bridge(self) -> None:
         """Open the Hue pairing dialog; on accept, store the config and re-list."""

--- a/src/smacc/panels/intercom.py
+++ b/src/smacc/panels/intercom.py
@@ -24,7 +24,13 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 from .. import audio, devices
 from ..dialogs import ManageChatPresetsDialog
 from ..session import SmaccSession
-from .base import ModalityWindow, describe_target, make_section_title, resolve_device
+from .base import (
+    ModalityWindow,
+    describe_target,
+    make_section_title,
+    require_device,
+    require_role_device,
+)
 from .chat import EXPERIMENTER, ChatPresets, ChatTranscript, post_chat_message
 from .meter import LevelMeter
 
@@ -351,12 +357,20 @@ class IntercomWindow(ModalityWindow):
         """Start/stop piping the experimenter mic to the participant output.
 
         Marked in the EEG record via LSL (the experimenter's voice is a manipulation
-        the participant hears). The mic is the system default input.
+        the participant hears). The experimenter mic has no role binding: it is
+        whatever the control-room machine's default input is.
         """
         if enabled:
-            output = resolve_device(
-                self.session.devices.device_for("intercom_talk"), devices.OUTPUT
+            output = require_device(
+                self.session,
+                "intercom_talk",
+                devices.OUTPUT,
+                failure="Could not start intercom talk.",
+                parent=self,
             )
+            if output is None:
+                self.talkButton.setChecked(False)
+                return
             try:
                 self._talk.start(None, output)
             except Exception as exc:  # PortAudio errors, no device, busy, etc.
@@ -377,13 +391,26 @@ class IntercomWindow(ModalityWindow):
         the source, the ``intercom_listen`` route the destination.
         """
         if enabled:
-            mic = resolve_device(
-                self.session.devices.device_for_role(devices.LISTEN_SOURCE_ROLE),
+            mic = require_role_device(
+                self.session,
+                devices.LISTEN_SOURCE_ROLE,
                 devices.INPUT,
+                failure="Could not start intercom listen.",
+                parent=self,
             )
-            output = resolve_device(
-                self.session.devices.device_for("intercom_listen"), devices.OUTPUT
+            if mic is None:
+                self.listenButton.setChecked(False)
+                return
+            output = require_device(
+                self.session,
+                "intercom_listen",
+                devices.OUTPUT,
+                failure="Could not start intercom listen.",
+                parent=self,
             )
+            if output is None:
+                self.listenButton.setChecked(False)
+                return
             try:
                 self._listen.start(mic, output)
             except Exception as exc:  # PortAudio errors, no device, busy, etc.

--- a/src/smacc/panels/noise.py
+++ b/src/smacc/panels/noise.py
@@ -16,7 +16,7 @@ from .base import (
     ModalityWindow,
     describe_target,
     make_section_title,
-    resolve_device,
+    require_device,
     restore_spin_value,
 )
 
@@ -256,9 +256,15 @@ class NoiseWindow(ModalityWindow):
         """Start streaming the selected noise (built-in color or file) on loop."""
         if self.noise_stream is not None:
             return  # already playing
-        device = resolve_device(
-            self.session.devices.device_for("noise_out"), devices.OUTPUT
+        device = require_device(
+            self.session,
+            "noise_out",
+            devices.OUTPUT,
+            failure="Could not start noise output",
+            parent=self,
         )
+        if device is None:
+            return
         rate = self._device_samplerate(device)
         try:
             buf = self._build_noise_buffer(rate)

--- a/src/smacc/panels/recording.py
+++ b/src/smacc/panels/recording.py
@@ -15,7 +15,7 @@ from ..dialogs import ManageSurveysDialog
 from ..paths import BUNDLED_SURVEYS_DIR, SURVEYS_DIR
 from ..session import SmaccSession
 from ..utils import format_elapsed
-from .base import ModalityWindow, describe_target, make_section_title, resolve_device
+from .base import ModalityWindow, describe_target, make_section_title, require_device
 from .meter import InputLevelMeter
 from .survey import SurveyWindow
 
@@ -118,10 +118,10 @@ class RecordingWindow(ModalityWindow):
         self._record_stream: sd.InputStream | None = None
         self._record_file: sf.SoundFile | None = None
 
-    def _selected_input_device(self) -> int | str | None:
-        """The mic device for the dream-report role (None == system default)."""
-        return resolve_device(
-            self.session.devices.device_for("report_in"), devices.INPUT
+    def _selected_input_device(self, failure: str) -> int | str | None:
+        """The dream-report mic, or ``None`` (after a ``failure`` popup) if unbound."""
+        return require_device(
+            self.session, "report_in", devices.INPUT, failure=failure, parent=self
         )
 
     def refresh_device_indicator(self) -> None:
@@ -176,7 +176,9 @@ class RecordingWindow(ModalityWindow):
         Reports live in this run's session folder; the folder already namespaces
         them, so a short report-NN name is enough.
         """
-        device = self._selected_input_device()
+        device = self._selected_input_device(failure="Could not start recording.")
+        if device is None:
+            return False
         assert self.session.session_dir is not None  # recording is gated on can_record
         # The counter advances only after the stream starts, so a failed attempt
         # can never leave a gap in the report numbering.
@@ -249,8 +251,14 @@ class RecordingWindow(ModalityWindow):
         """Start/stop monitoring the selected input device's level."""
         self.session.log_interaction(f"Input level meter {'on' if enabled else 'off'}")
         if enabled:
+            device = self._selected_input_device(
+                failure="Could not open input for monitoring."
+            )
+            if device is None:
+                self.monitorCheckBox.setChecked(False)
+                return
             try:
-                self.levelMeter.start(self._selected_input_device())
+                self.levelMeter.start(device)
             except Exception as exc:  # PortAudio errors, no device, etc.
                 self.session.show_error_popup(
                     "Could not open input for monitoring.", str(exc), parent=self

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,13 @@ def mock_devices(monkeypatch):
     def fake_wasapi_devices(kind: str) -> list[str]:
         return list(FAKE_INPUTS) if kind == devices.INPUT else list(FAKE_OUTPUTS)
 
+    def fake_default_wasapi_device(kind: str) -> str:
+        return FAKE_INPUTS[0] if kind == devices.INPUT else FAKE_OUTPUTS[0]
+
     monkeypatch.setattr(devices_panel, "wasapi_devices", fake_wasapi_devices)
+    monkeypatch.setattr(
+        devices_panel, "default_wasapi_device", fake_default_wasapi_device
+    )
     monkeypatch.setattr(
         devices_panel, "blinkstick_devices", lambda: list(FAKE_BLINKSTICKS)
     )
@@ -98,7 +104,19 @@ def mock_devices(monkeypatch):
         "outputs": list(FAKE_OUTPUTS),
         "inputs": list(FAKE_INPUTS),
         "blinksticks": list(FAKE_BLINKSTICKS),
+        "default_output": FAKE_OUTPUTS[0],
+        "default_input": FAKE_INPUTS[0],
     }
+
+
+@pytest.fixture
+def mock_no_devices(monkeypatch):
+    """Advertise no connected hardware at all (the "No … found" placeholders)."""
+    from smacc.panels import devices as devices_panel
+
+    monkeypatch.setattr(devices_panel, "wasapi_devices", lambda kind: [])
+    monkeypatch.setattr(devices_panel, "default_wasapi_device", lambda kind: "")
+    monkeypatch.setattr(devices_panel, "blinkstick_devices", lambda: [])
 
 
 @pytest.fixture

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -112,3 +112,33 @@ def test_both_light_technologies_are_visual_roles():
         {"bindings": {"hue": "light:3"}, "routing": {"visual_out": "hue"}}
     )
     assert cfg.device_for("visual_out") == "light:3"
+
+
+# ----- autobind (#139) ---------------------------------------------------------
+
+
+def test_autobind_roles_are_the_required_audio_defaults():
+    # Derived from TARGETS: the default role of each required audio target. Roles
+    # only optional routes point at (control-room, monitor mic) are excluded.
+    assert devices.AUTOBIND_ROLES == ("bedroom_out", "bedroom_mic")
+
+
+def test_autobind_fills_only_unbound_roles():
+    cfg = devices.default_config()
+    cfg.bindings["bedroom_out"] = "Kept (USB)"
+    filled = devices.autobind(
+        cfg, {devices.OUTPUT: "Default Out", devices.INPUT: "Default In"}
+    )
+    assert cfg.bindings["bedroom_out"] == "Kept (USB)"  # never overwritten
+    assert cfg.bindings["bedroom_mic"] == "Default In"
+    assert [(role.key, device) for role, device in filled] == [
+        ("bedroom_mic", "Default In")
+    ]
+    assert "control_out" not in cfg.bindings
+    assert "monitor_mic" not in cfg.bindings
+
+
+def test_autobind_skips_kinds_without_a_default():
+    cfg = devices.default_config()
+    assert devices.autobind(cfg, {devices.OUTPUT: "", devices.INPUT: ""}) == []
+    assert cfg.bindings == {}

--- a/tests/test_panels_audio.py
+++ b/tests/test_panels_audio.py
@@ -30,7 +30,7 @@ class _FakeInput:
 def test_monitor_device_label_shows_the_room_monitor_route(qtbot, design_session):
     panel = AudioCueWindow(design_session)
     qtbot.addWidget(panel)
-    # monitor_in defaults to the bedroom-mic role (unbound -> system default).
+    # monitor_in defaults to the bedroom-mic role (reads "(not set)" until bound).
     assert "Bedroom mic" in panel.monitorDeviceLabel.text()
 
 
@@ -47,6 +47,7 @@ def test_room_monitor_toggle_opens_and_closes_and_gates_streaming(
     qtbot, design_session, monkeypatch
 ):
     monkeypatch.setattr(meter.sd, "InputStream", _FakeInput)
+    design_session.devices.bindings["bedroom_mic"] = "Mic (Test)"
     panel = AudioCueWindow(design_session)
     qtbot.addWidget(panel)
     assert not panel.is_streaming()
@@ -65,8 +66,27 @@ def test_room_monitor_start_failure_reverts_the_checkbox(
         raise RuntimeError("no mic")
 
     monkeypatch.setattr(meter.sd, "InputStream", boom)
+    design_session.devices.bindings["bedroom_mic"] = "Mic (Test)"
     panel = AudioCueWindow(design_session)
     qtbot.addWidget(panel)
     panel.monitorCheckBox.setChecked(True)
     assert not panel.monitorCheckBox.isChecked()  # reverted on failure
     assert not panel.roomMeter.is_active()
+
+
+def test_room_monitor_with_no_bound_mic_errors_and_reverts(
+    qtbot, design_session, monkeypatch
+):
+    # #139: an unbound monitor role refuses to open (instead of listening on the
+    # system default input) and the checkbox reverts.
+    monkeypatch.setattr(meter.sd, "InputStream", _FakeInput)
+    errors = []
+    monkeypatch.setattr(
+        design_session, "show_error_popup", lambda *a, **k: errors.append(a)
+    )
+    panel = AudioCueWindow(design_session)
+    qtbot.addWidget(panel)
+    panel.monitorCheckBox.setChecked(True)
+    assert not panel.monitorCheckBox.isChecked()
+    assert not panel.roomMeter.is_active()
+    assert errors and "Bedroom mic" in errors[0][1]

--- a/tests/test_panels_base.py
+++ b/tests/test_panels_base.py
@@ -31,9 +31,10 @@ def test_describe_target_bound_device_reads_role_arrow_device(design_session):
     )
 
 
-def test_describe_target_unbound_audio_reads_system_default(design_session):
+def test_describe_target_unbound_audio_reads_not_set(design_session):
+    # No silent system-default fallback (#139): an unbound role reads "(not set)".
     session = _session_with(design_session, {})
-    assert base.describe_target(session, "report_in") == "Bedroom mic (system default)"
+    assert base.describe_target(session, "report_in") == "Bedroom mic (not set)"
 
 
 def test_describe_target_unbound_visual_reads_not_set(design_session):
@@ -45,6 +46,70 @@ def test_describe_target_off_route_reads_off(design_session):
     # cue_monitor is an optional route whose default role is "" (off).
     session = _session_with(design_session, {})
     assert base.describe_target(session, "cue_monitor") == "off"
+
+
+# ----- require_device / require_role_device (#139) ----------------------------
+
+
+def _capture_errors(monkeypatch, session) -> list[tuple]:
+    errors: list[tuple] = []
+    monkeypatch.setattr(session, "show_error_popup", lambda *a, **k: errors.append(a))
+    return errors
+
+
+def test_require_device_unbound_role_pops_error_and_returns_none(
+    design_session, monkeypatch
+):
+    session = _session_with(design_session, {})
+    errors = _capture_errors(monkeypatch, session)
+    got = base.require_device(
+        session, "cue_out", devices.OUTPUT, failure="Could not play.", parent=None
+    )
+    assert got is None
+    assert errors and errors[0][0] == "Could not play."
+    assert "Bedroom speakers" in errors[0][1]  # names the unbound role
+
+
+def test_require_device_off_route_pops_error_and_returns_none(
+    design_session, monkeypatch
+):
+    # cue_monitor's default route is off — no role to resolve through.
+    session = _session_with(design_session, {})
+    errors = _capture_errors(monkeypatch, session)
+    got = base.require_device(
+        session, "cue_monitor", devices.OUTPUT, failure="Could not play.", parent=None
+    )
+    assert got is None
+    assert errors and "not routed" in errors[0][1]
+
+
+def test_require_device_bound_role_resolves_without_error(design_session, monkeypatch):
+    _patch_sd(monkeypatch)
+    session = _session_with(
+        design_session, {"bedroom_out": "Speakers (Realtek(R) Audio)"}
+    )
+    errors = _capture_errors(monkeypatch, session)
+    got = base.require_device(
+        session, "cue_out", devices.OUTPUT, failure="Could not play.", parent=None
+    )
+    assert got == 3  # the WASAPI index (see the resolve_device tests below)
+    assert errors == []
+
+
+def test_require_role_device_unbound_pops_error_and_returns_none(
+    design_session, monkeypatch
+):
+    session = _session_with(design_session, {})
+    errors = _capture_errors(monkeypatch, session)
+    got = base.require_role_device(
+        session,
+        devices.LISTEN_SOURCE_ROLE,
+        devices.INPUT,
+        failure="Could not listen.",
+        parent=None,
+    )
+    assert got is None
+    assert errors and "Bedroom mic" in errors[0][1]
 
 
 # ----- resolve_device --------------------------------------------------------
@@ -113,7 +178,9 @@ def test_resolve_device_respects_the_channel_kind(monkeypatch):
     )
 
 
-def test_resolve_device_blank_is_system_default(monkeypatch):
+def test_resolve_device_blank_is_none(monkeypatch):
+    # "" / None mean "nothing bound" — callers guard via require_device instead
+    # of opening a stream on the PortAudio default (#139).
     _patch_sd(monkeypatch)
     assert base.resolve_device("", devices.OUTPUT) is None
     assert base.resolve_device(None, devices.OUTPUT) is None

--- a/tests/test_panels_devices.py
+++ b/tests/test_panels_devices.py
@@ -17,7 +17,8 @@ def test_role_combos_populate_from_enumeration(qtbot, design_session, mock_devic
     window = DevicesWindow(design_session)
     qtbot.addWidget(window)
     out_combo = window._role_combos["bedroom_out"]
-    # Index 0 is the default/none entry, then one row per advertised output.
+    # Index 0 is the "(none)" entry, then one row per advertised output.
+    assert out_combo.itemText(0) == "(none)"
     assert out_combo.count() == 1 + len(mock_devices["outputs"])
     assert out_combo.itemData(1) == mock_devices["outputs"][0]
 
@@ -42,12 +43,12 @@ def test_set_binding_writes_to_session(qtbot, design_session, mock_devices):
     changed = []
     window.changed.connect(lambda: changed.append(True))
 
-    # Selecting a real device row (index > 0) binds it to the role.
+    # Selecting a real device row binds it to the role.
     window._role_combos["bedroom_out"].setCurrentIndex(1)
     assert design_session.devices.bindings["bedroom_out"] == mock_devices["outputs"][0]
     assert changed  # the changed signal fired
 
-    # Returning to the default/none entry clears the binding.
+    # Returning to the "(none)" entry clears the binding.
     window._role_combos["bedroom_out"].setCurrentIndex(0)
     assert "bedroom_out" not in design_session.devices.bindings
 
@@ -68,9 +69,12 @@ def test_reload_flags_missing_bound_device(qtbot, design_session, mock_devices):
     window = DevicesWindow(design_session)
     qtbot.addWidget(window)
     window.reload_from_config()
-    # The bound device isn't among the advertised ones, so it's flagged and the
-    # combo falls back to the default entry.
-    assert window._role_combos["bedroom_out"].currentIndex() == 0
+    # The bound device isn't among the advertised ones, so it's flagged and shown
+    # as an explicit "(not connected)" row; the binding is kept, never swapped.
+    combo = window._role_combos["bedroom_out"]
+    assert combo.currentText() == "Unplugged speaker (not connected)"
+    assert combo.currentData() == "Unplugged speaker"
+    assert design_session.devices.bindings["bedroom_out"] == "Unplugged speaker"
     assert any("Unplugged speaker" in entry for entry in design_session.missing_devices)
 
 
@@ -103,8 +107,74 @@ def test_hue_role_combo_lists_bridge_targets(
     assert design_session.devices.bindings["hue"] == "light:1"
 
 
-def test_hue_role_combo_is_empty_without_a_bridge(qtbot, design_session, mock_devices):
+def test_hue_role_combo_says_no_bridge_without_one(qtbot, design_session, mock_devices):
     window = DevicesWindow(design_session)
     qtbot.addWidget(window)
     combo = window._role_combos["hue"]
-    assert [combo.itemText(i) for i in range(combo.count())] == ["(none)"]
+    assert [combo.itemText(i) for i in range(combo.count())] == ["No bridge paired"]
+
+
+def test_empty_enumeration_says_no_device_found(qtbot, design_session, mock_no_devices):
+    # With nothing connected, each combo's sole row says so (#139) instead of an
+    # ambiguous "(none)" (or the old "(system default)", which implied an output
+    # exists when none does).
+    window = DevicesWindow(design_session)
+    qtbot.addWidget(window)
+    texts = {
+        key: [combo.itemText(i) for i in range(combo.count())]
+        for key, combo in window._role_combos.items()
+    }
+    assert texts["bedroom_out"] == ["No output device found"]
+    assert texts["control_out"] == ["No output device found"]
+    assert texts["bedroom_mic"] == ["No input device found"]
+    assert texts["blinkstick"] == ["No BlinkStick found"]
+    assert texts["hue"] == ["No bridge paired"]
+
+
+def test_paired_bridge_with_no_targets_says_no_lights(
+    qtbot, design_session, mock_devices, monkeypatch
+):
+    from smacc import hue
+
+    design_session.hue_config = hue.HueConfig("192.168.1.50", "key")
+    monkeypatch.setattr(hue, "targets", lambda cfg: [])
+    window = DevicesWindow(design_session)
+    qtbot.addWidget(window)
+    combo = window._role_combos["hue"]
+    assert [combo.itemText(i) for i in range(combo.count())] == ["No lights found"]
+
+
+def test_autobind_defaults_pins_the_required_roles(qtbot, live_session, mock_devices):
+    window = DevicesWindow(live_session)
+    qtbot.addWidget(window)
+    changed = []
+    window.changed.connect(lambda: changed.append(True))
+    window.autobind_defaults()
+    # The current Windows defaults are bound explicitly, by name (#139); roles
+    # only optional routes use stay unbound.
+    bindings = live_session.devices.bindings
+    assert bindings["bedroom_out"] == mock_devices["default_output"]
+    assert bindings["bedroom_mic"] == mock_devices["default_input"]
+    assert "control_out" not in bindings
+    assert changed  # indicators are told to re-render
+    # The combos show the pinned devices.
+    out_combo = window._role_combos["bedroom_out"]
+    assert out_combo.currentData() == mock_devices["default_output"]
+
+
+def test_autobind_defaults_is_a_noop_in_the_editor(qtbot, design_session, mock_devices):
+    window = DevicesWindow(design_session)
+    qtbot.addWidget(window)
+    window.autobind_defaults()
+    # The editor often runs on a non-rig machine; the rig binds its own defaults.
+    assert design_session.devices.bindings == {}
+
+
+def test_autobind_defaults_keeps_existing_bindings(qtbot, live_session, mock_devices):
+    live_session.devices.bindings["bedroom_out"] = mock_devices["outputs"][1]
+    window = DevicesWindow(live_session)
+    qtbot.addWidget(window)
+    window.autobind_defaults()
+    # An explicit choice is never overwritten; only the unbound mic is filled.
+    assert live_session.devices.bindings["bedroom_out"] == mock_devices["outputs"][1]
+    assert live_session.devices.bindings["bedroom_mic"] == mock_devices["default_input"]

--- a/tests/test_panels_intercom.py
+++ b/tests/test_panels_intercom.py
@@ -97,8 +97,21 @@ def _stub_bridges(monkeypatch, fail=False):
     return calls
 
 
+def _bind_devices(session):
+    """Give both intercom directions definite devices (#139: no unbound opens).
+
+    Talk needs the participant output (bedroom speakers); Listen needs the
+    participant mic plus the optional return route pointed at a bound role.
+    """
+    session.devices.bindings["bedroom_out"] = "Speakers (Test)"
+    session.devices.bindings["bedroom_mic"] = "Mic (Test)"
+    session.devices.bindings["control_out"] = "Headphones (Test)"
+    session.devices.routing["intercom_listen"] = "control_out"
+
+
 def test_toggle_talk_starts_the_bridge_and_marks(qtbot, design_session, monkeypatch):
     calls = _stub_bridges(monkeypatch)
+    _bind_devices(design_session)
     window = IntercomWindow(design_session)
     qtbot.addWidget(window)
     emitted = []
@@ -121,6 +134,7 @@ def test_talk_start_failure_reverts_the_button(
     qtbot, design_session, monkeypatch, silence_dialogs
 ):
     _stub_bridges(monkeypatch, fail=True)
+    _bind_devices(design_session)
     window = IntercomWindow(design_session)
     qtbot.addWidget(window)
     emitted = []
@@ -135,6 +149,7 @@ def test_talk_start_failure_reverts_the_button(
 
 def test_listen_toggles_without_markers(qtbot, design_session, monkeypatch):
     calls = _stub_bridges(monkeypatch)
+    _bind_devices(design_session)
     window = IntercomWindow(design_session)
     qtbot.addWidget(window)
     emitted = []
@@ -148,6 +163,48 @@ def test_listen_toggles_without_markers(qtbot, design_session, monkeypatch):
     window.cleanup()
 
 
+def test_listen_with_route_off_errors_and_reverts(qtbot, design_session, monkeypatch):
+    # #139: the listen route is off by default; toggling it must refuse (instead
+    # of opening the participant mix on the system default output) and revert.
+    calls = _stub_bridges(monkeypatch)
+    design_session.devices.bindings["bedroom_mic"] = "Mic (Test)"
+    errors = []
+    monkeypatch.setattr(
+        design_session, "show_error_popup", lambda *a, **k: errors.append(a)
+    )
+    window = IntercomWindow(design_session)
+    qtbot.addWidget(window)
+    window.listenButton.setChecked(True)
+    assert not window.listenButton.isChecked()
+    assert calls["start"] == 0
+    assert errors and "not routed" in errors[0][1]
+    window.cleanup()
+
+
+def test_talk_with_no_bound_output_errors_and_reverts(
+    qtbot, design_session, monkeypatch
+):
+    # #139: an unbound participant output refuses to talk (instead of speaking
+    # through the system default device) and the button reverts, unmarked.
+    calls = _stub_bridges(monkeypatch)
+    errors = []
+    monkeypatch.setattr(
+        design_session, "show_error_popup", lambda *a, **k: errors.append(a)
+    )
+    emitted = []
+    monkeypatch.setattr(
+        design_session, "emit_event", lambda key, **k: emitted.append(key)
+    )
+    window = IntercomWindow(design_session)
+    qtbot.addWidget(window)
+    window.talkButton.setChecked(True)
+    assert not window.talkButton.isChecked()
+    assert calls["start"] == 0
+    assert emitted == []
+    assert errors and "Bedroom speakers" in errors[0][1]
+    window.cleanup()
+
+
 def _space_event(etype) -> QtGui.QKeyEvent:
     return QtGui.QKeyEvent(
         etype, QtCore.Qt.Key.Key_Space, QtCore.Qt.KeyboardModifier.NoModifier
@@ -156,6 +213,7 @@ def _space_event(etype) -> QtGui.QKeyEvent:
 
 def test_spacebar_push_to_talk_holds_and_releases(qtbot, design_session, monkeypatch):
     _stub_bridges(monkeypatch)
+    _bind_devices(design_session)
     window = IntercomWindow(design_session)
     qtbot.addWidget(window)
     monkeypatch.setattr(
@@ -171,6 +229,7 @@ def test_spacebar_push_to_talk_holds_and_releases(qtbot, design_session, monkeyp
 
 def test_spacebar_passes_through_while_typing(qtbot, design_session, monkeypatch):
     _stub_bridges(monkeypatch)
+    _bind_devices(design_session)
     window = IntercomWindow(design_session)
     qtbot.addWidget(window)
     monkeypatch.setattr(

--- a/tests/test_panels_noise.py
+++ b/tests/test_panels_noise.py
@@ -42,10 +42,16 @@ def _stub_output(monkeypatch, stream_cls=_FakeOutput, rate=8000.0):
     monkeypatch.setattr(noise.sd, "OutputStream", stream_cls)
 
 
+def _bind_output(session):
+    """Give the noise route a definite device (#139: nothing opens unbound)."""
+    session.devices.bindings["bedroom_out"] = "Speakers (Test)"
+
+
 def test_play_then_stop_builds_buffer_and_updates_status(
     qtbot, design_session, monkeypatch
 ):
     _stub_output(monkeypatch)
+    _bind_output(design_session)
     window = NoiseWindow(design_session)
     qtbot.addWidget(window)
     assert not window.is_streaming()
@@ -66,6 +72,7 @@ def test_play_then_stop_builds_buffer_and_updates_status(
 
 def test_play_marks_once_but_not_on_silent_restart(qtbot, design_session, monkeypatch):
     _stub_output(monkeypatch)
+    _bind_output(design_session)
     window = NoiseWindow(design_session)
     qtbot.addWidget(window)
     emitted = []
@@ -112,6 +119,7 @@ def test_file_source_without_a_file_shows_error_and_no_stream(
     qtbot, design_session, monkeypatch, silence_dialogs
 ):
     _stub_output(monkeypatch)
+    _bind_output(design_session)
     window = NoiseWindow(design_session)
     qtbot.addWidget(window)
     window.fileRadio.setChecked(True)
@@ -127,12 +135,31 @@ def test_failed_stream_start_clears_the_buffer(
         raise RuntimeError("no output device")
 
     _stub_output(monkeypatch, stream_cls=boom)
+    _bind_output(design_session)
     window = NoiseWindow(design_session)
     qtbot.addWidget(window)
     window.play_noise()
     assert not window.is_streaming()
     assert window._noise_buffer is None
     assert "stopped" in window.noiseStatusLabel.text()
+
+
+def test_play_with_no_bound_device_errors_and_keeps_quiet(
+    qtbot, design_session, monkeypatch
+):
+    # #139: an unbound role refuses to play (with an error pointing at the
+    # Devices window) instead of falling back to the system default device.
+    _stub_output(monkeypatch)
+    errors = []
+    monkeypatch.setattr(
+        design_session, "show_error_popup", lambda *a, **k: errors.append(a)
+    )
+    window = NoiseWindow(design_session)
+    qtbot.addWidget(window)
+    window.on_play_noise_clicked()
+    assert not window.is_streaming()
+    assert window._noise_buffer is None
+    assert errors and "Bedroom speakers" in errors[0][1]
 
 
 @pytest.mark.parametrize("color", ["white", "pink", "brown"])

--- a/tests/test_panels_recording.py
+++ b/tests/test_panels_recording.py
@@ -54,6 +54,7 @@ def test_record_start_to_stop_writes_the_report_wav(
     qtbot, live_session, monkeypatch, silence_dialogs
 ):
     _stub_recorder(monkeypatch)
+    live_session.devices.bindings["bedroom_mic"] = "Mic (Test)"
     window = RecordingWindow(live_session)
     qtbot.addWidget(window)
 
@@ -85,6 +86,7 @@ def test_failed_start_reverts_button_and_leaves_no_numbering_gap(
         raise RuntimeError("device busy")
 
     _stub_recorder(monkeypatch, stream_cls=boom)
+    live_session.devices.bindings["bedroom_mic"] = "Mic (Test)"
     window = RecordingWindow(live_session)
     qtbot.addWidget(window)
 
@@ -102,6 +104,25 @@ def test_failed_start_reverts_button_and_leaves_no_numbering_gap(
     window.micrecordButton.setChecked(False)
     window.start_or_stop_recording()
     assert (live_session.session_dir / "report-01.wav").is_file()
+    window.cleanup()
+
+
+def test_record_with_no_bound_mic_errors_and_reverts(qtbot, live_session, monkeypatch):
+    # #139: an unbound dream-report mic refuses to record (instead of capturing
+    # from the system default input); the button reverts and no WAV is opened.
+    _stub_recorder(monkeypatch)
+    errors = []
+    monkeypatch.setattr(
+        live_session, "show_error_popup", lambda *a, **k: errors.append(a)
+    )
+    window = RecordingWindow(live_session)
+    qtbot.addWidget(window)
+    window.micrecordButton.setChecked(True)
+    window.start_or_stop_recording()
+    assert not window.micrecordButton.isChecked()
+    assert window.n_report_counter == 0
+    assert not window.is_streaming()
+    assert errors and "Bedroom mic" in errors[0][1]
     window.cleanup()
 
 


### PR DESCRIPTION
Closes #139.

Removes "(system default)" as a routing concept. Windows reassigns its default audio device on its own (HDMI/Bluetooth plug-in), and an overnight study must not follow it.

**What changed**
- Live sessions pin unbound `bedroom_out`/`bedroom_mic` to the *current* Windows default — explicitly by name, logged — at construction and study load (never on rescans, so an explicit "(none)" sticks). The editor never auto-binds; a study built elsewhere pins the rig's own defaults on first load there.
- Every stream-opening path (cue, noise, biocal voice, recorder, intercom talk/listen, both level meters) now refuses an unbound role with an error pointing at the Devices window, instead of silently falling back to the PortAudio default. The intercom Listen and room-monitor paths were the worst offenders.
- Honest labels: empty enumeration shows per-kind "No output/input device found" / "No BlinkStick found", Hue distinguishes "No bridge paired" from "No lights found", and a bound-but-unplugged device shows a selected "X (not connected)" row (binding kept, flagged once) rather than the placeholder. Panel indicators read "(not set)".
- Docs: new "No system default" section in audio.md plus a note in the settings-file reference.

**Verified:** `pytest` (675 pass, incl. new model/guard/placeholder/auto-bind tests), `ruff`, `mypy`, and `mkdocs build --strict` all clean. Hardware-only checks (true default at launch; flipping the Windows default mid-session leaves streams pinned) noted for the rig.

A follow-up issue covers the one remaining default-following path: the experimenter (intercom talk) mic has no role.