### PR TITLE
fix: validate a .smacc before opening it, and keep failures out of recents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,4 @@ version_info.txt
 .coverage
 coverage.xml
 htmlcov/
-NOTES.txt
 site/

--- a/src/smacc/__main__.py
+++ b/src/smacc/__main__.py
@@ -259,8 +259,15 @@ def main() -> None:
     if file_arg:
         # A double-clicked / CLI .smacc opens straight into a session for it;
         # ending that session quits SMACC (see LauncherWindow._on_tool_closed).
+        # The launcher validates the file on construction (#186): an incompatible
+        # one is reported and rejected there, so show the launcher (with the
+        # built-in defaults selected) instead of starting a session it never
+        # asked for.
         launcher = LauncherWindow(file_arg)
-        launcher.start_session()
+        if launcher.settings_path:
+            launcher.start_session()
+        else:
+            launcher.show()
     else:
         prefs = preferences.load_preferences(preferences_path)
         launcher = LauncherWindow(resolve_initial_settings(prefs))

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -54,15 +54,24 @@ class LauncherWindow(QtWidgets.QMainWindow):
 
     def __init__(self, settings_path: str | None) -> None:
         super().__init__()
-        self._settings_path = settings_path  # current .smacc, or None for defaults
+        self._settings_path: str | None = None  # current .smacc, or None for defaults
         self._tool: ToolWindow | None = None
         self.setWindowTitle("SMACC Launcher")
         if LOGO_PATH.is_file():
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
         self._build()
+        # A file given at launch (double-clicked .smacc, or the last-used one) must
+        # load before it becomes the selection — an incompatible file is reported
+        # and stays out of recents (#186), leaving the built-in defaults selected.
         if settings_path:
-            self._remember(settings_path)
-        self._populate_settings_combo()
+            self._set_settings(settings_path)
+        else:
+            self._populate_settings_combo()
+
+    @property
+    def settings_path(self) -> str | None:
+        """The currently selected .smacc file (None = SMACC's built-in defaults)."""
+        return self._settings_path
 
     # ----- current-settings helpers ----------------------------------------
 
@@ -305,16 +314,52 @@ class LauncherWindow(QtWidgets.QMainWindow):
         self._set_settings(data)
 
     def _set_settings(self, path: str | None) -> None:
+        """Make ``path`` the current SMACC file — only if it actually loads (#186).
+
+        An incompatible file is reported and the previous selection stays; only a
+        successfully loading file is remembered in recents.
+        """
+        if path is not None and not self._check_loadable(path):
+            self._populate_settings_combo()  # re-sync the dropdown to the selection
+            return
         self._settings_path = path
         if path:
             self._remember(path)
         self._populate_settings_combo()
+
+    def _check_loadable(self, path: str) -> bool:
+        """True if ``path`` loads as a compatible SMACC file; report it otherwise.
+
+        A file that fails is also dropped from recents, so a stale or corrupted
+        entry doesn't keep resurfacing in the dropdown.
+        """
+        try:
+            settings.load_settings(path)
+        except (OSError, ValueError) as exc:
+            self._forget(path)
+            QtWidgets.QMessageBox.critical(
+                self,
+                "Open SMACC file",
+                f"Could not open {Path(path).name}.\n\n{exc}",
+            )
+            return False
+        return True
 
     def _remember(self, path: str) -> None:
         """Push ``path`` onto the persisted recent-settings list (most-recent first)."""
         prefs = preferences.load_preferences(preferences_path)
         recents = [r for r in prefs.get("recent_settings", []) if isinstance(r, str)]
         recents = preferences.push_recent(recents, str(path))
+        preferences.update_preferences(preferences_path, {"recent_settings": recents})
+
+    def _forget(self, path: str) -> None:
+        """Drop ``path`` from the persisted recent-settings list (it failed to load)."""
+        prefs = preferences.load_preferences(preferences_path)
+        recents = [
+            r
+            for r in prefs.get("recent_settings", [])
+            if isinstance(r, str) and r != str(path)
+        ]
         preferences.update_preferences(preferences_path, {"recent_settings": recents})
 
     def open_settings(self) -> None:
@@ -332,6 +377,12 @@ class LauncherWindow(QtWidgets.QMainWindow):
 
     def start_session(self) -> None:
         """Run a session using the current settings (writing to its data directory)."""
+        # Re-check right before committing: the file may have changed on disk since
+        # it was selected, and an incompatible file must never get a session window.
+        if self._settings_path and not self._check_loadable(self._settings_path):
+            self._set_settings(None)  # fall back to the built-in defaults
+            self.show()  # the double-click flow starts before the launcher is shown
+            return
         session = SmaccSession(self._data_dir())
         window = SmaccWindow(session, settings_path=self._settings_path)
         if self._settings_path:
@@ -347,6 +398,9 @@ class LauncherWindow(QtWidgets.QMainWindow):
 
     def edit_settings(self) -> None:
         """Open the editor on the current settings file."""
+        if self._settings_path and not self._check_loadable(self._settings_path):
+            self._set_settings(None)  # fall back to the built-in defaults
+            return
         session = SmaccSession(self._data_dir(), design=True)
         self._open_tool(SmaccWindow(session, settings_path=self._settings_path))
 

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -41,3 +41,98 @@ def test_design_cues_button_opens_the_cue_designer(qtbot, tmp_path, monkeypatch)
     assert not win.isVisible()  # and the launcher hides until it closes
     win._tool.close()  # returns control to the launcher (it reappears)
     assert win.isVisible()
+
+
+# ----- a .smacc must load before it is opened or remembered (#186) ------------
+
+
+def _silence_critical(monkeypatch):
+    """Replace the blocking error popup with a recorder; returns the call list."""
+    from PyQt6 import QtWidgets
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "critical",
+        lambda *a, **k: calls.append(a) or QtWidgets.QMessageBox.StandardButton.Ok,
+    )
+    return calls
+
+
+def _write_incompatible(path):
+    path.write_text(
+        "kind: smacc/settings\nschema_version: 99\nsettings: {}\n", encoding="utf-8"
+    )
+
+
+def test_incompatible_launch_file_is_rejected_and_kept_out_of_recents(
+    qtbot, tmp_path, monkeypatch
+):
+    from smacc import preferences
+
+    prefs_path = tmp_path / "preferences.yaml"
+    monkeypatch.setattr(launcher, "preferences_path", prefs_path)
+    bad = tmp_path / "old.smacc"
+    _write_incompatible(bad)
+    popups = _silence_critical(monkeypatch)
+    win = LauncherWindow(settings_path=str(bad))
+    qtbot.addWidget(win)
+    assert win.settings_path is None  # rejected → built-in defaults stay selected
+    assert len(popups) == 1  # and the user was told why
+    recents = preferences.load_preferences(prefs_path).get("recent_settings", [])
+    assert str(bad) not in recents
+
+
+def test_valid_launch_file_is_selected_and_remembered(qtbot, tmp_path, monkeypatch):
+    from smacc import preferences, settings
+
+    prefs_path = tmp_path / "preferences.yaml"
+    monkeypatch.setattr(launcher, "preferences_path", prefs_path)
+    good = tmp_path / "study.smacc"
+    settings.save_settings(good, {}, {})
+    win = LauncherWindow(settings_path=str(good))
+    qtbot.addWidget(win)
+    assert win.settings_path == str(good)
+    recents = preferences.load_preferences(prefs_path).get("recent_settings", [])
+    assert str(good) in recents
+
+
+def test_failed_selection_drops_a_stale_entry_from_recents(
+    qtbot, tmp_path, monkeypatch
+):
+    from smacc import preferences
+
+    # A file that was fine when remembered but is incompatible now must not
+    # keep resurfacing in the dropdown.
+    prefs_path = tmp_path / "preferences.yaml"
+    monkeypatch.setattr(launcher, "preferences_path", prefs_path)
+    bad = tmp_path / "old.smacc"
+    _write_incompatible(bad)
+    preferences.update_preferences(prefs_path, {"recent_settings": [str(bad)]})
+    _silence_critical(monkeypatch)
+    win = LauncherWindow(settings_path=None)
+    qtbot.addWidget(win)
+    win._set_settings(str(bad))  # e.g. picked from the recents dropdown
+    assert win.settings_path is None  # the selection did not change
+    recents = preferences.load_preferences(prefs_path).get("recent_settings", [])
+    assert str(bad) not in recents
+
+
+def test_start_session_aborts_when_the_file_breaks_after_selection(
+    qtbot, tmp_path, monkeypatch
+):
+    from smacc import settings
+
+    monkeypatch.setattr(launcher, "preferences_path", tmp_path / "preferences.yaml")
+    good = tmp_path / "study.smacc"
+    settings.save_settings(good, {}, {})
+    _silence_critical(monkeypatch)
+    win = LauncherWindow(settings_path=str(good))
+    qtbot.addWidget(win)
+    good.write_text("not: [valid", encoding="utf-8")  # corrupted after selection
+    win.start_session()
+    assert win._tool is None  # no session window was constructed
+    assert win.settings_path is None  # selection fell back to the defaults
+    # The double-click flow starts a session before the launcher is ever shown;
+    # on rejection the launcher must come up rather than leave no window at all.
+    assert win.isVisible()


### PR DESCRIPTION
Fixes #186. Fixes #193.

Two related problems with incompatible/unparseable `.smacc` files:

1. The schema check ran inside the already-constructed-and-shown session window, so the user got an error popup and then landed in a defaults session they never asked for.
2. The file entered the recents list before the load was attempted, so it kept resurfacing in the dropdown.

**Approach.** Validation moves into the launcher, ahead of any window construction:

- `_set_settings` (every path by which a file becomes the current selection: launch argument, dropdown pick, Browse…, editor adoption) now runs the file through `settings.load_settings` first. A failing file is reported, the previous selection stays, and the file is **removed** from recents — so a stale entry that has since become incompatible stops resurfacing. Only a file that loads successfully is remembered.
- `start_session` / `edit_settings` re-check right before committing, covering a file that changed on disk after selection; on failure no `SmaccWindow` is constructed and the selection falls back to the built-in defaults.
- The double-click / CLI flow (`__main__.py`) previously called `start_session()` unconditionally on a launcher that was never shown; a rejected file now shows the launcher (defaults selected) instead of silently starting a defaults session — and instead of leaving the process with no window at all.

`SmaccWindow._load_initial_settings`'s own error fallback is kept as a safety net for the (now unreachable in normal flow) race where the file breaks between the launcher's check and the window's load.

**Tests.** Four new cases in `tests/test_launcher.py`: an incompatible launch file is rejected and kept out of recents (with the error reported); a valid one is selected and remembered; a stale recents entry is dropped when picked; `start_session` aborts (no tool window, launcher shown) when the file breaks after selection. Full suite passes (797).

**Also included** (#193): removed the stray `NOTES.txt` entry from `.gitignore`.
