### PR TITLE
feat: tell the user the SMACC data folder was kept at the end of uninstall

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -95,13 +95,22 @@ jobs:
       # the test. For the EEG exe, --version only proves the import tree (MNE is
       # imported lazily), so --selftest additionally round-trips a synthetic
       # recording through MNE, the filters, and the annotation sidecar.
+      # Every Start-Process below is bounded like the crash-log test's: -Wait
+      # would sit behind any stray window/prompt until the 30-minute job
+      # timeout, reporting nothing about which command hung. A kill + throw
+      # names the culprit within minutes instead. 300s covers the slowest
+      # legitimate case (the MNE onefile extracting + importing on a runner
+      # under Defender's real-time scan).
       - name: Smoke-test the exes
         run: |
-          $p = Start-Process -FilePath dist/SMACC.exe -ArgumentList '--version' -Wait -PassThru
+          $p = Start-Process -FilePath dist/SMACC.exe -ArgumentList '--version' -PassThru
+          if (-not $p.WaitForExit(120000)) { $p.Kill(); throw "SMACC.exe --version did not exit within 120s" }
           if ($p.ExitCode -ne 0) { throw "SMACC.exe --version exited with code $($p.ExitCode)" }
-          $p = Start-Process -FilePath dist/SMACC-EEG.exe -ArgumentList '--version' -Wait -PassThru
+          $p = Start-Process -FilePath dist/SMACC-EEG.exe -ArgumentList '--version' -PassThru
+          if (-not $p.WaitForExit(300000)) { $p.Kill(); throw "SMACC-EEG.exe --version did not exit within 300s" }
           if ($p.ExitCode -ne 0) { throw "SMACC-EEG.exe --version exited with code $($p.ExitCode)" }
-          $p = Start-Process -FilePath dist/SMACC-EEG.exe -ArgumentList '--selftest' -Wait -PassThru
+          $p = Start-Process -FilePath dist/SMACC-EEG.exe -ArgumentList '--selftest' -PassThru
+          if (-not $p.WaitForExit(300000)) { $p.Kill(); throw "SMACC-EEG.exe --selftest did not exit within 300s" }
           if ($p.ExitCode -ne 0) { throw "SMACC-EEG.exe --selftest exited with code $($p.ExitCode)" }
       # The crash-log pipeline (#149) matters most in exactly this windowed build,
       # where nothing else can capture a crash — and it's the one build the test
@@ -136,22 +145,26 @@ jobs:
       # in-place upgrade path a lab uses to add the component later) must.
       - name: Smoke-test the installer (default - no EEG component)
         run: |
-          $p = Start-Process -FilePath dist/SMACC-Setup.exe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/CURRENTUSER' -Wait -PassThru
+          $p = Start-Process -FilePath dist/SMACC-Setup.exe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/CURRENTUSER' -PassThru
+          if (-not $p.WaitForExit(180000)) { $p.Kill(); throw "SMACC-Setup.exe did not exit within 180s" }
           if ($p.ExitCode -ne 0) { throw "SMACC-Setup.exe exited with code $($p.ExitCode)" }
           $exe = "$env:LOCALAPPDATA\Programs\SMACC\SMACC.exe"
           if (-not (Test-Path $exe)) { throw "Installed exe not found at $exe" }
-          $p = Start-Process -FilePath $exe -ArgumentList '--version' -Wait -PassThru
+          $p = Start-Process -FilePath $exe -ArgumentList '--version' -PassThru
+          if (-not $p.WaitForExit(120000)) { $p.Kill(); throw "Installed SMACC.exe --version did not exit within 120s" }
           if ($p.ExitCode -ne 0) { throw "Installed SMACC.exe --version exited with code $($p.ExitCode)" }
           $progid = (Get-ItemProperty -Path 'HKCU:\Software\Classes\.smacc').'(default)'
           if ($progid -ne 'SMACC.Study') { throw ".smacc association not registered (got '$progid')" }
           if (Test-Path "$env:LOCALAPPDATA\Programs\SMACC\SMACC-EEG.exe") { throw "Default install must not include SMACC-EEG.exe" }
       - name: Smoke-test the installer (adding the EEG component)
         run: |
-          $p = Start-Process -FilePath dist/SMACC-Setup.exe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/CURRENTUSER','/COMPONENTS="core,eeg"' -Wait -PassThru
+          $p = Start-Process -FilePath dist/SMACC-Setup.exe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/CURRENTUSER','/COMPONENTS="core,eeg"' -PassThru
+          if (-not $p.WaitForExit(180000)) { $p.Kill(); throw "SMACC-Setup.exe (core,eeg) did not exit within 180s" }
           if ($p.ExitCode -ne 0) { throw "SMACC-Setup.exe (core,eeg) exited with code $($p.ExitCode)" }
           $eeg = "$env:LOCALAPPDATA\Programs\SMACC\SMACC-EEG.exe"
           if (-not (Test-Path $eeg)) { throw "Installed EEG exe not found at $eeg" }
-          $p = Start-Process -FilePath $eeg -ArgumentList '--selftest' -Wait -PassThru
+          $p = Start-Process -FilePath $eeg -ArgumentList '--selftest' -PassThru
+          if (-not $p.WaitForExit(300000)) { $p.Kill(); throw "Installed SMACC-EEG.exe --selftest did not exit within 300s" }
           if ($p.ExitCode -ne 0) { throw "Installed SMACC-EEG.exe --selftest exited with code $($p.ExitCode)" }
       # Every run leaves the build products behind as workflow artifacts, so a
       # verification run's exes/installer can be downloaded and inspected

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,7 +15,10 @@ double-click `SMACC-Setup.exe` and click through. The installer:
     re-run the installer later to add it;
 - registers an uninstaller — remove SMACC from **Settings › Apps** like any other
     program. Uninstalling never touches your data: SMACC files, recordings, and
-    logs under `~/SMACC` (or your data directories) all stay put.
+    logs under `~/SMACC` (or your data directories) all stay put. The
+    uninstaller reminds you of this (and of the folder's location) when it
+    finishes, so finding the folder afterwards is expected — delete it manually
+    if you no longer need the data.
 
 Installing a newer version over an existing one upgrades it in place, keeping
 whichever components you had chosen.

--- a/tools/smacc.iss
+++ b/tools/smacc.iss
@@ -98,3 +98,27 @@ Root: HKA; Subkey: "Software\Classes\SMACC.Study\shell\open\command"; ValueType:
 
 [Run]
 Filename: "{app}\SMACC.exe"; Description: "{cm:LaunchProgram,SMACC}"; Flags: nowait postinstall skipifsilent
+
+[Code]
+{ Uninstalling never deletes the SMACC data folder (#189): it holds real study
+  data (recordings, logs, SMACC files) mixed with app-managed seeds, so an
+  automatic delete is never safe. Instead, say so at the end of uninstall —
+  whoever uninstalls and finds the folder later shouldn't be left wondering
+  whether removal failed. Skipped on a silent uninstall (no popups to hang an
+  unattended run). }
+function SmaccDataDir(): String;
+begin
+  { Mirrors smacc.utils.get_smacc_directory: $SMACC_DIRECTORY, else ~/SMACC. }
+  Result := GetEnv('SMACC_DIRECTORY');
+  if Result = '' then
+    Result := ExpandConstant('{%USERPROFILE}\SMACC');
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+  if (CurUninstallStep = usPostUninstall) and not UninstallSilent() then
+    MsgBox('SMACC was removed, but your SMACC data folder was kept:'#13#10#13#10
+      + SmaccDataDir() + #13#10#13#10
+      + 'It holds your SMACC files, recordings, and logs. If you no longer '
+      + 'need them, delete the folder manually.', mbInformation, MB_OK);
+end;


### PR DESCRIPTION
Fixes #189.

Implements the decision from the issue discussion: option (a) — the uninstaller never deletes the SMACC data folder — plus an end-of-uninstall notice so a user who uninstalls and later finds `~/SMACC` isn't left wondering whether removal failed.

- A `[Code]` section in [tools/smacc.iss](tools/smacc.iss) shows an information box at `usPostUninstall` naming the kept folder and what it holds (SMACC files, recordings, logs), with a pointer to delete it manually if unwanted.
- The folder path mirrors `smacc.utils.get_smacc_directory`: `%SMACC_DIRECTORY%` if set, else `%USERPROFILE%\SMACC`.
- The box is skipped on silent uninstalls (`/VERYSILENT`), so unattended runs (including the release workflow's installer smoke tests, if they ever uninstall) can't hang on a popup.
- The installation docs page already stated that uninstalling keeps the data; it now also mentions the reminder, per the issue comment.

No `[UninstallDelete]` is added — a blanket delete would take real recordings along with the app-managed seeds, exactly the complication the issue flags.