### PR TITLE
build: adopt mdformat for Markdown formatting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,12 @@ jobs:
         run: uv run --extra dev ruff check .
       - name: Ruff format check
         run: uv run --extra dev ruff format --check .
+      # Markdown formatter (the docs counterpart to ruff). `mdformat .` crawls the
+      # tree; the .mdformat.toml exclude scopes it (incl. the in-tree .venv this
+      # step creates). The exclude needs Python 3.13, which is why this waited on
+      # #168. --extra docs is where mdformat + its mkdocs/gfm/frontmatter plugins live.
+      - name: Markdown format check
+        run: uv run --extra docs mdformat --check .
       # mypy doesn't need the eeg extra: neither mne nor pyqtgraph ships
       # py.typed, so installing them adds no type information (and
       # ignore_missing_imports already covers their absence).

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,14 @@
+# Markdown formatter config (the docs counterpart to ruff). mdformat reads only
+# .mdformat.toml, not pyproject.toml's [tool.mdformat], so the config lives here.
+#
+# wrap = "keep" leaves prose line breaks alone (the docs hand-wrap at ~80 cols);
+# end_of_line = "lf" matches ruff. exclude needs Python 3.13 (glob.translate) —
+# the reason this waited on #168 — and is the single scope source: CI runs
+# `mdformat --check .` and the pre-commit hook crawls the same way, both reading
+# these globs. .claude/ holds the tool-managed AI-assistant configs (out of
+# scope); .venv/ and .pytest_cache/ are not gitignore-aware to mdformat, so the
+# in-tree venv that `uv run` creates must be excluded or the check drowns in
+# site-packages READMEs.
+wrap = "keep"
+end_of_line = "lf"
+exclude = [".claude/**", ".venv/**", ".pytest_cache/**"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,13 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+      # Crawls the tree (pass_filenames: false) so it reads the .mdformat.toml
+      # exclude — the same single scope source CI uses — rather than being handed
+      # an explicit file list that would bypass it. --extra docs supplies mdformat
+      # and its plugins. Mirrors the mypy hook above.
+      - id: mdformat
+        name: mdformat
+        entry: uv run --extra docs mdformat .
+        language: system
+        types: [markdown]
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,11 @@ bug reports before starting work.
 ## Conventions
 
 - Always use `uv` when running Python scripts or installing dependencies. Never
-  `pip install` or run naked `python`.
+    `pip install` or run naked `python`.
 - One-line commits with a [Conventional Commits](https://www.conventionalcommits.org)
-  prefix (`feat:`, `fix:`, `docs:`, …); no commit body and no AI attribution. Pull
-  request bodies stay brief. Full guide:
-  [Commit and pull-request style](./docs/contributing.md#commit-and-pull-request-style).
+    prefix (`feat:`, `fix:`, `docs:`, …); no commit body and no AI attribution. Pull
+    request bodies stay brief. Full guide:
+    [Commit and pull-request style](./docs/contributing.md#commit-and-pull-request-style).
 
 ## Architecture at a glance
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ A clickable interface for running sleep-related experiments.
 
 Used for dream engineering by the [Paller Lab](https://sites.northwestern.edu/pallerlab/) at Northwestern University and the [DxE Lab](https://www.dreamengineeringlab.com/) at the Center for Advanced Research in Sleep Medicine.
 
-* Trigger audio cues
-* Trigger visual cues (BlinkStick or Philips Hue)
-* Collect dream reports
-* Trigger EEG port codes
-* Save a detailed event log
-* and more!
+- Trigger audio cues
+- Trigger visual cues (BlinkStick or Philips Hue)
+- Collect dream reports
+- Trigger EEG port codes
+- Save a detailed event log
+- and more!
 
 ## Installation
 
@@ -27,17 +27,17 @@ Note that for some features, you will need to open SMACC with Administrator priv
 
 ## Optional setup
 
-* If you don't want to use the default `~/SMACC` folder, you can change this by setting an environment variable called `SMACC_DIRECTORY` equal to whatever directory you want to use (the older `SMACC_DATA_DIRECTORY` is still honored as a fallback). SMACC will create it and all the subfolders (if not already present).
+- If you don't want to use the default `~/SMACC` folder, you can change this by setting an environment variable called `SMACC_DIRECTORY` equal to whatever directory you want to use (the older `SMACC_DATA_DIRECTORY` is still honored as a fallback). SMACC will create it and all the subfolders (if not already present).
 
-* SMACC opens to its **Launcher**, where you pick a **SMACC file** (`.smacc`) and then start a session, create/edit a SMACC file, or analyze a past run. A SMACC file holds your data-related setup (cues, volumes, event codes, …) plus the **data directory** where its runs are written. SMACC seeds a `default.smacc` in your SMACC directory (data directory `~/SMACC/data`) and opens it when you don't pick another, so it works out of the box. A few `demo-*` cue files are seeded into `~/SMACC/data/cues/` (restored if you delete them); you can also drop your own sound files there (`.wav`, `.mp3`, `.flac`, `.ogg`, and `.aiff` are all supported).
+- SMACC opens to its **Launcher**, where you pick a **SMACC file** (`.smacc`) and then start a session, create/edit a SMACC file, or analyze a past run. A SMACC file holds your data-related setup (cues, volumes, event codes, …) plus the **data directory** where its runs are written. SMACC seeds a `default.smacc` in your SMACC directory (data directory `~/SMACC/data`) and opens it when you don't pick another, so it works out of the box. A few `demo-*` cue files are seeded into `~/SMACC/data/cues/` (restored if you delete them); you can also drop your own sound files there (`.wav`, `.mp3`, `.flac`, `.ogg`, and `.aiff` are all supported).
 
-* Each run gets its own timestamped folder under the SMACC file's data directory (e.g. `smacc-20260607-223015/`) holding that run's `.log`, dream-report recordings, and any exports. Subject/session are optional metadata (set from `File > Session info…`) recorded inside the log/exports rather than in filenames. Any older flat `~/SMACC/cues`, `~/SMACC/sessions`, `~/SMACC/logs`, and `~/SMACC/dreams` folders from earlier versions are left untouched.
+- Each run gets its own timestamped folder under the SMACC file's data directory (e.g. `smacc-20260607-223015/`) holding that run's `.log`, dream-report recordings, and any exports. Subject/session are optional metadata (set from `File > Session info…`) recorded inside the log/exports rather than in filenames. Any older flat `~/SMACC/cues`, `~/SMACC/sessions`, `~/SMACC/logs`, and `~/SMACC/dreams` folders from earlier versions are left untouched.
 
-* Build a SMACC file in the **Editor** (the Launcher's `Create` button, or `Edit` for an existing one): configure the tools, set the data directory, and save the `.smacc` anywhere. You can also snapshot a running session's current settings with `File > Save SMACC file as…`. Keep one per participant if you like — they can share a data directory. Cue/noise files and the data directory are stored relative to the `.smacc` when they sit beside it (so a self-contained folder is portable) and absolute otherwise. On Windows you can double-click a `.smacc` to open it. The display choices that apply to a session — always-on-top and which log-preview levels show — are stored in the SMACC file too, so they travel with the study. The machine itself remembers window positions and sizes and your recent files in `~/SMACC/preferences.yaml`, restored on the next launch.
+- Build a SMACC file in the **Editor** (the Launcher's `Create` button, or `Edit` for an existing one): configure the tools, set the data directory, and save the `.smacc` anywhere. You can also snapshot a running session's current settings with `File > Save SMACC file as…`. Keep one per participant if you like — they can share a data directory. Cue/noise files and the data directory are stored relative to the `.smacc` when they sit beside it (so a self-contained folder is portable) and absolute otherwise. On Windows you can double-click a `.smacc` to open it. The display choices that apply to a session — always-on-top and which log-preview levels show — are stored in the SMACC file too, so they travel with the study. The machine itself remembers window positions and sizes and your recent files in `~/SMACC/preferences.yaml`, restored on the next launch.
 
-* There is a `Record Dream Report` button that will start to record from whatever mic is routed to the **Record dream report** action (set in the **Devices** window). It can also pop open a survey URL — I use this to open a dream report survey I have set up on Qualtrics. Add your surveys with the `Manage…` button next to the survey dropdown (each has a name and URL, saved to your SMACC file); pick one to open automatically when recording starts, or open any saved survey on its own from `File > Surveys`. If planning to record dreams, bind your mic to **Bedroom mic 1** in the Devices window.
+- There is a `Record Dream Report` button that will start to record from whatever mic is routed to the **Record dream report** action (set in the **Devices** window). It can also pop open a survey URL — I use this to open a dream report survey I have set up on Qualtrics. Add your surveys with the `Manage…` button next to the survey dropdown (each has a name and URL, saved to your SMACC file); pick one to open automatically when recording starts, or open any saved survey on its own from `File > Surveys`. If planning to record dreams, bind your mic to **Bedroom mic 1** in the Devices window.
 
-* All device selection lives in one **Devices** window (in the *Tools* column): bind each piece of **equipment** — Bedroom speaker, Control-room speaker, Bedroom mics 1 and 2, Control-room mic, the lights (BlinkStick or Philips Hue) — to a device once, then route each **action** to equipment. Because cue, noise, and your voice can all share one speaker, re-pointing it is a single change. Optional routes add a **Listen to audio cue** (the cue also plays in the control room) and a **Listen to participant** (hear the participant on the Control-room speaker). The whole setup is saved in the SMACC file and restored on the next launch; a bound device that isn't connected is flagged. Plugging a device in is detected automatically, or click `Refresh devices (F5)` in the Devices window — audio devices rescan only while nothing is playing or recording.
+- All device selection lives in one **Devices** window (in the *Tools* column): bind each piece of **equipment** — Bedroom speaker, Control-room speaker, Bedroom mics 1 and 2, Control-room mic, the lights (BlinkStick or Philips Hue) — to a device once, then route each **action** to equipment. Because cue, noise, and your voice can all share one speaker, re-pointing it is a single change. Optional routes add a **Listen to audio cue** (the cue also plays in the control room) and a **Listen to participant** (hear the participant on the Control-room speaker). The whole setup is saved in the SMACC file and restored on the next launch; a bound device that isn't connected is flagged. Plugging a device in is detected automatically, or click `Refresh devices (F5)` in the Devices window — audio devices rescan only while nothing is playing or recording.
 
 ## Documentation
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -15,13 +15,13 @@ Instead of picking a device separately in every window, SMACC has one **Devices
 window** (in the *Tools* column) where you do two things:
 
 1. **Bind each piece of _equipment_ to a device, once.** Equipment entries are
-   the physical endpoints of a rig, named by place: **Bedroom speaker**, **Control-room speaker**, **Bedroom
-   mic 1** (and an optional **Bedroom mic 2**), the **Control-room mic** (the
-   experimenter's intercom voice), plus the light devices (**BlinkStick light**,
-   **Philips Hue light**).
-2. **Route each _action_ to equipment.** Every action names what SMACC does
-   with a device — *Play audio cue*, *Record dream report* — and each points
-   at a piece of equipment. Hover any row in the window for a full description.
+    the physical endpoints of a rig, named by place: **Bedroom speaker**, **Control-room speaker**, **Bedroom
+    mic 1** (and an optional **Bedroom mic 2**), the **Control-room mic** (the
+    experimenter's intercom voice), plus the light devices (**BlinkStick light**,
+    **Philips Hue light**).
+1. **Route each _action_ to equipment.** Every action names what SMACC does
+    with a device — *Play audio cue*, *Record dream report* — and each points
+    at a piece of equipment. Hover any row in the window for a full description.
 
 The cue, the noise, and your intercom voice can all share the **Bedroom
 speaker**, so swapping it is one change rather than several. Every other
@@ -51,18 +51,18 @@ SMACC never routes audio to "whatever the system default is". Windows reassigns
 its default device on its own — plugging in an HDMI monitor or a Bluetooth headset
 is enough — and an overnight study must not follow it. Instead:
 
-* When a session starts (or loads a study) with nothing bound to the **Bedroom
-  speaker**, **Bedroom mic 1**, or the **Control-room mic**, SMACC binds the device
-  that is *currently* the Windows default — explicitly, by name — and logs which
-  one it picked. From then on the binding is pinned: changing the Windows default
-  never re-routes a study.
-* Equipment with nothing bound reads **(none)**, and anything routed to it
-  reports a clear error instead of quietly playing somewhere else.
-* If no device is connected at all, the dropdown says so (e.g. **No output device
-  found**) rather than offering an empty choice.
-* A bound device that isn't currently connected shows as **(not connected)** and
-  is kept — never silently swapped — until you pick another device or plug it back
-  in (then **Refresh devices (F5)**).
+- When a session starts (or loads a study) with nothing bound to the **Bedroom
+    speaker**, **Bedroom mic 1**, or the **Control-room mic**, SMACC binds the device
+    that is *currently* the Windows default — explicitly, by name — and logs which
+    one it picked. From then on the binding is pinned: changing the Windows default
+    never re-routes a study.
+- Equipment with nothing bound reads **(none)**, and anything routed to it
+    reports a clear error instead of quietly playing somewhere else.
+- If no device is connected at all, the dropdown says so (e.g. **No output device
+    found**) rather than offering an empty choice.
+- A bound device that isn't currently connected shows as **(not connected)** and
+    is kept — never silently swapped — until you pick another device or plug it back
+    in (then **Refresh devices (F5)**).
 
 The study editor never auto-binds: a study built on an office machine arrives at
 the rig with its equipment unbound, and the rig pins its own defaults on first
@@ -72,19 +72,19 @@ load.
 
 Three optional routes cover the things you reach for mid-study:
 
-* **Listen to audio cue (fan-out).** Route *Listen to audio cue* to the
-  control-room speaker and each cue plays in the bedroom and the control room at
-  once, so you hear what the participant hears.
-* **Listen to participant.** The intercom is two-way: **Speak to participant**
-  sends your voice — picked up by the **Control-room mic** — to the participant
-  (and is marked in the EEG record), while **Listen to participant** brings the
-  participant's mic to your control-room speaker. The intercom also has a typed [text-chat mode](usage.md#text-chat)
-  (no audio device involved) for hearing-impaired participants.
-* **Monitor bedroom noise.** A microphone meter in the Audio cue window that
-  confirms a cue is audible in the bedroom (see
-  [below](#is-the-cue-reaching-the-bedroom)). It defaults to **Bedroom mic 1**, or
-  bind a dedicated, more sensitive **Bedroom mic 2** and route *Monitor bedroom
-  noise* to it.
+- **Listen to audio cue (fan-out).** Route *Listen to audio cue* to the
+    control-room speaker and each cue plays in the bedroom and the control room at
+    once, so you hear what the participant hears.
+- **Listen to participant.** The intercom is two-way: **Speak to participant**
+    sends your voice — picked up by the **Control-room mic** — to the participant
+    (and is marked in the EEG record), while **Listen to participant** brings the
+    participant's mic to your control-room speaker. The intercom also has a typed [text-chat mode](usage.md#text-chat)
+    (no audio device involved) for hearing-impaired participants.
+- **Monitor bedroom noise.** A microphone meter in the Audio cue window that
+    confirms a cue is audible in the bedroom (see
+    [below](#is-the-cue-reaching-the-bedroom)). It defaults to **Bedroom mic 1**, or
+    bind a dedicated, more sensitive **Bedroom mic 2** and route *Monitor bedroom
+    noise* to it.
 
 ## One audio engine
 
@@ -93,6 +93,7 @@ input-level meter) runs on [`sounddevice`](https://python-sounddevice.readthedoc
 (PortAudio), through the **Windows WASAPI** host API.
 
 !!! info "Why WASAPI"
+
     On Windows, PortAudio lists every speaker once per host API (MME, DirectSound,
     WASAPI, WDM-KS), which is where the "same device, several names" confusion comes
     from, and the legacy MME names are truncated to 31 characters. SMACC enumerates
@@ -100,6 +101,7 @@ input-level meter) runs on [`sounddevice`](https://python-sounddevice.readthedoc
     low-latency path.
 
 !!! info "Device names in the Devices window"
+
     Because SMACC enumerates only WASAPI devices, it drops the redundant
     ", Windows WASAPI" suffix that PortAudio appends to each device name. With only
     one host API in the list, the suffix added nothing, so a device reads as
@@ -119,19 +121,20 @@ A cue you can hear in the control room isn't proof the *participant* heard it �
 bedroom speaker could be muted, unplugged, or turned down at the hardware. The
 **Audio cue** window's **Monitoring** section shows two meters so you can tell:
 
-* **Sending** — the level SMACC is emitting to the cue output, the moment it plays.
-  It's exact, but it only confirms SMACC is *playing*; it's blind to everything
-  downstream (Windows volume, the speaker's power switch, the cable). Treat it as a
-  diagnostic: if *Sending* is dark, the problem is on SMACC's side (wrong cue, the
-  per-cue volume or the safety cap at zero); if it's lit but the room is silent, the
-  problem is the speaker.
-* **Bedroom** — the level a microphone actually picks up in the room. This is the
-  objective check: it only moves when sound really happens in the bedroom. Tick the
-  box beside it to start monitoring. Because a faint cue can sit close to a cheap
-  mic's noise floor, the meter also shows the **rise above the room's resting level**
-  (the `+N` next to the reading), so even a small bump stands out.
+- **Sending** — the level SMACC is emitting to the cue output, the moment it plays.
+    It's exact, but it only confirms SMACC is *playing*; it's blind to everything
+    downstream (Windows volume, the speaker's power switch, the cable). Treat it as a
+    diagnostic: if *Sending* is dark, the problem is on SMACC's side (wrong cue, the
+    per-cue volume or the safety cap at zero); if it's lit but the room is silent, the
+    problem is the speaker.
+- **Bedroom** — the level a microphone actually picks up in the room. This is the
+    objective check: it only moves when sound really happens in the bedroom. Tick the
+    box beside it to start monitoring. Because a faint cue can sit close to a cheap
+    mic's noise floor, the meter also shows the **rise above the room's resting level**
+    (the `+N` next to the reading), so even a small bump stands out.
 
 !!! tip "A dedicated monitoring mic"
+
     The *Bedroom* meter listens on the **Monitor bedroom noise** route, which
     defaults to **Bedroom mic 1**. For the most reliable check — especially for the
     very quiet cues a study often starts at — bind a separate, sensitive
@@ -140,6 +143,7 @@ bedroom speaker could be muted, unplugged, or turned down at the hardware. The
     voice-activated) dream-report mic.
 
 !!! warning "A quiet mic isn't proof of silence"
+
     A cheap or voice-activated mic may not register a very faint cue even when it is
     playing, so a dark *Bedroom* meter is a prompt to check — not proof the cue
     failed. Read it together with *Sending*.
@@ -155,15 +159,16 @@ per-cue volume  ×  output safety cap  ×  Windows app volume  ×  Windows devic
 Three of those live in the OS and are invisible from most apps. SMACC makes its own
 gain explicit and adds a safety limit, in the **Volume** window:
 
-* **Output safety cap.** A single master ceiling, applied as the last gain stage on
-  every cue and noise output. However loud an individual cue is set, the cap is a
-  hard limit, so a full-volume looped cue on a calibrated rig can't suddenly blast a
-  sleeping participant.
-* **A read-only view of the Windows stages.** The window shows the current **system
-  output volume** and **SMACC's own level** in the Windows Volume Mixer, so the
-  hidden OS stages are visible.
+- **Output safety cap.** A single master ceiling, applied as the last gain stage on
+    every cue and noise output. However loud an individual cue is set, the cap is a
+    hard limit, so a full-volume looped cue on a calibrated rig can't suddenly blast a
+    sleeping participant.
+- **A read-only view of the Windows stages.** The window shows the current **system
+    output volume** and **SMACC's own level** in the Windows Volume Mixer, so the
+    hidden OS stages are visible.
 
 !!! tip "Calibrating cue level"
+
     For levels that reproduce across nights and participants, set the Windows device
     and app volumes to 100%, then calibrate with the per-cue volumes and the safety
     cap inside SMACC. That way one place, SMACC, determines how loud a cue is.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,12 +1,14 @@
 # Contributing
 
 !!! info "For both human and AI contributors"
+
     This page is the canonical development guide for SMACC. It is written for both
     human contributors and AI coding assistants — AI agents are pointed here from
     [`AGENTS.md`](https://github.com/remrama/smacc/blob/main/AGENTS.md), so the
     instructions live here once rather than being duplicated across files.
 
 !!! info "Requesting a change? Open a GitHub issue"
+
     Human contributors should open a
     [GitHub issue](https://github.com/remrama/smacc/issues) for new feature
     requests or bug reports before starting work, so changes can be discussed
@@ -14,17 +16,17 @@
 
 ## Conventions
 
-* Always use [uv](https://docs.astral.sh/uv/) to run Python scripts and install
-  dependencies. Never `pip install` or run naked `python`.
-* Use the marker vocabulary consistently in UI text, docs, and docstrings — *event*,
-  *marker*, *port code*, *trigger*, *transport* each mean exactly one thing; see the
-  [terminology table](triggers.md#terminology).
-* Pick log levels by the [session-log convention](reference/session-log.md#log-levels):
-  `DEBUG` for housekeeping/high-frequency detail, `INFO` for markers and meaningful
-  operator actions, `WARNING` for mid-session config changes and recoverable faults,
-  `ERROR` for faults that cost something. The file records every level, so demoting a
-  line to `DEBUG` only moves it out of the default live preview, never out of the
-  record.
+- Always use [uv](https://docs.astral.sh/uv/) to run Python scripts and install
+    dependencies. Never `pip install` or run naked `python`.
+- Use the marker vocabulary consistently in UI text, docs, and docstrings — *event*,
+    *marker*, *port code*, *trigger*, *transport* each mean exactly one thing; see the
+    [terminology table](triggers.md#terminology).
+- Pick log levels by the [session-log convention](reference/session-log.md#log-levels):
+    `DEBUG` for housekeeping/high-frequency detail, `INFO` for markers and meaningful
+    operator actions, `WARNING` for mid-session config changes and recoverable faults,
+    `ERROR` for faults that cost something. The file records every level, so demoting a
+    line to `DEBUG` only moves it out of the default live preview, never out of the
+    record.
 
 ## Commit and pull-request style
 
@@ -32,13 +34,13 @@ Keep the history skimmable and merge commits clean.
 
 **Commits**
 
-* One line only — a subject, with no body or extended description.
-* Start with a [Conventional Commits](https://www.conventionalcommits.org/) prefix:
-  `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `build:`, `ci:`, or
-  `perf:`.
-* Imperative mood, lower-case after the prefix, no trailing period, and ideally
-  under ~72 characters.
-* No AI attribution or co-author trailers.
+- One line only — a subject, with no body or extended description.
+- Start with a [Conventional Commits](https://www.conventionalcommits.org/) prefix:
+    `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `build:`, `ci:`, or
+    `perf:`.
+- Imperative mood, lower-case after the prefix, no trailing period, and ideally
+    under ~72 characters.
+- No AI attribution or co-author trailers.
 
 ```text
 feat: optional hardware TTL trigger output
@@ -48,16 +50,16 @@ fix: clamp incrementing port codes to 255
 
 **Pull requests**
 
-* The title follows the same one-line Conventional-Commits rule — on a squash merge
-  it becomes the commit subject (GitHub appends the `(#NN)` PR number).
-* The body is a brief summary, not an exhaustive change list: what changed, why, and
-  how it was verified. A few sentences or bullets is plenty.
-* No AI attribution footer.
+- The title follows the same one-line Conventional-Commits rule — on a squash merge
+    it becomes the commit subject (GitHub appends the `(#NN)` PR number).
+- The body is a brief summary, not an exhaustive change list: what changed, why, and
+    how it was verified. A few sentences or bullets is plenty.
+- No AI attribution footer.
 
 **Merging**
 
-* Squash-merge, and clear the auto-generated commit body so the merged commit is the
-  one-line title alone — no bundled description or commit list.
+- Squash-merge, and clear the auto-generated commit body so the merged commit is the
+    one-line title alone — no bundled description or commit list.
 
 ## Development
 
@@ -68,6 +70,7 @@ uv run pytest              # run the test suite
 uv run ruff check .        # lint
 uv run ruff format .       # format
 uv run mypy                # type-check
+uv run --extra docs mdformat .   # format Markdown (docs, README, …)
 pre-commit install         # enable the lint/format/type-check git hooks
 ```
 
@@ -178,14 +181,14 @@ on each `v*` release tag.
 
 ## Project notes
 
-* `src/` layout: the package lives in `src/smacc/`.
-* The single source of truth for the version is `__version__` in
-  `src/smacc/__init__.py`; `config.py` and the packaging metadata both read from
-  it.
-* The build/runtime Python is pinned to **3.13** in `.python-version`. The
-  minimum OS is **Windows 10**, set by Qt 6 (PyQt6) — Qt 5 was the last line that
-  still ran on Windows 8.1. Keep the pin unless you intend to move the Python floor.
-* SMACC is distributed only as a frozen `SMACC.exe` (no PyPI), so CI tests what
-  ships rather than a version range: the `test` job in `ci.yaml` runs on the same
-  `windows-2022` + Python 3.13 + locked dependencies as the release build
-  (`release.yaml`), in a single job rather than a multi-version matrix.
+- `src/` layout: the package lives in `src/smacc/`.
+- The single source of truth for the version is `__version__` in
+    `src/smacc/__init__.py`; `config.py` and the packaging metadata both read from
+    it.
+- The build/runtime Python is pinned to **3.13** in `.python-version`. The
+    minimum OS is **Windows 10**, set by Qt 6 (PyQt6) — Qt 5 was the last line that
+    still ran on Windows 8.1. Keep the pin unless you intend to move the Python floor.
+- SMACC is distributed only as a frozen `SMACC.exe` (no PyPI), so CI tests what
+    ships rather than a version range: the `test` job in `ci.yaml` runs on the same
+    `windows-2022` + Python 3.13 + locked dependencies as the release build
+    (`release.yaml`), in a single job rather than a multi-version matrix.

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -15,27 +15,27 @@ sleep and lucid-dreaming experiments.
 
 ### What you need
 
-* **A BlinkStick device.** They are sold directly from
-  [blinkstick.com](https://www.blinkstick.com/). SMACC drives them through the
-  [`blinkstick`](https://pypi.org/project/BlinkStick/) Python library, so any
-  model that library supports (BlinkStick Square, Strip, Nano, Flex, …) will work.
-* **Nothing else to install.** The BlinkStick driver is bundled inside
-  `SMACC.exe`, so you only need to plug the device into a USB port before
-  launching SMACC.
+- **A BlinkStick device.** They are sold directly from
+    [blinkstick.com](https://www.blinkstick.com/). SMACC drives them through the
+    [`blinkstick`](https://pypi.org/project/BlinkStick/) Python library, so any
+    model that library supports (BlinkStick Square, Strip, Nano, Flex, …) will work.
+- **Nothing else to install.** The BlinkStick driver is bundled inside
+    `SMACC.exe`, so you only need to plug the device into a USB port before
+    launching SMACC.
 
 ### Using it in SMACC
 
 1. Plug the BlinkStick into a USB port, then launch SMACC.
-2. Click **Visual cue** in the *Tools* column.
-3. Bind your BlinkStick to the **BlinkStick light** equipment in the **Devices** window
-   (in the *Tools* column). Plug one in after launch and it's detected
-   automatically, or click **Refresh devices (F5)** in the Devices window to rescan.
-4. Configure a light cue — color, brightness, pattern (steady, or a pulse/flash at
-   a rate in Hz), and length (or **Loop** until stopped) — and add more cues with
-   **+ Add cue** if the protocol needs several. See [Visual cues](visual.md) for
-   what each pattern is for.
-5. Click a cue's **Play** to fire it; **Stop** turns the light off early. The rest
-   of SMACC stays responsive while the light is on.
+1. Click **Visual cue** in the *Tools* column.
+1. Bind your BlinkStick to the **BlinkStick light** equipment in the **Devices** window
+    (in the *Tools* column). Plug one in after launch and it's detected
+    automatically, or click **Refresh devices (F5)** in the Devices window to rescan.
+1. Configure a light cue — color, brightness, pattern (steady, or a pulse/flash at
+    a rate in Hz), and length (or **Loop** until stopped) — and add more cues with
+    **+ Add cue** if the protocol needs several. See [Visual cues](visual.md) for
+    what each pattern is for.
+1. Click a cue's **Play** to fire it; **Stop** turns the light off early. The rest
+    of SMACC stays responsive while the light is on.
 
 Your chosen device and the whole cue board are saved in the
 [SMACC file](smacc-files.md), so the visual-cue
@@ -43,6 +43,7 @@ setup travels with the rest of your configuration; the device is reconnected by
 serial on the next launch (and flagged if it isn't plugged in).
 
 !!! note
+
     If the visual cue window reports that no light is set, open the **Devices**
     window and bind one to **BlinkStick light** (plug it in first; click
     **Refresh devices (F5)** there if it isn't listed). No restart needed.
@@ -54,12 +55,12 @@ to the BlinkStick: the visual cue drives an ordinary Hue bulb (or a whole group)
 over the local network. Setup is once per bridge:
 
 1. In the **Devices** window, click **Set up Philips Hue…**.
-2. Click **Find bridge** (or type the bridge's IP — the Hue app shows it under
-   bridge settings).
-3. Press the round **link button** on the bridge itself, then click **Pair**
-   within 30 seconds. **Test** lists the bridge's lights to confirm.
-4. Bind a light or group to the **Philips Hue light** equipment, and route
-   **Play visual cue** to **Philips Hue light**.
+1. Click **Find bridge** (or type the bridge's IP — the Hue app shows it under
+    bridge settings).
+1. Press the round **link button** on the bridge itself, then click **Pair**
+    within 30 seconds. **Test** lists the bridge's lights to confirm.
+1. Bind a light or group to the **Philips Hue light** equipment, and route
+    **Play visual cue** to **Philips Hue light**.
 
 The bridge IP and pairing key are stored in the study's `.smacc` (the key is a
 local-network credential — treat the file accordingly). Hue suits ambient,

--- a/docs/eeg-review.md
+++ b/docs/eeg-review.md
@@ -11,6 +11,7 @@ entry (**SMACC EEG review**), and always runs as its own window and process —
 you can keep reviewing last night's file while tonight's session runs.
 
 !!! note "An optional component"
+
     The viewer ships as the installer's **EEG Review Tools** component, off by
     default (it carries the MNE library, which would triple the install for
     labs that only run sessions). To add it later, re-run the
@@ -21,11 +22,11 @@ you can keep reviewing last night's file while tonight's session runs.
 
 ## Supported recordings
 
-| Format | Open via |
-|---|---|
-| European Data Format | `.edf` |
-| BrainVision | `.vhdr` (of the `.vhdr`/`.eeg`/`.vmrk` triplet) |
-| FIF (MNE / Elekta) | `.fif` |
+| Format               | Open via                                        |
+| -------------------- | ----------------------------------------------- |
+| European Data Format | `.edf`                                          |
+| BrainVision          | `.vhdr` (of the `.vhdr`/`.eeg`/`.vmrk` triplet) |
+| FIF (MNE / Elekta)   | `.fif`                                          |
 
 Recordings are memory-mapped, never loaded whole: an 8-hour high-density
 night opens in seconds and scrolling stays smooth regardless of file size.
@@ -33,29 +34,29 @@ night opens in seconds and scrolling stays smooth regardless of file size.
 ## Viewing
 
 - **Window length** — 10/30/60/120 s pages; **30 s** (one scoring epoch) is
-  the default. PageUp/PageDown page; the mouse wheel and scrollbar scroll;
-  click the traces and the arrow keys nudge, Home/End jump.
+    the default. PageUp/PageDown page; the mouse wheel and scrollbar scroll;
+    click the traces and the arrow keys nudge, Home/End jump.
 - **Filters** — high-pass, low-pass, and a 50/60 Hz notch, applied to the
-  *display only* (zero-phase, so nothing shifts in time). Recordings open
-  **unfiltered** — the usual sleep view is two clicks away (HP 0.3 Hz, LP
-  35 Hz).
+    *display only* (zero-phase, so nothing shifts in time). Recordings open
+    **unfiltered** — the usual sleep view is two clicks away (HP 0.3 Hz, LP
+    35 Hz).
 - **Scale** — microvolts per channel lane; smaller numbers mean bigger
-  traces. Trigger/stim channels are auto-fit to their lane.
+    traces. Trigger/stim channels are auto-fit to their lane.
 - The status bar shows the cursor's time from recording start **and the
-  wall-clock time**, so events line up with the night's session log.
+    wall-clock time**, so events line up with the night's session log.
 
 ## Annotating
 
 1. **Drag** across the traces to mark a span (drag never pans — the time
-   axis only moves when you ask it to).
-2. Name it in the label dialog — recent labels and common marks (LRLR,
-   arousal, artifact, cue response) are one click; free text always works.
-   Tick **instantaneous** to keep just the moment instead of the dragged span.
-3. **Click** an annotation to select it; use the side list to rename,
-   delete, or jump to one (double-click).
-4. **Save annotations** writes the sidecar next to the recording:
-   `night1.edf` → `night1.annotations.tsv` (+ a small `.json` describing it).
-   Unsaved changes star the title and prompt before closing.
+    axis only moves when you ask it to).
+1. Name it in the label dialog — recent labels and common marks (LRLR,
+    arousal, artifact, cue response) are one click; free text always works.
+    Tick **instantaneous** to keep just the moment instead of the dragged span.
+1. **Click** an annotation to select it; use the side list to rename,
+    delete, or jump to one (double-click).
+1. **Save annotations** writes the sidecar next to the recording:
+    `night1.edf` → `night1.annotations.tsv` (+ a small `.json` describing it).
+    Unsaved changes star the title and prompt before closing.
 
 Events already stored **inside** the recording — amp markers, SMACC's own
 trigger codes — are imported automatically the *first* time a file is

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,12 +5,12 @@ executable file for running sleep and dream manipulation studies — experiments
 which you control dream content during sleep and collect dream reports. It provides
 a simple, clickable interface and is commonly used in dream engineering research.
 
-* Trigger audio cues
-* Trigger visual cues (BlinkStick or Philips Hue)
-* Collect dream reports
-* Trigger EEG port codes
-* Save a detailed event log
-* and more!
+- Trigger audio cues
+- Trigger visual cues (BlinkStick or Philips Hue)
+- Collect dream reports
+- Trigger EEG port codes
+- Save a detailed event log
+- and more!
 
 <!-- Add a screenshot of the main window here once available, e.g.:
 ![SMACC main window](assets/screenshot-main.png) -->
@@ -25,31 +25,31 @@ download, or for downloading older versions.
 
 ## Get started
 
-* [Installation](installation.md) — download and run SMACC.
-* [Usage](usage.md) — trigger cues, record dream reports, send port codes, and more.
-* [SMACC files](smacc-files.md) — create and reuse a study's configuration (`.smacc`).
-* [Audio & routing](audio.md) — bind the rig's equipment to devices, route cues/noise/intercom, and set volume.
-* [Visual cues](visual.md) — light cues on a BlinkStick or Philips Hue: patterns, timing, and safety.
-* [Devices](devices.md) — connect compatible hardware such as a BlinkStick or a Hue bridge.
-* [Contributing](contributing.md) — develop SMACC and build these docs locally.
+- [Installation](installation.md) — download and run SMACC.
+- [Usage](usage.md) — trigger cues, record dream reports, send port codes, and more.
+- [SMACC files](smacc-files.md) — create and reuse a study's configuration (`.smacc`).
+- [Audio & routing](audio.md) — bind the rig's equipment to devices, route cues/noise/intercom, and set volume.
+- [Visual cues](visual.md) — light cues on a BlinkStick or Philips Hue: patterns, timing, and safety.
+- [Devices](devices.md) — connect compatible hardware such as a BlinkStick or a Hue bridge.
+- [Contributing](contributing.md) — develop SMACC and build these docs locally.
 
 ## Used by
 
 SMACC is used in dream engineering research, including by:
 
-* [Ken Paller's Cognitive Neuroscience Lab](https://sites.northwestern.edu/pallerlab/)
-  at Northwestern University
-    * Torres-Platas et al. (2026). Intentional lucid dreaming with a transformative learning agenda. *Research Square* doi:[10.21203/rs.3.rs-8745420/v1](https://doi.org/10.21203/rs.3.rs-8745420/v1)
-    * Konkoly et al. (2026). Using real-time reporting to investigate visual experiences in dreams. *J Cogn Neurosci* doi:[10.1162/jocn.a.107](https://doi.org/10.1162/JOCN.a.107)
-    * Morris et al. (2026). Inducing lucid dreaming based on a contemplative practice of compassion. *Brain Sci* doi:[10.3390/brainsci16030315](https://doi.org/10.3390/brainsci16030315)
-    * Konkoly et al. (2026). Creative problem-solving after experimentally provoking dreams of unsolved puzzles during REM sleep. *Neurosci Conscious* doi:[10.1093/nc/niaf067](https://doi.org/10.1093/nc/niaf067)
-    * Konkoly et al. (2025). Investigating dreams by strategically presenting sounds during REM sleep to reactivate waking experiences. *Neuropsychologia* doi:[10.1016/j.neuropsychologia.2025.109229](https://doi.org/10.1016/j.neuropsychologia.2025.109229)
-    * Morris et al. (2025). Lucid dreaming of a prior virtual-reality experience with ego-transcendent qualities: A proof-of-concept study. *Neurosci Conscious* doi:[10.1093/nc/niaf017](https://doi.org/10.1093/nc/niaf017)
-    * Mundt et al. (2024). Treating narcolepsy-related nightmares with cognitive behavioural therapy and targeted lucidity reactivation: A pilot study. *J Sleep Res* doi:[10.1111/jsr.14384](https://doi.org/10.1111/jsr.14384)
-    * Wolk et al. (2024). Lucid dreams from reactivating mindfulness during REM sleep: A pilot study. *Int J Dream Res* doi:[10.11588/ijodr.2024.2.98233](https://doi.org/10.11588/ijodr.2024.2.98233)
-* [Michelle Carr's Dream Engineering Lab](https://www.dreamengineeringlab.com/)
-  at the University of Montreal and the Center for Advanced Research in Sleep Medicine
-    * Jafarzadeh Esfahani et al. (2024). Highly effective verified lucid dream induction using combined cognitive-sensory training and wearable EEG: A multi-centre study. *bioRxiv* doi:[10.1101/2024.06.21.600133](https://doi.org/10.1101/2024.06.21.600133)
+- [Ken Paller's Cognitive Neuroscience Lab](https://sites.northwestern.edu/pallerlab/)
+    at Northwestern University
+    - Torres-Platas et al. (2026). Intentional lucid dreaming with a transformative learning agenda. *Research Square* doi:[10.21203/rs.3.rs-8745420/v1](https://doi.org/10.21203/rs.3.rs-8745420/v1)
+    - Konkoly et al. (2026). Using real-time reporting to investigate visual experiences in dreams. *J Cogn Neurosci* doi:[10.1162/jocn.a.107](https://doi.org/10.1162/JOCN.a.107)
+    - Morris et al. (2026). Inducing lucid dreaming based on a contemplative practice of compassion. *Brain Sci* doi:[10.3390/brainsci16030315](https://doi.org/10.3390/brainsci16030315)
+    - Konkoly et al. (2026). Creative problem-solving after experimentally provoking dreams of unsolved puzzles during REM sleep. *Neurosci Conscious* doi:[10.1093/nc/niaf067](https://doi.org/10.1093/nc/niaf067)
+    - Konkoly et al. (2025). Investigating dreams by strategically presenting sounds during REM sleep to reactivate waking experiences. *Neuropsychologia* doi:[10.1016/j.neuropsychologia.2025.109229](https://doi.org/10.1016/j.neuropsychologia.2025.109229)
+    - Morris et al. (2025). Lucid dreaming of a prior virtual-reality experience with ego-transcendent qualities: A proof-of-concept study. *Neurosci Conscious* doi:[10.1093/nc/niaf017](https://doi.org/10.1093/nc/niaf017)
+    - Mundt et al. (2024). Treating narcolepsy-related nightmares with cognitive behavioural therapy and targeted lucidity reactivation: A pilot study. *J Sleep Res* doi:[10.1111/jsr.14384](https://doi.org/10.1111/jsr.14384)
+    - Wolk et al. (2024). Lucid dreams from reactivating mindfulness during REM sleep: A pilot study. *Int J Dream Res* doi:[10.11588/ijodr.2024.2.98233](https://doi.org/10.11588/ijodr.2024.2.98233)
+- [Michelle Carr's Dream Engineering Lab](https://www.dreamengineeringlab.com/)
+    at the University of Montreal and the Center for Advanced Research in Sleep Medicine
+    - Jafarzadeh Esfahani et al. (2024). Highly effective verified lucid dream induction using combined cognitive-sensory training and wearable EEG: A multi-centre study. *bioRxiv* doi:[10.1101/2024.06.21.600133](https://doi.org/10.1101/2024.06.21.600133)
 
 SMACC is free software released under the
 [GPL-3.0-or-later](https://github.com/remrama/smacc/blob/main/LICENSE.txt) license.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,14 +8,14 @@ double-click `SMACC-Setup.exe` and click through. The installer:
 - installs SMACC **per-user** — no administrator rights or IT involvement needed;
 - adds a **Start menu** entry (and, if you opt in, a desktop shortcut);
 - associates **`.smacc` files**, so double-clicking a SMACC file opens a session
-  with it;
+    with it;
 - optionally installs the **EEG Review Tools** — the post-hoc
-  [EEG viewer/annotator](eeg-review.md). Off by default (it carries the
-  heavyweight MNE library); choose **Full installation** to include it, or
-  re-run the installer later to add it;
+    [EEG viewer/annotator](eeg-review.md). Off by default (it carries the
+    heavyweight MNE library); choose **Full installation** to include it, or
+    re-run the installer later to add it;
 - registers an uninstaller — remove SMACC from **Settings › Apps** like any other
-  program. Uninstalling never touches your data: SMACC files, recordings, and
-  logs under `~/SMACC` (or your data directories) all stay put.
+    program. Uninstalling never touches your data: SMACC files, recordings, and
+    logs under `~/SMACC` (or your data directories) all stay put.
 
 Installing a newer version over an existing one upgrades it in place, keeping
 whichever components you had chosen.
@@ -27,15 +27,18 @@ on this documentation site switches the *docs* only — older copies of SMACC
 itself come from the releases page.)
 
 !!! note "System requirements"
+
     SMACC runs on 64-bit Windows 10 or later.
 
 !!! warning "Windows SmartScreen — “Windows protected your PC”"
+
     SMACC isn't code-signed yet, so when you run the installer Windows SmartScreen
     may show a blue **“Windows protected your PC”** box. This is expected for any
     new, unsigned program. To proceed anyway, click **More info**, then
     **Run anyway**.
 
 !!! note "Administrator privileges and the UAC prompt"
+
     For some features you will need to open SMACC with Administrator privileges
     (right-click the Start menu entry and select **Run as administrator**). Windows
     then shows a **User Account Control (UAC)** prompt asking whether to allow the
@@ -55,6 +58,7 @@ installer's conveniences (Start menu entry, uninstaller); it offers to associate
 EEG* button lights up (it also runs standalone).
 
 !!! note "For IT departments"
+
     The default install is per-user (under `%LOCALAPPDATA%\Programs\SMACC`, no
     elevation). On managed machines where per-user installs are blocked — e.g.
     AppLocker policies on `%LOCALAPPDATA%` — run the same installer machine-wide
@@ -62,7 +66,7 @@ EEG* button lights up (it also runs standalone).
 
 ## Updating SMACC
 
-From the Launcher, **File &rsaquo; Check for updates…** asks GitHub whether a
+From the Launcher, **File › Check for updates…** asks GitHub whether a
 newer release exists and, if one does, offers to open the download page in your
 browser — run the new installer and it upgrades the existing install in place.
 SMACC never checks on its own: lab machines are often offline, and studies
@@ -86,7 +90,7 @@ own SMACC files anywhere. See [SMACC files](smacc-files.md).
 
 Each run gets its own timestamped folder under the SMACC file's data directory
 (e.g. `smacc-20260607-223015/`) holding that run's `.log`, dream-report recordings,
-and any exports. Subject/session are optional metadata (set from **File &rsaquo;
+and any exports. Subject/session are optional metadata (set from **File ›
 Session info…**) recorded inside the log/exports rather than in filenames. Display
 choices that apply to a session — **always-on-top** and which **log-preview** levels
 show — are stored in the SMACC file too, so they travel with the study. The machine
@@ -99,7 +103,7 @@ Your reusable setup is saved to a portable SMACC file (see
 [SMACC files](smacc-files.md)). The installer associates `.smacc` files so you can
 **double-click one to open SMACC and run a session with it**. The portable
 `SMACC.exe` offers the same association the first time it runs; you can also
-(re)enable it any time from **File &rsaquo; Associate .smacc files (Windows)** in
+(re)enable it any time from **File › Associate .smacc files (Windows)** in
 the Launcher.
 
 ### Audio cues
@@ -118,7 +122,7 @@ run folder) or a survey URL hosted on e.g. Qualtrics or REDCap (opened in the
 browser). Manage them from the Dream-recording panel's **Manage…** button; saved
 URLs persist in your SMACC file. Pick one from the survey dropdown to open it
 automatically when recording starts, or open any survey on its own from
-**File &rsaquo; Surveys**. See [Surveys](surveys.md).
+**File › Surveys**. See [Surveys](surveys.md).
 
 ### Recording device
 

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -6,6 +6,7 @@ marker line up with it? This page answers that, shows how to measure it on your 
 rig, and explains what SMACC does to keep markers honest.
 
 !!! note "The short version"
+
     For the dream-engineering work SMACC is built for — cueing for lucidity or memory
     reactivation — **absolute latency is rarely critical**. A cue landing 20 ms early
     or late doesn't change whether it reaches REM. What matters is that the **marker
@@ -17,21 +18,21 @@ rig, and explains what SMACC does to keep markers honest.
 
 From the click to the sound, in order:
 
-| Stage | Typical | Notes |
-|---|---|---|
-| Click → handler | < 1 ms | Qt event dispatch. |
-| Decode + resample | a few ms | The cue is decoded when loaded; only the resample runs at play time. |
-| Open the output stream | tens of ms | A fresh WASAPI stream is opened per cue (see [#105](https://github.com/remrama/smacc/issues/105)). Affects *click→sound*, not the marker. |
-| **Output buffer** | **~3–25 ms** | The stream's buffer: sound reaches the DAC about one buffer after it starts. **This is the marker↔sound gap.** |
-| DAC → speaker → air | ~1–5 ms | Hardware + ~3 ms per metre of air. |
+| Stage                  | Typical      | Notes                                                                                                                                     |
+| ---------------------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Click → handler        | < 1 ms       | Qt event dispatch.                                                                                                                        |
+| Decode + resample      | a few ms     | The cue is decoded when loaded; only the resample runs at play time.                                                                      |
+| Open the output stream | tens of ms   | A fresh WASAPI stream is opened per cue (see [#105](https://github.com/remrama/smacc/issues/105)). Affects *click→sound*, not the marker. |
+| **Output buffer**      | **~3–25 ms** | The stream's buffer: sound reaches the DAC about one buffer after it starts. **This is the marker↔sound gap.**                            |
+| DAC → speaker → air    | ~1–5 ms      | Hardware + ~3 ms per metre of air.                                                                                                        |
 
 The two that matter are separate axes with separate fixes:
 
 - **Marker → sound** (the science): the **output buffer**. SMACC corrects for this
-  (below), and it's what a per-rig measurement pins down.
+    (below), and it's what a per-rig measurement pins down.
 - **Click → sound** (operator feel): dominated by the per-play **stream open**. Not a
-  marker-alignment problem; tracked separately in
-  [#105](https://github.com/remrama/smacc/issues/105).
+    marker-alignment problem; tracked separately in
+    [#105](https://github.com/remrama/smacc/issues/105).
 
 ## The marker marks the software event, not the photons
 
@@ -40,15 +41,16 @@ the sound leaves the speaker (by one output buffer) or, for a light, around when
 device write completes. To keep the marker aligned with the stimulus:
 
 - **Audio cue / noise.** SMACC stamps the marker (its LSL timestamp **and** the
-  canonical log line) at the *estimated onset* — the moment it fires **plus the
-  stream's reported output latency** — so the marker tracks the sound rather than
-  SMACC's buffer, and stays put when you change the latency setting. The raw
-  software-trigger instant is kept on a `DEBUG` line in the log for audit.
+    canonical log line) at the *estimated onset* — the moment it fires **plus the
+    stream's reported output latency** — so the marker tracks the sound rather than
+    SMACC's buffer, and stays put when you change the latency setting. The raw
+    software-trigger instant is kept on a `DEBUG` line in the log for audit.
 - **Visual cue.** The first frame is written to the device **synchronously**, and the
-  marker fires right after, so it trails the photons by microseconds (BlinkStick)
-  rather than leading them.
+    marker fires right after, so it trails the photons by microseconds (BlinkStick)
+    rather than leading them.
 
 !!! warning "This is an estimate, not a measurement"
+
     The correction uses the latency PortAudio *reports*. The residual — fade-in ramp,
     DAC, speaker, the Hue bridge — is small and roughly constant, but only a recording
     of the actual onset pins it down. If you need sample-accurate alignment, measure
@@ -76,11 +78,11 @@ Negotiated [high]:  22.0 ms   (SMACC stamps the marker this far ahead of the str
 Two things to take from this:
 
 1. The **negotiated** latency (~22 ms) is what you actually get — *not* the smaller
-   "reported" figure. SMACC corrects the cue marker by this negotiated value.
-2. On **shared-mode WASAPI**, the engine rounds up to its own period, so **Low and
-   High come out the same** here. The Low setting only helps on devices/drivers whose
-   buffer it can actually shrink; true low latency needs WASAPI *exclusive* mode,
-   which SMACC doesn't use today. **Don't assume Low helps — measure it.**
+    "reported" figure. SMACC corrects the cue marker by this negotiated value.
+1. On **shared-mode WASAPI**, the engine rounds up to its own period, so **Low and
+    High come out the same** here. The Low setting only helps on devices/drivers whose
+    buffer it can actually shrink; true low latency needs WASAPI *exclusive* mode,
+    which SMACC doesn't use today. **Don't assume Low helps — measure it.**
 
 ## The Low / High setting
 
@@ -88,10 +90,10 @@ The Volume window has an **Output latency** choice, saved in the `.smacc`
 ([`output_latency`](reference/settings-file.md)):
 
 - **High** (default) — PortAudio's robust buffer. Fewer underruns; the safe choice
-  for an overnight looping cue, where a glitch in a sleeper's ear is worse than 20 ms.
+    for an overnight looping cue, where a glitch in a sleeper's ear is worse than 20 ms.
 - **Low** — asks for a smaller buffer. Trims the marker↔sound gap *where the device
-  allows it* (often no change on shared-mode WASAPI). It applies to the next cue or
-  noise played, not the one currently sounding.
+    allows it* (often no change on shared-mode WASAPI). It applies to the next cue or
+    noise played, not the one currently sounding.
 
 Because the marker is corrected by the *negotiated* latency, switching High/Low never
 silently shifts your markers — the correction tracks the setting.
@@ -101,11 +103,11 @@ silently shifts your markers — the correction tracks the setting.
 Light latency depends entirely on the backend:
 
 - **BlinkStick** — a USB-HID write, a few milliseconds. Fast enough that the marker
-  effectively coincides with the light.
+    effectively coincides with the light.
 - **Philips Hue** — each command is an HTTP call to the bridge (~100 ms) plus the
-  bridge→bulb hop, and the bridge rate-limits, so Hue is unsuitable for tight timing
-  or flashing (SMACC refuses `flash` on Hue for this reason). Fine for slow ambient
-  cues; don't time-lock analyses to a Hue marker without measuring it.
+    bridge→bulb hop, and the bridge rate-limits, so Hue is unsuitable for tight timing
+    or flashing (SMACC refuses `flash` on Hue for this reason). Fine for slow ambient
+    cues; don't time-lock analyses to a Hue marker without measuring it.
 
 ## Measure it on your own rig
 
@@ -113,7 +115,7 @@ The numbers above are specific to one machine — **don't quote them for a diffe
 rig**. To characterise yours:
 
 - **Round-trip, on the bench.** Couple the output back to an input (a loopback cable,
-  or a microphone at the speaker) and run:
+    or a microphone at the speaker) and run:
 
     ```sh
     uv run tools/measure_latency.py --loopback --repeats 30
@@ -123,13 +125,14 @@ rig**. To characterise yours:
     **jitter** (the spread), not just the mean.
 
 - **Against the EEG, per session (authoritative).** Record the real stimulus onset on
-  a spare amplifier channel — a microphone for the cue, a photodiode for the light —
-  alongside the LSL port code. The difference between the port code and the recorded
-  onset, across the night, is the true distribution, and it can be visualised in the
-  Analyze tool. This needs a spare channel and is tracked in
-  [#104](https://github.com/remrama/smacc/issues/104).
+    a spare amplifier channel — a microphone for the cue, a photodiode for the light —
+    alongside the LSL port code. The difference between the port code and the recorded
+    onset, across the night, is the true distribution, and it can be visualised in the
+    Analyze tool. This needs a spare channel and is tracked in
+    [#104](https://github.com/remrama/smacc/issues/104).
 
 !!! note "Why the log can't give you this"
+
     You might hope to read latency straight from the log, since it records both the
     raw trigger time (`DEBUG`) and the corrected onset (`INFO`). But their difference
     is just the latency SMACC *added* — a constant, not a measurement. A real

--- a/docs/reference/annotations-file.md
+++ b/docs/reference/annotations-file.md
@@ -25,11 +25,11 @@ onset	duration	description
 80.500	22.000	Arousal
 ```
 
-| Column | Meaning |
-|---|---|
-| `onset` | Seconds from the start of the recording's **data** (not clock time), millisecond precision |
-| `duration` | Seconds; `0.000` marks an instantaneous event |
-| `description` | The label as entered by the reviewer |
+| Column        | Meaning                                                                                    |
+| ------------- | ------------------------------------------------------------------------------------------ |
+| `onset`       | Seconds from the start of the recording's **data** (not clock time), millisecond precision |
+| `duration`    | Seconds; `0.000` marks an instantaneous event                                              |
+| `description` | The label as entered by the reviewer                                                       |
 
 Overlapping annotations are allowed (an arousal inside a REM period is two
 rows). A label containing a double quote is csv-quoted (`"saw a ""light"""`);

--- a/docs/reference/bids-export.md
+++ b/docs/reference/bids-export.md
@@ -15,12 +15,12 @@ onset	duration	trial_type	value
 283.9	n/a	Dream report started	201
 ```
 
-| Column | Type | Meaning |
-|---|---|---|
-| `onset` | seconds | Time from the **first** parseable log line (the onset origin). |
-| `duration` | seconds or `n/a` | `n/a` for instantaneous markers (all SMACC markers are instantaneous). |
-| `trial_type` | string | The event label, exactly as logged. |
-| `value` | integer | The event's port code (1–255). |
+| Column       | Type             | Meaning                                                                |
+| ------------ | ---------------- | ---------------------------------------------------------------------- |
+| `onset`      | seconds          | Time from the **first** parseable log line (the onset origin).         |
+| `duration`   | seconds or `n/a` | `n/a` for instantaneous markers (all SMACC markers are instantaneous). |
+| `trial_type` | string           | The event label, exactly as logged.                                    |
+| `value`      | integer          | The event's port code (1–255).                                         |
 
 ## JSON sidecar
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,32 +4,32 @@ SMACC reads and writes a handful of files. This section is the **reference** for
 each one — its on-disk shape, every field, and how it is versioned — as distinct
 from the task-oriented [Usage](../usage.md) guide.
 
-| File | What it is | Format | Version |
-|---|---|---|---|
-| [SMACC file (`.smacc`)](settings-file.md) | A portable study configuration | YAML | `schema_version: 1` |
-| [`preferences.yaml`](preferences-file.md) | Per-machine operator preferences | YAML | `schema_version: 1` |
-| [Session `.log`](session-log.md) | The per-run record (events + settings) | Text | — |
-| [BIDS export](bids-export.md) | `events.tsv` + JSON sidecar | TSV / JSON | follows BIDS |
-| [Survey definition](../surveys.md) | An in-app survey (built-in or custom) | YAML | `schema_version: 1` |
-| [Survey response](../surveys.md#response-files) | One administration's answers | JSON | — |
-| [Annotations sidecar](annotations-file.md) | EEG review marks (`*.annotations.tsv`) | TSV / JSON | follows BIDS columns |
+| File                                            | What it is                             | Format     | Version              |
+| ----------------------------------------------- | -------------------------------------- | ---------- | -------------------- |
+| [SMACC file (`.smacc`)](settings-file.md)       | A portable study configuration         | YAML       | `schema_version: 1`  |
+| [`preferences.yaml`](preferences-file.md)       | Per-machine operator preferences       | YAML       | `schema_version: 1`  |
+| [Session `.log`](session-log.md)                | The per-run record (events + settings) | Text       | —                    |
+| [BIDS export](bids-export.md)                   | `events.tsv` + JSON sidecar            | TSV / JSON | follows BIDS         |
+| [Survey definition](../surveys.md)              | An in-app survey (built-in or custom)  | YAML       | `schema_version: 1`  |
+| [Survey response](../surveys.md#response-files) | One administration's answers           | JSON       | —                    |
+| [Annotations sidecar](annotations-file.md)      | EEG review marks (`*.annotations.tsv`) | TSV / JSON | follows BIDS columns |
 
 ## Where each file lives
 
 - The **SMACC directory** (`$SMACC_DIRECTORY`, else `~/SMACC`) holds `preferences.yaml`,
-  the seeded `default.smacc`, and the default data directory.
+    the seeded `default.smacc`, and the default data directory.
 - A **`.smacc`** can live anywhere; it names the **data directory** its runs are
-  written to.
+    written to.
 - Each **run** gets its own timestamped folder (`smacc-YYYYmmdd-HHMMSS/`) under that
-  data directory, holding the session `.log`, any dream-report audio, survey
-  responses, and exports.
+    data directory, holding the session `.log`, any dream-report audio, survey
+    responses, and exports.
 - **Custom survey definitions** live in the SMACC directory's `surveys/` folder;
-  built-in ones ship inside SMACC itself.
+    built-in ones ship inside SMACC itself.
 - **Bundled assets refresh on upgrade.** `default.smacc` (a read-only template) and
-  the `demo-` cues are re-seeded from the bundle when they change, so a newer
-  SMACC's improvements reach an existing directory; your own files are untouched.
-  Biocal voice recordings are read straight from the bundle, with the SMACC
-  directory's `biocals/` folder as an optional per-recording override.
+    the `demo-` cues are re-seeded from the bundle when they change, so a newer
+    SMACC's improvements reach an existing directory; your own files are untouched.
+    Biocal voice recordings are read straight from the bundle, with the SMACC
+    directory's `biocals/` folder as an optional per-recording override.
 
 ## Stability promise
 

--- a/docs/reference/preferences-file.md
+++ b/docs/reference/preferences-file.md
@@ -28,29 +28,30 @@ preferences:
 
 ## Fields
 
-| Key | Type | Meaning |
-|---|---|---|
-| `kind` | string | Always `smacc/preferences`; a file with a different `kind` is ignored (defaults are used). |
-| `schema_version` | integer | The preferences schema version (currently **1**). |
-| `preferences` | mapping | The preferences themselves (below). |
+| Key              | Type    | Meaning                                                                                    |
+| ---------------- | ------- | ------------------------------------------------------------------------------------------ |
+| `kind`           | string  | Always `smacc/preferences`; a file with a different `kind` is ignored (defaults are used). |
+| `schema_version` | integer | The preferences schema version (currently **1**).                                          |
+| `preferences`    | mapping | The preferences themselves (below).                                                        |
 
 ### `preferences`
 
-| Key | Type | Meaning |
-|---|---|---|
-| `windows` | mapping | Per-window geometry, keyed by a stable window id → `{x, y, w, h}`. Ids include `launcher`, `main` (the Session window), the analyze window, and each tool window. An absent/`null` `x`/`y` means "no saved position — open at a default". |
-| `association_prompted` | boolean | Whether the first-run "associate `.smacc` files (Windows)?" prompt has already been shown. |
-| `recent_settings` | list of paths | Recently opened `.smacc` files, most-recent first, de-duplicated and capped at 8. |
-| `last_settings` | path or `null` | The last `.smacc` opened, so the Launcher can preselect it. |
-| `log_preview_max_lines` | integer | How many lines the Session window's live log preview keeps (default **1000**); the oldest lines are dropped first. The log *file* always records everything, so nothing is lost. Very large values cost GUI memory and repaint time over an overnight session. |
+| Key                     | Type           | Meaning                                                                                                                                                                                                                                                        |
+| ----------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `windows`               | mapping        | Per-window geometry, keyed by a stable window id → `{x, y, w, h}`. Ids include `launcher`, `main` (the Session window), the analyze window, and each tool window. An absent/`null` `x`/`y` means "no saved position — open at a default".                      |
+| `association_prompted`  | boolean        | Whether the first-run "associate `.smacc` files (Windows)?" prompt has already been shown.                                                                                                                                                                     |
+| `recent_settings`       | list of paths  | Recently opened `.smacc` files, most-recent first, de-duplicated and capped at 8.                                                                                                                                                                              |
+| `last_settings`         | path or `null` | The last `.smacc` opened, so the Launcher can preselect it.                                                                                                                                                                                                    |
+| `log_preview_max_lines` | integer        | How many lines the Session window's live log preview keeps (default **1000**); the oldest lines are dropped first. The log *file* always records everything, so nothing is lost. Very large values cost GUI memory and repaint time over an overnight session. |
 
 !!! note "Partial files are fine"
+
     Loading merges a file's keys over the defaults, so a file missing some keys still
     yields every key. There is no cross-version migration; only `schema_version: 1`
     is current.
 
 ## Version history
 
-| Version | Changes |
-|---|---|
-| 1 | First stable schema: `windows`, `association_prompted`, `recent_settings`, `last_settings`. |
+| Version | Changes                                                                                     |
+| ------- | ------------------------------------------------------------------------------------------- |
+| 1       | First stable schema: `windows`, `association_prompted`, `recent_settings`, `last_settings`. |

--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -16,8 +16,8 @@ YYYY-MM-DD HH:MM:SS.mmm, LEVEL, message
 
 - **timestamp** — local wall-clock, millisecond precision.
 - **LEVEL** — a Python logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or
-  `CRITICAL`. The file records every level; the live on-screen preview shows only a
-  configurable subset.
+    `CRITICAL`. The file records every level; the live on-screen preview shows only a
+    configurable subset.
 - **message** — the log text. An **event-marker** line ends in `" - portcode N"`:
 
 ```text
@@ -38,13 +38,13 @@ The file records **every** level — a level never decides whether something is
 written, only whether it shows in the live preview (whose default gate starts at
 `INFO`). SMACC assigns levels by one convention:
 
-| Level | What it carries |
-|---|---|
-| `DEBUG` | Housekeeping and high-frequency detail: settings loads/saves, device rescans, live volume edits, raw trigger instants, chat text. In the file for the record; out of the preview by default. |
-| `INFO` | **Event markers** and meaningful operator actions — the session's scientific narrative. |
-| `WARNING` | Mid-session configuration changes (a port code or trigger transport edited during a run — loud so the code map stays traceable) and recoverable faults (a saved device not connected). |
-| `ERROR` | Faults that cost something: a hardware trigger write failing, a stream that couldn't open. |
-| `CRITICAL` | Uncaught exceptions — the app is in an unknown state. |
+| Level      | What it carries                                                                                                                                                                              |
+| ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `DEBUG`    | Housekeeping and high-frequency detail: settings loads/saves, device rescans, live volume edits, raw trigger instants, chat text. In the file for the record; out of the preview by default. |
+| `INFO`     | **Event markers** and meaningful operator actions — the session's scientific narrative.                                                                                                      |
+| `WARNING`  | Mid-session configuration changes (a port code or trigger transport edited during a run — loud so the code map stays traceable) and recoverable faults (a saved device not connected).       |
+| `ERROR`    | Faults that cost something: a hardware trigger write failing, a stream that couldn't open.                                                                                                   |
+| `CRITICAL` | Uncaught exceptions — the app is in an unknown state.                                                                                                                                        |
 
 ### Stimulus marker timing
 
@@ -103,5 +103,6 @@ quit). The `final` block may be absent if a session crashed before quitting. Ana
 can recover a `.smacc` from either block.
 
 !!! note "No separate version"
+
     The log itself isn't versioned; its embedded blocks carry the
     [settings `schema_version`](settings-file.md#version-history).

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -87,13 +87,13 @@ settings:
 
 ## Envelope
 
-| Key | Type | Meaning |
-|---|---|---|
-| `kind` | string | Always `smacc/settings`; a file with a different `kind` is rejected. |
-| `schema_version` | integer | The settings schema version — currently **1**. Only the current version loads; any other is rejected (see [Version history](#version-history)). |
-| `smacc_version` | string | The SMACC version that wrote the file (informational). |
-| `metadata` | mapping | Optional run metadata: `subject`, `session`, `notes`, and `created` (ISO timestamp). Blank by default; recorded in the log, not baked into filenames. |
-| `settings` | mapping | The configuration itself (below). |
+| Key              | Type    | Meaning                                                                                                                                               |
+| ---------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kind`           | string  | Always `smacc/settings`; a file with a different `kind` is rejected.                                                                                  |
+| `schema_version` | integer | The settings schema version — currently **1**. Only the current version loads; any other is rejected (see [Version history](#version-history)).       |
+| `smacc_version`  | string  | The SMACC version that wrote the file (informational).                                                                                                |
+| `metadata`       | mapping | Optional run metadata: `subject`, `session`, `notes`, and `created` (ISO timestamp). Blank by default; recorded in the log, not baked into filenames. |
+| `settings`       | mapping | The configuration itself (below).                                                                                                                     |
 
 ## `settings`
 
@@ -102,26 +102,26 @@ Any key may be omitted — each falls back to its default.
 
 ### Audio, noise, visual, survey, chat, volume
 
-| Key | Type | Meaning |
-|---|---|---|
-| `cues` | list | One entry per cue slot: `name` (string), `file` (WAV path), `volume` (0–1), `loop` (bool). |
-| `cue_attack` | seconds | Fade-in applied to a starting cue. |
-| `cue_release` | seconds | Fade-out applied to a stopping cue. |
-| `noise_volume` | 0–1 | Background-noise level. |
-| `noise_color` | string | Selected noise colour (as offered in the Noise panel, e.g. `white`). |
-| `noise_source` | `builtin` \| `file` | Generated noise, or a WAV file. |
-| `noise_file` | path | The noise WAV when `noise_source: file`. |
-| `visual_cues` | list | One entry per light slot: `name` (string), `color` (`#rrggbb`), `brightness` (0–1), `pattern` (`steady` \| `pulse` \| `flash`), `rate` (Hz, the pulse/flash speed), `length` (seconds; ignored while `loop`), `loop` (bool). |
-| `visual_attack` | seconds | Brightness fade-in applied to a starting visual cue. |
-| `visual_release` | seconds | Brightness fade-out applied to a stopping visual cue. |
-| `survey_url` | string | The selected survey: a web URL, or `smacc://survey/<key>` for an in-app survey. |
-| `survey_options` | mapping | Named *web* survey presets: label → URL. In-app surveys (built-in or custom) are not persisted here — they come from survey definition files (see [Surveys](../surveys.md)). |
-| `chat_font_size` | integer | Participant chat window text size, in points (8–72). |
-| `chat_red_text` | boolean | Red-shifted night text in the participant chat window. |
-| `chat_experimenter_presets` | list | Intercom quick-reply prompts the experimenter sends with one click (verbatim, like a typed message). Omitted → seeded defaults; an empty list is respected. |
-| `chat_participant_presets` | list | Participant quick replies, shown as numbered chips and sent with the number keys 1–9 (max 9). Omitted → seeded defaults; an empty list is respected. |
-| `volume_cap` | 0–1 | Master output safety cap multiplied into every stimulus (`1.0` = no cap). |
-| `output_latency` | `high` \| `low` | Output buffer for the cue + noise streams: `high` is robust (default), `low` trims marker-to-sound delay where the device allows it (often unchanged on shared-mode WASAPI). See [Latency](../latency.md). |
+| Key                         | Type                | Meaning                                                                                                                                                                                                                      |
+| --------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cues`                      | list                | One entry per cue slot: `name` (string), `file` (WAV path), `volume` (0–1), `loop` (bool).                                                                                                                                   |
+| `cue_attack`                | seconds             | Fade-in applied to a starting cue.                                                                                                                                                                                           |
+| `cue_release`               | seconds             | Fade-out applied to a stopping cue.                                                                                                                                                                                          |
+| `noise_volume`              | 0–1                 | Background-noise level.                                                                                                                                                                                                      |
+| `noise_color`               | string              | Selected noise colour (as offered in the Noise panel, e.g. `white`).                                                                                                                                                         |
+| `noise_source`              | `builtin` \| `file` | Generated noise, or a WAV file.                                                                                                                                                                                              |
+| `noise_file`                | path                | The noise WAV when `noise_source: file`.                                                                                                                                                                                     |
+| `visual_cues`               | list                | One entry per light slot: `name` (string), `color` (`#rrggbb`), `brightness` (0–1), `pattern` (`steady` \| `pulse` \| `flash`), `rate` (Hz, the pulse/flash speed), `length` (seconds; ignored while `loop`), `loop` (bool). |
+| `visual_attack`             | seconds             | Brightness fade-in applied to a starting visual cue.                                                                                                                                                                         |
+| `visual_release`            | seconds             | Brightness fade-out applied to a stopping visual cue.                                                                                                                                                                        |
+| `survey_url`                | string              | The selected survey: a web URL, or `smacc://survey/<key>` for an in-app survey.                                                                                                                                              |
+| `survey_options`            | mapping             | Named *web* survey presets: label → URL. In-app surveys (built-in or custom) are not persisted here — they come from survey definition files (see [Surveys](../surveys.md)).                                                 |
+| `chat_font_size`            | integer             | Participant chat window text size, in points (8–72).                                                                                                                                                                         |
+| `chat_red_text`             | boolean             | Red-shifted night text in the participant chat window.                                                                                                                                                                       |
+| `chat_experimenter_presets` | list                | Intercom quick-reply prompts the experimenter sends with one click (verbatim, like a typed message). Omitted → seeded defaults; an empty list is respected.                                                                  |
+| `chat_participant_presets`  | list                | Participant quick replies, shown as numbered chips and sent with the number keys 1–9 (max 9). Omitted → seeded defaults; an empty list is respected.                                                                         |
+| `volume_cap`                | 0–1                 | Master output safety cap multiplied into every stimulus (`1.0` = no cap).                                                                                                                                                    |
+| `output_latency`            | `high` \| `low`     | Output buffer for the cue + noise streams: `high` is robust (default), `low` trims marker-to-sound delay where the device allows it (often unchanged on shared-mode WASAPI). See [Latency](../latency.md).                   |
 
 ### `biocals`
 
@@ -131,21 +131,21 @@ stack row, in display order. Rows may repeat a biocal (e.g. eyes-closed twice in
 the played sequence). A missing block — or a block without `rows` — loads the
 default stack; an empty `rows` list is respected as a deliberately cleared one.
 
-| Field | Type | Meaning |
-|---|---|---|
-| `biocal` | string | Stable biocal id (e.g. `eyes_open`); unknown ids are dropped. |
-| `sequence` | boolean | Include this row when the sequence is played. |
-| `voice` | boolean | Speak the pre-recorded instruction when the biocal starts. |
+| Field      | Type    | Meaning                                                                                   |
+| ---------- | ------- | ----------------------------------------------------------------------------------------- |
+| `biocal`   | string  | Stable biocal id (e.g. `eyes_open`); unknown ids are dropped.                             |
+| `sequence` | boolean | Include this row when the sequence is played.                                             |
+| `voice`    | boolean | Speak the pre-recorded instruction when the biocal starts.                                |
 | `duration` | integer | Task-window length in seconds (1–600); the countdown and the completion marker run on it. |
 
 ### Window-level
 
-| Key | Type | Meaning |
-|---|---|---|
-| `data_directory` | path | Where this study's runs are written (relative to the `.smacc`, or absolute). |
-| `preview_levels` | list | Log levels shown in the live preview, e.g. `[INFO, WARNING, ERROR, CRITICAL]`. |
-| `always_on_top` | boolean | Whether the main session window floats on top. |
-| `tool_always_on_top` | mapping | Per-tool always-on-top, keyed by panel key. |
+| Key                  | Type    | Meaning                                                                        |
+| -------------------- | ------- | ------------------------------------------------------------------------------ |
+| `data_directory`     | path    | Where this study's runs are written (relative to the `.smacc`, or absolute).   |
+| `preview_levels`     | list    | Log levels shown in the live preview, e.g. `[INFO, WARNING, ERROR, CRITICAL]`. |
+| `always_on_top`      | boolean | Whether the main session window floats on top.                                 |
+| `tool_always_on_top` | mapping | Per-tool always-on-top, keyed by panel key.                                    |
 
 ### `event_codes`
 
@@ -153,14 +153,14 @@ The editable event-marker registry: a list of overrides applied over the
 [built-in registry](../triggers.md#default-event-codes). A study that omits it uses
 the built-ins; one that overrides a few codes keeps the rest.
 
-| Field | Type | Meaning |
-|---|---|---|
-| `key` | string | Stable event id (e.g. `REMDetected`). |
-| `code` | integer | Port code, 1–255. |
-| `lsl` | boolean | Whether a firing pushes the code over the LSL marker stream. |
-| `ttl` | boolean | Whether a firing pushes the code over the hardware TTL trigger (when one is configured). |
-| `preview` | boolean | Whether it shows in the live preview (the file always records it). |
-| `increment` | boolean | Whether successive firings advance the code (e.g. dream reports). |
+| Field       | Type    | Meaning                                                                                  |
+| ----------- | ------- | ---------------------------------------------------------------------------------------- |
+| `key`       | string  | Stable event id (e.g. `REMDetected`).                                                    |
+| `code`      | integer | Port code, 1–255.                                                                        |
+| `lsl`       | boolean | Whether a firing pushes the code over the LSL marker stream.                             |
+| `ttl`       | boolean | Whether a firing pushes the code over the hardware TTL trigger (when one is configured). |
+| `preview`   | boolean | Whether it shows in the live preview (the file always records it).                       |
+| `increment` | boolean | Whether successive firings advance the code (e.g. dream reports).                        |
 
 A built-in entry persists only those fields. A **custom** event also carries
 `label`, `category`, `tooltip`, and `builtin: false` so it can be reconstructed on
@@ -172,10 +172,10 @@ for TTL-routed codes (LSL carries any code).
 Equipment → device bindings plus action → equipment routing (see [Audio & routing](../audio.md)
 and [Devices](../devices.md)).
 
-| Key | Type | Meaning |
-|---|---|---|
+| Key        | Type    | Meaning                                                                                                                                                                                                                                                                   |
+| ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `bindings` | mapping | Equipment key → device key. Equipment: `bedroom_speaker`, `control_speaker`, `bedroom_mic_1`, `bedroom_mic_2`, `control_mic` (the experimenter's intercom mic), `blinkstick_light` (a stick's serial), `philips_hue_light` (a bridge target like `light:3` or `group:1`). |
-| `routing` | mapping | Action key → equipment key (`""` = off). Actions: `play_audio_cue`, `listen_audio_cue`, `play_noise`, `play_visual_cue`, `speak_to_participant`, `listen_to_participant`, `record_dream_report`, `monitor_bedroom_noise`. |
+| `routing`  | mapping | Action key → equipment key (`""` = off). Actions: `play_audio_cue`, `listen_audio_cue`, `play_noise`, `play_visual_cue`, `speak_to_participant`, `listen_to_participant`, `record_dream_report`, `monitor_bedroom_noise`.                                                 |
 
 A missing `devices` block loads the defaults (each action on its default equipment, with
 no devices bound). When a live session starts (or loads a study) with
@@ -189,15 +189,15 @@ no "system default" pseudo-selection (see
 Optional hardware TTL trigger output, mirrored alongside the always-on LSL stream
 (see [Triggers & port codes](../triggers.md)).
 
-| Field | Type | Meaning |
-|---|---|---|
-| `enabled` | boolean | Whether the hardware path is on (LSL is always on regardless). |
-| `transport` | `serial` \| `parallel` | USB trigger box, or parallel (LPT) port. |
-| `port` | string | Serial COM port, e.g. `COM3`. |
-| `baud` | integer | Serial baud rate (default 115200). |
-| `address` | string | Parallel-port base address as hex, e.g. `0x378`. |
-| `mode` | `pulsed` \| `hold` | Pulse the code then drop, or set-and-hold until the next event. |
-| `pulse_ms` | integer | Pulse width in ms when `mode: pulsed` (default 10). |
+| Field       | Type                   | Meaning                                                         |
+| ----------- | ---------------------- | --------------------------------------------------------------- |
+| `enabled`   | boolean                | Whether the hardware path is on (LSL is always on regardless).  |
+| `transport` | `serial` \| `parallel` | USB trigger box, or parallel (LPT) port.                        |
+| `port`      | string                 | Serial COM port, e.g. `COM3`.                                   |
+| `baud`      | integer                | Serial baud rate (default 115200).                              |
+| `address`   | string                 | Parallel-port base address as hex, e.g. `0x378`.                |
+| `mode`      | `pulsed` \| `hold`     | Pulse the code then drop, or set-and-hold until the next event. |
+| `pulse_ms`  | integer                | Pulse width in ms when `mode: pulsed` (default 10).             |
 
 ### `hue`
 
@@ -206,10 +206,10 @@ paired once in the Devices window. Like the device bindings, this is rig state
 that travels with the study — note that `app_key` is the bridge credential minted
 by pairing, stored in plain text.
 
-| Field | Type | Meaning |
-|---|---|---|
-| `bridge_ip` | string | The bridge's IP on the rig's network. |
-| `app_key` | string | The app key minted by press-button pairing (blank = not set up). |
+| Field       | Type   | Meaning                                                          |
+| ----------- | ------ | ---------------------------------------------------------------- |
+| `bridge_ip` | string | The bridge's IP on the rig's network.                            |
+| `app_key`   | string | The app key minted by press-button pairing (blank = not set up). |
 
 ## Paths and portability
 
@@ -219,6 +219,6 @@ folder stays valid when moved, copied, or zipped.
 
 ## Version history
 
-| Version | Changes |
-|---|---|
-| 1 | The v0.0.9 baseline (numbering restarted; pre-release schemas were retired without migration). Envelope (`kind` / `schema_version` / `smacc_version` / `metadata` / `settings`); panel state; the `biocals`, `devices`, `event_codes` + `event_code_safe_max`, `trigger_output`, `data_directory`, `preview_levels`, `always_on_top`, and `tool_always_on_top` blocks. |
+| Version | Changes                                                                                                                                                                                                                                                                                                                                                                |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1       | The v0.0.9 baseline (numbering restarted; pre-release schemas were retired without migration). Envelope (`kind` / `schema_version` / `smacc_version` / `metadata` / `settings`); panel state; the `biocals`, `devices`, `event_codes` + `event_code_safe_max`, `trigger_output`, `data_directory`, `preview_levels`, `always_on_top`, and `tool_always_on_top` blocks. |

--- a/docs/smacc-files.md
+++ b/docs/smacc-files.md
@@ -27,15 +27,15 @@ format, see the [SMACC file reference](reference/settings-file.md).
 There are two ways to make one:
 
 - **From scratch, in the Editor.** In the [Launcher](usage.md#opening-smacc),
-  click **Create** to open the **Editor** on a fresh configuration (or select an
-  existing SMACC file and click **Edit**). Configure each tool on the left, set
-  the data directory, and **Save as…** to a new `.smacc` anywhere you like. The
-  Editor never records a run — it only authors configuration.
-- **From a live session.** In a running **Session**, use **File &rsaquo; Save
-  SMACC file as…** to snapshot the session's *current* settings — including any
-  mid-session tweaks (volumes, device routing, event-code edits) — to a new
-  SMACC file. Handy when you've tuned things live and want tonight's setup to be
-  tomorrow's starting point.
+    click **Create** to open the **Editor** on a fresh configuration (or select an
+    existing SMACC file and click **Edit**). Configure each tool on the left, set
+    the data directory, and **Save as…** to a new `.smacc` anywhere you like. The
+    Editor never records a run — it only authors configuration.
+- **From a live session.** In a running **Session**, use **File › Save
+    SMACC file as…** to snapshot the session's *current* settings — including any
+    mid-session tweaks (volumes, device routing, event-code edits) — to a new
+    SMACC file. Handy when you've tuned things live and want tonight's setup to be
+    tomorrow's starting point.
 
 SMACC ships a `default.smacc` in your SMACC directory as a working example. It
 is treated as a read-only template — saving over it redirects to Save-As — so
@@ -59,9 +59,9 @@ determines where a night's data ends up.
 Opening a SMACC file starts a new session configured by it:
 
 - **Double-click the file** (Windows build): SMACC launches straight into a
-  Session for it. The first launch offers to set up this file association; you
-  can (re)enable it any time from **File &rsaquo; Associate .smacc files
-  (Windows)** in the Launcher.
+    Session for it. The first launch offers to set up this file association; you
+    can (re)enable it any time from **File › Associate .smacc files
+    (Windows)** in the Launcher.
 - **From the Launcher**: pick the file in the **Settings** dropdown (recent
-  files are listed; **Browse…** finds any other), then click **Start**.
+    files are listed; **Browse…** finds any other), then click **Start**.
 - **From a terminal**: `SMACC path/to/file.smacc`.

--- a/docs/surveys.md
+++ b/docs/surveys.md
@@ -4,11 +4,11 @@ After an awakening, a dream report is often followed by a questionnaire — how
 lucid was the dream, what did it contain, how confident is the participant. SMACC
 handles these two ways:
 
-* **In-app surveys** render in a SMACC window and save their responses straight
-  into the run folder, next to the dream-report WAV they accompany. SMACC ships
-  the standard lucid-dreaming instruments, and you can build your own.
-* **Web surveys** (e.g. a questionnaire hosted on Qualtrics or REDCap) open in
-  the browser, exactly as before — add them by URL.
+- **In-app surveys** render in a SMACC window and save their responses straight
+    into the run folder, next to the dream-report WAV they accompany. SMACC ships
+    the standard lucid-dreaming instruments, and you can build your own.
+- **Web surveys** (e.g. a questionnaire hosted on Qualtrics or REDCap) open in
+    the browser, exactly as before — add them by URL.
 
 In-app surveys exist because the night shift is a bad place for a hosted form:
 sleep labs are often offline, response data belongs with the night's recording
@@ -26,19 +26,19 @@ window):
 
 **Dreaming & lucidity**
 
-| Survey | Full name |
-|---|---|
-| **DLQ** | Dream Lucidity Questionnaire |
-| **LuCiD** | Lucidity and Consciousness in Dreams scale |
-| **LUSK** | Lucid Dreaming Skills Questionnaire |
-| **MUSK** | Morning Lucid Dreaming Skills Questionnaire |
-| **BLA** | Baseline Lucidity Assessment |
-| **MLA** | Morning Lucidity Assessment |
+| Survey    | Full name                                   |
+| --------- | ------------------------------------------- |
+| **DLQ**   | Dream Lucidity Questionnaire                |
+| **LuCiD** | Lucidity and Consciousness in Dreams scale  |
+| **LUSK**  | Lucid Dreaming Skills Questionnaire         |
+| **MUSK**  | Morning Lucid Dreaming Skills Questionnaire |
+| **BLA**   | Baseline Lucidity Assessment                |
+| **MLA**   | Morning Lucidity Assessment                 |
 
 **Dream traits / intake**
 
-| Survey | Full name |
-|---|---|
+| Survey    | Full name                    |
+| --------- | ---------------------------- |
 | **MADRE** | Mannheim Dream Questionnaire |
 
 MADRE is a trait/intake questionnaire (dream-recall habits, attitudes, age,
@@ -49,18 +49,18 @@ items described under [Building your own](#building-your-own).
 
 **Mindfulness**
 
-| Survey | Full name |
-|---|---|
-| **CAMSR** | Cognitive and Affective Mindfulness Scale - Revised |
-| **FFMQ** | Five Facet Mindfulness Questionnaire |
-| **FMI** | Freiburg Mindfulness Inventory |
-| **KIMS** | Kentucky Inventory of Mindfulness Skills |
-| **MAAS** | Mindfulness Attention Awareness Scale |
-| **MACE** | Metacognition, Affect, Cognitive Experiences Questionnaire |
-| **PHLMS** | Philadelphia Mindfulness Scale |
-| **SMAAS** | State Mindfulness Attention Awareness Scale |
-| **SMS** | State Mindfulness Scale |
-| **TMS** | Toronto Mindfulness Scale |
+| Survey    | Full name                                                  |
+| --------- | ---------------------------------------------------------- |
+| **CAMSR** | Cognitive and Affective Mindfulness Scale - Revised        |
+| **FFMQ**  | Five Facet Mindfulness Questionnaire                       |
+| **FMI**   | Freiburg Mindfulness Inventory                             |
+| **KIMS**  | Kentucky Inventory of Mindfulness Skills                   |
+| **MAAS**  | Mindfulness Attention Awareness Scale                      |
+| **MACE**  | Metacognition, Affect, Cognitive Experiences Questionnaire |
+| **PHLMS** | Philadelphia Mindfulness Scale                             |
+| **SMAAS** | State Mindfulness Attention Awareness Scale                |
+| **SMS**   | State Mindfulness Scale                                    |
+| **TMS**   | Toronto Mindfulness Scale                                  |
 
 Built-ins ship with SMACC itself (they are not stored in your `.smacc` study
 file), so updates reach every install. Each survey definition carries a content
@@ -88,10 +88,10 @@ renders but cannot be submitted — there is no run folder to save into.
 
 One JSON file per administration, in the run folder:
 
-* `report-02-survey-dlq.json` — auto-opened with dream report 2 (sorts beside
-  `report-02.wav`).
-* `survey-01-lusk.json` — opened standalone; standalone administrations are
-  numbered in their own sequence.
+- `report-02-survey-dlq.json` — auto-opened with dream report 2 (sorts beside
+    `report-02.wav`).
+- `survey-01-lusk.json` — opened standalone; standalone administrations are
+    numbered in their own sequence.
 
 The payload records the survey's key, title, and content version, the optional
 subject/session metadata, opened/submitted timestamps, the time since the
@@ -157,13 +157,13 @@ A bare-string item is a **Likert** item rated against the survey's shared
 `scale` — the original shape, and all the builder produces. Definition files can
 also mix in other item types by writing an item as a mapping with a `type`:
 
-| `type` | Renders as | Extra fields |
-|---|---|---|
-| `likert` (default) | radio matrix on the shared `scale` | — |
-| `select` | dropdown | `levels` (a `value: label` mapping) |
-| `number` | number entry (blank = unanswered) | `min`, `max`, `unit` (all optional) |
-| `text` | single-line text entry | — |
-| `heading` | a bold section title (collects no response) | — |
+| `type`             | Renders as                                  | Extra fields                        |
+| ------------------ | ------------------------------------------- | ----------------------------------- |
+| `likert` (default) | radio matrix on the shared `scale`          | —                                   |
+| `select`           | dropdown                                    | `levels` (a `value: label` mapping) |
+| `number`           | number entry (blank = unanswered)           | `min`, `max`, `unit` (all optional) |
+| `text`             | single-line text entry                      | —                                   |
+| `heading`          | a bold section title (collects no response) | —                                   |
 
 Any item may carry a `help:` line, shown under it (used for the definitions in
 MADRE). Consecutive Likert items collapse into one shared matrix; other types

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -26,14 +26,14 @@ The words *event*, *marker*, *trigger*, and *port code* get used loosely in the
 field; SMACC uses each one for exactly one thing, in the UI, the docs, and the
 session log:
 
-| Term | Meaning in SMACC |
-|---|---|
-| **Event** | A named thing that can happen during a session — a cue started, REM observed, lights off. Each is an entry in the study's event registry, with a label and a port code. |
-| **Marker** | The durable record produced when an event fires. A marker is always a [log line](reference/session-log.md); if the event is routed to a transport, it also carries the port code there. |
-| **Port code** | The 8-bit number (**1–255**) identifying an event on the amplifier's trigger channel. Also called a *trigger code*. |
-| **Trigger** | The act of *sending* a port code over a transport. An event can be logged without being triggered. |
-| **Transport** | A path that carries the code to the recording: the **LSL** marker stream, or a hardware **TTL** line (serial trigger box / parallel port). |
-| **Log level** | The severity tag on a log line (`DEBUG`…`CRITICAL`). The log *file* records every level; levels only filter the live preview. See [log levels](reference/session-log.md#log-levels). |
+| Term          | Meaning in SMACC                                                                                                                                                                        |
+| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Event**     | A named thing that can happen during a session — a cue started, REM observed, lights off. Each is an entry in the study's event registry, with a label and a port code.                 |
+| **Marker**    | The durable record produced when an event fires. A marker is always a [log line](reference/session-log.md); if the event is routed to a transport, it also carries the port code there. |
+| **Port code** | The 8-bit number (**1–255**) identifying an event on the amplifier's trigger channel. Also called a *trigger code*.                                                                     |
+| **Trigger**   | The act of *sending* a port code over a transport. An event can be logged without being triggered.                                                                                      |
+| **Transport** | A path that carries the code to the recording: the **LSL** marker stream, or a hardware **TTL** line (serial trigger box / parallel port).                                              |
+| **Log level** | The severity tag on a log line (`DEBUG`…`CRITICAL`). The log *file* records every level; levels only filter the live preview. See [log levels](reference/session-log.md#log-levels).    |
 
 ## Default event codes
 
@@ -43,61 +43,63 @@ study can retune any code in the **Markers** window; the change travels in its
 [`.smacc`](reference/settings-file.md) and is written into every session log.
 
 <!-- BEGIN auto:event-codes (kept in lockstep with smacc.events.default_events by tests/test_docs_schema.py) -->
-| Code | Event | Key | Notes |
-|------|-------|-----|-------|
-| 41 | REM detected | `REMDetected` | |
-| 42 | Tech in room | `TechInRoom` | |
-| 43 | Training start | `TrainingStart` | start of a training/learning phase (TMR cue learning, TLR practice) |
-| 44 | Training end | `TrainingEnd` | |
-| 45 | Signal observed | `SignalObserved` | a lucidity/communication signal; the signal type + confidence are logged as the detail |
-| 46 | Sleep onset | `SleepOnset` | |
-| 47 | Lights off | `LightsOff` | |
-| 48 | Lights on | `LightsOn` | |
-| 49 | Clapper | `Clapper` | sync marker |
-| 50 | Note | `Note` | |
-| 51 | Start recording | `RecordingStarted` | sets the reference clock for dream-report timestamps |
-| 52 | Wake detected | `WakeDetected` | sleep-stage observation (keypad 0 in the Event logging window) |
-| 53 | N1 detected | `N1Detected` | sleep-stage observation (keypad 1) |
-| 54 | N2 detected | `N2Detected` | sleep-stage observation (keypad 2) |
-| 55 | N3 detected | `N3Detected` | sleep-stage observation (keypad 3) |
-| 56 | Arousal detected | `ArousalDetected` | a brief transient arousal (distinct from a sustained Wake) |
-| 57 | Artifact detected | `ArtifactDetected` | EEG artifact (movement, electrode noise, etc.) |
-| 60 | Cue started | `CueStarted` | |
-| 61 | Cue stopped | `CueStopped` | |
-| 62 | Noise started | `NoiseStarted` | |
-| 63 | Noise stopped | `NoiseStopped` | |
-| 64 | Intercom started | `IntercomStarted` | |
-| 65 | Intercom stopped | `IntercomStopped` | |
-| 66 | Visual started | `VisualStarted` | |
-| 67 | Survey opened | `SurveyOpened` | |
-| 68 | Visual stopped | `VisualStopped` | the light is actually off (pairs with 66) |
-| 69 | Chat to participant | `ChatMessageSent` | typed intercom message; log-only by default |
-| 70 | Chat from participant | `ChatMessageReceived` | participant's typed reply; log-only by default |
-| 71 | Survey submitted | `SurveySubmitted` | in-app survey responses saved; log-only by default |
-| 100 | SMACC initialized | `TriggerInitialization` | startup connection test; not a stimulus marker |
-| 105 | Biocal sequence started | `BiocalSequenceStarted` | brackets a played biocal sequence |
-| 106 | Biocal sequence stopped | `BiocalSequenceStopped` | completed or aborted |
-| 107 | Biocal cancelled | `BiocalCancelled` | shared; the preceding start code identifies the biocal |
-| 108 | Biocal completed | `BiocalCompleted` | shared; the task window ran out |
-| 110 | Biocal: Eyes Open | `BiocalEyesOpen` | biocal starts mark the task-window opening |
-| 111 | Biocal: Eyes Closed | `BiocalEyesClosed` | |
-| 112 | Biocal: Look L/R | `BiocalLookLR` | |
-| 113 | Biocal: Look U/D | `BiocalLookUD` | |
-| 114 | Biocal: Blink | `BiocalBlink` | |
-| 115 | Biocal: Clench Jaw | `BiocalClenchJaw` | |
-| 116 | Biocal: Flex Feet | `BiocalFlexFeet` | |
-| 117 | Biocal: Hold Breath | `BiocalHoldBreath` | |
-| 118 | Biocal: Breathe | `BiocalBreathe` | |
-| 119 | Biocal: Rest | `BiocalRest` | |
-| 120 | Biocal: LRLR Open | `BiocalLRLROpen` | |
-| 121 | Biocal: LRLR Closed | `BiocalLRLRClosed` | |
-| 122 | Biocal: LRLR Slow | `BiocalLRLRSlow` | |
-| 123 | Biocal: Fist Clench | `BiocalFistClench` | |
-| 124 | Biocal: Fist Closed | `BiocalFistClosed` | |
-| 125 | Biocal: Sniff Open | `BiocalSniffOpen` | |
-| 126 | Biocal: Sniff Closed | `BiocalSniffClosed` | |
-| 200 | Dream report stopped | `DreamReportStopped` | |
-| 201 | Dream report started | `DreamReportStarted` | increments per report (201, 202, …) |
+
+| Code | Event                   | Key                     | Notes                                                                                  |
+| ---- | ----------------------- | ----------------------- | -------------------------------------------------------------------------------------- |
+| 41   | REM detected            | `REMDetected`           |                                                                                        |
+| 42   | Tech in room            | `TechInRoom`            |                                                                                        |
+| 43   | Training start          | `TrainingStart`         | start of a training/learning phase (TMR cue learning, TLR practice)                    |
+| 44   | Training end            | `TrainingEnd`           |                                                                                        |
+| 45   | Signal observed         | `SignalObserved`        | a lucidity/communication signal; the signal type + confidence are logged as the detail |
+| 46   | Sleep onset             | `SleepOnset`            |                                                                                        |
+| 47   | Lights off              | `LightsOff`             |                                                                                        |
+| 48   | Lights on               | `LightsOn`              |                                                                                        |
+| 49   | Clapper                 | `Clapper`               | sync marker                                                                            |
+| 50   | Note                    | `Note`                  |                                                                                        |
+| 51   | Start recording         | `RecordingStarted`      | sets the reference clock for dream-report timestamps                                   |
+| 52   | Wake detected           | `WakeDetected`          | sleep-stage observation (keypad 0 in the Event logging window)                         |
+| 53   | N1 detected             | `N1Detected`            | sleep-stage observation (keypad 1)                                                     |
+| 54   | N2 detected             | `N2Detected`            | sleep-stage observation (keypad 2)                                                     |
+| 55   | N3 detected             | `N3Detected`            | sleep-stage observation (keypad 3)                                                     |
+| 56   | Arousal detected        | `ArousalDetected`       | a brief transient arousal (distinct from a sustained Wake)                             |
+| 57   | Artifact detected       | `ArtifactDetected`      | EEG artifact (movement, electrode noise, etc.)                                         |
+| 60   | Cue started             | `CueStarted`            |                                                                                        |
+| 61   | Cue stopped             | `CueStopped`            |                                                                                        |
+| 62   | Noise started           | `NoiseStarted`          |                                                                                        |
+| 63   | Noise stopped           | `NoiseStopped`          |                                                                                        |
+| 64   | Intercom started        | `IntercomStarted`       |                                                                                        |
+| 65   | Intercom stopped        | `IntercomStopped`       |                                                                                        |
+| 66   | Visual started          | `VisualStarted`         |                                                                                        |
+| 67   | Survey opened           | `SurveyOpened`          |                                                                                        |
+| 68   | Visual stopped          | `VisualStopped`         | the light is actually off (pairs with 66)                                              |
+| 69   | Chat to participant     | `ChatMessageSent`       | typed intercom message; log-only by default                                            |
+| 70   | Chat from participant   | `ChatMessageReceived`   | participant's typed reply; log-only by default                                         |
+| 71   | Survey submitted        | `SurveySubmitted`       | in-app survey responses saved; log-only by default                                     |
+| 100  | SMACC initialized       | `TriggerInitialization` | startup connection test; not a stimulus marker                                         |
+| 105  | Biocal sequence started | `BiocalSequenceStarted` | brackets a played biocal sequence                                                      |
+| 106  | Biocal sequence stopped | `BiocalSequenceStopped` | completed or aborted                                                                   |
+| 107  | Biocal cancelled        | `BiocalCancelled`       | shared; the preceding start code identifies the biocal                                 |
+| 108  | Biocal completed        | `BiocalCompleted`       | shared; the task window ran out                                                        |
+| 110  | Biocal: Eyes Open       | `BiocalEyesOpen`        | biocal starts mark the task-window opening                                             |
+| 111  | Biocal: Eyes Closed     | `BiocalEyesClosed`      |                                                                                        |
+| 112  | Biocal: Look L/R        | `BiocalLookLR`          |                                                                                        |
+| 113  | Biocal: Look U/D        | `BiocalLookUD`          |                                                                                        |
+| 114  | Biocal: Blink           | `BiocalBlink`           |                                                                                        |
+| 115  | Biocal: Clench Jaw      | `BiocalClenchJaw`       |                                                                                        |
+| 116  | Biocal: Flex Feet       | `BiocalFlexFeet`        |                                                                                        |
+| 117  | Biocal: Hold Breath     | `BiocalHoldBreath`      |                                                                                        |
+| 118  | Biocal: Breathe         | `BiocalBreathe`         |                                                                                        |
+| 119  | Biocal: Rest            | `BiocalRest`            |                                                                                        |
+| 120  | Biocal: LRLR Open       | `BiocalLRLROpen`        |                                                                                        |
+| 121  | Biocal: LRLR Closed     | `BiocalLRLRClosed`      |                                                                                        |
+| 122  | Biocal: LRLR Slow       | `BiocalLRLRSlow`        |                                                                                        |
+| 123  | Biocal: Fist Clench     | `BiocalFistClench`      |                                                                                        |
+| 124  | Biocal: Fist Closed     | `BiocalFistClosed`      |                                                                                        |
+| 125  | Biocal: Sniff Open      | `BiocalSniffOpen`       |                                                                                        |
+| 126  | Biocal: Sniff Closed    | `BiocalSniffClosed`     |                                                                                        |
+| 200  | Dream report stopped    | `DreamReportStopped`    |                                                                                        |
+| 201  | Dream report started    | `DreamReportStarted`    | increments per report (201, 202, …)                                                    |
+
 <!-- END auto:event-codes -->
 
 Codes are integers in **1–255** and must be unique among events routed to a
@@ -112,13 +114,14 @@ and each event routes to either path independently: its **LSL** and **TTL** flag
 the registry decide where its code goes (both by default; an event routed to
 neither is log-only).
 
-| Transport | What it is | What you need |
-|---|---|---|
-| **LSL** (always on) | A network marker stream recorded by an LSL-aware recorder (e.g. LabRecorder → XDF). Works on the same computer or across the network. | Nothing extra. |
-| **Serial (USB trigger box)** | The modern replacement for the parallel port. The box appears as a COM port; SMACC writes the code as one byte and the box mirrors it onto 8 TTL lines. | A USB-serial trigger box and its COM port. |
-| **Parallel port (LPT)** | The classic 25-pin port. Eight data pins carry the code byte, sampled by the amplifier. | An LPT port (often an add-in card) and the **InpOut32** driver (see below). |
+| Transport                    | What it is                                                                                                                                              | What you need                                                               |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| **LSL** (always on)          | A network marker stream recorded by an LSL-aware recorder (e.g. LabRecorder → XDF). Works on the same computer or across the network.                   | Nothing extra.                                                              |
+| **Serial (USB trigger box)** | The modern replacement for the parallel port. The box appears as a COM port; SMACC writes the code as one byte and the box mirrors it onto 8 TTL lines. | A USB-serial trigger box and its COM port.                                  |
+| **Parallel port (LPT)**      | The classic 25-pin port. Eight data pins carry the code byte, sampled by the amplifier.                                                                 | An LPT port (often an add-in card) and the **InpOut32** driver (see below). |
 
 !!! note "LSL stays on"
+
     Enabling a hardware transport does **not** turn LSL off — events routed to both
     (the default) reach the LSL stream and the hardware line together. The hardware
     path is purely additional. LSL support ships inside SMACC itself — there is
@@ -126,6 +129,7 @@ neither is log-only).
     LabRecorder, is its own program).
 
 !!! tip "Why route per event?"
+
     Most studies leave every event on both transports. Per-event routing earns its
     keep when the TTL hardware is restricted — an older amplifier that only accepts
     a limited code range can keep its key events on TTL (inside the
@@ -143,14 +147,14 @@ The one rule that matters is that **both ends must use the same baud rate.** You
 is configured (by a switch, firmware, or its manual) to expect a specific rate, and
 SMACC has to match it — a mismatch produces garbled or missed triggers, not an error.
 
-* **Where to find it:** check your trigger box's manual or its configuration utility.
-  Common rates are 9600, 19200, 38400, 57600, **115200**, and 230400.
-* **SMACC's default is 115200**, which many modern USB trigger boxes (e.g. typical
-  BrainProducts/Neurospec-style adapters) use out of the box. If yours specifies a
-  different rate, pick it from the dropdown (or type any other value).
-* **Higher isn't "better."** A faster rate shaves only microseconds off a one-byte
-  write, which is negligible next to audio/event timing — so choose the rate your box
-  expects rather than the largest one.
+- **Where to find it:** check your trigger box's manual or its configuration utility.
+    Common rates are 9600, 19200, 38400, 57600, **115200**, and 230400.
+- **SMACC's default is 115200**, which many modern USB trigger boxes (e.g. typical
+    BrainProducts/Neurospec-style adapters) use out of the box. If yours specifies a
+    different rate, pick it from the dropdown (or type any other value).
+- **Higher isn't "better."** A faster rate shaves only microseconds off a one-byte
+    write, which is negligible next to audio/event timing — so choose the rate your box
+    expects rather than the largest one.
 
 If triggers don't register, a wrong baud rate is one of the first things to check
 (alongside the COM port and the [pulsed vs. set-and-hold](#pulsed-vs-set-and-hold)
@@ -161,14 +165,14 @@ mode).
 Amplifiers and trigger boxes differ in how they expect the code to appear on the
 lines, so SMACC offers two modes:
 
-* **Pulsed** — SMACC raises the code on the lines, waits a configurable **pulse
-  width** (e.g. 10 ms), then drops them back to 0. Each event is a brief, distinct
-  pulse. Choose this when the amplifier expects a momentary trigger, or when you want
-  SMACC to control the pulse length.
-* **Set-and-hold** — SMACC writes the code once and leaves it on the lines until the
-  next event. Choose this for amplifiers that sample a held level, **and** for boxes
-  that generate their own fixed-width pulse when they receive a byte (SMACC just sets
-  the value; the box shapes the pulse).
+- **Pulsed** — SMACC raises the code on the lines, waits a configurable **pulse
+    width** (e.g. 10 ms), then drops them back to 0. Each event is a brief, distinct
+    pulse. Choose this when the amplifier expects a momentary trigger, or when you want
+    SMACC to control the pulse length.
+- **Set-and-hold** — SMACC writes the code once and leaves it on the lines until the
+    next event. Choose this for amplifiers that sample a held level, **and** for boxes
+    that generate their own fixed-width pulse when they receive a byte (SMACC just sets
+    the value; the box shapes the pulse).
 
 If you're not sure which your hardware wants, start with **pulsed at 10 ms** and
 verify with the **Test** button (below); switch to set-and-hold if events don't
@@ -177,20 +181,20 @@ register cleanly.
 ## Configuring trigger output in SMACC
 
 1. Open the **Markers** window from the Tools column (available both in a live
-   Session and in the Editor) and find its **Hardware TTL transport** section.
-2. Tick **Enable hardware trigger output**.
-3. Choose a **Transport**:
-    * **Serial** — pick your box's **Port** from the dropdown (click **Refresh** if
-      you plugged it in after opening the window) and set the **Baud** rate to match
-      your box (see [What is the baud rate?](#what-is-the-baud-rate); SMACC defaults to
-      115200). If the rig isn't attached right now, you can type the port name (e.g.
-      `COM3`) directly.
-    * **Parallel port** — enter the **Address** as hex (see
-      [Finding your parallel-port address](#finding-your-parallel-port-address)).
-4. Choose a **Mode** (pulsed or set-and-hold) and, for pulsed, a **Pulse width**.
-5. Click **Test** to send one pulse and confirm the amplifier sees it. The result
-   appears next to the button; an error explains what went wrong.
-6. Click **Apply**.
+    Session and in the Editor) and find its **Hardware TTL transport** section.
+1. Tick **Enable hardware trigger output**.
+1. Choose a **Transport**:
+    - **Serial** — pick your box's **Port** from the dropdown (click **Refresh** if
+        you plugged it in after opening the window) and set the **Baud** rate to match
+        your box (see [What is the baud rate?](#what-is-the-baud-rate); SMACC defaults to
+        115200). If the rig isn't attached right now, you can type the port name (e.g.
+        `COM3`) directly.
+    - **Parallel port** — enter the **Address** as hex (see
+        [Finding your parallel-port address](#finding-your-parallel-port-address)).
+1. Choose a **Mode** (pulsed or set-and-hold) and, for pulsed, a **Pulse width**.
+1. Click **Test** to send one pulse and confirm the amplifier sees it. The result
+    appears next to the button; an error explains what went wrong.
+1. Click **Apply**.
 
 The whole configuration is saved in your
 [SMACC file](smacc-files.md), so it travels with the rest of your
@@ -199,6 +203,7 @@ reports a clear error if the saved port can't be opened on the machine you load 
 — re-pick it in the Markers window and save again.
 
 !!! warning "Always validate on the real hardware"
+
     A successful **Test** confirms SMACC could open the port and write to it. It does
     **not** prove the amplifier recorded the correct code on its trigger channel.
     Before relying on triggers for a study, record a few test events and confirm they
@@ -209,17 +214,17 @@ reports a clear error if the saved port can't be opened on the machine you load 
 A parallel port is addressed by a base **I/O address**, written in hexadecimal. The
 most common values are:
 
-* `0x378` — the usual address for the first parallel port (LPT1).
-* `0x278` — a common second port (LPT2).
-* `0x3BC` — older onboard ports.
+- `0x378` — the usual address for the first parallel port (LPT1).
+- `0x278` — a common second port (LPT2).
+- `0x3BC` — older onboard ports.
 
 Add-in PCIe/PCI parallel cards are frequently mapped somewhere else entirely, so
 **don't assume** — look it up:
 
 1. Open **Device Manager** (press `Win+X`, then choose Device Manager).
-2. Expand **Ports (COM & LPT)** and double-click your parallel port.
-3. Go to the **Resources** tab and read the first **I/O Range** — the start of that
-   range is your address. Enter it in SMACC with a `0x` prefix (e.g. `0x378`).
+1. Expand **Ports (COM & LPT)** and double-click your parallel port.
+1. Go to the **Resources** tab and read the first **I/O Range** — the start of that
+    range is your address. Enter it in SMACC with a `0x` prefix (e.g. `0x378`).
 
 ## Installing the InpOut32 driver (parallel port only)
 
@@ -229,18 +234,18 @@ download or install it for you (an earlier version did, and it proved fragile an
 required admin rights every launch). Install it once, manually:
 
 1. Download **InpOutBinaries** from [highrez.co.uk](https://www.highrez.co.uk/downloads/inpout32/).
-2. Run the included **`InstallDriver.exe`** once (as administrator) to install the
-   kernel driver.
-3. Make sure **`inpoutx64.dll`** is where SMACC can load it — on the system path, in
-   `C:\Windows\System32`, or beside `SMACC.exe`.
+1. Run the included **`InstallDriver.exe`** once (as administrator) to install the
+    kernel driver.
+1. Make sure **`inpoutx64.dll`** is where SMACC can load it — on the system path, in
+    `C:\Windows\System32`, or beside `SMACC.exe`.
 
 If the driver isn't available, SMACC's parallel transport reports a clear error and
 falls back to LSL only — it never crashes a session over a missing driver.
 
 ## Verifying
 
-* Use the **Test** button in the Markers window's transport section for a quick
-  "can SMACC drive the line?" check.
-* Then confirm end-to-end on the amplifier: record a short block, fire a few events
-  from the **Event logging** window, and check that the codes land on the EEG trigger
-  channel. Only the real recording proves the path works.
+- Use the **Test** button in the Markers window's transport section for a quick
+    "can SMACC drive the line?" check.
+- Then confirm end-to-end on the amplifier: record a short block, fire a few events
+    from the **Event logging** window, and check that the codes land on the EEG trigger
+    channel. Only the real recording proves the path works.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,11 +7,11 @@ through the main features.
 SMACC has three main windows, named consistently throughout these docs:
 
 - the **SMACC Launcher** (*Launcher* for short) — the small hub that opens when
-  you start the app;
+    you start the app;
 - the **SMACC Session** window (*Session*) — the live interface for running a
-  night and collecting data;
+    night and collecting data;
 - the **SMACC Editor** window (*Editor*) — where you create or edit a
-  [SMACC file](smacc-files.md) without recording anything.
+    [SMACC file](smacc-files.md) without recording anything.
 
 <!-- Add an annotated screenshot of the Launcher + Session window here once
 available, e.g.: ![SMACC Session window](assets/screenshot-session.png) -->
@@ -23,23 +23,23 @@ session (the one exception: double-clicking a `.smacc` file, which starts a
 Session for it directly). In the Launcher you:
 
 - **pick a SMACC file** — the dropdown lists the seeded `default.smacc`, your
-  recent files, and **Browse…** to find any other. With none chosen, SMACC uses
-  built-in defaults, so it works out of the box. (See
-  [SMACC files](smacc-files.md) for what one holds.)
+    recent files, and **Browse…** to find any other. With none chosen, SMACC uses
+    built-in defaults, so it works out of the box. (See
+    [SMACC files](smacc-files.md) for what one holds.)
 - **Start** — open a live Session using the selected SMACC file, writing runs to
-  that file's **data directory**. The run folder and log are created only now,
-  when the session starts.
+    that file's **data directory**. The run folder and log are created only now,
+    when the session starts.
 - **Create** — build a new SMACC file in the Editor: configure the tools (cues,
-  noise, visual, event codes, surveys), choose a data directory, and save it
-  anywhere.
+    noise, visual, event codes, surveys), choose a data directory, and save it
+    anywhere.
 - **Edit** — reopen the selected SMACC file in the Editor.
 - **Design cues** — open the standalone **Cue designer** to build a simple tone cue
-  and export it as a WAV into a study's `cues/` folder, ready to use from the Audio
-  cue board (see [Designing a cue](#designing-a-cue)).
+    and export it as a WAV into a study's `cues/` folder, ready to use from the Audio
+    cue board (see [Designing a cue](#designing-a-cue)).
 - **Analyze** — open a past session (a `.log`, a session folder, or a
-  zipped session) to see a summary (events, duration, subject/session, dream
-  reports), export its events to a BIDS `events.tsv`, or recover its settings to a
-  `.smacc` — all without starting a new session.
+    zipped session) to see a summary (events, duration, subject/session, dream
+    reports), export its events to a BIDS `events.tsv`, or recover its settings to a
+    `.smacc` — all without starting a new session.
 
 Closing the Editor or a standalone tool returns you to the Launcher. Ending a
 Session quits SMACC entirely — the night is over. Closing the Launcher also
@@ -77,7 +77,7 @@ ignores the session's device routing and volume safety cap.
 The Audio cue window has a **Monitoring** section — a *Sending* meter (what SMACC is
 emitting) beside a *Bedroom* meter (what a mic actually picks up in the room) — so you
 can confirm a cue is audible to the participant, not just leaving SMACC. See
-[Audio &amp; routing](audio.md#is-the-cue-reaching-the-bedroom) for how to read them
+[Audio & routing](audio.md#is-the-cue-reaching-the-bedroom) for how to read them
 and how to set up a second bedroom mic dedicated to monitoring.
 
 ## Visual cues
@@ -106,7 +106,7 @@ responses into the run folder next to the report; **web surveys** (e.g. a
 questionnaire on Qualtrics or REDCap, added by URL) open in your browser. Manage
 both with the **Manage…** button next to the survey dropdown. Select a survey in
 the dropdown to open it automatically when recording starts, or open any survey
-on its own from **File &rsaquo; Surveys** (each open is logged as a
+on its own from **File › Surveys** (each open is logged as a
 `SurveyOpened` event). See [Surveys](surveys.md) for the bundled instruments,
 the response-file format, and building your own.
 
@@ -121,17 +121,17 @@ variants, fist clenches, sniffs), each on its own row.
 Each row has a toggle button plus two checkboxes and a duration:
 
 - **Press the biocal's button** to run it. The button stays depressed while it
-  runs and the countdown at the top shows the time remaining in its task window;
-  press it again to cancel early (no waiting out a botched 30-second window).
+    runs and the countdown at the top shows the time remaining in its task window;
+    press it again to cancel early (no waiting out a botched 30-second window).
 - **Voice** — speak the pre-recorded instruction (e.g. *"Please close your eyes
-  and relax for thirty seconds."*) over the cue output when the biocal starts.
-  Leave it unchecked if you prefer to give instructions yourself.
+    and relax for thirty seconds."*) over the cue output when the biocal starts.
+    Leave it unchecked if you prefer to give instructions yourself.
 - **Seq** — include this row when **Play sequence** runs the whole stack in
-  order. Standard biocals start checked; the lucid-dreaming ones start unchecked.
+    order. Standard biocals start checked; the lucid-dreaming ones start unchecked.
 - **Duration** — the task window in seconds. With the voice on, the window (and
-  its countdown) starts when the instruction *ends*, so a 10-second breath hold
-  is a full 10 seconds — matching the manual practice of speaking first and
-  marking when the participant complies.
+    its countdown) starts when the instruction *ends*, so a 10-second breath hold
+    is a full 10 seconds — matching the manual practice of speaking first and
+    marking when the participant complies.
 
 **Markers.** Each biocal's *start* code fires when its task window opens; a shared
 **completed** code fires when the window runs out and a shared **cancelled** code
@@ -167,7 +167,7 @@ latch, or hold the **spacebar** anywhere in SMACC as push-to-talk) and is marked
 the EEG record; **Listen** brings the bedroom mic to your control-room speakers,
 unmarked.
 The two directions route through equipment set once in the **Devices** window (see
-[Audio &amp; routing](audio.md)). A **level meter** beside each button shows the
+[Audio & routing](audio.md)). A **level meter** beside each button shows the
 live input level while that direction is on — signal on the bar means audio is
 actually flowing (your mic for Talk, the participant's mic for Listen), not just
 a latched button.
@@ -233,15 +233,15 @@ For each event you can set:
 - **Code** — the 8-bit port code (1–255) sent when the event triggers.
 - **LSL** — whether a firing sends the code over the LSL marker stream.
 - **TTL** — whether a firing sends the code over the hardware TTL trigger. The
-  column is grayed out until a transport is enabled in the window's **Hardware
-  TTL transport** section (the ticks are kept and re-arm with it). An event with
-  neither LSL nor TTL ticked is log-only.
+    column is grayed out until a transport is enabled in the window's **Hardware
+    TTL transport** section (the ticks are kept and re-arm with it). An event with
+    neither LSL nor TTL ticked is log-only.
 - **Preview** — whether the event shows in the live log preview. The session log
-  *file* always records every event regardless; this only controls the on-screen
-  preview.
+    *file* always records every event regardless; this only controls the on-screen
+    preview.
 - **Increment** — give an event a unique, increasing code on each firing (e.g. **dream
-  reports**: 201, 202, 203, …) so individual occurrences are findable in the trigger
-  channel. Off uses one fixed code each time.
+    reports**: 201, 202, 203, …) so individual occurrences are findable in the trigger
+    channel. Off uses one fixed code each time.
 
 **TTL safe max code** raises a soft warning for TTL-routed codes above it — handy
 when your trigger hardware only accepts a limited range (some older systems do; LSL
@@ -312,7 +312,7 @@ A **SMACC file** captures your study's whole configuration — cue files, volume
 noise, visual cues, survey presets, event codes, display choices, and the **data
 directory** where runs are written — in a single portable `.smacc`. Create one in
 the Editor (the Launcher's **Create**/**Edit** buttons) or snapshot a running
-Session with **File &rsaquo; Save SMACC file as…**. Opening one starts a new
+Session with **File › Save SMACC file as…**. Opening one starts a new
 session with that configuration. See [SMACC files](smacc-files.md) for the full
 story (creating, the data directory, opening by double-click), and the
 [SMACC file reference](reference/settings-file.md) for the exact on-disk format.
@@ -324,9 +324,9 @@ file: **always-on-top** (toggled per window — the Session window's **File**
 menu, or each tool window's **View** menu, or **Ctrl+T** in whichever window is
 active) and which **log levels** show in the preview (the checkboxes above the
 log preview). Save them with the rest of the configuration from the Editor or
-with **File &rsaquo; Save SMACC file as…** in a Session.
+with **File › Save SMACC file as…** in a Session.
 
-Tool windows close with **Ctrl+W** (or **File &rsaquo; Close window**) — that
+Tool windows close with **Ctrl+W** (or **File › Close window**) — that
 only hides the window, with its state intact; the session keeps running and the
 Session window's Tools column reopens it.
 

--- a/docs/visual.md
+++ b/docs/visual.md
@@ -43,14 +43,14 @@ proof, that's what the bedroom camera (or your own eyes) is for.
 
 ## Patterns
 
-* **Steady** — constant light for the length. With a long fade-in this is also the
-  ambient/dawn workhorse (see [Recipes](#recipes)).
-* **Pulse** — a smooth brightness wave at the chosen rate (it starts dark and peaks
-  mid-cycle, so onset is gentle). The usual choice for a salient-but-sleep-friendly
-  cue.
-* **Flash** — full on/off at the chosen rate (half on, half off). Maximal salience;
-  the classic photic stimulus. BlinkStick only — see
-  [the comparison](#blinkstick-or-philips-hue) and [Safety](#safety).
+- **Steady** — constant light for the length. With a long fade-in this is also the
+    ambient/dawn workhorse (see [Recipes](#recipes)).
+- **Pulse** — a smooth brightness wave at the chosen rate (it starts dark and peaks
+    mid-cycle, so onset is gentle). The usual choice for a salient-but-sleep-friendly
+    cue.
+- **Flash** — full on/off at the chosen rate (half on, half off). Maximal salience;
+    the classic photic stimulus. BlinkStick only — see
+    [the comparison](#blinkstick-or-philips-hue) and [Safety](#safety).
 
 The rate is set in **Hz**, the unit your methods section wants. The fades stay
 separate from the pattern on purpose: the pattern *is* the stimulus, while the
@@ -64,15 +64,15 @@ Every play and stop is marked in the log and on the trigger channel with the
 [`VisualStarted` (66) and `VisualStopped` (68)](triggers.md#default-event-codes)
 events, each carrying the cue's name. Two details matter for analysis:
 
-* **`VisualStarted` fires after the first frame is committed to the device.** On a
-  BlinkStick the USB write takes ~1–2 ms, so the marker trails the photons by
-  about that much. On Hue, "committed" means the bridge accepted the command — the
-  bulb itself transitions over the following ~100–200 ms, so the marker *leads*
-  the photons by that lag (and it varies). Time-locked analyses should use the
-  BlinkStick.
-* **`VisualStopped` fires once the light is actually dark** — after the fade-out
-  completes, not when Stop is pressed. The pair brackets the physical stimulus,
-  not the button presses.
+- **`VisualStarted` fires after the first frame is committed to the device.** On a
+    BlinkStick the USB write takes ~1–2 ms, so the marker trails the photons by
+    about that much. On Hue, "committed" means the bridge accepted the command — the
+    bulb itself transitions over the following ~100–200 ms, so the marker *leads*
+    the photons by that lag (and it varies). Time-locked analyses should use the
+    BlinkStick.
+- **`VisualStopped` fires once the light is actually dark** — after the fade-out
+    completes, not when Stop is pressed. The pair brackets the physical stimulus,
+    not the button presses.
 
 Every stop path turns the light off — Stop, the length running out, switching to
 another cue, a device failure, or quitting SMACC — so a cue can't be left burning
@@ -80,16 +80,16 @@ over a sleeping participant.
 
 ## BlinkStick or Philips Hue?
 
-| | **BlinkStick** | **Philips Hue** |
-|---|---|---|
-| What it is | A USB stick/strip of RGB LEDs | Ordinary smart bulbs + a bridge |
-| Connection | One USB cable, no network | Bridge on the rig's LAN; bulbs via Zigbee |
-| Buying | [blinkstick.com](https://www.blinkstick.com/) only | Retail everywhere, but pricier |
-| Setup | Plug in, bind, done | Pair once with the bridge's link button ([Devices › Philips Hue](devices.md#philips-hue)) |
-| Cue onset | ~1–2 ms after the marker | ~100–200 ms of lag and jitter |
-| Patterns | Steady, pulse, and flash (up to 20 Hz) | Steady and slow pulse; **flash is refused** (the bridge rate-limits commands far below a square wave) |
-| Coverage | A point source near the bed | Whole-room illumination, or a group of rooms |
-| Fails when | The USB cable/port acts up | The bridge IP changes or the network drops |
+|            | **BlinkStick**                                     | **Philips Hue**                                                                                       |
+| ---------- | -------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| What it is | A USB stick/strip of RGB LEDs                      | Ordinary smart bulbs + a bridge                                                                       |
+| Connection | One USB cable, no network                          | Bridge on the rig's LAN; bulbs via Zigbee                                                             |
+| Buying     | [blinkstick.com](https://www.blinkstick.com/) only | Retail everywhere, but pricier                                                                        |
+| Setup      | Plug in, bind, done                                | Pair once with the bridge's link button ([Devices › Philips Hue](devices.md#philips-hue))             |
+| Cue onset  | ~1–2 ms after the marker                           | ~100–200 ms of lag and jitter                                                                         |
+| Patterns   | Steady, pulse, and flash (up to 20 Hz)             | Steady and slow pulse; **flash is refused** (the bridge rate-limits commands far below a square wave) |
+| Coverage   | A point source near the bed                        | Whole-room illumination, or a group of rooms                                                          |
+| Fails when | The USB cable/port acts up                         | The bridge IP changes or the network drops                                                            |
 
 Rules of thumb: for **time-locked cueing** (EEG-aligned onsets, flicker at a
 defined Hz) use the **BlinkStick**. For **ambient light** — dawn simulation,
@@ -97,6 +97,7 @@ whole-room color, slow breathing pulses — **Hue** is the better lamp. A rig ca
 bind both and switch by re-routing *Play visual cue* in the Devices window.
 
 !!! note "Hue on a university network"
+
     The bridge and the control PC must reach each other on the same network, and
     institutional Wi-Fi often blocks exactly that (client isolation, registration
     portals). The dependable setup is a small dedicated router (or an Ethernet
@@ -107,6 +108,7 @@ bind both and switch by re-routing *Play visual cue* in the Devices window.
 ## Safety
 
 !!! warning "Photosensitive epilepsy"
+
     Flicker between roughly 3 and 30 Hz can trigger seizures in photosensitive
     individuals, with peak sensitivity around 15–25 Hz. SMACC shows a warning on
     the board whenever any pulse/flash rate is set above **10 Hz** and caps the
@@ -125,34 +127,34 @@ point.
 
 ## Recipes
 
-* **A TLR-style lucidity cue** — red, brightness ~0.2, **pulse** at 1 Hz, length
-  10 s, fade in/out ~1 s. Salient enough to penetrate REM, gentle enough to keep
-  it.
-* **Dawn simulation** — warm white, **steady**, length 300 s, fade in 60 s, on a
-  Hue group: the room brightens like a sunrise for a gentler scheduled awakening.
-* **Cue vs. sham** — two identical rows, the sham at brightness 0. The sham fires
-  real `VisualStarted`/`VisualStopped` markers with zero light, so the trigger
-  channel shows both conditions while only one stimulates.
+- **A TLR-style lucidity cue** — red, brightness ~0.2, **pulse** at 1 Hz, length
+    10 s, fade in/out ~1 s. Salient enough to penetrate REM, gentle enough to keep
+    it.
+- **Dawn simulation** — warm white, **steady**, length 300 s, fade in 60 s, on a
+    Hue group: the room brightens like a sunrise for a gentler scheduled awakening.
+- **Cue vs. sham** — two identical rows, the sham at brightness 0. The sham fires
+    real `VisualStarted`/`VisualStopped` markers with zero light, so the trigger
+    channel shows both conditions while only one stimulates.
 
 ## Known limitations
 
-* A BlinkStick's LEDs all show **one color at a time** — per-LED patterns are a
-  documented non-goal
-  ([#11](https://github.com/remrama/smacc/issues/11), closed as documented).
-* **One light at a time**: cues are one-at-a-time on one routed device; SMACC does
-  not fire a BlinkStick and a Hue simultaneously.
-* **No flash on Hue**, and Hue onsets lag their markers — see
-  [the comparison](#blinkstick-or-philips-hue).
+- A BlinkStick's LEDs all show **one color at a time** — per-LED patterns are a
+    documented non-goal
+    ([#11](https://github.com/remrama/smacc/issues/11), closed as documented).
+- **One light at a time**: cues are one-at-a-time on one routed device; SMACC does
+    not fire a BlinkStick and a Hue simultaneously.
+- **No flash on Hue**, and Hue onsets lag their markers — see
+    [the comparison](#blinkstick-or-philips-hue).
 
 ## Troubleshooting
 
-* **The BlinkStick isn't listed** — replug it and press `F5` (or click **Refresh
-  devices** in the Devices window). The driver ships inside SMACC; nothing to install.
-* **"No light is set."** — bind the device in the **Devices** window *and* check
-  that *Play visual cue* is routed to that light.
-* **The Hue bridge stopped responding** — its IP probably changed; re-enter it in
-  **Set up Philips Hue…** (and give the bridge a DHCP reservation so it stays
-  put). If pairing fails from lab Wi-Fi, see the network note above.
-* **A light stayed on** — SMACC turns lights off on every stop and on quit, so a
-  stuck light means the app was killed mid-cue or the device dropped: replug the
-  stick, or power-cycle the bulb (or toggle it in the Hue app).
+- **The BlinkStick isn't listed** — replug it and press `F5` (or click **Refresh
+    devices** in the Devices window). The driver ships inside SMACC; nothing to install.
+- **"No light is set."** — bind the device in the **Devices** window *and* check
+    that *Play visual cue* is routed to that light.
+- **The Hue bridge stopped responding** — its IP probably changed; re-enter it in
+    **Set up Philips Hue…** (and give the bridge a DHCP reservation so it stays
+    put). If pairing fails from lab Wi-Fi, see the network note above.
+- **A light stayed on** — SMACC turns lights off on every stop and on quit, so a
+    stuck light means the app was killed mid-cue or the device dropped: replug the
+    stick, or power-cycle the bulb (or toggle it in the Hue app).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,14 @@ dependencies = [
 docs = [
     "mkdocs-material",
     "mike",
+    # Markdown formatter (the docs counterpart to ruff). The mkdocs plugin is
+    # required so mkdocs-material syntax — admonitions, content tabs, four-space
+    # list nesting — is understood rather than mangled; gfm covers tables/
+    # autolinks and frontmatter leaves the docs' YAML front matter untouched.
+    "mdformat",
+    "mdformat-gfm",
+    "mdformat-mkdocs",
+    "mdformat-frontmatter",
 ]
 # The optional EEG review tool (#136). MNE is far too heavy for the base install,
 # so the viewer ships as a separate frozen exe / installer component; this extra

--- a/uv.lock
+++ b/uv.lock
@@ -631,6 +631,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -727,6 +739,83 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/67/b2/ef8d6bb59b0edb6c16c968b70f548aa13b54348972def5aa6ac85df67145/matplotlib-3.10.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4e42042d54db34fda4e95a7bd3e5789c2a995d2dad3eb8850232ee534092fbbf", size = 9680884, upload-time = "2026-04-24T00:13:48.066Z" },
     { url = "https://files.pythonhosted.org/packages/61/1c/d21bfeb9931881ebe96bcfcff27c7ae4b160ae0ec291a714c42641a56d75/matplotlib-3.10.9-cp314-cp314t-win_amd64.whl", hash = "sha256:c27df8b3848f32a83d1767566595e43cfaa4460380974da06f4279a7ec143c39", size = 8432333, upload-time = "2026-04-24T00:13:51.008Z" },
     { url = "https://files.pythonhosted.org/packages/78/23/92493c3e6e1b635ccfff146f7b99e674808787915420373ac399283764c2/matplotlib-3.10.9-cp314-cp314t-win_arm64.whl", hash = "sha256:a49f1eadc84ca85fd72fa4e89e70e61bf86452df6f971af04b12c60761a0772c", size = 8324785, upload-time = "2026-04-24T00:13:53.633Z" },
+]
+
+[[package]]
+name = "mdformat"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/05/32b5e14b192b0a8a309f32232c580aefedd9d06017cb8fe8fce34bec654c/mdformat-1.0.0.tar.gz", hash = "sha256:4954045fcae797c29f86d4ad879e43bb151fa55dbaf74ac6eaeacf1d45bb3928", size = 56953, upload-time = "2025-10-16T12:05:03.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/9a/8fe71b95985ca7a4001effbcc58e5a07a1f2a2884203f74dcf48a3b08315/mdformat-1.0.0-py3-none-any.whl", hash = "sha256:bca015d65a1d063a02e885a91daee303057bc7829c2cd37b2075a50dbb65944b", size = 53288, upload-time = "2025-10-16T12:05:02.607Z" },
+]
+
+[[package]]
+name = "mdformat-frontmatter"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+    { name = "ruamel-yaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/90/ae8a3d20066295367d9048ad480bcde3afe694eb592fec9c35bbdb7d68eb/mdformat_frontmatter-2.1.2.tar.gz", hash = "sha256:9c9c3159c38407f47e567202749c74ce7680017516cd158c82400f015c6a01d1", size = 9425, upload-time = "2026-05-23T05:14:26.324Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/a0/20b6f53593139d8b64fa8e7f750033fbb580c096c241cd551b59907e6abe/mdformat_frontmatter-2.1.2-py3-none-any.whl", hash = "sha256:bcbb1dd7e35ce4387603acd32f2c092dd4518bbfaa2a4b801a0f29a4e69bf2ca", size = 4927, upload-time = "2026-05-23T05:14:24.747Z" },
+]
+
+[[package]]
+name = "mdformat-gfm"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "mdformat" },
+    { name = "mdit-py-plugins" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/6f/a626ebb142a290474401b67e2d61e73ce096bf7798ee22dfe6270f924b3f/mdformat_gfm-1.0.0.tar.gz", hash = "sha256:d1d49a409a6acb774ce7635c72d69178df7dce1dc8cdd10e19f78e8e57b72623", size = 10112, upload-time = "2025-10-16T09:12:22.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/18/6bc2189b744dd383cad03764f41f30352b1278d2205096f77a29c0b327ad/mdformat_gfm-1.0.0-py3-none-any.whl", hash = "sha256:7305a50efd2a140d7c83505b58e3ac5df2b09e293f9bbe72f6c7bee8c678b005", size = 10970, upload-time = "2025-10-16T09:12:21.276Z" },
+]
+
+[[package]]
+name = "mdformat-mkdocs"
+version = "5.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdformat" },
+    { name = "mdformat-gfm" },
+    { name = "mdit-py-plugins" },
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/25/df38de72a291b96fb7af7549c5285e934267f8f0b269d3ccacda84ef764c/mdformat_mkdocs-5.1.4.tar.gz", hash = "sha256:d3ecf035100328c5ff2b3bd7de87a16ee0484e5c317add9c70022598d15af6a1", size = 28160, upload-time = "2026-01-26T12:12:41.983Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/bf/00ba31df7cd955eb0dbb1b8b0eb388bc6f717f033f807656a12eb8f12a5b/mdformat_mkdocs-5.1.4-py3-none-any.whl", hash = "sha256:6ff339c1023926077c0c598533768433b38981a9eb792ebfe02d2438ba71514d", size = 38377, upload-time = "2026-01-26T12:12:40.326Z" },
+]
+
+[[package]]
+name = "mdit-py-plugins"
+version = "0.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/69/6da5581c6a7fede7dc261bf4e67d6adca4196f176b43288b55b3db395b6e/mdit_py_plugins-0.6.1-py3-none-any.whl", hash = "sha256:214c82fb2ac524472ab6a5bcab1de80f73b50443e187f401bfd77efbc7c6481d", size = 66663, upload-time = "2026-05-13T09:03:37.76Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -842,6 +931,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/72/24cd8137df5a185fe0856ff9b6f8a8f9d387d6783c51961a1c6300a4efe8/mne-1.12.1.tar.gz", hash = "sha256:244f844057f28a4da2509039dba637832ffb65f678ca76fc667312c493b12044", size = 7211821, upload-time = "2026-04-20T17:16:57.295Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/da/a3280dbd8f0024b287b625ef97f8ef79ae853ed852e7732641d0ec3c2160/mne-1.12.1-py3-none-any.whl", hash = "sha256:7823bd276d570e9bed2e63e8d86fdbe74d5ee7817b6d01a8e4dc9510ef9e3a91", size = 7509566, upload-time = "2026-04-20T17:16:54.447Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "11.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -1432,6 +1530,15 @@ wheels = [
 ]
 
 [[package]]
+name = "ruamel-yaml"
+version = "0.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
+]
+
+[[package]]
 name = "ruff"
 version = "0.15.16"
 source = { registry = "https://pypi.org/simple" }
@@ -1553,6 +1660,10 @@ dev = [
     { name = "types-pyyaml" },
 ]
 docs = [
+    { name = "mdformat" },
+    { name = "mdformat-frontmatter" },
+    { name = "mdformat-gfm" },
+    { name = "mdformat-mkdocs" },
     { name = "mike" },
     { name = "mkdocs-material" },
 ]
@@ -1564,6 +1675,10 @@ eeg = [
 [package.metadata]
 requires-dist = [
     { name = "blinkstick", marker = "sys_platform == 'win32'" },
+    { name = "mdformat", marker = "extra == 'docs'" },
+    { name = "mdformat-frontmatter", marker = "extra == 'docs'" },
+    { name = "mdformat-gfm", marker = "extra == 'docs'" },
+    { name = "mdformat-mkdocs", marker = "extra == 'docs'" },
     { name = "mike", marker = "extra == 'docs'" },
     { name = "mkdocs-material", marker = "extra == 'docs'" },
     { name = "mne", marker = "extra == 'eeg'", specifier = ">=1.6" },
@@ -1707,4 +1822,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
 ]


### PR DESCRIPTION
Closes #169. Sequenced after #170 (Python 3.13), which this needed.

Adopts [mdformat](https://mdformat.readthedocs.io/) as the Markdown formatter — the docs counterpart to ruff — enforced in CI (`quality` job) and pre-commit. Python/uv-native, no Node toolchain. The bulk of the diff is the one-time reformat of every tracked Markdown file except `.claude/`.

## Two deviations from the issue (both forced by mdformat's actual behavior on 1.0.0)

The issue specified config in `pyproject.toml` `[tool.mdformat]` with `exclude = [".claude/**"]`. Testing showed neither works as written:

1. **Config lives in `.mdformat.toml`, not `pyproject.toml`.** mdformat 1.0.0 reads config *only* from `.mdformat.toml` (`mdformat/_conf.py` hard-codes the filename and never looks at `pyproject.toml`). A `[tool.mdformat]` block is silently ignored, so the exclude never applied. Moved the same keys (`wrap = "keep"`, `end_of_line = "lf"`, `exclude`) into `.mdformat.toml`.
2. **The exclude must also cover `.venv`/`.pytest_cache`.** mdformat isn't `.gitignore`-aware and `mdformat .` crawls the in-tree venv that `uv run` creates — hundreds of site-packages READMEs — so `.claude/**` alone leaves CI drowning in noise. Exclude is now `[".claude/**", ".venv/**", ".pytest_cache/**"]`.

The exclude key still requires Python 3.13 (`glob.translate`), so the dependency on #168 is real either way. Scope stays single-sourced: CI runs `mdformat --check .` and the pre-commit hook crawls `.` the same way (`pass_filenames: false`), both reading `.mdformat.toml` — no second file list.

## Formatting outcomes (as accepted in the #167 review)

- List-continuation indent 2 → 4 spaces (what Python-Markdown expects).
- HTML entities (`&rsaquo;` → `›`) become literal Unicode.
- Tables padded so columns align.
- Bullet markers normalized `*` → `-` (gfm default).

## Verification

- `mdformat --check .` clean; the pre-commit hook passes (`pre-commit run mdformat --all-files`).
- `mkdocs build --strict` succeeds on the reformatted output; the `{ .md-button }` download button and the auto-generated event-codes table render unchanged.
- Full suite green (793 passed), including `tests/test_docs_schema.py` which keeps the event-codes table in lockstep with `smacc.events` (mdformat's padding is compatible).
- ruff / mypy unaffected.