### PR TITLE
feat: EEG annotator channel picker, per-type display, and saved view profiles

### DIFF
--- a/src/smacc/eeg/profiles.py
+++ b/src/smacc/eeg/profiles.py
@@ -1,0 +1,134 @@
+"""Saveable display ("view") profiles for the EEG review tool (#177).
+
+A view profile is a named, shareable *montage*: which channels to show and in
+what order, the per-channel-type display filter and amplitude, and the
+window/epoch lengths. It is a standalone JSON file — deliberately not stored
+inside the recording or in the operator's preferences — so a montage can be
+reused across nights and handed to a colleague.
+
+The model carries no absolutes that are specific to one recording: channels are
+named (resolved against whatever file is open, missing ones skipped), and the
+epoch *anchor* is left out (it is a per-recording choice, unlike epoch length).
+
+Pure dataclasses + JSON I/O, no GUI and no MNE — directly unit-testable, like
+:mod:`smacc.eeg.annotations`.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any
+
+from ..config import VERSION
+from .dsp import FilterSpec
+
+# JSON envelope: a stable kind + schema version so a stray file is rejected
+# rather than half-applied, and a future format change is detectable.
+KIND = "smacc/eeg-view-profile"
+SCHEMA_VERSION = 1
+
+# Profiles live as standalone files; this suffix makes them recognizable and
+# keeps the open/save dialogs filterable.
+PROFILE_SUFFIX = ".smacc-view.json"
+FILE_FILTER = "SMACC view profile (*.smacc-view.json);;All files (*)"
+
+
+@dataclass(frozen=True)
+class ViewProfile:
+    """A reusable display montage for the trace view.
+
+    ``channels`` is the ordered list of visible channel *names*; empty means
+    "show all channels in file order". ``base_*`` apply to any channel type
+    without an entry in the ``type_*`` overrides; ``type_*`` are keyed by MNE
+    channel type ("eeg", "eog", "emg", …).
+    """
+
+    channels: tuple[str, ...] = ()
+    base_scale_uv: float = 100.0
+    type_scales: dict[str, float] = field(default_factory=dict)
+    base_filter: FilterSpec = FilterSpec()
+    type_filters: dict[str, FilterSpec] = field(default_factory=dict)
+    window_seconds: float = 30.0
+    epoch_seconds: float = 30.0
+
+
+def _spec_to_dict(spec: FilterSpec) -> dict[str, float | None]:
+    return {"highpass": spec.highpass, "lowpass": spec.lowpass, "notch": spec.notch}
+
+
+def _spec_from_dict(payload: Any) -> FilterSpec:
+    if not isinstance(payload, dict):
+        raise ValueError(f"Filter must be an object, got {type(payload).__name__}")
+    try:
+        return FilterSpec(
+            highpass=payload.get("highpass"),
+            lowpass=payload.get("lowpass"),
+            notch=payload.get("notch"),
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid filter {payload!r}: {exc}") from exc
+
+
+def profile_payload(profile: ViewProfile) -> dict[str, Any]:
+    """Return the JSON-serializable envelope for ``profile``."""
+    return {
+        "kind": KIND,
+        "schema_version": SCHEMA_VERSION,
+        "channels": list(profile.channels),
+        "base_scale_uv": profile.base_scale_uv,
+        "type_scales": dict(profile.type_scales),
+        "base_filter": _spec_to_dict(profile.base_filter),
+        "type_filters": {
+            ch_type: _spec_to_dict(spec)
+            for ch_type, spec in profile.type_filters.items()
+        },
+        "window_seconds": profile.window_seconds,
+        "epoch_seconds": profile.epoch_seconds,
+        "generated_by": {"name": "SMACC", "version": VERSION},
+    }
+
+
+def write_view_profile(profile: ViewProfile, path: str | Path) -> None:
+    """Write ``profile`` to ``path`` as JSON."""
+    Path(path).write_text(
+        json.dumps(profile_payload(profile), indent=2), encoding="utf-8"
+    )
+
+
+def read_view_profile(path: str | Path) -> ViewProfile:
+    """Read a view profile back, raising on a file that is not one.
+
+    Raises:
+        OSError: if the file can't be read.
+        ValueError: on a wrong/missing ``kind`` or an unparseable field — better
+            to refuse than to silently apply a half-understood montage.
+    """
+    text = Path(path).read_text(encoding="utf-8-sig")  # tolerate a Notepad BOM
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict) or payload.get("kind") != KIND:
+        raise ValueError(f"Not a SMACC view profile (kind={payload.get('kind')!r})")
+    base = ViewProfile()
+    channels = payload.get("channels", [])
+    if not isinstance(channels, list) or not all(isinstance(c, str) for c in channels):
+        raise ValueError("'channels' must be a list of channel names")
+    type_scales = payload.get("type_scales", {})
+    if not isinstance(type_scales, dict):
+        raise ValueError("'type_scales' must be an object")
+    type_filters_raw = payload.get("type_filters", {})
+    if not isinstance(type_filters_raw, dict):
+        raise ValueError("'type_filters' must be an object")
+    return replace(
+        base,
+        channels=tuple(channels),
+        base_scale_uv=float(payload.get("base_scale_uv", base.base_scale_uv)),
+        type_scales={k: float(v) for k, v in type_scales.items()},
+        base_filter=_spec_from_dict(payload.get("base_filter", {})),
+        type_filters={k: _spec_from_dict(v) for k, v in type_filters_raw.items()},
+        window_seconds=float(payload.get("window_seconds", base.window_seconds)),
+        epoch_seconds=float(payload.get("epoch_seconds", base.epoch_seconds)),
+    )

--- a/src/smacc/eeg/view.py
+++ b/src/smacc/eeg/view.py
@@ -44,10 +44,13 @@ _VOLTS_TO_MICROVOLTS = 1e6
 # Lane-units excursion an auto-fit (non-bioelectric) channel is normalized to.
 _AUTOFIT_EXCURSION = 0.4
 
-# Per-channel-type display gain applied on top of the global scale. EMG rides
-# hotter than EEG on most montages; halving it keeps the trace inside its lane
-# without a per-channel scaling UI (cut deliberately — see issue #136).
-TYPE_GAINS = {"emg": 0.5}
+# Default amplitude (µV per channel lane) and the per-type overrides applied on
+# top of it. EMG rides hotter than EEG on most montages, so it defaults to a
+# larger µV/lane (a smaller on-screen trace); every type is now overridable per
+# montage (#177) — these are only the starting points. (200 µV reproduces the
+# old EMG ×0.5 gain against the 100 µV base.)
+DEFAULT_BASE_SCALE_UV = 100.0
+DEFAULT_TYPE_SCALES = {"emg": 200.0}
 
 # Clicking selects the annotation under the cursor; a zero-duration mark gets
 # this much slack on each side, as a fraction of the visible window.
@@ -206,10 +209,15 @@ class TraceView(pg.PlotWidget):
             axisItems={"bottom": self._time_axis},
         )
         self._provider: SliceProvider | None = None
-        self._spec = dsp.UNFILTERED
+        self._spec = dsp.UNFILTERED  # the base filter; per-type overrides below
+        self._type_specs: dict[str, dsp.FilterSpec] = {}
         self._window_start = 0.0
         self._window_seconds = 30.0  # the standard sleep-scoring epoch
-        self._scale_uv = 100.0  # microvolts per channel lane
+        self._scale_uv = DEFAULT_BASE_SCALE_UV  # base µV per lane; overrides below
+        self._type_scales: dict[str, float] = dict(DEFAULT_TYPE_SCALES)
+        # Channel indices to draw, in display order; all channels until set_provider
+        # (or a view profile) narrows or reorders them (#177).
+        self._visible: list[int] = []
         # Epoch model (#173): the scoring epoch is separate from the on-screen
         # window. Boundaries fall at anchor + k·epoch for integer k, so anchoring
         # on a feature back/front-fills the whole grid from that point.
@@ -270,6 +278,8 @@ class TraceView(pg.PlotWidget):
         self._provider = provider
         self._window_start = 0.0
         self._epoch_anchor = 0.0  # a new recording starts epoch 1 at its start
+        # Show every channel in file order by default; a profile may narrow this.
+        self._visible = list(range(len(provider.ch_names))) if provider else []
         self._build_curves()
         self._refresh_data()
         self._refresh_annotations()
@@ -280,9 +290,100 @@ class TraceView(pg.PlotWidget):
         self._refresh_data()
 
     def set_scale(self, microvolts: float) -> None:
-        """Set the lane height in µV (smaller value → visually bigger traces)."""
+        """Set the base lane height in µV (smaller value → visually bigger traces)."""
         self._scale_uv = max(1e-9, microvolts)
         self._refresh_data()
+
+    # ----- per-type display + channel selection (#177) ----------------------
+
+    @property
+    def spec(self) -> dsp.FilterSpec:
+        """The base display filter (used by types without an override)."""
+        return self._spec
+
+    @property
+    def scale_uv(self) -> float:
+        """The base lane height in µV (used by types without an override)."""
+        return self._scale_uv
+
+    def type_scales(self) -> dict[str, float]:
+        return dict(self._type_scales)
+
+    def type_specs(self) -> dict[str, dsp.FilterSpec]:
+        return dict(self._type_specs)
+
+    def effective_spec(self, ch_type: str) -> dsp.FilterSpec:
+        return self._type_specs.get(ch_type, self._spec)
+
+    def effective_scale(self, ch_type: str) -> float:
+        return self._type_scales.get(ch_type, self._scale_uv)
+
+    def set_type_spec(self, ch_type: str, spec: dsp.FilterSpec | None) -> None:
+        """Override (or clear, with ``None``) the display filter for one type."""
+        if spec is None:
+            self._type_specs.pop(ch_type, None)
+        else:
+            self._type_specs[ch_type] = spec
+        self._refresh_data()
+
+    def set_type_scale(self, ch_type: str, microvolts: float | None) -> None:
+        """Override (or clear, with ``None``) the lane height for one type."""
+        if microvolts is None:
+            self._type_scales.pop(ch_type, None)
+        else:
+            self._type_scales[ch_type] = max(1e-9, microvolts)
+        self._refresh_data()
+
+    def set_type_scales(self, scales: dict[str, float]) -> None:
+        """Replace every per-type amplitude override (when applying a profile)."""
+        self._type_scales = {k: max(1e-9, v) for k, v in scales.items()}
+        self._refresh_data()
+
+    def set_type_specs(self, specs: dict[str, dsp.FilterSpec]) -> None:
+        """Replace every per-type filter override (when applying a profile)."""
+        self._type_specs = dict(specs)
+        self._refresh_data()
+
+    @property
+    def channel_names(self) -> list[str]:
+        return list(self._provider.ch_names) if self._provider else []
+
+    @property
+    def channel_types(self) -> list[str]:
+        return list(self._provider.ch_types) if self._provider else []
+
+    @property
+    def visible_indices(self) -> list[int]:
+        """The channel positions currently drawn, in display order."""
+        return list(self._visible)
+
+    @property
+    def visible_channels(self) -> list[str]:
+        """The names of the currently drawn channels, in display order."""
+        names = self.channel_names
+        return [names[i] for i in self._visible]
+
+    def set_visible_channels(self, indices: list[int]) -> None:
+        """Show exactly ``indices`` (channel positions), in the given order.
+
+        Out-of-range and duplicate indices are dropped; an empty result is
+        ignored (a montage with no channels is never useful), so the current
+        selection stays.
+        """
+        if self._provider is None:
+            return
+        count = len(self._provider.ch_names)
+        seen: list[int] = []
+        for i in indices:
+            if 0 <= i < count and i not in seen:
+                seen.append(i)
+        if not seen:
+            return
+        self._visible = seen
+        self._build_curves()
+        self._refresh_data()
+        self._refresh_annotations()
+        self._refresh_epochs()
 
     def set_window_seconds(self, seconds: float) -> None:
         self._window_seconds = max(1.0, seconds)
@@ -412,7 +513,7 @@ class TraceView(pg.PlotWidget):
         self._window_start = min(max(0.0, self._window_start), latest)
 
     def _build_curves(self) -> None:
-        """Recreate one curve per channel (on open/clear), tuned for speed."""
+        """Recreate one curve per *visible* channel (on open/clear), tuned for speed."""
         plot_item = self.getPlotItem()
         assert plot_item is not None
         for curve in self._curves:
@@ -423,7 +524,7 @@ class TraceView(pg.PlotWidget):
             return
         pen = pg.mkPen(self.palette().color(QtGui.QPalette.ColorRole.Text), width=1)
         names = self._provider.ch_names
-        for _ in names:
+        for _ in self._visible:
             curve = pg.PlotDataItem(pen=pen)
             # Peak (min/max) downsampling keeps extremes visible at any zoom;
             # clip-to-view skips offscreen points when a margin is set.
@@ -431,37 +532,53 @@ class TraceView(pg.PlotWidget):
             curve.setClipToView(True)
             plot_item.addItem(curve)
             self._curves.append(curve)
+        # Lanes follow display order: the channel at display position ``lane`` is
+        # centered at y = -lane, labelled with its name.
         plot_item.getAxis("left").setTicks(
-            [[(-i, name) for i, name in enumerate(names)]]
+            [[(-lane, names[i]) for lane, i in enumerate(self._visible)]]
         )
-        self.setYRange(-len(names) + 0.4, 0.6, padding=0)
+        self.setYRange(-len(self._visible) + 0.4, 0.6, padding=0)
 
     def _refresh_data(self) -> None:
-        """Fetch, filter, scale, and draw the visible slice of every channel."""
+        """Fetch, filter, scale, and draw the visible slice of every shown channel."""
         if self._provider is None:
             return
-        pad = dsp.pad_seconds(self._spec)
+        ch_types = self._provider.ch_types
+        sfreq = self._provider.sfreq
+        # Each visible channel filters by its type's effective spec; fetch a
+        # margin wide enough for the longest transient across all active specs.
+        specs = {i: self.effective_spec(ch_types[i]) for i in self._visible}
+        pad = max((dsp.pad_seconds(s) for s in specs.values()), default=1.0)
         lo = self._window_start
         hi = self._window_start + self._window_seconds
-        times, data = self._provider.get_slice(lo - pad, hi + pad)
-        data = dsp.apply(np.asarray(data), self._provider.sfreq, self._spec)
+        times, raw = self._provider.get_slice(lo - pad, hi + pad)
+        raw = np.asarray(raw)
         times = np.asarray(times)
+        data = raw.astype(float, copy=True)
+        # Filter each group of like-spec channels together — one designed filter
+        # per distinct spec (the dsp cache keys on it), not one per channel.
+        groups: dict[dsp.FilterSpec, list[int]] = {}
+        for i, spec in specs.items():
+            groups.setdefault(spec, []).append(i)
+        for spec, idx in groups.items():
+            if not spec.is_identity:
+                data[idx] = dsp.apply(raw[idx], sfreq, spec)
         # Trim the filter margin so its edge transients never reach the screen.
         keep = (times >= lo) & (times <= hi)
-        times, data = times[keep], data[:, keep]
-        ch_types = self._provider.ch_types
-        for i, curve in enumerate(self._curves):
-            trace = data[i]
+        times = times[keep]
+        for lane, i in enumerate(self._visible):
+            trace = data[i][keep]
             if ch_types[i] in _MICROVOLT_TYPES:
-                gain = TYPE_GAINS.get(ch_types[i], 1.0)
-                scaled = trace * _VOLTS_TO_MICROVOLTS * (gain / self._scale_uv)
+                scaled = (
+                    trace * _VOLTS_TO_MICROVOLTS / self.effective_scale(ch_types[i])
+                )
             else:
                 # Unit-less channel (stim/misc/…): fit it to its own lane per
                 # visible slice. Absolute amplitude is meaningless for these;
                 # the edges (a trigger firing) are what a reviewer looks for.
                 peak = float(np.max(np.abs(trace))) if trace.size else 0.0
                 scaled = trace * (_AUTOFIT_EXCURSION / peak) if peak else trace
-            curve.setData(times, -i + scaled)
+            self._curves[lane].setData(times, -lane + scaled)
         self.setXRange(lo, hi, padding=0)
 
     def _refresh_annotations(self) -> None:

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -43,6 +43,8 @@ from .annotations import (
     write_annotations_json,
     write_annotations_tsv,
 )
+from .profiles import FILE_FILTER as PROFILE_FILE_FILTER
+from .profiles import PROFILE_SUFFIX, ViewProfile, read_view_profile, write_view_profile
 from .view import DEFAULT_EPOCH_SECONDS, TraceView
 
 # Stable id for this window's geometry entry in the per-window prefs map.
@@ -189,6 +191,89 @@ class LabelDialog(QtWidgets.QDialog):
         return label, offer_instant and dialog.instantCheck.isChecked()
 
 
+class ChannelPickerDialog(QtWidgets.QDialog):
+    """Pick and order which channels the trace view shows (#177).
+
+    Each channel has a checkbox (checked = shown); the Up/Down buttons reorder.
+    Visible channels lead, in display order, then the hidden ones — so the common
+    "hide a few, nudge the order" edit is quick.
+    """
+
+    def __init__(
+        self, parent: QtWidgets.QWidget | None, ch_names: list[str], visible: list[int]
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Channels")
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(
+            QtWidgets.QLabel("Shown channels (checked), top to bottom:", self)
+        )
+        body = QtWidgets.QHBoxLayout()
+        self.listWidget = QtWidgets.QListWidget(self)
+        self.listWidget.setMinimumWidth(240)
+        hidden = [i for i in range(len(ch_names)) if i not in visible]
+        for i in [*visible, *hidden]:
+            item = QtWidgets.QListWidgetItem(ch_names[i])
+            item.setData(QtCore.Qt.ItemDataRole.UserRole, i)
+            item.setFlags(item.flags() | QtCore.Qt.ItemFlag.ItemIsUserCheckable)
+            item.setCheckState(
+                QtCore.Qt.CheckState.Checked
+                if i in visible
+                else QtCore.Qt.CheckState.Unchecked
+            )
+            self.listWidget.addItem(item)
+        body.addWidget(self.listWidget, 1)
+        buttonColumn = QtWidgets.QVBoxLayout()
+        upButton = QtWidgets.QPushButton("Up", self)
+        upButton.clicked.connect(lambda: self._move(-1))
+        downButton = QtWidgets.QPushButton("Down", self)
+        downButton.clicked.connect(lambda: self._move(1))
+        buttonColumn.addWidget(upButton)
+        buttonColumn.addWidget(downButton)
+        buttonColumn.addStretch(1)
+        body.addLayout(buttonColumn)
+        layout.addLayout(body)
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _move(self, delta: int) -> None:
+        row = self.listWidget.currentRow()
+        target = row + delta
+        if row < 0 or not 0 <= target < self.listWidget.count():
+            return
+        item = self.listWidget.takeItem(row)
+        self.listWidget.insertItem(target, item)
+        self.listWidget.setCurrentRow(target)
+
+    def result_indices(self) -> list[int]:
+        out: list[int] = []
+        for row in range(self.listWidget.count()):
+            item = self.listWidget.item(row)
+            if item is not None and item.checkState() == QtCore.Qt.CheckState.Checked:
+                out.append(int(item.data(QtCore.Qt.ItemDataRole.UserRole)))
+        return out
+
+    @staticmethod
+    def get_visible(
+        parent: QtWidgets.QWidget | None, ch_names: list[str], visible: list[int]
+    ) -> list[int] | None:
+        """Run the dialog; return the chosen channel order, or ``None`` on cancel.
+
+        An empty selection also reads as ``None`` (no change) — a montage with no
+        channels is never what the operator wants.
+        """
+        dialog = ChannelPickerDialog(parent, ch_names, visible)
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return None
+        return dialog.result_indices() or None
+
+
 class EegReviewWindow(QtWidgets.QMainWindow):
     """Review and annotate one recording; the EEG component's main window."""
 
@@ -282,6 +367,19 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         row.addWidget(openButton)
         row.addSpacing(12)
 
+        # Per-type display (#177): the filter and scale controls below edit the
+        # channel type selected here. "All channels" edits the base that every
+        # type without its own override inherits.
+        row.addWidget(QtWidgets.QLabel("Apply to:", self))
+        self.filterScopeCombo = QtWidgets.QComboBox(self)
+        self.filterScopeCombo.addItem("All channels", None)
+        self.filterScopeCombo.setStatusTip(
+            "Which channels the filter and scale below edit (a type, or all)."
+        )
+        self.filterScopeCombo.currentIndexChanged.connect(self._on_scope_changed)
+        row.addWidget(self.filterScopeCombo)
+        row.addSpacing(8)
+
         # Display filters. 0 reads as "Off" (special value text): the viewer
         # opens unfiltered — silently rewriting amplitudes before the operator
         # asked would misrepresent the recording.
@@ -339,9 +437,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.scaleSpin.setStatusTip(
             "Microvolts per channel lane — smaller means visually bigger traces."
         )
-        self.scaleSpin.valueChanged.connect(
-            lambda value: self.view.set_scale(float(value))
-        )
+        self.scaleSpin.valueChanged.connect(self._on_scale_changed)
         row.addWidget(self.scaleSpin)
 
         row.addStretch(1)
@@ -412,6 +508,20 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         )
         row.addWidget(self.axisModeCombo)
         row.addStretch(1)
+        self.channelsButton = QtWidgets.QPushButton("Channels…", self)
+        self.channelsButton.setStatusTip("Choose and reorder which channels are shown.")
+        self.channelsButton.clicked.connect(self._open_channel_picker)
+        row.addWidget(self.channelsButton)
+        self.saveProfileButton = QtWidgets.QPushButton("Save profile…", self)
+        self.saveProfileButton.setStatusTip(
+            "Save this montage (channels, filters, scale, window/epoch) to a file."
+        )
+        self.saveProfileButton.clicked.connect(self._save_profile)
+        row.addWidget(self.saveProfileButton)
+        self.loadProfileButton = QtWidgets.QPushButton("Load profile…", self)
+        self.loadProfileButton.setStatusTip("Apply a saved montage to this recording.")
+        self.loadProfileButton.clicked.connect(self._load_profile)
+        row.addWidget(self.loadProfileButton)
         return row
 
     def _build_contract_caption(self) -> QtWidgets.QLabel:
@@ -496,6 +606,10 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             self.editButton,
             self.deleteButton,
             self.scrollBar,
+            self.filterScopeCombo,
+            self.channelsButton,
+            self.saveProfileButton,
+            self.loadProfileButton,
         ):
             widget.setEnabled(loaded)
 
@@ -557,6 +671,10 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.axisModeCombo.setCurrentIndex(0 if started is not None else 1)
         self.axisModeCombo.blockSignals(False)
         self.view.set_time_axis_mode(self.axisModeCombo.currentData())
+        # Rebuild the per-type filter scope from this recording's types and show
+        # the base filter/scale in the controls (#177).
+        self._populate_scope_combo()
+        self._load_scope_into_controls()
         self._refresh_list()
         self._refresh_title()
         self._configure_scrollbar()
@@ -948,7 +1066,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             status_bar.showMessage(
                 "High-pass must stay below low-pass — filters unchanged.", 4000
             )
-            applied = self.view._spec
+            applied = self._scoped_applied_spec()
             for spin, value in (
                 (self.highpassSpin, applied.highpass),
                 (self.lowpassSpin, applied.lowpass),
@@ -957,7 +1075,172 @@ class EegReviewWindow(QtWidgets.QMainWindow):
                 spin.setValue(value or 0.0)  # 0.0 displays as "Off"
                 spin.blockSignals(False)
             return
-        self.view.set_spec(spec)
+        scope = self._current_scope()
+        if scope is None:
+            self.view.set_spec(spec)
+        else:
+            self.view.set_type_spec(scope, spec)
+
+    # ----- per-type display + view profiles (#177) ------------------------------------
+
+    def _current_scope(self) -> str | None:
+        """The channel type the filter/scale controls edit (``None`` = the base)."""
+        return self.filterScopeCombo.currentData()
+
+    def _scoped_applied_spec(self) -> dsp.FilterSpec:
+        scope = self._current_scope()
+        return self.view.spec if scope is None else self.view.effective_spec(scope)
+
+    def _notch_index(self, notch: float | None) -> int:
+        for index in range(self.notchCombo.count()):
+            if self.notchCombo.itemData(index) == notch:
+                return index
+        return 0
+
+    def _populate_scope_combo(self) -> None:
+        """Rebuild the per-type scope list from the loaded recording's types."""
+        self.filterScopeCombo.blockSignals(True)
+        self.filterScopeCombo.clear()
+        self.filterScopeCombo.addItem("All channels", None)
+        seen: list[str] = []
+        for ch_type in self.view.channel_types:
+            if ch_type not in seen:
+                seen.append(ch_type)
+                self.filterScopeCombo.addItem(ch_type.upper(), ch_type)
+        self.filterScopeCombo.setCurrentIndex(0)
+        self.filterScopeCombo.blockSignals(False)
+
+    def _load_scope_into_controls(self) -> None:
+        """Show the current scope's filter + scale in the controls (no signals)."""
+        scope = self._current_scope()
+        spec = self.view.spec if scope is None else self.view.effective_spec(scope)
+        scale = (
+            self.view.scale_uv if scope is None else self.view.effective_scale(scope)
+        )
+        for spin, value in (
+            (self.highpassSpin, spec.highpass),
+            (self.lowpassSpin, spec.lowpass),
+        ):
+            spin.blockSignals(True)
+            spin.setValue(value or 0.0)  # 0.0 displays as "Off"
+            spin.blockSignals(False)
+        self.notchCombo.blockSignals(True)
+        self.notchCombo.setCurrentIndex(self._notch_index(spec.notch))
+        self.notchCombo.blockSignals(False)
+        self.scaleSpin.blockSignals(True)
+        self.scaleSpin.setValue(scale)
+        self.scaleSpin.blockSignals(False)
+
+    def _on_scope_changed(self) -> None:
+        self._load_scope_into_controls()
+
+    def _on_scale_changed(self, value: float) -> None:
+        scope = self._current_scope()
+        if scope is None:
+            self.view.set_scale(float(value))
+        else:
+            self.view.set_type_scale(scope, float(value))
+
+    def _open_channel_picker(self) -> None:
+        if self._recording is None:
+            return
+        result = ChannelPickerDialog.get_visible(
+            self, self.view.channel_names, self.view.visible_indices
+        )
+        if result is not None:
+            self.view.set_visible_channels(result)
+
+    def _current_profile(self) -> ViewProfile:
+        """Capture the current montage as a profile."""
+        return ViewProfile(
+            channels=tuple(self.view.visible_channels),
+            base_scale_uv=self.view.scale_uv,
+            type_scales=self.view.type_scales(),
+            base_filter=self.view.spec,
+            type_filters=self.view.type_specs(),
+            window_seconds=self.view.window_seconds,
+            epoch_seconds=self.view.epoch_seconds,
+        )
+
+    def _apply_profile(self, profile: ViewProfile) -> None:
+        """Apply a saved montage; channels are matched by name (missing skipped)."""
+        names = self.view.channel_names
+        if profile.channels:
+            index_of = {name: i for i, name in enumerate(names)}
+            indices = [index_of[name] for name in profile.channels if name in index_of]
+            self.view.set_visible_channels(indices or list(range(len(names))))
+        else:
+            self.view.set_visible_channels(list(range(len(names))))
+        self.view.set_scale(profile.base_scale_uv)
+        self.view.set_type_scales(profile.type_scales)
+        self.view.set_spec(profile.base_filter)
+        self.view.set_type_specs(profile.type_filters)
+        self._select_window_seconds(profile.window_seconds)
+        self.epochSpin.setValue(int(profile.epoch_seconds))  # drives the view
+        self._populate_scope_combo()
+        self._load_scope_into_controls()
+        self._update_epoch_readout()
+
+    def _select_window_seconds(self, seconds: float) -> None:
+        options = [float(s) for s in WINDOW_LENGTHS]
+        if seconds in options:
+            self.windowCombo.setCurrentIndex(options.index(seconds))  # drives the view
+        else:
+            self.view.set_window_seconds(seconds)
+            self._configure_scrollbar()
+
+    def _save_profile(self) -> None:
+        if self._recording is None:
+            return
+        prefs = preferences.load_preferences(preferences_path)
+        start_dir = prefs.get("eeg_last_profile_dir") or str(
+            self._recording.path.parent
+        )
+        default = str(Path(start_dir) / f"montage{PROFILE_SUFFIX}")
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Save view profile", default, PROFILE_FILE_FILTER
+        )
+        if not path:
+            return
+        target = Path(path)
+        if target.suffix != ".json":  # the dialog may drop the compound suffix
+            target = target.with_name(target.name + PROFILE_SUFFIX)
+        try:
+            write_view_profile(self._current_profile(), target)
+        except OSError as exc:
+            self._error("Could not save the view profile.", str(exc))
+            return
+        preferences.update_preferences(
+            preferences_path, {"eeg_last_profile_dir": str(target.parent)}
+        )
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.showMessage(f"Saved view profile to {target.name}", 5000)
+
+    def _load_profile(self) -> None:
+        if self._recording is None:
+            return
+        prefs = preferences.load_preferences(preferences_path)
+        start_dir = prefs.get("eeg_last_profile_dir") or str(
+            self._recording.path.parent
+        )
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Load view profile", str(start_dir), PROFILE_FILE_FILTER
+        )
+        if not path:
+            return
+        try:
+            profile = read_view_profile(path)
+        except (OSError, ValueError) as exc:
+            self._error("Could not read the view profile.", str(exc))
+            return
+        self._apply_profile(profile)
+        preferences.update_preferences(
+            preferences_path, {"eeg_last_profile_dir": str(Path(path).parent)}
+        )
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.showMessage(f"Applied view profile {Path(path).name}", 5000)
 
     def _on_cursor_moved(self, seconds: float) -> None:
         if self._recording is None:

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -51,6 +51,8 @@ DEFAULTS: dict[str, Any] = {
     # tool is an optional component.
     "eeg_recent_labels": [],
     "eeg_last_dir": None,
+    # The folder the EEG review tool last saved/loaded a view profile from (#177).
+    "eeg_last_profile_dir": None,
 }
 
 _logger = logging.getLogger("smacc")

--- a/tests/test_eeg_profiles.py
+++ b/tests/test_eeg_profiles.py
@@ -1,0 +1,72 @@
+"""Tests for the EEG view-profile model and its JSON file (#177).
+
+Pure model + I/O, no Qt and no MNE — like the annotations tests.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from smacc.eeg.dsp import FilterSpec
+from smacc.eeg.profiles import (
+    KIND,
+    SCHEMA_VERSION,
+    ViewProfile,
+    read_view_profile,
+    write_view_profile,
+)
+
+
+def test_profile_round_trips_through_json(tmp_path):
+    profile = ViewProfile(
+        channels=("C3", "C4", "EMG"),
+        base_scale_uv=120.0,
+        type_scales={"emg": 250.0},
+        base_filter=FilterSpec(highpass=0.3, lowpass=35.0),
+        type_filters={"emg": FilterSpec(highpass=10.0, notch=60.0)},
+        window_seconds=60.0,
+        epoch_seconds=20.0,
+    )
+    path = tmp_path / "montage.smacc-view.json"
+    write_view_profile(profile, path)
+    assert read_view_profile(path) == profile
+
+
+def test_defaults_round_trip(tmp_path):
+    path = tmp_path / "empty.smacc-view.json"
+    write_view_profile(ViewProfile(), path)
+    assert read_view_profile(path) == ViewProfile()
+
+
+def test_written_file_records_kind_and_version(tmp_path):
+    path = tmp_path / "m.smacc-view.json"
+    write_view_profile(ViewProfile(), path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["kind"] == KIND
+    assert payload["schema_version"] == SCHEMA_VERSION
+
+
+def test_reading_a_foreign_json_is_rejected(tmp_path):
+    path = tmp_path / "not-a-profile.json"
+    path.write_text(json.dumps({"kind": "something-else"}), encoding="utf-8")
+    with pytest.raises(ValueError, match="view profile"):
+        read_view_profile(path)
+
+
+def test_reading_non_json_is_rejected(tmp_path):
+    path = tmp_path / "junk.json"
+    path.write_text("not json at all", encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON"):
+        read_view_profile(path)
+
+
+def test_a_bom_from_notepad_is_tolerated(tmp_path):
+    # A profile re-saved in Notepad comes back with a UTF-8 BOM; reading must
+    # still recognize it rather than choke on the first byte.
+    path = tmp_path / "m.smacc-view.json"
+    write_view_profile(ViewProfile(epoch_seconds=20.0), path)
+    raw = path.read_bytes()
+    path.write_bytes(b"\xef\xbb\xbf" + raw)
+    assert read_view_profile(path).epoch_seconds == 20.0

--- a/tests/test_eeg_view.py
+++ b/tests/test_eeg_view.py
@@ -16,7 +16,7 @@ from PyQt6 import QtCore, QtGui
 
 from smacc.eeg import dsp
 from smacc.eeg.annotations import Annotation
-from smacc.eeg.view import TYPE_GAINS, TimeAxis, TraceView
+from smacc.eeg.view import DEFAULT_TYPE_SCALES, TimeAxis, TraceView
 
 SFREQ = 100.0
 DURATION = 60.0
@@ -75,7 +75,8 @@ def test_traces_are_scaled_to_microvolt_lanes(loaded):
     _, y0 = view._curves[0].getData()
     assert y0 == pytest.approx(0.0 + 0.5)
     _, y3 = view._curves[3].getData()
-    emg = 0.5 * TYPE_GAINS["emg"]
+    # EMG (50 µV) sits on its larger default lane (200 µV) → +0.25 above center.
+    emg = CONSTANT_VOLTS * 1e6 / DEFAULT_TYPE_SCALES["emg"]
     assert y3 == pytest.approx(-3 + emg)
 
 
@@ -490,3 +491,58 @@ def test_time_axis_falls_back_to_elapsed_without_an_origin(qtbot):
     axis.set_mode("clock")  # asked for clock, but no origin is known
     strings = axis.tickStrings([0.0, 30.0], 1.0, 1.0)
     assert all(":" not in s for s in strings)  # plain seconds, not HH:MM:SS
+
+
+# ----- channel selection + per-type display (#177) --------------------------------
+
+
+def test_hiding_channels_draws_only_the_chosen_curves(loaded):
+    view, _ = loaded  # FakeProvider: C3, C4, EOG, EMG
+    view.set_visible_channels([0, 2])  # C3, EOG
+    assert len(view._curves) == 2
+    assert view.visible_channels == ["C3", "EOG"]
+
+
+def test_reordering_channels_sets_the_lane_order(loaded):
+    view, _ = loaded
+    view.set_visible_channels([3, 0])  # EMG on top lane, then C3
+    assert view.visible_channels == ["EMG", "C3"]
+    _, y_emg = view._curves[0].getData()  # EMG 50 µV on its 200 µV lane → +0.25
+    assert y_emg == pytest.approx(0.25)  # lane 0 centered at y = 0
+    _, y_c3 = view._curves[1].getData()  # C3 50 µV on the 100 µV base → +0.5
+    assert y_c3 == pytest.approx(-1 + 0.5)  # lane 1 centered at y = -1
+
+
+def test_empty_or_out_of_range_selection_is_ignored(loaded):
+    view, _ = loaded
+    view.set_visible_channels([])  # nothing valid → keep the current selection
+    assert len(view._curves) == 4
+    view.set_visible_channels([99, -1])  # out of range → ignored
+    assert len(view._curves) == 4
+
+
+def test_per_type_scale_overrides_the_base(loaded):
+    view, _ = loaded
+    view.set_type_scale("eeg", 50.0)  # EEG channels now on a 50 µV lane
+    _, y_c3 = view._curves[0].getData()  # C3 (eeg) 50 µV / 50 → 1.0
+    assert y_c3 == pytest.approx(1.0)
+    _, y_eog = view._curves[2].getData()  # EOG (no override) still on 100 µV base
+    assert y_eog == pytest.approx(-2 + 0.5)
+
+
+def test_per_type_filter_applies_only_to_its_type(loaded):
+    view, _ = loaded
+    view.set_type_spec("emg", dsp.FilterSpec(highpass=1.0))  # removes EMG's DC
+    _, y_c3 = view._curves[0].getData()  # unfiltered EEG unchanged
+    assert y_c3 == pytest.approx(0.5)
+    _, y_emg = view._curves[3].getData()  # EMG flattened toward its lane center
+    assert np.allclose(y_emg, -3, atol=0.05)
+
+
+def test_effective_spec_and_scale_fall_back_to_the_base(loaded):
+    view, _ = loaded
+    assert view.effective_scale("eeg") == view.scale_uv  # no override → base 100
+    assert view.effective_scale("emg") == 200.0  # default per-type override
+    assert view.effective_spec("eeg") == view.spec  # base
+    view.set_type_spec("eog", dsp.FilterSpec(notch=50.0))
+    assert view.effective_spec("eog") == dsp.FilterSpec(notch=50.0)

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -607,6 +607,103 @@ def test_clean_close_removes_the_recovery_file(window, recording_path, monkeypat
     assert not autosave_path(recording_path).is_file()
 
 
+# ----- channel picker + per-type display + view profiles (#177) --------------------
+
+
+def test_scope_combo_lists_all_channels_then_present_types(window, recording_path):
+    window._load(recording_path)  # FakeRecording types: eeg, eeg, eog, emg
+    datas = [
+        window.filterScopeCombo.itemData(i)
+        for i in range(window.filterScopeCombo.count())
+    ]
+    assert datas == [None, "eeg", "eog", "emg"]
+
+
+def test_filter_controls_edit_the_base_by_default(window, recording_path):
+    window._load(recording_path)  # scope defaults to "All channels"
+    window.highpassSpin.setValue(0.3)
+    assert window.view.spec == dsp.FilterSpec(highpass=0.3)
+
+
+def test_filter_controls_edit_one_type_when_scoped(window, recording_path):
+    window._load(recording_path)
+    window.filterScopeCombo.setCurrentIndex(3)  # EMG
+    window.highpassSpin.setValue(10.0)
+    assert window.view.effective_spec("emg") == dsp.FilterSpec(highpass=10.0)
+    assert window.view.spec == dsp.FilterSpec()  # base left alone
+
+
+def test_scale_control_edits_one_type_when_scoped(window, recording_path):
+    window._load(recording_path)
+    window.filterScopeCombo.setCurrentIndex(1)  # EEG
+    window.scaleSpin.setValue(60.0)
+    assert window.view.effective_scale("eeg") == 60.0
+
+
+def test_scope_change_loads_that_types_settings_into_the_controls(
+    window, recording_path
+):
+    window._load(recording_path)
+    window.filterScopeCombo.setCurrentIndex(3)  # EMG defaults to a 200 µV lane
+    assert window.scaleSpin.value() == 200.0
+    window.filterScopeCombo.setCurrentIndex(0)  # back to the 100 µV base
+    assert window.scaleSpin.value() == 100.0
+
+
+def test_channel_picker_applies_the_chosen_order(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    monkeypatch.setattr(
+        window_mod.ChannelPickerDialog,
+        "get_visible",
+        staticmethod(lambda *a, **k: [2, 0]),  # EOG then C3
+    )
+    window._open_channel_picker()
+    assert window.view.visible_channels == ["EOG", "C3"]
+
+
+def test_save_then_load_profile_round_trips(
+    window, recording_path, tmp_path, monkeypatch
+):
+    window._load(recording_path)
+    window.view.set_visible_channels([0, 3])  # C3, EMG
+    window.filterScopeCombo.setCurrentIndex(1)  # EEG scope
+    window.scaleSpin.setValue(70.0)
+    window.highpassSpin.setValue(0.5)
+    path = tmp_path / "montage.smacc-view.json"
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog, "getSaveFileName", lambda *a, **k: (str(path), "")
+    )
+    window._save_profile()
+    assert path.is_file()
+    # Wipe the montage, then load it back.
+    window.view.set_visible_channels([0, 1, 2, 3])
+    window.view.set_scale(100.0)
+    window.view.set_type_scales({})
+    window.view.set_type_specs({})
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog, "getOpenFileName", lambda *a, **k: (str(path), "")
+    )
+    window._load_profile()
+    assert window.view.visible_channels == ["C3", "EMG"]
+    assert window.view.effective_scale("eeg") == 70.0
+    assert window.view.effective_spec("eeg") == dsp.FilterSpec(highpass=0.5)
+
+
+def test_load_profile_skips_channels_not_in_the_recording(
+    window, recording_path, tmp_path, monkeypatch
+):
+    from smacc.eeg.profiles import ViewProfile, write_view_profile
+
+    path = tmp_path / "m.smacc-view.json"
+    write_view_profile(ViewProfile(channels=("C4", "NOSUCH", "C3")), path)
+    window._load(recording_path)
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog, "getOpenFileName", lambda *a, **k: (str(path), "")
+    )
+    window._load_profile()
+    assert window.view.visible_channels == ["C4", "C3"]  # NOSUCH skipped
+
+
 # ----- label dialog / entry point -----------------------------------------------------
 
 


### PR DESCRIPTION
Closes #177. The display foundation that export (#180) and blind-rater (#181) build on — "show exactly these channels, like this."

- **Channel picker** (Channels… dialog): choose and reorder which channels are shown; the view draws and labels only the visible set, in display order.
- **Per-type filter and amplitude**: an "Apply to" scope selector ("All channels" or a specific type) makes the filter/scale controls edit a base that every type inherits, or one type's override. Replaces the old hard-coded EMG ×0.5; `_refresh_data` filters each like-spec group together so the DSP cache stays effective.
- **Saved view profiles**: a standalone, shareable `*.smacc-view.json` file capturing channels (by name), per-type filters/scales, and window/epoch lengths — Save profile… / Load profile…. Channels are matched by name when applied, missing ones skipped; the last-used folder is remembered.

New module `smacc/eeg/profiles.py` (pure model + JSON I/O, like `annotations.py`).

867 tests pass; ruff + mypy clean.

Design decisions (confirmed): per-type (not per-channel) granularity; standalone profile files; per-type filter included. Deferred follow-ups: auto-applying a default/last profile on open, and per-channel (vs per-type) overrides if a lab needs them.