### PR TITLE
fix: only prompt to save on editor close when there are unsaved changes

### DIFF
--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 from functools import partial
 from pathlib import Path
@@ -152,6 +153,10 @@ class SmaccWindow(ToolWindow):
         # A study file passed on launch becomes this session's initial setup.
         if settings_path:
             self._load_initial_settings(settings_path)
+        if self.design:
+            # Baseline for the close-time unsaved-changes check (#183): what the
+            # editor would save right now. Re-captured on every successful save.
+            self._saved_snapshot = self._design_snapshot()
         self.show()  # single show, after window flags + geometry are applied
 
         # The designer records no run, so it skips the log header, the file
@@ -1071,6 +1076,8 @@ class SmaccWindow(ToolWindow):
             self.show_error_popup("Could not save settings.", str(exc))
             return False
         self.settings_path = path  # subsequent saves update this file
+        if self.design:
+            self._saved_snapshot = self._design_snapshot()  # editor is clean again
         self.session.log_debug_msg(f"Saved settings to {path}")
         # Status-bar confirmation: the editor has no log viewer to show the line.
         status_bar = self.statusBar()
@@ -1177,6 +1184,17 @@ class SmaccWindow(ToolWindow):
             panel.cleanup()
             panel.close()
 
+    def _design_snapshot(self) -> dict:
+        """A deep copy of the savable editor state (settings + metadata).
+
+        Compared against the post-load/post-save baseline to decide whether the
+        editor has unsaved changes; state-equality also treats "edited, then
+        undone back to the original" as clean (#183).
+        """
+        return copy.deepcopy(
+            {"settings": self.gather_settings(), "metadata": self.session.metadata}
+        )
+
     def closeEvent(self, event):
         """End the session (or close the designer) and emit ``closed``.
 
@@ -1186,25 +1204,28 @@ class SmaccWindow(ToolWindow):
         ``LauncherWindow._on_tool_closed``).
         """
         if self.design:
-            box = QtWidgets.QMessageBox(self)
-            box.setWindowTitle("Close editor")
-            box.setText("Save changes to the SMACC file before closing?")
-            box.setStandardButtons(
-                QtWidgets.QMessageBox.StandardButton.Save
-                | QtWidgets.QMessageBox.StandardButton.Discard
-                | QtWidgets.QMessageBox.StandardButton.Cancel
-            )
-            box.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Save)
-            choice = box.exec()
-            if choice == QtWidgets.QMessageBox.StandardButton.Cancel:
-                event.ignore()
-                return
-            if (
-                choice == QtWidgets.QMessageBox.StandardButton.Save
-                and not self.save_settings_in_place()
-            ):
-                event.ignore()  # save was cancelled/failed → keep the editor open
-                return
+            # Only prompt when the editor differs from what was last loaded or
+            # saved; an untouched editor closes silently (#183).
+            if self._design_snapshot() != self._saved_snapshot:
+                box = QtWidgets.QMessageBox(self)
+                box.setWindowTitle("Close editor")
+                box.setText("Save changes to the SMACC file before closing?")
+                box.setStandardButtons(
+                    QtWidgets.QMessageBox.StandardButton.Save
+                    | QtWidgets.QMessageBox.StandardButton.Discard
+                    | QtWidgets.QMessageBox.StandardButton.Cancel
+                )
+                box.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Save)
+                choice = box.exec()
+                if choice == QtWidgets.QMessageBox.StandardButton.Cancel:
+                    event.ignore()
+                    return
+                if (
+                    choice == QtWidgets.QMessageBox.StandardButton.Save
+                    and not self.save_settings_in_place()
+                ):
+                    event.ignore()  # save was cancelled/failed → keep the editor open
+                    return
             # No run to finalize and no operator prefs to write from the editor.
             self._teardown_panels()
             self.session.close()

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -405,3 +405,67 @@ def test_hue_config_round_trips_through_settings(
     window.apply_settings(state)
     assert window.gather_settings()["hue"]["bridge_ip"] == "192.168.1.50"
     assert design_session.hue_config.configured
+
+
+# ----- editor close prompts only when there are unsaved changes (#183) --------
+
+
+def _watch_close_prompt(monkeypatch):
+    """Record the editor's "save before closing?" prompt instead of blocking."""
+    prompts: list[str] = []
+
+    def fake_exec(self):
+        prompts.append(self.text())
+        return QtWidgets.QMessageBox.StandardButton.Discard
+
+    monkeypatch.setattr(QtWidgets.QMessageBox, "exec", fake_exec)
+    return prompts
+
+
+def test_editor_close_without_changes_skips_prompt(
+    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+):
+    window = SmaccWindow(design_session)
+    qtbot.addWidget(window)
+    prompts = _watch_close_prompt(monkeypatch)
+    assert window.close() is True
+    assert prompts == []
+
+
+def test_editor_close_after_edit_prompts(
+    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+):
+    window = SmaccWindow(design_session)
+    qtbot.addWidget(window)
+    # Session metadata is part of the saved file (File → Session info…).
+    window.session.metadata["notes"] = "tweaked"
+    prompts = _watch_close_prompt(monkeypatch)
+    assert window.close() is True  # Discard → still closes
+    assert len(prompts) == 1
+
+
+def test_editor_close_after_undone_edit_skips_prompt(
+    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+):
+    # State equality (not an edit-signal flag) is the dirty check, so editing
+    # and then undoing back to the original counts as clean.
+    window = SmaccWindow(design_session)
+    qtbot.addWidget(window)
+    original = window.session.metadata.get("notes", "")
+    window.session.metadata["notes"] = "tweaked"
+    window.session.metadata["notes"] = original
+    prompts = _watch_close_prompt(monkeypatch)
+    assert window.close() is True
+    assert prompts == []
+
+
+def test_editor_save_marks_clean(
+    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch, tmp_path
+):
+    window = SmaccWindow(design_session)
+    qtbot.addWidget(window)
+    window.session.metadata["notes"] = "tweaked"
+    assert window._write_settings(str(tmp_path / "study.smacc")) is True
+    prompts = _watch_close_prompt(monkeypatch)
+    assert window.close() is True
+    assert prompts == []


### PR DESCRIPTION
Fixes #183.

The editor's `closeEvent` unconditionally showed "Save changes to the SMACC file before closing?" — there was no dirty/modified state, so it prompted even when nothing had changed.

**Approach.** The issue's assessment listed two options (an edit-signal dirty flag, or a state-equality check against the loaded baseline); this takes the state-equality route:

- `_design_snapshot()` deep-copies the savable editor state — `gather_settings()` plus the session metadata, i.e. exactly what `_write_settings` persists.
- The baseline is captured once at construction (after the initial `.smacc` load) and re-captured on every successful save.
- `closeEvent`'s editor branch shows the Save/Discard/Cancel prompt only when the current snapshot differs from the baseline; otherwise the editor closes silently.

Compared to a signal-wired flag, this needs no per-panel signal plumbing and treats "edited, then undone back to the original" as clean.

**Tests.** Four new cases in `tests/test_gui_window.py`: untouched editor closes without a prompt; an edit triggers the prompt; an edit that is reverted closes without a prompt; a save marks the editor clean again. Full suite passes (797).