### PR TITLE
feat: give the experimenter intercom mic its own device role

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -15,8 +15,9 @@ Instead of picking a device separately in every window, SMACC has one **Devices
 window** (in the *Tools* column) where you do two things:
 
 1. **Bind each _role_ to a device, once.** The roles are the physical endpoints of a
-   rig: **Bedroom speakers**, **Control-room speakers**, **Bedroom mic**, plus the
-   light devices (**BlinkStick**, **Philips Hue**).
+   rig: **Bedroom speakers**, **Control-room speakers**, **Bedroom mic**, the
+   **Control-room mic** (the experimenter's intercom voice), plus the light
+   devices (**BlinkStick**, **Philips Hue**).
 2. **Route each modality to a role.** The cue, noise, intercom, and dream-report
    recorder each point at a role.
 
@@ -47,9 +48,10 @@ its default device on its own — plugging in an HDMI monitor or a Bluetooth hea
 is enough — and an overnight study must not follow it. Instead:
 
 * When a session starts (or loads a study) with nothing bound to **Bedroom
-  speakers** or **Bedroom mic**, SMACC binds the device that is *currently* the
-  Windows default — explicitly, by name — and logs which one it picked. From then
-  on the binding is pinned: changing the Windows default never re-routes a study.
+  speakers**, **Bedroom mic**, or the **Control-room mic**, SMACC binds the device
+  that is *currently* the Windows default — explicitly, by name — and logs which
+  one it picked. From then on the binding is pinned: changing the Windows default
+  never re-routes a study.
 * A role with nothing bound reads **(none)**, and anything routed to it reports a
   clear error instead of quietly playing somewhere else.
 * If no device is connected at all, the dropdown says so (e.g. **No output device
@@ -69,9 +71,9 @@ Three optional routes cover the things you reach for mid-study:
   speakers and the cue plays in the bedroom and the control room at once, so you hear
   what the participant heard.
 * **Listen through intercom.** The intercom is two-way: **Speak through intercom**
-  sends your voice to the participant (and is marked in the EEG record), while
-  **Listen through intercom** brings the participant's mic to your control-room
-  speakers. The intercom also has a typed [text-chat mode](usage.md#text-chat)
+  sends your voice — picked up by the **Control-room mic** — to the participant
+  (and is marked in the EEG record), while **Listen through intercom** brings the
+  participant's mic to your control-room speakers. The intercom also has a typed [text-chat mode](usage.md#text-chat)
   (no audio device involved) for hearing-impaired participants.
 * **Monitor the bedroom.** A microphone meter in the Audio cue window that confirms a
   cue is audible in the bedroom (see

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -174,14 +174,14 @@ and [Devices](../devices.md)).
 
 | Key | Type | Meaning |
 |---|---|---|
-| `bindings` | mapping | Role key → device key. Roles: `bedroom_out`, `control_out`, `bedroom_mic`, `monitor_mic`, `blinkstick` (a stick's serial), `hue` (a bridge target like `light:3` or `group:1`). |
+| `bindings` | mapping | Role key → device key. Roles: `bedroom_out`, `control_out`, `bedroom_mic`, `monitor_mic`, `control_mic` (the experimenter's intercom mic), `blinkstick` (a stick's serial), `hue` (a bridge target like `light:3` or `group:1`). |
 | `routing` | mapping | Target key → role key (`""` = off). Targets: `cue_out`, `cue_monitor`, `noise_out`, `intercom_talk`, `intercom_listen`, `report_in`, `monitor_in`, `visual_out`. |
 
 A missing `devices` block loads the defaults (each target on its default role, with
-no devices bound). When a live session starts (or loads a study) with `bedroom_out`
-or `bedroom_mic` unbound, SMACC binds the current Windows default device explicitly,
-by name, and logs the choice — there is no "system default" pseudo-selection (see
-[Audio & routing](../audio.md#no-system-default)).
+no devices bound). When a live session starts (or loads a study) with `bedroom_out`,
+`bedroom_mic`, or `control_mic` unbound, SMACC binds the current Windows default
+device explicitly, by name, and logs the choice — there is no "system default"
+pseudo-selection (see [Audio & routing](../audio.md#no-system-default)).
 
 ### `trigger_output`
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -162,9 +162,10 @@ instructions exactly as they do to cues.
 ## Intercom
 
 The **Intercom** window is the live channel between the control room and the
-bedroom. **Talk** pipes your mic to the participant's output (click to latch, or
-hold the **spacebar** anywhere in SMACC as push-to-talk) and is marked in the EEG
-record; **Listen** brings the bedroom mic to your control-room speakers, unmarked.
+bedroom. **Talk** pipes the control-room mic to the participant's output (click to
+latch, or hold the **spacebar** anywhere in SMACC as push-to-talk) and is marked in
+the EEG record; **Listen** brings the bedroom mic to your control-room speakers,
+unmarked.
 The two directions route through roles set once in the **Devices** window (see
 [Audio &amp; routing](audio.md)). A **level meter** beside each button shows the
 live input level while that direction is on — signal on the bar means audio is

--- a/src/smacc/devices.py
+++ b/src/smacc/devices.py
@@ -41,17 +41,20 @@ class Role:
     kind: str
 
 
-# The fixed role set. Two outputs and one mic cover the issue's rig; the two light
-# technologies are separate visual roles (#53: a BlinkStick binds one USB stick, a
-# Hue binds one bridge light/group — the visual cue routes to whichever is in use).
-# The monitor mic (#37) is a second, optional input so a lab can place a dedicated,
-# sensitive mic for verifying cues without disturbing the (often cheaper)
-# dream-report mic. Kept small on purpose — more can be added later.
+# The fixed role set. Two outputs and three mics cover the issue's rig; the two
+# light technologies are separate visual roles (#53: a BlinkStick binds one USB
+# stick, a Hue binds one bridge light/group — the visual cue routes to whichever is
+# in use). The monitor mic (#37) is a second, optional input so a lab can place a
+# dedicated, sensitive mic for verifying cues without disturbing the (often
+# cheaper) dream-report mic; the control-room mic (#160) picks up the
+# experimenter's voice for the intercom. Kept small on purpose — more can be
+# added later.
 ROLES: tuple[Role, ...] = (
     Role("bedroom_out", "Bedroom speakers", OUTPUT),
     Role("control_out", "Control-room speakers", OUTPUT),
     Role("bedroom_mic", "Bedroom mic", INPUT),
     Role("monitor_mic", "Monitor mic", INPUT),
+    Role("control_mic", "Control-room mic", INPUT),
     Role("blinkstick", "BlinkStick", VISUAL),
     Role("hue", "Philips Hue", VISUAL),
 )
@@ -89,17 +92,26 @@ TARGETS_BY_KEY: dict[str, Target] = {t.key: t for t in TARGETS}
 # Source role for the intercom "listen" path (participant mic -> control room) and
 # any other input monitor: the same mic the dream report uses.
 LISTEN_SOURCE_ROLE = "bedroom_mic"
+# Source role for the intercom "talk" path (#160): the mic that picks up the
+# experimenter's voice. A role (not a routable target) on purpose — routing the
+# talk source to a bedroom mic would loop the bedroom's own sound back out its
+# speakers at a sleeping participant.
+TALK_SOURCE_ROLE = "control_mic"
 
 # Roles SMACC binds automatically when left unbound (live sessions only): the
-# default role of every required audio target, so a fresh study has a definite
-# device for the paths that play/record out of the box. Roles only optional
-# routes point at (control-room speakers, the dedicated monitor mic) imply
-# hardware a rig may not have, so they are never auto-bound.
+# default role of every required audio target, plus the intercom source roles,
+# so a fresh study has a definite device for the paths that play/record out of
+# the box. Roles only optional routes point at (control-room speakers, the
+# dedicated monitor mic) imply hardware a rig may not have, so they are never
+# auto-bound.
 AUTOBIND_ROLES: tuple[str, ...] = tuple(
     dict.fromkeys(
-        t.default_role
-        for t in TARGETS
-        if not t.optional and t.kind in (OUTPUT, INPUT) and t.default_role
+        [
+            t.default_role
+            for t in TARGETS
+            if not t.optional and t.kind in (OUTPUT, INPUT) and t.default_role
+        ]
+        + [LISTEN_SOURCE_ROLE, TALK_SOURCE_ROLE]
     )
 )
 

--- a/src/smacc/panels/base.py
+++ b/src/smacc/panels/base.py
@@ -67,6 +67,21 @@ def describe_target(session: SmaccSession, target_key: str) -> str:
     return f"{role_label} (not set)"
 
 
+def describe_role(session: SmaccSession, role_key: str) -> str:
+    """A short 'Role → device' description of a role's binding.
+
+    Like :func:`describe_target`, but for the source *roles* the intercom reads
+    directly (the talk and listen mics, which deliberately have no routing
+    target — see :data:`smacc.devices.TALK_SOURCE_ROLE`).
+    """
+    role = devices.ROLES_BY_KEY.get(role_key)
+    role_label = role.label if role else role_key
+    device = session.devices.device_for_role(role_key)
+    if device:
+        return f"{role_label} → {device}"
+    return f"{role_label} (not set)"
+
+
 def require_role_device(
     session: SmaccSession,
     role_key: str,

--- a/src/smacc/panels/intercom.py
+++ b/src/smacc/panels/intercom.py
@@ -26,6 +26,7 @@ from ..dialogs import ManageChatPresetsDialog
 from ..session import SmaccSession
 from .base import (
     ModalityWindow,
+    describe_role,
     describe_target,
     make_section_title,
     require_device,
@@ -325,9 +326,20 @@ class IntercomWindow(ModalityWindow):
             self.session.log_interaction("Edited chat quick-reply presets")
 
     def refresh_device_indicator(self) -> None:
-        """Show where each direction routes (devices set in the Devices window)."""
-        self.talkDeviceLabel.setText(describe_target(self.session, "intercom_talk"))
-        self.listenDeviceLabel.setText(describe_target(self.session, "intercom_listen"))
+        """Show both halves of each direction (devices set in the Devices window).
+
+        Talk and Listen are mic → output paths, so each indicator shows the
+        output route plus the source mic ("• mic: …"), the same separator idiom
+        the Audio cue window uses for its monitor.
+        """
+        talk = describe_target(self.session, "intercom_talk")
+        talk += f"   •   mic: {describe_role(self.session, devices.TALK_SOURCE_ROLE)}"
+        self.talkDeviceLabel.setText(talk)
+        listen = describe_target(self.session, "intercom_listen")
+        listen += (
+            f"   •   mic: {describe_role(self.session, devices.LISTEN_SOURCE_ROLE)}"
+        )
+        self.listenDeviceLabel.setText(listen)
 
     def is_streaming(self) -> bool:
         """True while either direction is live."""
@@ -357,10 +369,21 @@ class IntercomWindow(ModalityWindow):
         """Start/stop piping the experimenter mic to the participant output.
 
         Marked in the EEG record via LSL (the experimenter's voice is a manipulation
-        the participant hears). The experimenter mic has no role binding: it is
-        whatever the control-room machine's default input is.
+        the participant hears). The mic is the control-room mic role (#160), the
+        output the ``intercom_talk`` route — both pinned by name, like every other
+        audio path.
         """
         if enabled:
+            mic = require_role_device(
+                self.session,
+                devices.TALK_SOURCE_ROLE,
+                devices.INPUT,
+                failure="Could not start intercom talk.",
+                parent=self,
+            )
+            if mic is None:
+                self.talkButton.setChecked(False)
+                return
             output = require_device(
                 self.session,
                 "intercom_talk",
@@ -372,7 +395,7 @@ class IntercomWindow(ModalityWindow):
                 self.talkButton.setChecked(False)
                 return
             try:
-                self._talk.start(None, output)
+                self._talk.start(mic, output)
             except Exception as exc:  # PortAudio errors, no device, busy, etc.
                 self.session.show_error_popup(
                     "Could not start intercom talk.", str(exc), parent=self

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -118,9 +118,18 @@ def test_both_light_technologies_are_visual_roles():
 
 
 def test_autobind_roles_are_the_required_audio_defaults():
-    # Derived from TARGETS: the default role of each required audio target. Roles
-    # only optional routes point at (control-room, monitor mic) are excluded.
-    assert devices.AUTOBIND_ROLES == ("bedroom_out", "bedroom_mic")
+    # Derived from TARGETS (the default role of each required audio target) plus
+    # the intercom source roles (#160). Roles only optional routes point at
+    # (control-room speakers, monitor mic) are excluded.
+    assert devices.AUTOBIND_ROLES == ("bedroom_out", "bedroom_mic", "control_mic")
+
+
+def test_talk_source_is_the_control_room_mic():
+    # #160: the intercom talk mic is a bound role, not a routable target (routing
+    # it to a bedroom mic would feed the bedroom's sound back out its speakers).
+    role = devices.ROLES_BY_KEY[devices.TALK_SOURCE_ROLE]
+    assert role.key == "control_mic"
+    assert role.kind == devices.INPUT
 
 
 def test_autobind_fills_only_unbound_roles():
@@ -131,8 +140,10 @@ def test_autobind_fills_only_unbound_roles():
     )
     assert cfg.bindings["bedroom_out"] == "Kept (USB)"  # never overwritten
     assert cfg.bindings["bedroom_mic"] == "Default In"
+    assert cfg.bindings["control_mic"] == "Default In"
     assert [(role.key, device) for role, device in filled] == [
-        ("bedroom_mic", "Default In")
+        ("bedroom_mic", "Default In"),
+        ("control_mic", "Default In"),
     ]
     assert "control_out" not in cfg.bindings
     assert "monitor_mic" not in cfg.bindings

--- a/tests/test_panels_base.py
+++ b/tests/test_panels_base.py
@@ -48,6 +48,19 @@ def test_describe_target_off_route_reads_off(design_session):
     assert base.describe_target(session, "cue_monitor") == "off"
 
 
+def test_describe_role_bound_and_unbound(design_session):
+    # The intercom source roles (#160) are described directly, without a target.
+    session = _session_with(design_session, {"control_mic": "Headset Mic"})
+    assert (
+        base.describe_role(session, devices.TALK_SOURCE_ROLE)
+        == "Control-room mic → Headset Mic"
+    )
+    assert (
+        base.describe_role(session, devices.LISTEN_SOURCE_ROLE)
+        == "Bedroom mic (not set)"
+    )
+
+
 # ----- require_device / require_role_device (#139) ----------------------------
 
 

--- a/tests/test_panels_devices.py
+++ b/tests/test_panels_devices.py
@@ -127,6 +127,7 @@ def test_empty_enumeration_says_no_device_found(qtbot, design_session, mock_no_d
     assert texts["bedroom_out"] == ["No output device found"]
     assert texts["control_out"] == ["No output device found"]
     assert texts["bedroom_mic"] == ["No input device found"]
+    assert texts["control_mic"] == ["No input device found"]
     assert texts["blinkstick"] == ["No BlinkStick found"]
     assert texts["hue"] == ["No bridge paired"]
 
@@ -155,7 +156,9 @@ def test_autobind_defaults_pins_the_required_roles(qtbot, live_session, mock_dev
     bindings = live_session.devices.bindings
     assert bindings["bedroom_out"] == mock_devices["default_output"]
     assert bindings["bedroom_mic"] == mock_devices["default_input"]
+    assert bindings["control_mic"] == mock_devices["default_input"]  # #160
     assert "control_out" not in bindings
+    assert "monitor_mic" not in bindings
     assert changed  # indicators are told to re-render
     # The combos show the pinned devices.
     out_combo = window._role_combos["bedroom_out"]
@@ -175,6 +178,7 @@ def test_autobind_defaults_keeps_existing_bindings(qtbot, live_session, mock_dev
     window = DevicesWindow(live_session)
     qtbot.addWidget(window)
     window.autobind_defaults()
-    # An explicit choice is never overwritten; only the unbound mic is filled.
+    # An explicit choice is never overwritten; only the unbound mics are filled.
     assert live_session.devices.bindings["bedroom_out"] == mock_devices["outputs"][1]
     assert live_session.devices.bindings["bedroom_mic"] == mock_devices["default_input"]
+    assert live_session.devices.bindings["control_mic"] == mock_devices["default_input"]

--- a/tests/test_panels_intercom.py
+++ b/tests/test_panels_intercom.py
@@ -100,11 +100,13 @@ def _stub_bridges(monkeypatch, fail=False):
 def _bind_devices(session):
     """Give both intercom directions definite devices (#139: no unbound opens).
 
-    Talk needs the participant output (bedroom speakers); Listen needs the
-    participant mic plus the optional return route pointed at a bound role.
+    Talk needs the control-room mic (#160) and the participant output; Listen
+    needs the participant mic plus the optional return route pointed at a bound
+    role.
     """
     session.devices.bindings["bedroom_out"] = "Speakers (Test)"
     session.devices.bindings["bedroom_mic"] = "Mic (Test)"
+    session.devices.bindings["control_mic"] = "Headset Mic (Test)"
     session.devices.bindings["control_out"] = "Headphones (Test)"
     session.devices.routing["intercom_listen"] = "control_out"
 
@@ -187,6 +189,7 @@ def test_talk_with_no_bound_output_errors_and_reverts(
     # #139: an unbound participant output refuses to talk (instead of speaking
     # through the system default device) and the button reverts, unmarked.
     calls = _stub_bridges(monkeypatch)
+    design_session.devices.bindings["control_mic"] = "Headset Mic (Test)"
     errors = []
     monkeypatch.setattr(
         design_session, "show_error_popup", lambda *a, **k: errors.append(a)
@@ -202,6 +205,29 @@ def test_talk_with_no_bound_output_errors_and_reverts(
     assert calls["start"] == 0
     assert emitted == []
     assert errors and "Bedroom speakers" in errors[0][1]
+    window.cleanup()
+
+
+def test_talk_with_no_bound_mic_errors_and_reverts(qtbot, design_session, monkeypatch):
+    # #160: an unbound control-room mic refuses to talk (instead of capturing
+    # from the system default input) and the button reverts, unmarked.
+    calls = _stub_bridges(monkeypatch)
+    design_session.devices.bindings["bedroom_out"] = "Speakers (Test)"
+    errors = []
+    monkeypatch.setattr(
+        design_session, "show_error_popup", lambda *a, **k: errors.append(a)
+    )
+    emitted = []
+    monkeypatch.setattr(
+        design_session, "emit_event", lambda key, **k: emitted.append(key)
+    )
+    window = IntercomWindow(design_session)
+    qtbot.addWidget(window)
+    window.talkButton.setChecked(True)
+    assert not window.talkButton.isChecked()
+    assert calls["start"] == 0
+    assert emitted == []
+    assert errors and "Control-room mic" in errors[0][1]
     window.cleanup()
 
 


### PR DESCRIPTION
Closes #160.

The intercom Talk direction was the last audio path with no device role — `toggle_talk` opened its input as `None`, i.e. whatever Windows currently calls the default input. After #159 removed every other silent default fallback, this closes the loop:

- New **Control-room mic** role (`control_mic`); `TALK_SOURCE_ROLE` constant mirrors the existing `LISTEN_SOURCE_ROLE` pattern. Deliberately a role, not a routable target: a talk-source dropdown offering a bedroom mic would loop the bedroom's own sound back out its speakers.
- `control_mic` joins the auto-bind set, so a fresh session pins the control machine's current default input by name (logged) and Talk keeps working with zero setup; the strict unbound guard only ever fires on a machine with no input devices at all.
- `toggle_talk` resolves the mic through the same `require_role_device` guard as every other path (mic first, then output), reverting the button with a clear error instead of opening the default.
- The intercom panel indicators now show both halves of each direction ("Bedroom speakers → X • mic: Control-room mic → Y"), for Listen too, whose source mic was also invisible.

**Verified:** 678 tests pass (new model/guard/indicator tests), ruff, mypy, and `mkdocs build --strict` clean. Rig-only checks: the auto-selected mic is logged at session start; flipping the Windows default input mid-session must not move Talk.