### PR TITLE
fix: show 'SMACC' (not 'SMACC version X') in Windows Installed apps

### DIFF
--- a/tools/smacc.iss
+++ b/tools/smacc.iss
@@ -37,6 +37,9 @@ OutputDir=..\dist
 OutputBaseFilename=SMACC-Setup
 SetupIconFile=..\src\smacc\assets\icon.ico
 UninstallDisplayIcon={app}\SMACC.exe
+; Without this, Inno defaults the Installed-apps entry to "SMACC version x.y.z"
+; even though Windows shows the version (from AppVersion) in its own column.
+UninstallDisplayName=SMACC
 ; Tells Windows to refresh Explorer's file-association cache after (un)install.
 ChangesAssociations=yes
 WizardStyle=modern


### PR DESCRIPTION
Fixes #188.

Windows Settings → Installed apps showed the entry as "SMACC version 0.0.9" even though the version is displayed in its own column. Inno Setup defaults the uninstall **DisplayName** to `AppName version AppVersion` when neither `AppVerName` nor `UninstallDisplayName` is set.

This sets `UninstallDisplayName=SMACC` in [tools/smacc.iss](tools/smacc.iss) — the most targeted of the two options from the issue: it changes only the Add/Remove-Programs entry and leaves every wizard string derived from `AppName`/`AppVersion` untouched. `AppVersion` still feeds the version column and upgrade detection.