### PR TITLE
feat: prompt for subject/session metadata when a session starts

### DIFF
--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -1143,8 +1143,16 @@ class SmaccWindow(ToolWindow):
         return ask_initial_or_final(self, title="Load settings from log")
 
     def _apply_loaded_settings(self, state: dict, metadata: dict) -> None:
-        """Apply panel state and merge any non-empty loaded metadata into the session."""
+        """Apply panel state; in the editor, also adopt the file's metadata.
+
+        A live session's metadata comes from the start-of-session prompt (#184),
+        which was already prefilled from the file — re-merging the file's values
+        here would silently undo whatever the operator edited or cleared in that
+        prompt. The editor has no prompt, so it adopts the loaded file's values.
+        """
         self.apply_settings(state)
+        if not self.design:
+            return
         for key in ("subject", "session", "notes"):
             value = metadata.get(key)
             if value:

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -23,6 +23,7 @@ from . import eeg, preferences, settings, updates, winassoc, windowstate
 from .analyze import AnalyzeWindow
 from .config import VERSION
 from .cuedesigner import CueDesignerWindow
+from .dialogs import SessionInfoDialog
 from .gui import SmaccWindow
 from .paths import DEFAULT_DATA_DIR, DEFAULT_SETTINGS_PATH, LOGO_PATH, preferences_path
 from .session import SmaccSession
@@ -383,13 +384,47 @@ class LauncherWindow(QtWidgets.QMainWindow):
             self._set_settings(None)  # fall back to the built-in defaults
             self.show()  # the double-click flow starts before the launcher is shown
             return
-        session = SmaccSession(self._data_dir())
+        # Capture subject/session/notes before the session window opens (#184):
+        # metadata not entered at the start is usually lost. The fields stay
+        # optional — OK with blanks is a conscious skip — but Cancel backs out
+        # of starting the session at all.
+        metadata = self._prompt_session_info()
+        if metadata is None:
+            self.show()  # the double-click flow starts before the launcher is shown
+            return
+        session = SmaccSession(self._data_dir(), metadata=metadata)
         window = SmaccWindow(session, settings_path=self._settings_path)
         if self._settings_path:
             preferences.update_preferences(
                 preferences_path, {"last_settings": self._settings_path}
             )
         self._open_tool(window)
+
+    def _prompt_session_info(self) -> dict[str, str] | None:
+        """Ask for the optional subject/session/notes; None means Cancel.
+
+        Prefilled from the metadata stored in the selected SMACC file, so a study
+        template's values are offered for confirmation rather than retyped. The
+        prompt's result is the session's metadata — the file's stored values are
+        deliberately not re-merged after this (see SmaccWindow._apply_loaded_settings),
+        so clearing a prefilled field here sticks.
+        """
+        stored: dict = {}
+        if self._settings_path:
+            try:
+                _, stored = settings.load_settings(self._settings_path)
+            except (OSError, ValueError):
+                stored = {}  # already reported by the pre-start check
+        dialog = SessionInfoDialog(
+            str(stored.get("subject") or ""),
+            str(stored.get("session") or ""),
+            str(stored.get("notes") or ""),
+            parent=self,
+        )
+        if not dialog.exec():
+            return None
+        subject, session, notes = dialog.get_inputs()
+        return {"subject": subject, "session": session, "notes": notes}
 
     def create_settings(self) -> None:
         """Open the editor on a fresh settings file (built-in defaults; Save-As)."""

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -469,3 +469,33 @@ def test_editor_save_marks_clean(
     prompts = _watch_close_prompt(monkeypatch)
     assert window.close() is True
     assert prompts == []
+
+
+# ----- metadata precedence: the start-of-session prompt wins (#184) -----------
+
+
+def test_live_session_keeps_prompted_metadata_over_file_metadata(
+    qtbot, live_session, mock_devices, silence_dialogs
+):
+    # The start-of-session prompt (already prefilled from the file) owns the
+    # metadata; loading the file must not overwrite or restore values, or a
+    # field the operator edited/cleared in the prompt would silently revert.
+    live_session.metadata.update({"subject": "tonight", "session": ""})
+    window = SmaccWindow(live_session)
+    qtbot.addWidget(window)
+    window._apply_loaded_settings(
+        window.gather_settings(), {"subject": "template", "session": "ses-9"}
+    )
+    assert live_session.metadata["subject"] == "tonight"
+    assert live_session.metadata["session"] == ""
+
+
+def test_editor_adopts_loaded_file_metadata(
+    qtbot, design_session, mock_devices, silence_dialogs
+):
+    # The editor has no start prompt; a loaded file's metadata lands so it can
+    # be viewed/edited and saved back.
+    window = SmaccWindow(design_session)
+    qtbot.addWidget(window)
+    window._apply_loaded_settings(window.gather_settings(), {"subject": "template"})
+    assert design_session.metadata["subject"] == "template"

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -136,3 +136,61 @@ def test_start_session_aborts_when_the_file_breaks_after_selection(
     # The double-click flow starts a session before the launcher is ever shown;
     # on rejection the launcher must come up rather than leave no window at all.
     assert win.isVisible()
+
+
+# ----- the start-of-session metadata prompt (#184) ----------------------------
+
+
+def test_start_session_prompts_and_passes_metadata(qtbot, tmp_path, monkeypatch):
+    from smacc.toolwindow import ToolWindow
+
+    monkeypatch.setattr(launcher, "preferences_path", tmp_path / "preferences.yaml")
+    captured = {}
+
+    class FakeSession:
+        def __init__(self, data_dir, metadata=None):
+            captured["metadata"] = metadata
+
+    monkeypatch.setattr(launcher, "SmaccSession", FakeSession)
+    monkeypatch.setattr(
+        launcher, "SmaccWindow", lambda session, settings_path=None: ToolWindow()
+    )
+    entered = {"subject": "sub-001", "session": "ses-02", "notes": "first night"}
+    monkeypatch.setattr(
+        LauncherWindow, "_prompt_session_info", lambda self: dict(entered)
+    )
+    win = LauncherWindow(settings_path=None)
+    qtbot.addWidget(win)
+    win.start_session()
+    assert captured["metadata"] == entered
+    assert win._tool is not None  # the session window was opened
+
+
+def test_start_session_cancelled_prompt_aborts(qtbot, tmp_path, monkeypatch):
+    monkeypatch.setattr(launcher, "preferences_path", tmp_path / "preferences.yaml")
+    monkeypatch.setattr(LauncherWindow, "_prompt_session_info", lambda self: None)
+    win = LauncherWindow(settings_path=None)
+    qtbot.addWidget(win)
+    win.start_session()
+    assert win._tool is None  # no session was started
+    # The double-click flow prompts before the launcher is ever shown; on Cancel
+    # the launcher must come up rather than leave no window at all.
+    assert win.isVisible()
+
+
+def test_prompt_session_info_prefills_from_the_smacc_file(qtbot, tmp_path, monkeypatch):
+    from smacc import dialogs, settings
+
+    monkeypatch.setattr(launcher, "preferences_path", tmp_path / "preferences.yaml")
+    good = tmp_path / "study.smacc"
+    settings.save_settings(
+        good, {}, {"subject": "sub-001", "session": "ses-02", "notes": "template"}
+    )
+    monkeypatch.setattr(dialogs.SessionInfoDialog, "exec", lambda self: True)
+    win = LauncherWindow(settings_path=str(good))
+    qtbot.addWidget(win)
+    assert win._prompt_session_info() == {
+        "subject": "sub-001",
+        "session": "ses-02",
+        "notes": "template",
+    }


### PR DESCRIPTION
Fixes #184.

Subject/session IDs were entered only via File → Session info…, fully optional and easy to miss, so a real night could run with no metadata recorded.

**Behavior:**
- **Start** (and the double-click / CLI `.smacc` flow, which goes through `start_session`) now shows the existing `SessionInfoDialog` *before* the session window opens, prefilled from the metadata stored in the selected SMACC file — a template's values are confirmed rather than retyped.
- The fields stay optional: **OK with blanks is a conscious skip**; **Cancel backs out** of starting the session (in the double-click flow the launcher comes up instead of leaving no window).
- The prompt's result is authoritative: `_apply_loaded_settings` no longer merges the file's stored metadata into a **live session**, since those are exactly the values the prompt already offered — re-merging would silently restore a field the operator edited or cleared. The **editor** (no prompt) still adopts a loaded file's metadata so it can be viewed and saved back.

**On "remove it from the File menu":** the issue's proposal offers two options — remove the entry, or keep it purely as the mid-session edit affordance. This PR takes the second: with the capture problem solved by the prompt, the menu entry remains the only way to fix a typo'd ID or add notes mid-run without restarting the session. Happy to remove it instead if full removal is preferred.

**Tests:** prompt result reaches the session's metadata; Cancel aborts (no window, launcher shown); the prompt prefills from the file; live-session metadata survives a file load; the editor adopts file metadata. Full suite passes (806).