### PR TITLE
refactor: remove the first-run .smacc association prompt (the installer owns it)

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -51,8 +51,9 @@ itself come from the releases page.)
 Every release also ships the same app as a single portable `SMACC.exe` — download
 it, double-click it, no installation. This suits USB-stick deployment, machines
 where nothing may be installed, and quick tests. The portable build skips the
-installer's conveniences (Start menu entry, uninstaller); it offers to associate
-`.smacc` files itself the first time it runs (see below). The
+installer's conveniences (Start menu entry, uninstaller, the `.smacc`
+file association) — you can associate `.smacc` files from the Launcher's File
+menu instead (see below). The
 [EEG review tool](eeg-review.md) is likewise available portable as
 `SMACC-EEG.exe` — put it **next to** `SMACC.exe` and the Launcher's *Review
 EEG* button lights up (it also runs standalone).
@@ -101,10 +102,9 @@ itself remembers window positions and sizes and your recent files in
 
 Your reusable setup is saved to a portable SMACC file (see
 [SMACC files](smacc-files.md)). The installer associates `.smacc` files so you can
-**double-click one to open SMACC and run a session with it**. The portable
-`SMACC.exe` offers the same association the first time it runs; you can also
-(re)enable it any time from **File › Associate .smacc files (Windows)** in
-the Launcher.
+**double-click one to open SMACC and run a session with it**. With the portable
+`SMACC.exe`, enable (or repair) the association any time from
+**File › Associate .smacc files (Windows)** in the Launcher.
 
 ### Audio cues
 

--- a/docs/reference/preferences-file.md
+++ b/docs/reference/preferences-file.md
@@ -18,7 +18,6 @@ preferences:
   windows:
     launcher: {x: 100, y: 100, w: 340, h: 360}
     main: {x: 120, y: 80, w: 900, h: 700}
-  association_prompted: true
   recent_settings:
     - C:\Users\you\SMACC\peter.smacc
     - C:\Users\you\SMACC\paul.smacc
@@ -39,7 +38,6 @@ preferences:
 | Key                     | Type           | Meaning                                                                                                                                                                                                                                                        |
 | ----------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `windows`               | mapping        | Per-window geometry, keyed by a stable window id → `{x, y, w, h}`. Ids include `launcher`, `main` (the Session window), the analyze window, and each tool window. An absent/`null` `x`/`y` means "no saved position — open at a default".                      |
-| `association_prompted`  | boolean        | Whether the first-run "associate `.smacc` files (Windows)?" prompt has already been shown.                                                                                                                                                                     |
 | `recent_settings`       | list of paths  | Recently opened `.smacc` files, most-recent first, de-duplicated and capped at 8.                                                                                                                                                                              |
 | `last_settings`         | path or `null` | The last `.smacc` opened, so the Launcher can preselect it.                                                                                                                                                                                                    |
 | `log_preview_max_lines` | integer        | How many lines the Session window's live log preview keeps (default **1000**); the oldest lines are dropped first. The log *file* always records everything, so nothing is lost. Very large values cost GUI memory and repaint time over an overnight session. |
@@ -52,6 +50,6 @@ preferences:
 
 ## Version history
 
-| Version | Changes                                                                                     |
-| ------- | ------------------------------------------------------------------------------------------- |
-| 1       | First stable schema: `windows`, `association_prompted`, `recent_settings`, `last_settings`. |
+| Version | Changes                                                                                                                                                                                                                                                      |
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 1       | First stable schema: `windows`, `recent_settings`, `last_settings`. (The pre-release `association_prompted` key was dropped along with the first-run association prompt — the installer owns the association now; a leftover key in an old file is ignored.) |

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -20,7 +20,6 @@ from smacc import (
     preferences,
     settings,
     triggers,
-    winassoc,
     windowstate,
 )
 
@@ -159,14 +158,13 @@ class SmaccWindow(ToolWindow):
             self._saved_snapshot = self._design_snapshot()
         self.show()  # single show, after window flags + geometry are applied
 
-        # The designer records no run, so it skips the log header, the file
-        # association prompt, and interaction logging — it only edits config.
+        # The designer records no run, so it skips the log header and
+        # interaction logging — it only edits config.
         if not self.design:
             # Panels (and any launch-file overrides) are in place, so capture the
             # initial state into the log header (also emits the "Opened SMACC" line).
             self.session.begin_log(self.gather_settings())
             self._notify_missing_biocal_voices()
-            self._maybe_prompt_association()
             # Startup widget setup is done; from here on, log soft interactions.
             self.session.log_interactions = True
 
@@ -996,39 +994,6 @@ class SmaccWindow(ToolWindow):
             return
         self._apply_loaded_settings(state, metadata)
         self.session.log_debug_msg(f"Loaded settings from {settings_path}")
-
-    def _maybe_prompt_association(self) -> None:
-        """Once, on the first packaged-build launch, offer to associate .smacc files."""
-        if not winassoc.is_associatable() or self._prefs.get("association_prompted"):
-            return
-        # If .smacc is already associated with this build (e.g. from a prior install,
-        # or a launch whose preferences didn't persist), there is nothing to ask —
-        # just record that the prompt is done so we don't keep re-asking.
-        if winassoc.is_registered():
-            self._remember_association_prompted()
-            return
-        self._remember_association_prompted()  # one-time, whatever they choose
-        reply = QtWidgets.QMessageBox.question(
-            self,
-            "Associate .smacc files?",
-            "Associate .smacc files with SMACC so double-clicking one opens "
-            "the app already configured?",
-        )
-        if reply == QtWidgets.QMessageBox.StandardButton.Yes:
-            try:
-                winassoc.register_smacc()
-            except OSError as exc:
-                self.show_error_popup("Could not associate .smacc files.", str(exc))
-
-    def _remember_association_prompted(self) -> None:
-        """Record (in memory and on disk) that the one-time association prompt is done.
-
-        Persisted immediately so it survives even if several windows write preferences
-        this run (the launcher also writes recents). The association itself is a
-        machine/registry action, not session data, so it is deliberately not logged.
-        """
-        self._prefs["association_prompted"] = True
-        preferences.update_preferences(preferences_path, {"association_prompted": True})
 
     def save_settings_in_place(self) -> bool:
         """Save to the current .smacc without prompting; fall back to Save-As if new.

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -198,8 +198,10 @@ class LauncherWindow(QtWidgets.QMainWindow):
         assert menu_bar is not None
         fileMenu = menu_bar.addMenu("&File")
         assert fileMenu is not None
-        # Only the packaged Windows build can register the .smacc handler; hide the
-        # action entirely on dev runs / other platforms (a dev run is python.exe).
+        # The installer owns the .smacc association (#187); this action is the
+        # portable-SMACC.exe / repair affordance. Only a packaged Windows build
+        # can register the handler; hide the action entirely on dev runs / other
+        # platforms (a dev run is python.exe).
         if winassoc.is_associatable():
             associateAction = fileMenu.addAction("&Associate .smacc files (Windows)")
             assert associateAction is not None

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -36,7 +36,6 @@ DEFAULTS: dict[str, Any] = {
     # window classes). Each entry is {x, y, w, h}; an absent/None x or y means
     # "no saved position yet" (open at a sensible default). Empty out of the box.
     "windows": {},
-    "association_prompted": False,
     # Launcher state: recently used settings files (paths, most-recent first) and
     # the last one opened, so the launcher can preselect it and offer quick switching.
     "recent_settings": [],

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -36,7 +36,7 @@ def test_partial_file_merges_over_defaults(tmp_path):
     prefs = preferences.load_preferences(path)
     assert prefs["last_settings"] == "/x"  # from file
     assert prefs["windows"] == {}  # default
-    assert "association_prompted" in prefs  # every default key present
+    assert "log_preview_max_lines" in prefs  # every default key present
 
 
 def test_log_preview_max_lines_reads_a_positive_int():

--- a/tools/smacc.iss
+++ b/tools/smacc.iss
@@ -85,10 +85,11 @@ Name: "{autoprograms}\SMACC EEG review"; Filename: "{app}\SMACC-EEG.exe"; Compon
 Name: "{autodesktop}\SMACC"; Filename: "{app}\SMACC.exe"; Tasks: desktopicon
 
 [Registry]
-; The .smacc file association — these entries mirror winassoc.association_entries()
-; exactly (tests/test_winassoc.py cross-checks them), so an installed build passes
-; winassoc.is_registered() and the in-app first-run prompt skips itself. HKA is
-; HKCU for the default per-user install and HKLM for an /ALLUSERS install.
+; The .smacc file association — the installer is the primary owner (#187); the
+; portable exe can opt in via the Launcher's File menu (smacc.winassoc). These
+; entries mirror winassoc.association_entries() exactly (tests/test_winassoc.py
+; cross-checks them), so an installed build passes winassoc.is_registered(). HKA
+; is HKCU for the default per-user install and HKLM for an /ALLUSERS install.
 Root: HKA; Subkey: "Software\Classes\.smacc"; ValueType: string; ValueName: ""; ValueData: "SMACC.Study"; Flags: uninsdeletekey
 Root: HKA; Subkey: "Software\Classes\.smacc"; ValueType: string; ValueName: "Content Type"; ValueData: "application/x-smacc"; Flags: uninsdeletekey
 Root: HKA; Subkey: "Software\Classes\SMACC.Study"; ValueType: string; ValueName: ""; ValueData: "SMACC study configuration"; Flags: uninsdeletekey


### PR DESCRIPTION
Fixes #187.

The installer registers the `.smacc` association at install time, so the app's first-run prompt was redundant for installed users (it self-skipped via `winassoc.is_registered()`, but only after the registry check, and it still fired for portable users on every fresh machine).

**Removed:**
- The first-run prompt (`_maybe_prompt_association` / `_remember_association_prompted` in [gui.py](src/smacc/gui.py)) and its `association_prompted` preferences key (defaults, docs, test). A leftover key in an existing `preferences.yaml` is ignored — loading merges file keys over the defaults.

**Kept — resolving the issue's open dependency:**
- The issue asked to confirm whether the portable exe (no installer) is a supported use case before deleting `winassoc` entirely. It is: the release workflow attaches the bare `SMACC.exe` to every release, and the installation docs document portable/USB-stick use. So `smacc.winassoc`, its test (which also cross-checks the installer's `[Registry]` section), and the Launcher's **File › Associate .smacc files (Windows)** action all stay — the menu action is now the portable build's only association path and doubles as a repair affordance for broken installs.

**Docs:** the installation page's two mentions of the first-run offer now point at the File-menu action; the preferences reference drops the key.

Full suite passes (793).