### PR TITLE
feat: EEG annotator — .cnt/.set, point marks, epoch model, keyboard nav, save safety, autosave

### DIFF
--- a/src/smacc/eeg/annotations.py
+++ b/src/smacc/eeg/annotations.py
@@ -36,6 +36,10 @@ ANNOTATION_COLUMNS = ["onset", "duration", "description"]
 TSV_SUFFIX = ".annotations.tsv"
 JSON_SUFFIX = ".annotations.json"
 
+# Crash-recovery autosave, kept distinct from the canonical sidecar so autosave
+# can never clobber a deliberate save ("night1.edf" → the .autosave.tsv).
+AUTOSAVE_SUFFIX = ".annotations.autosave.tsv"
+
 # Onsets/durations are written with millisecond precision: finer than any human
 # click on a plot, and exact for every sample at the rates sleep labs record.
 _SECONDS_DECIMALS = 3
@@ -105,6 +109,16 @@ def sidecar_paths(source: str | Path) -> tuple[Path, Path]:
     """
     src = Path(source)
     return src.with_suffix(TSV_SUFFIX), src.with_suffix(JSON_SUFFIX)
+
+
+def autosave_path(source: str | Path) -> Path:
+    """Return the crash-recovery autosave path for a source recording.
+
+    Deliberately separate from :func:`sidecar_paths` (``night1.edf`` →
+    ``night1.annotations.autosave.tsv``) so an in-progress autosave is never
+    mistaken for, and never overwrites, the reviewer's deliberate sidecar.
+    """
+    return Path(source).with_suffix(AUTOSAVE_SUFFIX)
 
 
 def write_annotations_tsv(annotations: list[Annotation], path: str | Path) -> None:

--- a/src/smacc/eeg/io.py
+++ b/src/smacc/eeg/io.py
@@ -26,16 +26,24 @@ from .annotations import Annotation
 if TYPE_CHECKING:  # only for annotations; mne itself is imported lazily
     import mne
 
-# Suffix → the mne.io reader that opens it. BrainVision recordings are a
-# triplet (.vhdr/.eeg/.vmrk) opened via the header file.
+# Suffix → the mne.io reader that opens it; the single source of truth for what
+# the tool can open, so adding a format is a one-line change (the dialog filter
+# and the unsupported-type error both derive from it). BrainVision recordings
+# are a triplet (.vhdr/.eeg/.vmrk) opened via the header file; EEGLAB .set may
+# store its data in a sibling .fdt, and only *continuous* .set files are
+# supported — an epoched .set raises in MNE, surfaced verbatim by open_recording.
 _READERS = {
     ".edf": "read_raw_edf",
     ".vhdr": "read_raw_brainvision",
     ".fif": "read_raw_fif",
+    ".cnt": "read_raw_cnt",
+    ".set": "read_raw_eeglab",
 }
 
-# Qt file-dialog filter for the open dialog.
-FILE_FILTER = "EEG recordings (*.edf *.vhdr *.fif);;All files (*)"
+# Qt file-dialog filter, built from the reader table so it never drifts from it.
+FILE_FILTER = (
+    "EEG recordings (" + " ".join(f"*{ext}" for ext in _READERS) + ");;All files (*)"
+)
 
 # Label for embedded events that arrive without one (rare, but EDF+ allows it);
 # the Annotation model rejects empty descriptions, and inventing nothing is

--- a/src/smacc/eeg/view.py
+++ b/src/smacc/eeg/view.py
@@ -23,6 +23,8 @@ no MNE and nothing from the wider app.
 
 from __future__ import annotations
 
+import math
+from datetime import datetime, timedelta
 from typing import Any, Protocol
 
 import numpy as np
@@ -57,6 +59,53 @@ _REGION_BRUSH_SELECTED = (70, 130, 180, 110)
 _REGION_PEN = (70, 130, 180, 160)
 _LINE_PEN = (178, 34, 34, 160)  # firebrick for instantaneous marks
 _LINE_PEN_SELECTED = (178, 34, 34, 255)
+
+# Epoch gridlines: a faint dashed grey so the boundaries read as background
+# scaffolding behind the traces, never competing with the firebrick marks.
+_EPOCH_PEN = pg.mkPen((128, 128, 128, 110), width=1, style=QtCore.Qt.PenStyle.DashLine)
+_EPOCH_LABEL_COLOR = (128, 128, 128, 200)
+# The standard polysomnography scoring epoch; the sleep default everywhere.
+DEFAULT_EPOCH_SECONDS = 30.0
+
+
+class TimeAxis(pg.AxisItem):
+    """Bottom axis that labels x (data seconds) as elapsed time or wall clock.
+
+    The tick *positions* stay in data seconds (pyqtgraph picks them); only the
+    strings change. Clock mode needs an ``origin`` datetime — the recording's
+    localized start, computed format-aware in :func:`smacc.eeg.window.wall_time`
+    and handed down here, so this axis stays free of MNE and format quirks.
+    Falls back to elapsed seconds whenever no origin is known (anonymized files).
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._mode = "elapsed"
+        self._origin: datetime | None = None
+        self.setLabel("time (s)")
+
+    def set_mode(self, mode: str) -> None:
+        """Switch between ``"clock"`` and ``"elapsed"`` tick labels."""
+        self._mode = mode
+        self.setLabel("clock time" if mode == "clock" else "time (s)")
+        self.picture = None  # drop the cached render so tickStrings re-runs
+        self.update()
+
+    def set_origin(self, origin: datetime | None) -> None:
+        """Set the wall-clock instant of data-second 0 (``None`` disables clock)."""
+        self._origin = origin
+        self.picture = None
+        self.update()
+
+    def tickStrings(
+        self, values: list[float], scale: float, spacing: float
+    ) -> list[str]:
+        if self._mode == "clock" and self._origin is not None:
+            return [
+                (self._origin + timedelta(seconds=float(v))).strftime("%H:%M:%S")
+                for v in values
+            ]
+        return super().tickStrings(values, scale, spacing)
 
 
 class SliceProvider(Protocol):
@@ -150,12 +199,24 @@ class TraceView(pg.PlotWidget):
 
     def __init__(self) -> None:
         self._viewbox = _AnnotateViewBox()
-        super().__init__(viewBox=self._viewbox, background=None)
+        self._time_axis = TimeAxis(orientation="bottom")
+        super().__init__(
+            viewBox=self._viewbox,
+            background=None,
+            axisItems={"bottom": self._time_axis},
+        )
         self._provider: SliceProvider | None = None
         self._spec = dsp.UNFILTERED
         self._window_start = 0.0
         self._window_seconds = 30.0  # the standard sleep-scoring epoch
         self._scale_uv = 100.0  # microvolts per channel lane
+        # Epoch model (#173): the scoring epoch is separate from the on-screen
+        # window. Boundaries fall at anchor + k·epoch for integer k, so anchoring
+        # on a feature back/front-fills the whole grid from that point.
+        self._epoch_seconds = DEFAULT_EPOCH_SECONDS
+        self._epoch_anchor = 0.0
+        self._show_epochs = True
+        self._epoch_items: list[pg.InfiniteLine] = []
         self._annotations: list[Annotation] = []
         self._selected = -1
         self._annotation_items: list[pg.LinearRegionItem | pg.InfiniteLine] = []
@@ -174,8 +235,7 @@ class TraceView(pg.PlotWidget):
         plot_item.setMenuEnabled(False)
         left_axis = plot_item.getAxis("left")
         left_axis.setStyle(tickLength=0)
-        bottom_axis = plot_item.getAxis("bottom")
-        bottom_axis.setLabel("time (s)")
+        # The bottom axis is the custom TimeAxis (clock/elapsed); it labels itself.
         # Track the mouse for the status-bar clock readout.
         self.scene().sigMouseMoved.connect(self._on_mouse_moved)
 
@@ -197,13 +257,23 @@ class TraceView(pg.PlotWidget):
     def selected(self) -> int:
         return self._selected
 
+    @property
+    def epoch_seconds(self) -> float:
+        return self._epoch_seconds
+
+    @property
+    def epoch_anchor(self) -> float:
+        return self._epoch_anchor
+
     def set_provider(self, provider: SliceProvider | None) -> None:
         """Show a (new) recording from its start; ``None`` clears the view."""
         self._provider = provider
         self._window_start = 0.0
+        self._epoch_anchor = 0.0  # a new recording starts epoch 1 at its start
         self._build_curves()
         self._refresh_data()
         self._refresh_annotations()
+        self._refresh_epochs()
 
     def set_spec(self, spec: dsp.FilterSpec) -> None:
         self._spec = spec
@@ -219,12 +289,40 @@ class TraceView(pg.PlotWidget):
         self._clamp_window_start()
         self._refresh_data()
         self._refresh_annotations()
+        self._refresh_epochs()
 
     def set_window_start(self, seconds: float) -> None:
         self._window_start = seconds
         self._clamp_window_start()
         self._refresh_data()
         self._refresh_annotations()
+        self._refresh_epochs()
+
+    def set_epoch_seconds(self, seconds: float) -> None:
+        """Set the scoring-epoch length (≥ 1 s); redraws the epoch grid."""
+        self._epoch_seconds = max(1.0, float(seconds))
+        self._refresh_epochs()
+
+    def set_epoch_anchor(self, seconds: float) -> None:
+        """Set the time at which an epoch boundary falls (epoch 1 starts here).
+
+        The grid back/front-fills from the anchor, so passing a feature's time
+        (e.g. the start of an LRLR) lets the signal sit cleanly inside one epoch.
+        """
+        self._epoch_anchor = max(0.0, float(seconds))
+        self._refresh_epochs()
+
+    def set_epochs_visible(self, visible: bool) -> None:
+        self._show_epochs = bool(visible)
+        self._refresh_epochs()
+
+    def set_time_axis_mode(self, mode: str) -> None:
+        """Label the time axis with ``"clock"`` wall time or ``"elapsed"`` seconds."""
+        self._time_axis.set_mode(mode)
+
+    def set_time_origin(self, origin: datetime | None) -> None:
+        """Tell the axis the wall-clock instant of data-second 0 (for clock mode)."""
+        self._time_axis.set_origin(origin)
 
     def scroll_by(self, fraction: float) -> None:
         """Scroll by a fraction of the window (±1.0 is a full page)."""
@@ -421,3 +519,35 @@ class TraceView(pg.PlotWidget):
             item.setZValue(10)
             plot_item.addItem(item)
             self._annotation_items.append(item)
+
+    def _refresh_epochs(self) -> None:
+        """Redraw the epoch boundary gridlines for the visible window.
+
+        Lines fall at ``anchor + k·epoch`` and are numbered with the epoch they
+        begin (the boundary at the anchor starts epoch 1). Only the handful of
+        boundaries inside the window are drawn, so this stays cheap on scroll.
+        """
+        plot_item = self.getPlotItem()
+        assert plot_item is not None
+        for old in self._epoch_items:
+            plot_item.removeItem(old)
+        self._epoch_items = []
+        if self._provider is None or not self._show_epochs:
+            return
+        lo = self._window_start
+        hi = self._window_start + self._window_seconds
+        first = math.ceil((lo - self._epoch_anchor) / self._epoch_seconds)
+        last = math.floor((hi - self._epoch_anchor) / self._epoch_seconds)
+        for k in range(first, last + 1):
+            boundary = self._epoch_anchor + k * self._epoch_seconds
+            line = pg.InfiniteLine(
+                pos=boundary,
+                angle=90,
+                movable=False,
+                pen=_EPOCH_PEN,
+                label=str(k + 1),  # the epoch this boundary starts
+                labelOpts={"position": 0.96, "color": _EPOCH_LABEL_COLOR},
+            )
+            line.setZValue(2)  # above the curves, below the annotations
+            plot_item.addItem(line)
+            self._epoch_items.append(line)

--- a/src/smacc/eeg/view.py
+++ b/src/smacc/eeg/view.py
@@ -88,6 +88,7 @@ class _AnnotateViewBox(pg.ViewBox):
 
     dragFinished = QtCore.pyqtSignal(float, float)  # span in data seconds
     clicked = QtCore.pyqtSignal(float)  # click time in data seconds
+    markRequested = QtCore.pyqtSignal(float)  # ctrl-click: drop a point mark here
 
     def __init__(self) -> None:
         super().__init__(enableMouse=False, enableMenu=False)
@@ -118,7 +119,13 @@ class _AnnotateViewBox(pg.ViewBox):
             ev.ignore()
             return
         ev.accept()
-        self.clicked.emit(float(self.mapToView(ev.pos()).x()))
+        seconds = float(self.mapToView(ev.pos()).x())
+        # Ctrl+click drops a point mark; a plain click selects. The modifier
+        # keeps the frequent selection-click from ever creating stray markers.
+        if ev.modifiers() & QtCore.Qt.KeyboardModifier.ControlModifier:
+            self.markRequested.emit(seconds)
+        else:
+            self.clicked.emit(seconds)
 
 
 class TraceView(pg.PlotWidget):
@@ -132,12 +139,14 @@ class TraceView(pg.PlotWidget):
     * ``windowChanged(start)`` — the view scrolled itself (mouse wheel), so the
       window can sync its scrollbar.
     * ``cursorMoved(seconds)`` — mouse position, for the status-bar clock.
+    * ``pointMarkRequested(seconds)`` — ctrl-click asked for a point mark here.
     """
 
     regionDrawn = QtCore.pyqtSignal(float, float)
     annotationSelected = QtCore.pyqtSignal(int)
     windowChanged = QtCore.pyqtSignal(float)
     cursorMoved = QtCore.pyqtSignal(float)
+    pointMarkRequested = QtCore.pyqtSignal(float)
 
     def __init__(self) -> None:
         self._viewbox = _AnnotateViewBox()
@@ -154,6 +163,7 @@ class TraceView(pg.PlotWidget):
 
         self._viewbox.dragFinished.connect(self._on_drag_finished)
         self._viewbox.clicked.connect(self._on_clicked)
+        self._viewbox.markRequested.connect(self._on_mark_requested)
         # Click-to-focus so the arrow-key navigation in keyPressEvent reaches
         # the traces after the operator clicks them.
         self.setFocusPolicy(QtCore.Qt.FocusPolicy.ClickFocus)
@@ -239,6 +249,12 @@ class TraceView(pg.PlotWidget):
         hi = min(self._provider.duration, hi)
         if hi > lo:
             self.regionDrawn.emit(lo, hi)
+
+    def _on_mark_requested(self, seconds: float) -> None:
+        if self._provider is None:
+            return
+        seconds = min(max(0.0, seconds), self._provider.duration)
+        self.pointMarkRequested.emit(seconds)
 
     def _on_clicked(self, seconds: float) -> None:
         index = self._annotation_at(seconds)

--- a/src/smacc/eeg/view.py
+++ b/src/smacc/eeg/view.py
@@ -225,9 +225,9 @@ class TraceView(pg.PlotWidget):
         self._viewbox.dragFinished.connect(self._on_drag_finished)
         self._viewbox.clicked.connect(self._on_clicked)
         self._viewbox.markRequested.connect(self._on_mark_requested)
-        # Click-to-focus so the arrow-key navigation in keyPressEvent reaches
-        # the traces after the operator clicks them.
-        self.setFocusPolicy(QtCore.Qt.FocusPolicy.ClickFocus)
+        # Keyboard navigation is owned by the window (a single app-level filter,
+        # so it works without first clicking the traces — see window.py); the
+        # view only exposes the navigation primitives it drives.
         self.setAntialiasing(False)  # measurably faster, invisible at 1 px pens
         plot_item = self.getPlotItem()
         assert plot_item is not None
@@ -329,6 +329,16 @@ class TraceView(pg.PlotWidget):
         self.set_window_start(self._window_start + fraction * self._window_seconds)
         self.windowChanged.emit(self._window_start)
 
+    def step_epochs(self, count: int) -> None:
+        """Move the window by ``count`` epoch lengths (the arrow-key page step)."""
+        self.set_window_start(self._window_start + count * self._epoch_seconds)
+        self.windowChanged.emit(self._window_start)
+
+    def nudge_seconds(self, seconds: float) -> None:
+        """Scroll a fixed number of seconds (the Shift+arrow fine step)."""
+        self.set_window_start(self._window_start + seconds)
+        self.windowChanged.emit(self._window_start)
+
     def set_annotations(
         self, annotations: list[Annotation], selected: int = -1
     ) -> None:
@@ -390,34 +400,6 @@ class TraceView(pg.PlotWidget):
             return
         notches = ev.angleDelta().y() / 120.0
         self.scroll_by(-0.1 * notches)
-        ev.accept()
-
-    def keyPressEvent(self, ev: QtGui.QKeyEvent | None) -> None:
-        """Arrow/Home/End navigation while the traces have focus.
-
-        These live here (with click-to-focus) rather than as window shortcuts
-        because a focused spin box consumes cursor keys via ShortcutOverride —
-        a window-level Left/Right would silently die right after the operator
-        adjusts a filter. Clicking the traces focuses them, and from there the
-        arrows always work. PageUp/PageDown are window shortcuts (no text
-        widget steals them), so paging works regardless of focus.
-        """
-        if ev is None:
-            return
-        key = ev.key()
-        if key == QtCore.Qt.Key.Key_Right:
-            self.scroll_by(0.1)
-        elif key == QtCore.Qt.Key.Key_Left:
-            self.scroll_by(-0.1)
-        elif key == QtCore.Qt.Key.Key_Home:
-            self.set_window_start(0.0)
-            self.windowChanged.emit(self._window_start)
-        elif key == QtCore.Qt.Key.Key_End:
-            self.set_window_start(float("inf"))
-            self.windowChanged.emit(self._window_start)
-        else:
-            super().keyPressEvent(ev)
-            return
         ev.accept()
 
     # ----- drawing ---------------------------------------------------------------

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -193,6 +193,9 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._annotations: list[Annotation] = []
         self._dirty = False
         self._cursor_seconds: float | None = None  # last mouse time over the traces
+        # True once this review's annotations live in the canonical sidecar (we
+        # loaded it, or we have saved at least once); gates the overwrite prompt.
+        self._owns_sidecar = False
         self.setWindowTitle("SMACC — EEG review")
         if LOGO_PATH.is_file():
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
@@ -216,6 +219,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         layout.setContentsMargins(12, 8, 12, 8)
         layout.setSpacing(8)
         layout.addWidget(_section_title("EEG review"))
+        layout.addWidget(self._build_contract_caption())
         layout.addLayout(self._build_controls_row())
         layout.addLayout(self._build_epoch_row())
 
@@ -329,7 +333,13 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         row.addStretch(1)
         self.saveButton = QtWidgets.QPushButton("Save annotations", self)
         self.saveButton.setStatusTip(
-            "Write the annotations TSV/JSON sidecar next to the recording."
+            "Write the annotation sidecar next to the recording; the recording "
+            "itself is never modified."
+        )
+        self.saveButton.setToolTip(
+            "Saves the annotation sidecar (TSV/JSON) next to the recording.\n"
+            "The recording is never modified; filters, scaling, channel selection "
+            "and the epoch grid are view-only."
         )
         self.saveButton.clicked.connect(self.save_annotations)
         row.addWidget(self.saveButton)
@@ -389,6 +399,16 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         row.addWidget(self.axisModeCombo)
         row.addStretch(1)
         return row
+
+    def _build_contract_caption(self) -> QtWidgets.QLabel:
+        """A quiet, always-visible reminder of the tool's safety contract (#175)."""
+        caption = QtWidgets.QLabel(
+            "Saves annotations to a sidecar — your recording is never modified.",
+            self,
+        )
+        caption.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        caption.setEnabled(False)  # renders dimmed, following the palette
+        return caption
 
     def _build_annotation_panel(self) -> QtWidgets.QLayout:
         panel = QtWidgets.QVBoxLayout()
@@ -482,6 +502,9 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._recording = recording
         self._annotations = annotations
         self._dirty = False
+        # We own the sidecar when we loaded from it; a fresh review does not yet,
+        # so its first save guards against overwriting one that appeared meanwhile.
+        self._owns_sidecar = tsv_path.is_file()
         self.view.set_provider(recording)
         self.view.set_annotations(annotations)
         # Hand the view the localized recording start so the time axis can label
@@ -584,6 +607,12 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         if self._recording is None:
             return
         tsv_path, json_path = sidecar_paths(self._recording.path)
+        # Guard the one case where a save would silently clobber someone else's
+        # work: a sidecar we did not open (a fresh review, or one that appeared
+        # while we worked). A sidecar we loaded — or already saved — is ours.
+        if not self._owns_sidecar and tsv_path.is_file():
+            if not self._confirm_overwrite(tsv_path):
+                return
         try:
             write_annotations_tsv(self._annotations, tsv_path)
             write_annotations_json(
@@ -595,12 +624,25 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             self._error("Could not save the annotations.", str(exc))
             return
         self._dirty = False
+        self._owns_sidecar = True  # ours now; later saves don't re-prompt
         self._refresh_title()
         status_bar = self.statusBar()
         assert status_bar is not None
         status_bar.showMessage(
             f"Saved {len(self._annotations)} annotations to {tsv_path.name}", 5000
         )
+
+    def _confirm_overwrite(self, tsv_path: Path) -> bool:
+        """Ask before overwriting a sidecar this review did not open."""
+        button = QtWidgets.QMessageBox.question(
+            self,
+            "Overwrite annotations?",
+            f"{tsv_path.name} already exists and was not opened in this review.\n\n"
+            "Overwrite it with the current annotations?",
+            QtWidgets.QMessageBox.StandardButton.Yes
+            | QtWidgets.QMessageBox.StandardButton.No,
+        )
+        return button == QtWidgets.QMessageBox.StandardButton.Yes
 
     # ----- annotation bookkeeping ----------------------------------------------------
 

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -217,7 +217,9 @@ class EegReviewWindow(QtWidgets.QMainWindow):
     def _build_controls_row(self) -> QtWidgets.QLayout:
         row = QtWidgets.QHBoxLayout()
         openButton = QtWidgets.QPushButton("Open recording…", self)
-        openButton.setStatusTip("Open an EEG recording (EDF, BrainVision, or FIF).")
+        openButton.setStatusTip(
+            "Open an EEG recording (EDF, BrainVision, FIF, Neuroscan .cnt, EEGLAB .set)."
+        )
         openButton.clicked.connect(self.open_file)
         row.addWidget(openButton)
         row.addSpacing(12)

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -34,6 +34,7 @@ from ..paths import LOGO_PATH, preferences_path
 from . import dsp, io
 from .annotations import (
     Annotation,
+    autosave_path,
     insert,
     read_annotations_tsv,
     remove,
@@ -61,6 +62,10 @@ DEFAULT_WINDOW_LENGTH = 30
 # The scrollbar works in tenths of a second: fine enough to land anywhere,
 # coarse enough that an 8 h night stays within QScrollBar's int range.
 _SCROLL_TICKS_PER_SECOND = 10
+
+# Autosave (#176) is debounced: each annotation change restarts this timer, so a
+# burst of edits writes the recovery file once, shortly after the last of them.
+_AUTOSAVE_DEBOUNCE_MS = 2000
 
 # Keyboard navigation (#174). Plain Left/Right page by one epoch; Shift nudges a
 # second to peek across a boundary. Up/Down step the amplitude multiplicatively
@@ -196,6 +201,14 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         # True once this review's annotations live in the canonical sidecar (we
         # loaded it, or we have saved at least once); gates the overwrite prompt.
         self._owns_sidecar = False
+        # Annotations recovered from an autosave, held until the user restores or
+        # dismisses them (#176).
+        self._recovery_annotations: list[Annotation] | None = None
+        # Debounced crash-recovery autosave (#176): restarted on every change.
+        self._autosave_timer = QtCore.QTimer(self)
+        self._autosave_timer.setSingleShot(True)
+        self._autosave_timer.setInterval(_AUTOSAVE_DEBOUNCE_MS)
+        self._autosave_timer.timeout.connect(self._write_autosave)
         self.setWindowTitle("SMACC — EEG review")
         if LOGO_PATH.is_file():
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
@@ -220,6 +233,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         layout.setSpacing(8)
         layout.addWidget(_section_title("EEG review"))
         layout.addWidget(self._build_contract_caption())
+        layout.addWidget(self._build_recovery_banner())
         layout.addLayout(self._build_controls_row())
         layout.addLayout(self._build_epoch_row())
 
@@ -410,6 +424,30 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         caption.setEnabled(False)  # renders dimmed, following the palette
         return caption
 
+    def _build_recovery_banner(self) -> QtWidgets.QWidget:
+        """A non-modal bar offering to restore autosaved annotations (#176).
+
+        Hidden until a recovery file is found on open; restoring is always an
+        explicit choice, never applied silently.
+        """
+        banner = QtWidgets.QFrame(self)
+        banner.setFrameShape(QtWidgets.QFrame.Shape.StyledPanel)
+        banner.setVisible(False)
+        row = QtWidgets.QHBoxLayout(banner)
+        row.setContentsMargins(8, 4, 8, 4)
+        self.recoveryLabel = QtWidgets.QLabel("", banner)
+        row.addWidget(self.recoveryLabel, 1)
+        restoreButton = QtWidgets.QPushButton("Restore", banner)
+        restoreButton.setStatusTip("Load the autosaved annotations into this review.")
+        restoreButton.clicked.connect(self._restore_autosave)
+        row.addWidget(restoreButton)
+        dismissButton = QtWidgets.QPushButton("Dismiss", banner)
+        dismissButton.setStatusTip("Discard the autosaved annotations and delete them.")
+        dismissButton.clicked.connect(self._dismiss_autosave)
+        row.addWidget(dismissButton)
+        self.recoveryBanner = banner
+        return banner
+
     def _build_annotation_panel(self) -> QtWidgets.QLayout:
         panel = QtWidgets.QVBoxLayout()
         panel.addWidget(QtWidgets.QLabel("Annotations:", self))
@@ -480,6 +518,10 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         except (ValueError, OSError, RuntimeError) as exc:
             self._error("Could not open the recording.", str(exc))
             return
+        # Opened cleanly: stop autosaving the recording we're leaving and drop its
+        # recovery file (the user already saved or discarded it via open_file).
+        self._autosave_timer.stop()
+        self._clear_autosave()
         tsv_path, _ = sidecar_paths(path)
         if tsv_path.is_file():
             # Resume a previous review. A sidecar that exists but won't parse
@@ -528,6 +570,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             f"{path.name} — {len(recording.ch_names)} ch · "
             f"{recording.sfreq:g} Hz · {recording.duration:.0f} s{clock}"
         )
+        self._check_for_recovery(tsv_path)
 
     # ----- annotation editing -----------------------------------------------------
 
@@ -625,6 +668,8 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             return
         self._dirty = False
         self._owns_sidecar = True  # ours now; later saves don't re-prompt
+        self._autosave_timer.stop()
+        self._clear_autosave()  # the work is persisted; no recovery needed
         self._refresh_title()
         status_bar = self.statusBar()
         assert status_bar is not None
@@ -648,6 +693,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
 
     def _mark_dirty(self) -> None:
         self._dirty = True
+        self._autosave_timer.start()  # (re)arm the debounced recovery write
         self._refresh_title()
 
     def _select(self, index: int) -> None:
@@ -688,6 +734,68 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             self._recent_labels(), label, limit=_MAX_RECENT_LABELS
         )
         preferences.update_preferences(preferences_path, {"eeg_recent_labels": recents})
+
+    # ----- autosave / crash recovery (#176) ----------------------------------------
+
+    def _write_autosave(self) -> None:
+        """Write the recovery file (best-effort, atomic); fired by the debounce timer."""
+        if self._recording is None or not self._dirty:
+            return
+        path = autosave_path(self._recording.path)
+        tmp = path.with_suffix(".tmp")  # write-then-rename so a crash never half-writes
+        try:
+            write_annotations_tsv(self._annotations, tmp)
+            tmp.replace(path)
+        except OSError:
+            pass  # autosave must never interrupt the review
+
+    def _clear_autosave(self) -> None:
+        """Delete the current recording's recovery file, if any."""
+        if self._recording is not None:
+            autosave_path(self._recording.path).unlink(missing_ok=True)
+
+    def _check_for_recovery(self, tsv_path: Path) -> None:
+        """On open, offer to restore a recovery file newer than the saved sidecar."""
+        self.recoveryBanner.setVisible(False)
+        self._recovery_annotations = None
+        if self._recording is None:
+            return
+        recovery = autosave_path(self._recording.path)
+        if not recovery.is_file():
+            return
+        # A recovery file with a clean save strictly newer than it is stale — the
+        # save happened after the autosave, so there is nothing left to recover.
+        # Strict so a same-second tie errs toward offering recovery, never losing it.
+        stale = (
+            tsv_path.is_file() and tsv_path.stat().st_mtime > recovery.stat().st_mtime
+        )
+        if stale:
+            recovery.unlink(missing_ok=True)
+            return
+        try:
+            recovered = read_annotations_tsv(recovery)
+        except (OSError, ValueError):
+            return  # an unreadable recovery file must not block the open
+        self._recovery_annotations = recovered
+        self.recoveryLabel.setText(
+            f"Recovered {len(recovered)} unsaved annotation(s) from a previous session."
+        )
+        self.recoveryBanner.setVisible(True)
+
+    def _restore_autosave(self) -> None:
+        if self._recovery_annotations is None:
+            return
+        self._annotations = self._recovery_annotations
+        self._recovery_annotations = None
+        self.recoveryBanner.setVisible(False)
+        self.view.set_annotations(self._annotations)
+        self._refresh_list()
+        self._mark_dirty()  # restored but not yet saved — keep the recovery alive
+
+    def _dismiss_autosave(self) -> None:
+        self._recovery_annotations = None
+        self.recoveryBanner.setVisible(False)
+        self._clear_autosave()  # the user declined the recovery; drop it
 
     # ----- selection sync ---------------------------------------------------------
 
@@ -820,7 +928,9 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         current = self.scaleSpin.value()
         target = current / factor if louder else current * factor
         clamped = max(self.scaleSpin.minimum(), min(self.scaleSpin.maximum(), target))
-        self.scaleSpin.setValue(round(clamped))  # drives view.set_scale, shows the value
+        self.scaleSpin.setValue(
+            round(clamped)
+        )  # drives view.set_scale, shows the value
 
     def _on_filters_changed(self) -> None:
         highpass = self.highpassSpin.value() or None  # 0.0 displays as "Off"
@@ -894,6 +1004,10 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             if event is not None:
                 event.ignore()
             return
+        # Closing cleanly (saved or discarded): there is no unsaved work to
+        # recover, so drop the recovery file and stop the autosave timer.
+        self._autosave_timer.stop()
+        self._clear_autosave()
         # Drop the app-level key filter before this window goes away, so a stray
         # late event can never reach a half-deleted window.
         app = QtWidgets.QApplication.instance()

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -23,6 +23,7 @@ must never share a process with a running night).
 
 from __future__ import annotations
 
+import math
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -60,6 +61,33 @@ DEFAULT_WINDOW_LENGTH = 30
 # The scrollbar works in tenths of a second: fine enough to land anywhere,
 # coarse enough that an 8 h night stays within QScrollBar's int range.
 _SCROLL_TICKS_PER_SECOND = 10
+
+# Keyboard navigation (#174). Plain Left/Right page by one epoch; Shift nudges a
+# second to peek across a boundary. Up/Down step the amplitude multiplicatively
+# (Shift = a gentler factor) — louder means a smaller µV/lane, i.e. bigger traces.
+_FINE_NUDGE_SECONDS = 1.0
+_SCALE_KEY_FACTOR = 1.25
+_SCALE_KEY_FACTOR_FINE = 1.1
+_NAV_KEYS = frozenset(
+    {
+        QtCore.Qt.Key.Key_Left,
+        QtCore.Qt.Key.Key_Right,
+        QtCore.Qt.Key.Key_Up,
+        QtCore.Qt.Key.Key_Down,
+        QtCore.Qt.Key.Key_Home,
+        QtCore.Qt.Key.Key_End,
+    }
+)
+# Keys a focused combo box, list, or spin box uses for its own up/down selection;
+# the filter yields these to such widgets but still claims Left/Right for paging.
+_VERTICAL_NAV_KEYS = frozenset(
+    {
+        QtCore.Qt.Key.Key_Up,
+        QtCore.Qt.Key.Key_Down,
+        QtCore.Qt.Key.Key_Home,
+        QtCore.Qt.Key.Key_End,
+    }
+)
 
 
 def _section_title(text: str) -> QtWidgets.QLabel:
@@ -170,6 +198,11 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
         self._build()
         self._set_loaded(False)
+        # An application-level filter so epoch/amplitude keys work from anywhere in
+        # the window, not only after clicking the traces (#174); removed on close.
+        app = QtWidgets.QApplication.instance()
+        if app is not None:
+            app.installEventFilter(self)
         if file_path is not None:
             # After the event loop starts, so the window is up before any
             # open-error dialog (and a long load doesn't block the first paint).
@@ -204,11 +237,15 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         layout.addLayout(body, 1)
 
         self.statusBar()
-        # Permanent (right-aligned) recording summary; transient messages and
-        # the cursor clock use the normal message area.
+        # Permanent (right-aligned) state: the epoch at the left edge of the view
+        # and the recording summary. Transient messages and the cursor clock use
+        # the normal message area.
+        self.epochLabel = QtWidgets.QLabel("", self)
+        self.epochLabel.setStatusTip("The epoch at the left edge of the view.")
         self.fileInfoLabel = QtWidgets.QLabel("", self)
         status_bar = self.statusBar()
         assert status_bar is not None
+        status_bar.addPermanentWidget(self.epochLabel)
         status_bar.addPermanentWidget(self.fileInfoLabel)
 
         self._build_shortcuts()
@@ -314,9 +351,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.epochSpin.setStatusTip(
             "Scoring-epoch length (30 s is standard) — independent of the window."
         )
-        self.epochSpin.valueChanged.connect(
-            lambda value: self.view.set_epoch_seconds(float(value))
-        )
+        self.epochSpin.valueChanged.connect(self._on_epoch_seconds_changed)
         row.addWidget(self.epochSpin)
 
         self.epochGridCheck = QtWidgets.QCheckBox("Epoch grid", self)
@@ -331,15 +366,13 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.anchorButton.setStatusTip(
             "Start an epoch at the left edge of the view (back/front-fills the grid)."
         )
-        self.anchorButton.clicked.connect(
-            lambda: self.view.set_epoch_anchor(self.view.window_start)
-        )
+        self.anchorButton.clicked.connect(self._anchor_epochs_to_view)
         row.addWidget(self.anchorButton)
         self.resetAnchorButton = QtWidgets.QPushButton("Reset anchor", self)
         self.resetAnchorButton.setStatusTip(
             "Put epoch 1 back at the start of the recording."
         )
-        self.resetAnchorButton.clicked.connect(lambda: self.view.set_epoch_anchor(0.0))
+        self.resetAnchorButton.clicked.connect(self._reset_epoch_anchor)
         row.addWidget(self.resetAnchorButton)
 
         row.addSpacing(12)
@@ -383,12 +416,12 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         return panel
 
     def _build_shortcuts(self) -> None:
-        """Window-wide paging on PageUp/PageDown only.
+        """Window-wide paging on PageUp/PageDown, plus M to drop a point mark.
 
-        Arrows and Home/End live on the TraceView itself (click the traces,
-        then navigate): as window shortcuts they would be consumed by whichever
-        spin box or list last had focus. No text widget steals PageUp/Down, so
-        paging works from anywhere.
+        Arrow/Home/End navigation and amplitude are handled by the application
+        event filter (see :meth:`eventFilter`), which works regardless of focus;
+        no text widget steals PageUp/Down or a bare M, so those stay plain
+        QShortcuts here.
         """
         for keys, fraction in (
             (QtCore.Qt.Key.Key_PageDown, 1.0),
@@ -462,6 +495,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._refresh_list()
         self._refresh_title()
         self._configure_scrollbar()
+        self._update_epoch_readout()
         self._set_loaded(True)
         preferences.update_preferences(
             preferences_path, {"eeg_last_dir": str(path.parent)}
@@ -642,15 +676,109 @@ class EegReviewWindow(QtWidgets.QMainWindow):
 
     def _on_scrollbar(self, value: int) -> None:
         self.view.set_window_start(value / _SCROLL_TICKS_PER_SECOND)
+        self._update_epoch_readout()
 
     def _sync_scrollbar(self, window_start: float) -> None:
         self.scrollBar.blockSignals(True)
         self.scrollBar.setValue(int(window_start * _SCROLL_TICKS_PER_SECOND))
         self.scrollBar.blockSignals(False)
+        self._update_epoch_readout()
 
     def _on_window_length_changed(self) -> None:
         self.view.set_window_seconds(float(self.windowCombo.currentData()))
         self._configure_scrollbar()
+        self._update_epoch_readout()
+
+    # ----- epoch model + keyboard navigation (#173, #174) -----------------------------
+
+    def _on_epoch_seconds_changed(self, value: int) -> None:
+        self.view.set_epoch_seconds(float(value))
+        self._update_epoch_readout()
+
+    def _anchor_epochs_to_view(self) -> None:
+        self.view.set_epoch_anchor(self.view.window_start)
+        self._update_epoch_readout()
+
+    def _reset_epoch_anchor(self) -> None:
+        self.view.set_epoch_anchor(0.0)
+        self._update_epoch_readout()
+
+    def _update_epoch_readout(self) -> None:
+        """Show the epoch number at the left edge of the view in the status bar."""
+        if self._recording is None:
+            self.epochLabel.clear()
+            return
+        number = (
+            math.floor(
+                (self.view.window_start - self.view.epoch_anchor)
+                / self.view.epoch_seconds
+            )
+            + 1
+        )
+        self.epochLabel.setText(f"Epoch {number}")
+
+    def eventFilter(
+        self, obj: QtCore.QObject | None, event: QtCore.QEvent | None
+    ) -> bool:
+        """Route epoch/amplitude keys to the view regardless of which child has focus.
+
+        Installed on the application so the keys work without first clicking the
+        traces; scoped to this window being active (so a modal dialog keeps them)
+        and to a recording being loaded.
+        """
+        if (
+            isinstance(event, QtGui.QKeyEvent)
+            and event.type() == QtCore.QEvent.Type.KeyPress
+            and self.isActiveWindow()
+            and self._recording is not None
+            and self._handle_nav_key(event)
+        ):
+            return True
+        return super().eventFilter(obj, event)
+
+    def _focus_wants(self, key: int) -> bool:
+        """True if the focused widget should keep ``key`` for its own editing/nav.
+
+        Text/number entry (spin box, line edit) keeps every navigation key; a
+        combo box or the annotation list keeps only the vertical keys, so
+        Left/Right still page epochs while the list has focus.
+        """
+        focus = QtWidgets.QApplication.focusWidget()
+        if isinstance(focus, QtWidgets.QAbstractSpinBox | QtWidgets.QLineEdit):
+            return True
+        if isinstance(focus, QtWidgets.QComboBox | QtWidgets.QAbstractItemView):
+            return key in _VERTICAL_NAV_KEYS
+        return False
+
+    def _handle_nav_key(self, event: QtGui.QKeyEvent) -> bool:
+        """Apply one navigation/amplitude key; return whether it was consumed."""
+        key = event.key()
+        if key not in _NAV_KEYS or self._focus_wants(key):
+            return False
+        shift = bool(event.modifiers() & QtCore.Qt.KeyboardModifier.ShiftModifier)
+        if key in (QtCore.Qt.Key.Key_Left, QtCore.Qt.Key.Key_Right):
+            sign = 1 if key == QtCore.Qt.Key.Key_Right else -1
+            if shift:
+                self.view.nudge_seconds(sign * _FINE_NUDGE_SECONDS)
+            else:
+                self.view.step_epochs(sign)
+        elif key == QtCore.Qt.Key.Key_Up:
+            self._nudge_scale(louder=True, fine=shift)
+        elif key == QtCore.Qt.Key.Key_Down:
+            self._nudge_scale(louder=False, fine=shift)
+        elif key == QtCore.Qt.Key.Key_Home:
+            self._jump_to(0.0)
+        elif key == QtCore.Qt.Key.Key_End:
+            self._jump_to(float("inf"))
+        return True
+
+    def _nudge_scale(self, *, louder: bool, fine: bool) -> None:
+        """Step the amplitude through the scale spin box (louder → smaller µV/lane)."""
+        factor = _SCALE_KEY_FACTOR_FINE if fine else _SCALE_KEY_FACTOR
+        current = self.scaleSpin.value()
+        target = current / factor if louder else current * factor
+        clamped = max(self.scaleSpin.minimum(), min(self.scaleSpin.maximum(), target))
+        self.scaleSpin.setValue(round(clamped))  # drives view.set_scale, shows the value
 
     def _on_filters_changed(self) -> None:
         highpass = self.highpassSpin.value() or None  # 0.0 displays as "Off"
@@ -724,6 +852,11 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             if event is not None:
                 event.ignore()
             return
+        # Drop the app-level key filter before this window goes away, so a stray
+        # late event can never reach a half-deleted window.
+        app = QtWidgets.QApplication.instance()
+        if app is not None:
+            app.removeEventFilter(self)
         # Remember where this window sat for next launch (best-effort, never raises).
         preferences.update_window_geometry(
             preferences_path, _EEG_WINDOW_ID, windowstate.geometry_of(self)

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -164,6 +164,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._recording: io.Recording | None = None
         self._annotations: list[Annotation] = []
         self._dirty = False
+        self._cursor_seconds: float | None = None  # last mouse time over the traces
         self.setWindowTitle("SMACC — EEG review")
         if LOGO_PATH.is_file():
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
@@ -191,6 +192,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.view.annotationSelected.connect(self._on_view_selection)
         self.view.windowChanged.connect(self._sync_scrollbar)
         self.view.cursorMoved.connect(self._on_cursor_moved)
+        self.view.pointMarkRequested.connect(self._add_point_mark)
         viewColumn.addWidget(self.view, 1)
         self.scrollBar = QtWidgets.QScrollBar(QtCore.Qt.Orientation.Horizontal, self)
         self.scrollBar.setStatusTip("Scroll through the recording.")
@@ -334,6 +336,8 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         ):
             shortcut = QtGui.QShortcut(QtGui.QKeySequence(keys), self)
             shortcut.activated.connect(lambda f=fraction: self.view.scroll_by(f))
+        mark = QtGui.QShortcut(QtGui.QKeySequence(QtCore.Qt.Key.Key_M), self)
+        mark.activated.connect(self._mark_at_cursor)
 
     def _set_loaded(self, loaded: bool) -> None:
         for widget in (
@@ -413,6 +417,34 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._remember_label(label)
         self._mark_dirty()
         self._select(self._annotations.index(annotation))
+
+    def _add_point_mark(self, seconds: float) -> None:
+        """Drop a zero-duration mark at ``seconds`` (ctrl-click or the M key).
+
+        Goes straight to the label picker with no span to draw and no instant
+        checkbox to tick — the mark is already a point.
+        """
+        if self._recording is None:
+            return
+        seconds = min(max(0.0, seconds), self._recording.duration)
+        result = LabelDialog.get_label(self, self._recent_labels(), offer_instant=False)
+        if result is None:
+            return
+        label, _ = result
+        annotation = Annotation(seconds, 0.0, label)
+        self._annotations = insert(self._annotations, annotation)
+        self._remember_label(label)
+        self._mark_dirty()
+        self._select(self._annotations.index(annotation))
+
+    def _mark_at_cursor(self) -> None:
+        """Mark at the last cursor position, or the view's center if unknown."""
+        if self._recording is None:
+            return
+        seconds = self._cursor_seconds
+        if seconds is None:  # the mouse never entered the traces
+            seconds = self.view.window_start + self.view.window_seconds / 2
+        self._add_point_mark(seconds)
 
     def edit_selected(self) -> None:
         index = self.annotationList.currentRow()
@@ -583,6 +615,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
     def _on_cursor_moved(self, seconds: float) -> None:
         if self._recording is None:
             return
+        self._cursor_seconds = seconds  # remembered for the M (mark) shortcut
         text = f"t = {seconds:.3f} s"
         clock = wall_time(self._recording, seconds) if seconds >= 0 else None
         if clock is not None:

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -41,7 +41,7 @@ from .annotations import (
     write_annotations_json,
     write_annotations_tsv,
 )
-from .view import TraceView
+from .view import DEFAULT_EPOCH_SECONDS, TraceView
 
 # Stable id for this window's geometry entry in the per-window prefs map.
 _EEG_WINDOW_ID = "eeg-review"
@@ -184,6 +184,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         layout.setSpacing(8)
         layout.addWidget(_section_title("EEG review"))
         layout.addLayout(self._build_controls_row())
+        layout.addLayout(self._build_epoch_row())
 
         body = QtWidgets.QHBoxLayout()
         viewColumn = QtWidgets.QVBoxLayout()
@@ -297,6 +298,65 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         row.addWidget(self.saveButton)
         return row
 
+    def _build_epoch_row(self) -> QtWidgets.QLayout:
+        """The epoch model controls (#173): length, grid, anchor, time-axis mode.
+
+        A second row so the busy filter/window/scale row above stays legible. The
+        epoch length is deliberately *separate* from the on-screen window length —
+        a 30 s scoring epoch can be inspected inside a 60 s window.
+        """
+        row = QtWidgets.QHBoxLayout()
+        row.addWidget(QtWidgets.QLabel("Epoch:", self))
+        self.epochSpin = QtWidgets.QSpinBox(self)
+        self.epochSpin.setRange(1, 300)
+        self.epochSpin.setValue(int(DEFAULT_EPOCH_SECONDS))
+        self.epochSpin.setSuffix(" s")
+        self.epochSpin.setStatusTip(
+            "Scoring-epoch length (30 s is standard) — independent of the window."
+        )
+        self.epochSpin.valueChanged.connect(
+            lambda value: self.view.set_epoch_seconds(float(value))
+        )
+        row.addWidget(self.epochSpin)
+
+        self.epochGridCheck = QtWidgets.QCheckBox("Epoch grid", self)
+        self.epochGridCheck.setChecked(True)
+        self.epochGridCheck.setStatusTip("Show faint, numbered epoch boundaries.")
+        self.epochGridCheck.toggled.connect(
+            lambda checked: self.view.set_epochs_visible(checked)
+        )
+        row.addWidget(self.epochGridCheck)
+
+        self.anchorButton = QtWidgets.QPushButton("Anchor epochs to view", self)
+        self.anchorButton.setStatusTip(
+            "Start an epoch at the left edge of the view (back/front-fills the grid)."
+        )
+        self.anchorButton.clicked.connect(
+            lambda: self.view.set_epoch_anchor(self.view.window_start)
+        )
+        row.addWidget(self.anchorButton)
+        self.resetAnchorButton = QtWidgets.QPushButton("Reset anchor", self)
+        self.resetAnchorButton.setStatusTip(
+            "Put epoch 1 back at the start of the recording."
+        )
+        self.resetAnchorButton.clicked.connect(lambda: self.view.set_epoch_anchor(0.0))
+        row.addWidget(self.resetAnchorButton)
+
+        row.addSpacing(12)
+        row.addWidget(QtWidgets.QLabel("Time axis:", self))
+        self.axisModeCombo = QtWidgets.QComboBox(self)
+        self.axisModeCombo.addItem("Clock", "clock")
+        self.axisModeCombo.addItem("Elapsed", "elapsed")
+        self.axisModeCombo.setStatusTip(
+            "Label the time axis with wall-clock time or seconds from the start."
+        )
+        self.axisModeCombo.currentIndexChanged.connect(
+            lambda: self.view.set_time_axis_mode(self.axisModeCombo.currentData())
+        )
+        row.addWidget(self.axisModeCombo)
+        row.addStretch(1)
+        return row
+
     def _build_annotation_panel(self) -> QtWidgets.QLayout:
         panel = QtWidgets.QVBoxLayout()
         panel.addWidget(QtWidgets.QLabel("Annotations:", self))
@@ -391,6 +451,14 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._dirty = False
         self.view.set_provider(recording)
         self.view.set_annotations(annotations)
+        # Hand the view the localized recording start so the time axis can label
+        # clock time; default to clock when the file carries one, else elapsed.
+        started = wall_time(recording, 0.0)
+        self.view.set_time_origin(started)
+        self.axisModeCombo.blockSignals(True)
+        self.axisModeCombo.setCurrentIndex(0 if started is not None else 1)
+        self.axisModeCombo.blockSignals(False)
+        self.view.set_time_axis_mode(self.axisModeCombo.currentData())
         self._refresh_list()
         self._refresh_title()
         self._configure_scrollbar()
@@ -398,7 +466,6 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         preferences.update_preferences(
             preferences_path, {"eeg_last_dir": str(path.parent)}
         )
-        started = wall_time(recording, 0.0)
         clock = f" · started {started.strftime('%H:%M:%S')}" if started else ""
         self.fileInfoLabel.setText(
             f"{path.name} — {len(recording.ch_names)} ch · "

--- a/tests/test_eeg_io.py
+++ b/tests/test_eeg_io.py
@@ -70,11 +70,18 @@ def test_open_recording_rejects_unknown_suffixes(tmp_path):
 
 
 def test_reader_table_matches_real_mne_readers():
-    # The EDF/BrainVision branches can't be round-tripped without their writers;
-    # at minimum every name in the dispatch table must be a real mne.io reader.
-    assert set(io._READERS) == {".edf", ".vhdr", ".fif"}
+    # The non-FIF branches can't be round-tripped without their writers; at
+    # minimum every name in the dispatch table must be a real mne.io reader.
+    assert set(io._READERS) == {".edf", ".vhdr", ".fif", ".cnt", ".set"}
     for reader_name in io._READERS.values():
         assert callable(getattr(mne.io, reader_name))
+
+
+def test_file_filter_lists_every_supported_extension():
+    # FILE_FILTER is derived from _READERS, so a new format never needs a second
+    # edit here; guard that the derivation actually covers the whole table.
+    for ext in io._READERS:
+        assert f"*{ext}" in io.FILE_FILTER
 
 
 # ----- slicing ------------------------------------------------------------------

--- a/tests/test_eeg_view.py
+++ b/tests/test_eeg_view.py
@@ -196,6 +196,15 @@ def test_drawn_region_is_clamped_and_empty_drags_dropped(loaded):
     assert len(drawn) == 1
 
 
+def test_point_mark_request_is_clamped_to_the_recording(loaded):
+    view, _ = loaded
+    marks: list[float] = []
+    view.pointMarkRequested.connect(marks.append)
+    view._on_mark_requested(-3.0)
+    view._on_mark_requested(80.0)  # past the 60 s duration
+    assert marks == [pytest.approx(0.0), pytest.approx(60.0)]
+
+
 # ----- non-bioelectric channels ----------------------------------------------------
 
 
@@ -234,16 +243,29 @@ class _FakeMouseEvent:
     item coordinates with mapFromView — the frame the real events deliver.
     """
 
-    def __init__(self, viewbox, down_x: float, x: float, *, finish=True, button=None):
+    def __init__(
+        self,
+        viewbox,
+        down_x: float,
+        x: float,
+        *,
+        finish=True,
+        button=None,
+        modifiers=None,
+    ):
         self._button = button or QtCore.Qt.MouseButton.LeftButton
         self._down = viewbox.mapFromView(pg.Point(down_x, 0.0))
         self._pos = viewbox.mapFromView(pg.Point(x, 0.0))
         self._finish = finish
+        self._modifiers = modifiers or QtCore.Qt.KeyboardModifier.NoModifier
         self.accepted = False
         self.ignored = False
 
     def button(self):
         return self._button
+
+    def modifiers(self):
+        return self._modifiers
 
     def buttonDownPos(self):
         return self._down
@@ -314,6 +336,24 @@ def test_click_event_maps_to_data_seconds(exposed):
     view.annotationSelected.connect(selections.append)
     view._viewbox.mouseClickEvent(_FakeMouseEvent(view._viewbox, 6.0, 6.0))
     assert selections == [0]
+
+
+def test_ctrl_click_requests_a_point_mark_instead_of_selecting(exposed):
+    view, _ = exposed
+    view.set_annotations([Annotation(5.0, 2.0, "region")])
+    marks: list[float] = []
+    selections: list[int] = []
+    view.pointMarkRequested.connect(marks.append)
+    view.annotationSelected.connect(selections.append)
+    ev = _FakeMouseEvent(
+        view._viewbox,
+        6.0,
+        6.0,
+        modifiers=QtCore.Qt.KeyboardModifier.ControlModifier,
+    )
+    view._viewbox.mouseClickEvent(ev)
+    assert marks == [pytest.approx(6.0, abs=0.05)]
+    assert selections == []  # ctrl-click marks; it must never also select
 
 
 # ----- wheel and keyboard navigation -------------------------------------------------

--- a/tests/test_eeg_view.py
+++ b/tests/test_eeg_view.py
@@ -7,6 +7,8 @@ offsets can then be asserted exactly.
 
 from __future__ import annotations
 
+from datetime import datetime
+
 import numpy as np
 import pyqtgraph as pg
 import pytest
@@ -14,7 +16,7 @@ from PyQt6 import QtCore, QtGui
 
 from smacc.eeg import dsp
 from smacc.eeg.annotations import Annotation
-from smacc.eeg.view import TYPE_GAINS, TraceView
+from smacc.eeg.view import TYPE_GAINS, TimeAxis, TraceView
 
 SFREQ = 100.0
 DURATION = 60.0
@@ -400,3 +402,88 @@ def test_arrow_and_home_end_keys_navigate(loaded):
     assert view.window_start == pytest.approx(DURATION - view.window_seconds)
     view.keyPressEvent(_key_event(QtCore.Qt.Key.Key_Home))
     assert view.window_start == pytest.approx(0.0)
+
+
+# ----- epoch model (#173) ---------------------------------------------------------
+
+
+def _epoch_boundaries(view) -> list[float]:
+    return sorted(line.value() for line in view._epoch_items)
+
+
+def _epoch_numbers(view) -> list[str]:
+    # InfiniteLine stores the label text on its InfLineLabel's ``format``.
+    return [
+        line.label.format for line in sorted(view._epoch_items, key=lambda i: i.value())
+    ]
+
+
+def test_epoch_grid_draws_numbered_boundaries_in_window(loaded):
+    # Default: 30 s epochs anchored at 0, 30 s window → boundaries at 0 and 30,
+    # starting epochs 1 and 2.
+    view, _ = loaded
+    assert _epoch_boundaries(view) == pytest.approx([0.0, 30.0])
+    assert _epoch_numbers(view) == ["1", "2"]
+
+
+def test_epoch_length_is_independent_of_window_length(loaded):
+    view, _ = loaded
+    view.set_epoch_seconds(10.0)  # 10 s epochs in the same 30 s window
+    assert _epoch_boundaries(view) == pytest.approx([0.0, 10.0, 20.0, 30.0])
+    assert view.window_seconds == 30.0  # window unchanged
+
+
+def test_epoch_seconds_clamp_to_at_least_one(loaded):
+    view, _ = loaded
+    view.set_epoch_seconds(0.0)
+    assert view.epoch_seconds == 1.0
+
+
+def test_anchor_back_and_front_fills_the_grid(loaded):
+    # Anchoring at 12 s puts a boundary there and fills outward by ±epoch; the
+    # boundary at the anchor starts epoch 1, the next one epoch 2.
+    view, _ = loaded
+    view.set_epoch_anchor(12.0)
+    assert view.epoch_anchor == 12.0
+    assert _epoch_boundaries(view) == pytest.approx([12.0])  # only 12 lands in 0–30
+    view.set_window_start(20.0)  # window 20–50 now spans 12+30=42
+    assert _epoch_boundaries(view) == pytest.approx([42.0])
+    assert _epoch_numbers(view) == ["2"]
+
+
+def test_epoch_grid_can_be_hidden(loaded):
+    view, _ = loaded
+    view.set_epochs_visible(False)
+    assert view._epoch_items == []
+    view.set_epochs_visible(True)
+    assert len(view._epoch_items) == 2
+
+
+def test_new_recording_resets_the_anchor(loaded):
+    view, provider = loaded
+    view.set_epoch_anchor(12.0)
+    view.set_provider(provider)  # reopening must start epoch 1 at the start
+    assert view.epoch_anchor == 0.0
+
+
+def test_grid_follows_the_scroll(loaded):
+    view, _ = loaded
+    view.set_window_start(45.0)  # 60 s file, 30 s window → clamps to 30 (30–60)
+    assert _epoch_boundaries(view) == pytest.approx([30.0, 60.0])
+
+
+# ----- time axis ------------------------------------------------------------------
+
+
+def test_time_axis_formats_clock_strings_from_an_origin(qtbot):
+    axis = TimeAxis(orientation="bottom")
+    axis.set_origin(datetime(2026, 6, 5, 22, 0, 0))
+    axis.set_mode("clock")
+    assert axis.tickStrings([0.0, 90.0], 1.0, 1.0) == ["22:00:00", "22:01:30"]
+
+
+def test_time_axis_falls_back_to_elapsed_without_an_origin(qtbot):
+    axis = TimeAxis(orientation="bottom")
+    axis.set_mode("clock")  # asked for clock, but no origin is known
+    strings = axis.tickStrings([0.0, 30.0], 1.0, 1.0)
+    assert all(":" not in s for s in strings)  # plain seconds, not HH:MM:SS

--- a/tests/test_eeg_view.py
+++ b/tests/test_eeg_view.py
@@ -386,22 +386,25 @@ def test_wheel_down_scrolls_forward(loaded):
     assert view.window_start == pytest.approx(0.0)
 
 
-def _key_event(key) -> QtGui.QKeyEvent:
-    return QtGui.QKeyEvent(
-        QtCore.QEvent.Type.KeyPress, key, QtCore.Qt.KeyboardModifier.NoModifier
-    )
-
-
-def test_arrow_and_home_end_keys_navigate(loaded):
+def test_step_epochs_moves_by_one_epoch_length(loaded):
+    # The window's Left/Right arrows drive this (keyboard routing lives in the
+    # window now); the view just exposes the epoch-sized step and reports it.
     view, _ = loaded
-    view.keyPressEvent(_key_event(QtCore.Qt.Key.Key_Right))
+    view.set_epoch_seconds(10.0)
+    moves: list[float] = []
+    view.windowChanged.connect(moves.append)
+    view.step_epochs(2)
+    assert view.window_start == pytest.approx(20.0)
+    assert moves == [20.0]
+
+
+def test_nudge_seconds_scrolls_a_fixed_amount(loaded):
+    view, _ = loaded
+    moves: list[float] = []
+    view.windowChanged.connect(moves.append)
+    view.nudge_seconds(3.0)
     assert view.window_start == pytest.approx(3.0)
-    view.keyPressEvent(_key_event(QtCore.Qt.Key.Key_Left))
-    assert view.window_start == pytest.approx(0.0)
-    view.keyPressEvent(_key_event(QtCore.Qt.Key.Key_End))
-    assert view.window_start == pytest.approx(DURATION - view.window_seconds)
-    view.keyPressEvent(_key_event(QtCore.Qt.Key.Key_Home))
-    assert view.window_start == pytest.approx(0.0)
+    assert moves == [3.0]
 
 
 # ----- epoch model (#173) ---------------------------------------------------------

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -204,6 +204,31 @@ def test_go_to_selected_jumps_the_view(window, recording_path, monkeypatch):
     assert window.view.window_start == pytest.approx(50.0 - 7.5)
 
 
+def test_ctrl_click_path_adds_a_point_mark(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window.view.pointMarkRequested.emit(42.0)  # the ctrl-click signal
+    assert window._annotations == [Annotation(42.0, 0.0, "LRLR")]
+    assert window._dirty
+
+
+def test_mark_key_marks_at_the_last_cursor_position(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)
+    window._on_cursor_moved(33.0)  # remember where the cursor is
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._mark_at_cursor()
+    assert window._annotations == [Annotation(33.0, 0.0, "LRLR")]
+
+
+def test_mark_key_falls_back_to_the_view_center(window, recording_path, monkeypatch):
+    window._load(recording_path)  # cursor never moved; window 0–30 → center 15
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._mark_at_cursor()
+    assert window._annotations == [Annotation(15.0, 0.0, "LRLR")]
+
+
 # ----- saving and closing -----------------------------------------------------------
 
 

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from PyQt6 import QtWidgets
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 from smacc import preferences
 from smacc.config import VERSION
@@ -357,6 +357,110 @@ def test_anchor_button_anchors_epochs_to_the_view(window, recording_path):
     assert window.view.epoch_anchor == pytest.approx(45.0)
     window.resetAnchorButton.click()  # back to the start of the recording
     assert window.view.epoch_anchor == 0.0
+
+
+# ----- keyboard navigation (#174) --------------------------------------------------
+
+
+def _key(key, *, shift=False):
+    mods = (
+        QtCore.Qt.KeyboardModifier.ShiftModifier
+        if shift
+        else QtCore.Qt.KeyboardModifier.NoModifier
+    )
+    return QtGui.QKeyEvent(QtCore.QEvent.Type.KeyPress, key, mods)
+
+
+@pytest.fixture
+def nav_window(window, recording_path, monkeypatch):
+    """A loaded window with focus pinned to nothing, so the key filter acts."""
+    window._load(recording_path)
+    monkeypatch.setattr(
+        QtWidgets.QApplication, "focusWidget", staticmethod(lambda: None)
+    )
+    return window
+
+
+def test_left_right_arrows_page_by_one_epoch(nav_window):
+    window = nav_window  # 30 s epochs by default
+    assert window._handle_nav_key(_key(QtCore.Qt.Key.Key_Right)) is True
+    assert window.view.window_start == pytest.approx(30.0)
+    window._handle_nav_key(_key(QtCore.Qt.Key.Key_Left))
+    assert window.view.window_start == pytest.approx(0.0)
+
+
+def test_shift_arrows_nudge_finely(nav_window):
+    nav_window._handle_nav_key(_key(QtCore.Qt.Key.Key_Right, shift=True))
+    assert nav_window.view.window_start == pytest.approx(1.0)  # a 1 s fine nudge
+
+
+def test_up_down_arrows_step_the_amplitude(nav_window):
+    window = nav_window
+    window.scaleSpin.setValue(100)
+    window._handle_nav_key(_key(QtCore.Qt.Key.Key_Up))  # louder → smaller µV/lane
+    assert window.scaleSpin.value() == 80  # 100 / 1.25
+    window._handle_nav_key(_key(QtCore.Qt.Key.Key_Down))
+    assert window.scaleSpin.value() == 100  # 80 * 1.25
+
+
+def test_shift_up_down_step_the_amplitude_finely(nav_window):
+    window = nav_window
+    window.scaleSpin.setValue(100)
+    window._handle_nav_key(_key(QtCore.Qt.Key.Key_Up, shift=True))
+    assert window.scaleSpin.value() == 91  # round(100 / 1.1)
+
+
+def test_home_and_end_jump_to_the_edges(nav_window):
+    window = nav_window
+    window._handle_nav_key(_key(QtCore.Qt.Key.Key_End))
+    span = DURATION - window.view.window_seconds
+    assert window.view.window_start == pytest.approx(span)
+    window._handle_nav_key(_key(QtCore.Qt.Key.Key_Home))
+    assert window.view.window_start == 0.0
+
+
+def test_epoch_readout_tracks_the_current_epoch(nav_window):
+    window = nav_window
+    assert window.epochLabel.text() == "Epoch 1"
+    window._handle_nav_key(_key(QtCore.Qt.Key.Key_Right))  # to 30 s → epoch 2
+    assert window.epochLabel.text() == "Epoch 2"
+
+
+def test_a_focused_spinbox_keeps_its_arrow_keys(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    monkeypatch.setattr(
+        QtWidgets.QApplication, "focusWidget", staticmethod(lambda: window.scaleSpin)
+    )
+    assert window._handle_nav_key(_key(QtCore.Qt.Key.Key_Right)) is False
+    assert window.view.window_start == 0.0  # the spin box kept the key
+
+
+def test_a_focused_list_keeps_up_down_but_yields_left_right(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)
+    monkeypatch.setattr(
+        QtWidgets.QApplication,
+        "focusWidget",
+        staticmethod(lambda: window.annotationList),
+    )
+    assert window._handle_nav_key(_key(QtCore.Qt.Key.Key_Down)) is False  # row nav
+    assert window._handle_nav_key(_key(QtCore.Qt.Key.Key_Right)) is True  # still pages
+
+
+def test_event_filter_routes_keys_only_when_active(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)
+    monkeypatch.setattr(
+        QtWidgets.QApplication, "focusWidget", staticmethod(lambda: None)
+    )
+    monkeypatch.setattr(window, "isActiveWindow", lambda: False)
+    assert window.eventFilter(window, _key(QtCore.Qt.Key.Key_Right)) is False
+    assert window.view.window_start == 0.0  # inactive: the key is left alone
+    monkeypatch.setattr(window, "isActiveWindow", lambda: True)
+    assert window.eventFilter(window, _key(QtCore.Qt.Key.Key_Right)) is True
+    assert window.view.window_start == pytest.approx(30.0)
 
 
 # ----- label dialog / entry point -----------------------------------------------------

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -9,6 +9,7 @@ touches the machine's real ``preferences.yaml``.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from datetime import UTC, datetime, timedelta
@@ -26,6 +27,7 @@ from smacc.eeg import window as window_mod
 from smacc.eeg.__main__ import pick_recording_path
 from smacc.eeg.annotations import (
     Annotation,
+    autosave_path,
     read_annotations_tsv,
     sidecar_paths,
     write_annotations_tsv,
@@ -448,9 +450,7 @@ def test_a_focused_list_keeps_up_down_but_yields_left_right(
     assert window._handle_nav_key(_key(QtCore.Qt.Key.Key_Right)) is True  # still pages
 
 
-def test_event_filter_routes_keys_only_when_active(
-    window, recording_path, monkeypatch
-):
+def test_event_filter_routes_keys_only_when_active(window, recording_path, monkeypatch):
     window._load(recording_path)
     monkeypatch.setattr(
         QtWidgets.QApplication, "focusWidget", staticmethod(lambda: None)
@@ -494,7 +494,9 @@ def test_resuming_a_sidecar_saves_without_a_prompt(window, recording_path, monke
     monkeypatch.setattr(
         QtWidgets.QMessageBox,
         "question",
-        lambda *a, **k: pytest.fail("no overwrite prompt when resuming our own sidecar"),
+        lambda *a, **k: pytest.fail(
+            "no overwrite prompt when resuming our own sidecar"
+        ),
     )
     window.save_annotations()
     assert not window._dirty
@@ -535,6 +537,74 @@ def test_save_overwrites_a_foreign_sidecar_once_confirmed(
     window.save_annotations()
     assert read_annotations_tsv(tsv_path) == [Annotation(10.0, 4.0, "LRLR")]
     assert not window._dirty
+
+
+# ----- autosave / crash recovery (#176) --------------------------------------------
+
+
+def test_autosave_writes_a_recovery_file(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    window._write_autosave()  # fire the debounced write directly
+    recovery = autosave_path(recording_path)
+    assert recovery.is_file()
+    assert read_annotations_tsv(recovery) == [Annotation(10.0, 4.0, "LRLR")]
+    # The recovery file must be distinct from the canonical sidecar.
+    tsv_path, _ = sidecar_paths(recording_path)
+    assert recovery != tsv_path and not tsv_path.is_file()
+
+
+def test_clean_save_removes_the_recovery_file(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    window._write_autosave()
+    assert autosave_path(recording_path).is_file()
+    window.save_annotations()
+    assert not autosave_path(recording_path).is_file()
+
+
+def test_recovery_is_offered_and_can_be_restored(window, recording_path):
+    recovery = autosave_path(recording_path)
+    write_annotations_tsv([Annotation(7.0, 0.0, "LRLR")], recovery)  # a crashed session
+    window._load(recording_path)
+    assert window.recoveryBanner.isVisible()
+    window._restore_autosave()
+    assert window._annotations == [Annotation(7.0, 0.0, "LRLR")]
+    assert window._dirty  # restored but not yet saved
+    assert not window.recoveryBanner.isVisible()
+
+
+def test_recovery_can_be_dismissed_and_is_deleted(window, recording_path):
+    recovery = autosave_path(recording_path)
+    write_annotations_tsv([Annotation(7.0, 0.0, "LRLR")], recovery)
+    window._load(recording_path)
+    assert window.recoveryBanner.isVisible()
+    window._dismiss_autosave()
+    assert not window.recoveryBanner.isVisible()
+    assert not recovery.is_file()
+
+
+def test_stale_autosave_older_than_the_sidecar_is_ignored(window, recording_path):
+    tsv_path, _ = sidecar_paths(recording_path)
+    write_annotations_tsv([Annotation(5.0, 2.0, "saved")], tsv_path)  # a clean save
+    recovery = autosave_path(recording_path)
+    write_annotations_tsv([Annotation(7.0, 0.0, "old")], recovery)
+    os.utime(recovery, (1000, 1000))  # force the autosave to look old
+    window._load(recording_path)
+    assert not window.recoveryBanner.isVisible()
+    assert not recovery.is_file()  # stale autosave is cleaned on open
+
+
+def test_clean_close_removes_the_recovery_file(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    window._write_autosave()
+    assert autosave_path(recording_path).is_file()
+    assert window.close()  # the fixture answers the dirty prompt with Discard
+    assert not autosave_path(recording_path).is_file()
 
 
 # ----- label dialog / entry point -----------------------------------------------------

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -320,6 +320,45 @@ def test_cursor_readout_shows_data_and_clock_time(window, recording_path):
     assert "22:01:30" in message  # 22:00:00 meas_date + 90 s, amp wall clock
 
 
+# ----- epoch model (#173) ----------------------------------------------------------
+
+
+def test_epoch_spin_sets_the_epoch_length(window, recording_path):
+    window._load(recording_path)
+    window.epochSpin.setValue(20)
+    assert window.view.epoch_seconds == 20.0
+
+
+def test_time_axis_defaults_to_clock_when_the_file_has_a_start(window, recording_path):
+    window._load(recording_path)  # FakeRecording carries a meas_date
+    assert window.axisModeCombo.currentData() == "clock"
+    assert window.view._time_axis._mode == "clock"
+
+
+def test_time_axis_defaults_to_elapsed_without_a_start(
+    window, recording_path, monkeypatch
+):
+    def no_date(path):
+        rec = FakeRecording(path)
+        rec.meas_date = None  # anonymized: only elapsed/epoch time is meaningful
+        return rec
+
+    monkeypatch.setattr(window_mod.io, "open_recording", no_date)
+    window._load(recording_path)
+    assert window.axisModeCombo.currentData() == "elapsed"
+    assert window.view._time_axis._mode == "elapsed"
+
+
+def test_anchor_button_anchors_epochs_to_the_view(window, recording_path):
+    window._load(recording_path)
+    window.scrollBar.setValue(450)  # 45.0 s
+    assert window.view.window_start == pytest.approx(45.0)
+    window.anchorButton.click()
+    assert window.view.epoch_anchor == pytest.approx(45.0)
+    window.resetAnchorButton.click()  # back to the start of the recording
+    assert window.view.epoch_anchor == 0.0
+
+
 # ----- label dialog / entry point -----------------------------------------------------
 
 

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -463,6 +463,80 @@ def test_event_filter_routes_keys_only_when_active(
     assert window.view.window_start == pytest.approx(30.0)
 
 
+# ----- save safety (#175) ----------------------------------------------------------
+
+
+def test_save_button_states_the_no_modify_contract(window):
+    assert "never modified" in window.saveButton.toolTip()
+
+
+def test_fresh_save_with_no_existing_sidecar_does_not_prompt(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)  # fresh review, no sidecar on disk yet
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: pytest.fail("no prompt when nothing is overwritten"),
+    )
+    window.save_annotations()
+    assert not window._dirty
+
+
+def test_resuming_a_sidecar_saves_without_a_prompt(window, recording_path, monkeypatch):
+    tsv_path, _ = sidecar_paths(recording_path)
+    write_annotations_tsv([Annotation(5.0, 2.0, "REM period")], tsv_path)
+    window._load(recording_path)  # loaded from it → we own it
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: pytest.fail("no overwrite prompt when resuming our own sidecar"),
+    )
+    window.save_annotations()
+    assert not window._dirty
+
+
+def test_save_prompts_before_overwriting_a_foreign_sidecar(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)  # fresh review (we do not own a sidecar)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    tsv_path, _ = sidecar_paths(recording_path)
+    foreign = [Annotation(1.0, 0.0, "other rater")]
+    write_annotations_tsv(foreign, tsv_path)  # a sidecar appeared meanwhile
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: QtWidgets.QMessageBox.StandardButton.No,
+    )
+    window.save_annotations()
+    assert read_annotations_tsv(tsv_path) == foreign  # declined: left untouched
+    assert window._dirty  # still unsaved
+
+
+def test_save_overwrites_a_foreign_sidecar_once_confirmed(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    window._on_region_drawn(10.0, 14.0)
+    tsv_path, _ = sidecar_paths(recording_path)
+    write_annotations_tsv([Annotation(1.0, 0.0, "other rater")], tsv_path)
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: QtWidgets.QMessageBox.StandardButton.Yes,
+    )
+    window.save_annotations()
+    assert read_annotations_tsv(tsv_path) == [Annotation(10.0, 4.0, "LRLR")]
+    assert not window._dirty
+
+
 # ----- label dialog / entry point -----------------------------------------------------
 
 


### PR DESCRIPTION
Six focused improvements to the EEG annotator, one commit each (review per-commit):

- Open Neuroscan `.cnt` and EEGLAB `.set`; the open-dialog filter is now derived from the reader registry. Closes #172
- Ctrl+click (or the `M` key) drops a point marker; a plain click still selects. Closes #178
- Epoch model: faint numbered epoch gridlines, a clock-vs-elapsed time axis, and a configurable epoch anchor. Closes #173
- Epoch/amplitude keyboard navigation via a window-level event filter (←/→ epoch, Shift = 1 s nudge, ↑/↓ amplitude, Home/End edges) that works without first clicking the traces. Closes #174
- Explicit save contract (a "recording is never modified" caption/tooltip) plus confirm-on-overwrite for a sidecar this review did not open. Closes #175
- Debounced autosave to a distinct `.annotations.autosave.tsv` with a non-modal restore/dismiss recovery banner on open. Closes #176

847 tests pass; ruff + mypy clean.

Note: #172 still needs a small anonymized `.cnt` and a continuous `.set` fixture from the labs to validate the readers end-to-end.