### PR TITLE
feat: publication figure export (PNG/PDF/SVG) for the EEG annotator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,12 @@ docs = [
 ]
 # The optional EEG review tool (#136). MNE is far too heavy for the base install,
 # so the viewer ships as a separate frozen exe / installer component; this extra
-# is its dev/CI environment. MNE is I/O and annotation conversion only — rendering
-# is pyqtgraph and display filtering is scipy (a core dependency).
+# is its dev/CI environment. MNE is I/O and annotation conversion only — on-screen
+# rendering is pyqtgraph and display filtering is scipy (a core dependency).
+# matplotlib is pinned explicitly because the figure export (#180) imports it
+# directly; it already ships in the bundle as an MNE dependency, so this is free.
 eeg = [
+    "matplotlib>=3.7",
     "mne>=1.6",
     "pyqtgraph>=0.13",
 ]

--- a/src/smacc/eeg/__main__.py
+++ b/src/smacc/eeg/__main__.py
@@ -78,6 +78,20 @@ def selftest() -> int:
         tsv = Path(tmp) / "selftest.annotations.tsv"
         write_annotations_tsv([Annotation(1.0, 0.5, "selftest")], tsv)
         assert read_annotations_tsv(tsv) == [Annotation(1.0, 0.5, "selftest")]
+        # Figure export (#180): prove matplotlib's PNG/PDF/SVG backends are bundled
+        # — a missed backend only surfaces when one actually writes a file.
+        from .export import ExportOptions, render
+        from .snapshot import Snapshot, SnapshotTrace
+
+        figure_snapshot = Snapshot(
+            times=np.linspace(0.0, 6.0, 600),
+            window_seconds=6.0,
+            traces=(SnapshotTrace("C3", "eeg", 0, np.zeros(600), 100.0),),
+        )
+        for fmt in ("png", "pdf", "svg"):
+            out = Path(tmp) / f"selftest.{fmt}"
+            render(figure_snapshot, ExportOptions(fmt=fmt, dpi=100), out)
+            assert out.stat().st_size > 0, fmt
     print("selftest ok")
     return 0
 

--- a/src/smacc/eeg/export.py
+++ b/src/smacc/eeg/export.py
@@ -1,0 +1,187 @@
+"""Publication-figure export for the EEG review tool (#180).
+
+Renders a :class:`~smacc.eeg.snapshot.Snapshot` to PNG / PDF / SVG with
+matplotlib's headless backends — the engine MNE itself uses for static figures,
+and the only one of the available libraries that does PDF and reliable vector
+text (pyqtgraph has no PDF exporter and its SVG exporter mishandles the view's
+stacked transforms). matplotlib already ships inside ``SMACC-EEG.exe`` as an MNE
+dependency, so this adds no packaging weight.
+
+The figure is built straight on a :class:`matplotlib.figure.Figure` with an
+explicit Agg canvas — never via ``pyplot`` — so there is no global backend state
+to clash with MNE in the same process, and ``savefig`` selects the PDF/SVG
+backend from the format. Dense traces are flattened into one rasterized layer at
+the chosen DPI while axes, ticks, marks and labels stay crisp vector (the
+file-size fix for thousands of samples in a vector file).
+
+Pure numpy + matplotlib, no Qt and no MNE — directly unit-testable headless,
+mirroring :mod:`smacc.eeg.dsp` / :mod:`smacc.eeg.profiles`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import matplotlib
+from matplotlib.backends.backend_agg import FigureCanvasAgg
+from matplotlib.figure import Figure
+
+from .snapshot import Snapshot
+
+# The three output formats; PNG raster (DPI), PDF/SVG vector.
+FORMATS = ("png", "pdf", "svg")
+
+# Publication palette: black traces, grey epoch grid, firebrick point marks (the
+# screen's accent), near-black span brackets and labels. Light, print-friendly.
+_TRACE_COLOR = "black"
+_EPOCH_COLOR = "0.6"
+_EPOCH_LABEL_COLOR = "0.45"
+_POINT_COLOR = "firebrick"
+_SPAN_COLOR = "0.1"
+_SHADE_COLOR = "steelblue"
+
+
+@dataclass(frozen=True)
+class ExportOptions:
+    """What to keep, strip, relabel, and how to write the file.
+
+    The figure is faithful to the on-screen view by construction; these options
+    only *remove* chrome (grid/shading), *relabel* marks, set line weight, and
+    pick the output format/resolution.
+    """
+
+    # Content (requirements a/b/c)
+    show_epoch_grid: bool = True  # honored only if the snapshot carries epochs
+    show_mark_shading: bool = False  # span wash; off = clean publication default
+    show_mark_labels: bool = True  # caret/bracket labels for marks
+    show_channel_labels: bool = True  # left-axis channel-name ticks
+    line_width_pt: float = 0.7  # all traces; publication-thin
+    # Output (requirement d)
+    fmt: str = "png"  # "png" | "pdf" | "svg"
+    dpi: int = 300  # PNG pixels and rasterized-trace resolution in PDF/SVG
+    width_in: float = 10.0
+    height_per_channel_in: float = 0.5  # total height auto from channel count (capped)
+    rasterize_traces: bool = True  # flatten traces to one image; False = full vector
+    svg_text_as_text: bool = (
+        True  # editable <text> (svg.fonttype="none") vs outlined paths
+    )
+    title: str = ""  # optional caption
+
+
+def render(snapshot: Snapshot, options: ExportOptions, path: str | Path) -> None:
+    """Render ``snapshot`` to ``path`` in ``options.fmt``.
+
+    Raises:
+        ValueError: for an unknown ``options.fmt``.
+        OSError: if the file cannot be written.
+    """
+    if options.fmt not in FORMATS:
+        raise ValueError(
+            f"Unknown export format {options.fmt!r}; expected one of {FORMATS}"
+        )
+    figure = build_figure(snapshot, options)
+    # rc_context so these never leak into the shared process (MNE also uses
+    # matplotlib). svg.fonttype "none" keeps text as editable <text>; a fixed
+    # hashsalt makes SVG ids deterministic; pdf.fonttype 42 embeds TrueType.
+    overrides = {
+        "svg.fonttype": "none" if options.svg_text_as_text else "path",
+        "svg.hashsalt": "smacc-eeg",
+        "pdf.fonttype": 42,
+    }
+    # Drop the per-format timestamp so re-renders are reproducible (no git churn).
+    metadata = {"CreationDate": None} if options.fmt == "pdf" else {"Date": None}
+    with matplotlib.rc_context(overrides):
+        figure.savefig(path, format=options.fmt, dpi=options.dpi, metadata=metadata)
+
+
+def build_figure(snapshot: Snapshot, options: ExportOptions) -> Figure:
+    """Build (but do not write) the figure — the unit-test seam for artists."""
+    lanes = [t.lane for t in snapshot.traces]
+    height = min(14.0, max(1, len(lanes)) * options.height_per_channel_in + 1.0)
+    figure = Figure(figsize=(options.width_in, height))
+    FigureCanvasAgg(figure)  # bind a canvas without pyplot's global state
+    axes = figure.add_subplot(111)
+    axes.set_xlim(0.0, snapshot.window_seconds)
+    top = 0.6
+    axes.set_ylim(-(max(lanes, default=0) + 0.6), top)
+
+    # Rasterized layer (zorder < 0): span shading + every trace flatten to one
+    # image at `dpi`. Rasterizing per-line instead would embed one bitmap per
+    # artist and bloat the file; this keeps everything above zorder 0 vector.
+    axes.set_rasterization_zorder(0 if options.rasterize_traces else None)
+    if options.show_mark_shading:
+        for mark in snapshot.marks:
+            if mark.duration > 0:
+                axes.axvspan(
+                    mark.onset,
+                    mark.onset + mark.duration,
+                    color=_SHADE_COLOR,
+                    alpha=0.18,
+                    lw=0,
+                    zorder=-20,
+                )
+    for trace in snapshot.traces:
+        axes.plot(
+            snapshot.times,
+            -trace.lane + trace.values,
+            color=_TRACE_COLOR,
+            lw=options.line_width_pt,
+            antialiased=True,
+            zorder=-10,
+        )
+
+    # Vector layer (zorder >= 0): grid, marks, labels stay crisp at any zoom.
+    if options.show_epoch_grid:
+        for epoch in snapshot.epochs:
+            axes.axvline(epoch.x, color=_EPOCH_COLOR, lw=0.6, ls=(0, (4, 4)), zorder=1)
+            axes.text(
+                epoch.x,
+                top - 0.04,
+                epoch.number,
+                color=_EPOCH_LABEL_COLOR,
+                fontsize=6,
+                ha="left",
+                va="top",
+                zorder=1,
+            )
+    for mark in snapshot.marks:
+        if mark.duration == 0:
+            axes.axvline(mark.onset, color=_POINT_COLOR, lw=0.8, zorder=2)
+        else:
+            axes.plot(
+                [mark.onset, mark.onset + mark.duration],
+                [top - 0.14, top - 0.14],
+                color=_SPAN_COLOR,
+                lw=0.9,
+                zorder=2,
+            )
+        if options.show_mark_labels and mark.label:
+            axes.text(
+                mark.onset + mark.duration / 2,
+                top - 0.02,
+                mark.label,
+                color=_SPAN_COLOR,
+                fontsize=7,
+                ha="center",
+                va="bottom",
+                zorder=2,
+            )
+
+    if options.show_channel_labels:
+        axes.set_yticks([-t.lane for t in snapshot.traces])
+        axes.set_yticklabels([t.name for t in snapshot.traces])
+        axes.tick_params(left=False)  # names only, no tick marks (as on screen)
+    else:
+        axes.set_yticks([])
+    if snapshot.time_ticks:
+        axes.set_xticks([x for x, _ in snapshot.time_ticks])
+        axes.set_xticklabels([label for _, label in snapshot.time_ticks])
+    axes.set_xlabel(snapshot.time_axis_label)
+    for side in ("top", "right", "left"):
+        axes.spines[side].set_visible(False)
+    title = options.title or snapshot.title
+    if title:
+        axes.set_title(title)
+    figure.tight_layout()  # reproducible: keeps figsize, unlike bbox_inches="tight"
+    return figure

--- a/src/smacc/eeg/snapshot.py
+++ b/src/smacc/eeg/snapshot.py
@@ -1,0 +1,73 @@
+"""Plain-data snapshot of the trace view for publication export (#180).
+
+A frozen, numpy-only description of exactly what the view is drawing for one
+window — already filtered, trimmed, and scaled into lane units — plus the
+scaffolding (epoch boundaries, marks, time ticks) the exporter may keep or
+strip. The view builds it (:meth:`smacc.eeg.view.TraceView.build_snapshot`); the
+exporter (:mod:`smacc.eeg.export`) consumes it. No Qt, no pyqtgraph, no MNE and
+no matplotlib here, so it is trivially constructable in a headless test —
+mirroring the pure-module pattern of :mod:`smacc.eeg.dsp`/``annotations``/``profiles``.
+
+Everything is **window-relative**: ``times`` and ``mark.onset`` have the window
+start subtracted, so the exporter never needs to know where in the recording the
+window sits, and clock time is carried as pre-rendered ``time_ticks`` strings so
+the exporter never touches ``datetime``. ``trace.values`` is the lane-unit array
+*centered on zero* (the exporter draws ``-lane + values``), i.e. exactly the
+``scaled`` array the live view hands each curve — so the export is provably the
+same picture the operator saw.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+# eq=False on every dataclass: a numpy array field makes the generated __eq__
+# ambiguous ("truth value of an array"), so tests compare fields explicitly.
+
+
+@dataclass(frozen=True, eq=False)
+class SnapshotTrace:
+    """One channel's drawn trace, in display (lane) order."""
+
+    name: str  # channel display name (left-axis label), e.g. "C3"
+    ch_type: str  # MNE type ("eeg"/"eog"/"emg"/"stim"/…); for styling + #180b
+    lane: int  # display row; baseline drawn at y = -lane
+    values: (
+        np.ndarray
+    )  # 1-D float, lane units, centered on 0 (export draws -lane + values)
+    scale_uv: float | None  # effective µV/lane for bioelectric channels; None for
+    # auto-fit (stim/misc — arbitrary units, no µV calibration)
+
+
+@dataclass(frozen=True, eq=False)
+class SnapshotMark:
+    """An annotation to draw on the figure (window-relative, already relabeled)."""
+
+    onset: float  # seconds, window-relative (window_start already subtracted)
+    duration: float  # seconds; 0 == an instantaneous point mark
+    label: str  # clean, user-overridable text (defaults to the description)
+
+
+@dataclass(frozen=True, eq=False)
+class SnapshotEpoch:
+    """One epoch boundary line."""
+
+    x: float  # window-relative seconds of the boundary
+    number: str  # epoch label as the grid shows it (k+1, stringified)
+
+
+@dataclass(frozen=True, eq=False)
+class Snapshot:
+    """Everything the exporter needs for one window — pure data, no behavior."""
+
+    times: np.ndarray  # 1-D window-relative seconds, shared x; starts at ~0
+    window_seconds: float  # the x-axis spans [0, window_seconds]
+    traces: tuple[SnapshotTrace, ...]  # display order, top lane (lane 0) first
+    marks: tuple[SnapshotMark, ...] = ()  # window-filtered + relabeled; () => none
+    epochs: tuple[SnapshotEpoch, ...] = ()  # () => no grid (caller passes () when off)
+    time_ticks: tuple[tuple[float, str], ...] = ()  # (window-rel x, label); () => auto
+    time_axis_label: str = "time (s)"  # "time (s)" or "clock time"
+    sfreq: float = 0.0  # informational (titles / provenance)
+    title: str = ""  # optional caption; "" => none

--- a/src/smacc/eeg/view.py
+++ b/src/smacc/eeg/view.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 import math
 from datetime import datetime, timedelta
-from typing import Any, Protocol
+from typing import Any, NamedTuple, Protocol
 
 import numpy as np
 import pyqtgraph as pg
@@ -33,6 +33,7 @@ from PyQt6 import QtCore, QtGui
 
 from . import dsp
 from .annotations import Annotation
+from .snapshot import Snapshot, SnapshotEpoch, SnapshotMark, SnapshotTrace
 
 # Bioelectric channels are recorded in volts and displayed in microvolts.
 # Other kinds (stim/misc/…) carry arbitrary units — a trigger channel holds
@@ -100,14 +101,26 @@ class TimeAxis(pg.AxisItem):
         self.picture = None
         self.update()
 
+    @property
+    def mode(self) -> str:
+        """``"clock"`` or ``"elapsed"`` — which kind of tick label is shown."""
+        return self._mode
+
+    def tick_label(self, value: float) -> str:
+        """Format one x value the way the axis labels it (clock or elapsed seconds).
+
+        Shared with the figure export (#180) so a snapshot's time ticks read
+        exactly like the screen's, without re-deriving the clock formatting.
+        """
+        if self._mode == "clock" and self._origin is not None:
+            return (self._origin + timedelta(seconds=float(value))).strftime("%H:%M:%S")
+        return f"{value:g}"
+
     def tickStrings(
         self, values: list[float], scale: float, spacing: float
     ) -> list[str]:
         if self._mode == "clock" and self._origin is not None:
-            return [
-                (self._origin + timedelta(seconds=float(v))).strftime("%H:%M:%S")
-                for v in values
-            ]
+            return [self.tick_label(float(v)) for v in values]
         return super().tickStrings(values, scale, spacing)
 
 
@@ -178,6 +191,21 @@ class _AnnotateViewBox(pg.ViewBox):
             self.markRequested.emit(seconds)
         else:
             self.clicked.emit(seconds)
+
+
+class _LaneTrace(NamedTuple):
+    """One drawn channel as :meth:`TraceView._lane_traces` returns it.
+
+    ``values`` is the lane-unit array centered on 0 (the curve draws
+    ``-lane + values``); ``scale_uv`` is the µV/lane used for a bioelectric
+    channel, ``None`` for the auto-fit (stim/misc) branch.
+    """
+
+    lane: int
+    channel: int
+    ch_type: str
+    values: np.ndarray
+    scale_uv: float | None
 
 
 class TraceView(pg.PlotWidget):
@@ -385,6 +413,70 @@ class TraceView(pg.PlotWidget):
         self._refresh_annotations()
         self._refresh_epochs()
 
+    def build_snapshot(
+        self,
+        *,
+        marks: list[tuple[float, float, str]],
+        show_epochs: bool,
+        n_time_ticks: int = 7,
+        title: str = "",
+    ) -> Snapshot:
+        """Assemble a pure :class:`Snapshot` of the current window for export (#180).
+
+        ``marks`` is the list of ``(onset, duration, clean_label)`` to draw — the
+        window chooses which annotations to include and how to relabel them.
+        Times come back window-relative. Reuses :meth:`_lane_traces` and
+        :meth:`_epoch_boundaries`, so the figure is the same picture as the
+        screen. Safe with no recording loaded (returns empty traces).
+        """
+        lo = self._window_start
+        hi = lo + self._window_seconds
+        if self._provider is None:
+            return Snapshot(
+                times=np.empty(0), window_seconds=self._window_seconds, traces=()
+            )
+        times, lanes = self._lane_traces()
+        names = self.channel_names
+        traces = tuple(
+            SnapshotTrace(
+                name=names[entry.channel],
+                ch_type=entry.ch_type,
+                lane=entry.lane,
+                values=entry.values,
+                scale_uv=entry.scale_uv,
+            )
+            for entry in lanes
+        )
+        snapshot_marks = tuple(
+            SnapshotMark(onset=onset - lo, duration=duration, label=label)
+            for onset, duration, label in marks
+        )
+        epochs = (
+            tuple(
+                SnapshotEpoch(x=x - lo, number=number)
+                for x, number in self._epoch_boundaries(lo, hi)
+            )
+            if show_epochs
+            else ()
+        )
+        ticks = tuple(
+            (float(t - lo), self._time_axis.tick_label(float(t)))
+            for t in np.linspace(lo, hi, n_time_ticks)
+        )
+        return Snapshot(
+            times=times - lo,
+            window_seconds=self._window_seconds,
+            traces=traces,
+            marks=snapshot_marks,
+            epochs=epochs,
+            time_ticks=ticks,
+            time_axis_label=(
+                "clock time" if self._time_axis.mode == "clock" else "time (s)"
+            ),
+            sfreq=self._provider.sfreq,
+            title=title,
+        )
+
     def set_window_seconds(self, seconds: float) -> None:
         self._window_seconds = max(1.0, seconds)
         self._clamp_window_start()
@@ -539,10 +631,16 @@ class TraceView(pg.PlotWidget):
         )
         self.setYRange(-len(self._visible) + 0.4, 0.6, padding=0)
 
-    def _refresh_data(self) -> None:
-        """Fetch, filter, scale, and draw the visible slice of every shown channel."""
-        if self._provider is None:
-            return
+    def _lane_traces(self) -> tuple[np.ndarray, list[_LaneTrace]]:
+        """Fetch, filter, trim, and scale the visible window into lane-unit traces.
+
+        The single source of truth for both :meth:`_refresh_data` (which draws
+        them) and :meth:`build_snapshot` (which exports them), so the screen and
+        the figure are guaranteed to be the same picture. ``times`` is in data
+        seconds, trimmed to the window; each :class:`_LaneTrace` carries the
+        lane-unit ``values`` (centered on 0; draw ``-lane + values``).
+        """
+        assert self._provider is not None
         ch_types = self._provider.ch_types
         sfreq = self._provider.sfreq
         # Each visible channel filters by its type's effective spec; fetch a
@@ -566,20 +664,31 @@ class TraceView(pg.PlotWidget):
         # Trim the filter margin so its edge transients never reach the screen.
         keep = (times >= lo) & (times <= hi)
         times = times[keep]
+        lanes: list[_LaneTrace] = []
         for lane, i in enumerate(self._visible):
             trace = data[i][keep]
             if ch_types[i] in _MICROVOLT_TYPES:
-                scaled = (
-                    trace * _VOLTS_TO_MICROVOLTS / self.effective_scale(ch_types[i])
-                )
+                scale_uv: float | None = self.effective_scale(ch_types[i])
+                scaled = trace * _VOLTS_TO_MICROVOLTS / scale_uv
             else:
                 # Unit-less channel (stim/misc/…): fit it to its own lane per
                 # visible slice. Absolute amplitude is meaningless for these;
                 # the edges (a trigger firing) are what a reviewer looks for.
+                scale_uv = None
                 peak = float(np.max(np.abs(trace))) if trace.size else 0.0
                 scaled = trace * (_AUTOFIT_EXCURSION / peak) if peak else trace
-            self._curves[lane].setData(times, -lane + scaled)
-        self.setXRange(lo, hi, padding=0)
+            lanes.append(_LaneTrace(lane, i, ch_types[i], scaled, scale_uv))
+        return times, lanes
+
+    def _refresh_data(self) -> None:
+        """Draw the visible slice of every shown channel."""
+        if self._provider is None:
+            return
+        times, lanes = self._lane_traces()
+        for entry in lanes:
+            self._curves[entry.lane].setData(times, -entry.lane + entry.values)
+        lo = self._window_start
+        self.setXRange(lo, lo + self._window_seconds, padding=0)
 
     def _refresh_annotations(self) -> None:
         """Redraw the annotation overlay for the visible window (cheap)."""
@@ -635,18 +744,28 @@ class TraceView(pg.PlotWidget):
             return
         lo = self._window_start
         hi = self._window_start + self._window_seconds
-        first = math.ceil((lo - self._epoch_anchor) / self._epoch_seconds)
-        last = math.floor((hi - self._epoch_anchor) / self._epoch_seconds)
-        for k in range(first, last + 1):
-            boundary = self._epoch_anchor + k * self._epoch_seconds
+        for boundary, number in self._epoch_boundaries(lo, hi):
             line = pg.InfiniteLine(
                 pos=boundary,
                 angle=90,
                 movable=False,
                 pen=_EPOCH_PEN,
-                label=str(k + 1),  # the epoch this boundary starts
+                label=number,  # the epoch this boundary starts
                 labelOpts={"position": 0.96, "color": _EPOCH_LABEL_COLOR},
             )
             line.setZValue(2)  # above the curves, below the annotations
             plot_item.addItem(line)
             self._epoch_items.append(line)
+
+    def _epoch_boundaries(self, lo: float, hi: float) -> list[tuple[float, str]]:
+        """``(boundary_seconds, "k+1")`` for every epoch line within ``[lo, hi]``.
+
+        Shared by :meth:`_refresh_epochs` (the on-screen grid) and
+        :meth:`build_snapshot` (the export), so both number epochs identically.
+        """
+        first = math.ceil((lo - self._epoch_anchor) / self._epoch_seconds)
+        last = math.floor((hi - self._epoch_anchor) / self._epoch_seconds)
+        return [
+            (self._epoch_anchor + k * self._epoch_seconds, str(k + 1))
+            for k in range(first, last + 1)
+        ]

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import math
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
@@ -46,6 +47,9 @@ from .annotations import (
 from .profiles import FILE_FILTER as PROFILE_FILE_FILTER
 from .profiles import PROFILE_SUFFIX, ViewProfile, read_view_profile, write_view_profile
 from .view import DEFAULT_EPOCH_SECONDS, TraceView
+
+if TYPE_CHECKING:  # matplotlib is heavy: import the export module only on demand
+    from .export import ExportOptions
 
 # Stable id for this window's geometry entry in the per-window prefs map.
 _EEG_WINDOW_ID = "eeg-review"
@@ -272,6 +276,196 @@ class ChannelPickerDialog(QtWidgets.QDialog):
         if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
             return None
         return dialog.result_indices() or None
+
+
+class ExportDialog(QtWidgets.QDialog):
+    """Choose what to export and how, for a publication figure (#180).
+
+    Faithful to the on-screen view by construction; the controls only strip
+    chrome (epoch grid, span shading), relabel marks (per-annotation editable
+    text), set line weight, pick channels (via the #177 picker), and select the
+    output format/resolution. Returns plain values — the window builds the
+    ``ExportOptions`` so this dialog never imports matplotlib.
+    """
+
+    def __init__(
+        self,
+        parent: QtWidgets.QWidget | None,
+        ch_names: list[str],
+        visible: list[int],
+        window_annotations: list[tuple[float, float, str]],
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Export figure")
+        self._ch_names = ch_names
+        self._chosen_channels: list[int] | None = None
+        # (onset, duration) per table row, parallel to the annotation rows.
+        self._anno_spans = [
+            (onset, duration) for onset, duration, _ in window_annotations
+        ]
+        form = QtWidgets.QFormLayout()
+
+        self.channelsLabel = QtWidgets.QLabel(f"{len(visible)} shown", self)
+        channelsButton = QtWidgets.QPushButton("Channels…", self)
+        channelsButton.setStatusTip(
+            "Choose and reorder which channels the figure shows."
+        )
+        channelsButton.clicked.connect(lambda: self._pick_channels(ch_names, visible))
+        channelsRow = QtWidgets.QHBoxLayout()
+        channelsRow.addWidget(self.channelsLabel)
+        channelsRow.addWidget(channelsButton)
+        channelsRow.addStretch(1)
+        form.addRow("Channels:", channelsRow)
+
+        self.titleEdit = QtWidgets.QLineEdit(self)
+        self.titleEdit.setPlaceholderText("optional caption")
+        form.addRow("Title:", self.titleEdit)
+
+        self.formatCombo = QtWidgets.QComboBox(self)
+        for label, value in (
+            ("PNG (raster)", "png"),
+            ("PDF (vector)", "pdf"),
+            ("SVG (vector)", "svg"),
+        ):
+            self.formatCombo.addItem(label, value)
+        self.formatCombo.currentIndexChanged.connect(self._on_format_changed)
+        form.addRow("Format:", self.formatCombo)
+
+        self.dpiCombo = QtWidgets.QComboBox(self)
+        for dpi in (150, 300, 600):
+            self.dpiCombo.addItem(f"{dpi} dpi", dpi)
+        self.dpiCombo.setCurrentIndex(1)  # 300
+        self.dpiCombo.setStatusTip(
+            "Pixel density (PNG) and the rasterized trace layer in PDF/SVG."
+        )
+        form.addRow("Resolution:", self.dpiCombo)
+
+        self.widthSpin = QtWidgets.QDoubleSpinBox(self)
+        self.widthSpin.setRange(2.0, 30.0)
+        self.widthSpin.setSingleStep(0.5)
+        self.widthSpin.setValue(10.0)
+        self.widthSpin.setSuffix(" in")
+        form.addRow("Width:", self.widthSpin)
+
+        self.lineWidthSpin = QtWidgets.QDoubleSpinBox(self)
+        self.lineWidthSpin.setRange(0.2, 3.0)
+        self.lineWidthSpin.setSingleStep(0.1)
+        self.lineWidthSpin.setValue(0.7)
+        self.lineWidthSpin.setSuffix(" pt")
+        form.addRow("Trace weight:", self.lineWidthSpin)
+
+        self.channelLabelsCheck = QtWidgets.QCheckBox("Channel labels", self)
+        self.channelLabelsCheck.setChecked(True)
+        self.epochGridCheck = QtWidgets.QCheckBox(
+            "Epoch gridlines", self
+        )  # off = clean
+        self.shadingCheck = QtWidgets.QCheckBox(
+            "Annotation shading", self
+        )  # off = clean
+        self.markLabelsCheck = QtWidgets.QCheckBox("Annotation labels", self)
+        self.markLabelsCheck.setChecked(True)
+        self.svgTextCheck = QtWidgets.QCheckBox("Editable SVG text", self)
+        self.svgTextCheck.setChecked(True)
+        self.svgTextCheck.setEnabled(False)  # only meaningful for SVG
+        for check in (
+            self.channelLabelsCheck,
+            self.epochGridCheck,
+            self.shadingCheck,
+            self.markLabelsCheck,
+            self.svgTextCheck,
+        ):
+            form.addRow("", check)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addLayout(form)
+        layout.addWidget(QtWidgets.QLabel("Annotations in this window:", self))
+        self.annoTable = QtWidgets.QTableWidget(len(window_annotations), 2, self)
+        self.annoTable.setHorizontalHeaderLabels(["Show", "Label"])
+        self.annoTable.setMinimumWidth(320)
+        vheader = self.annoTable.verticalHeader()
+        if vheader is not None:
+            vheader.setVisible(False)
+        header = self.annoTable.horizontalHeader()
+        assert header is not None
+        header.setSectionResizeMode(1, QtWidgets.QHeaderView.ResizeMode.Stretch)
+        for row, (_onset, _duration, description) in enumerate(window_annotations):
+            include = QtWidgets.QTableWidgetItem()
+            include.setFlags(
+                QtCore.Qt.ItemFlag.ItemIsUserCheckable
+                | QtCore.Qt.ItemFlag.ItemIsEnabled
+            )
+            include.setCheckState(QtCore.Qt.CheckState.Checked)
+            self.annoTable.setItem(row, 0, include)
+            self.annoTable.setItem(row, 1, QtWidgets.QTableWidgetItem(description))
+        layout.addWidget(self.annoTable, 1)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _on_format_changed(self) -> None:
+        self.svgTextCheck.setEnabled(self.formatCombo.currentData() == "svg")
+
+    def _pick_channels(self, ch_names: list[str], visible: list[int]) -> None:
+        current = (
+            self._chosen_channels if self._chosen_channels is not None else visible
+        )
+        result = ChannelPickerDialog.get_visible(self, ch_names, current)
+        if result is not None:
+            self._chosen_channels = result
+            self.channelsLabel.setText(f"{len(result)} shown")
+
+    def result_values(
+        self,
+    ) -> tuple[ExportOptions, list[tuple[float, float, str]], list[int] | None]:
+        """Return ``(options, marks, chosen_channels)`` from the controls.
+
+        Lazy-imports the export module (matplotlib) only here, once the dialog is
+        accepted — never at window startup.
+        """
+        from . import export
+
+        marks: list[tuple[float, float, str]] = []
+        for row, (onset, duration) in enumerate(self._anno_spans):
+            include = self.annoTable.item(row, 0)
+            label_item = self.annoTable.item(row, 1)
+            if (
+                include is not None
+                and include.checkState() == QtCore.Qt.CheckState.Checked
+            ):
+                label = label_item.text().strip() if label_item is not None else ""
+                marks.append((onset, duration, label))
+        options = export.ExportOptions(
+            fmt=self.formatCombo.currentData(),
+            dpi=int(self.dpiCombo.currentData()),
+            width_in=float(self.widthSpin.value()),
+            line_width_pt=float(self.lineWidthSpin.value()),
+            show_channel_labels=self.channelLabelsCheck.isChecked(),
+            show_epoch_grid=self.epochGridCheck.isChecked(),
+            show_mark_shading=self.shadingCheck.isChecked(),
+            show_mark_labels=self.markLabelsCheck.isChecked(),
+            svg_text_as_text=self.svgTextCheck.isChecked(),
+            title=self.titleEdit.text().strip(),
+        )
+        return options, marks, self._chosen_channels
+
+    @staticmethod
+    def get_export(
+        parent: QtWidgets.QWidget | None,
+        ch_names: list[str],
+        visible: list[int],
+        window_annotations: list[tuple[float, float, str]],
+    ) -> tuple[ExportOptions, list[tuple[float, float, str]], list[int] | None] | None:
+        """Run the dialog; return ``(options, marks, channels)`` or ``None`` on cancel."""
+        dialog = ExportDialog(parent, ch_names, visible, window_annotations)
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return None
+        return dialog.result_values()
 
 
 class EegReviewWindow(QtWidgets.QMainWindow):
@@ -522,6 +716,12 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.loadProfileButton.setStatusTip("Apply a saved montage to this recording.")
         self.loadProfileButton.clicked.connect(self._load_profile)
         row.addWidget(self.loadProfileButton)
+        self.exportButton = QtWidgets.QPushButton("Export figure…", self)
+        self.exportButton.setStatusTip(
+            "Export the current window as a publication PNG, PDF, or SVG."
+        )
+        self.exportButton.clicked.connect(self._export_figure)
+        row.addWidget(self.exportButton)
         return row
 
     def _build_contract_caption(self) -> QtWidgets.QLabel:
@@ -610,6 +810,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             self.channelsButton,
             self.saveProfileButton,
             self.loadProfileButton,
+            self.exportButton,
         ):
             widget.setEnabled(loaded)
 
@@ -1241,6 +1442,60 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         status_bar = self.statusBar()
         assert status_bar is not None
         status_bar.showMessage(f"Applied view profile {Path(path).name}", 5000)
+
+    def _export_figure(self) -> None:
+        if self._recording is None or not self.view.visible_indices:
+            return
+        lo = self.view.window_start
+        hi = lo + self.view.window_seconds
+        in_window = [
+            (a.onset, a.duration, a.description)
+            for a in self._annotations
+            if not (a.onset + a.duration < lo or a.onset > hi)
+        ]
+        result = ExportDialog.get_export(
+            self, self.view.channel_names, self.view.visible_indices, in_window
+        )
+        if result is None:
+            return
+        options, marks, channels = result
+        if channels is not None:  # the dialog's picker also updates the live view
+            self.view.set_visible_channels(channels)
+        from . import export  # lazy: matplotlib is heavy and only needed here
+
+        snapshot = self.view.build_snapshot(
+            marks=marks, show_epochs=options.show_epoch_grid
+        )
+        path = self._ask_export_path(options.fmt)
+        if path is None:
+            return
+        try:
+            export.render(snapshot, options, path)
+        except (OSError, ValueError) as exc:
+            self._error("Could not export the figure.", str(exc))
+            return
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.showMessage(f"Exported {path.name}", 5000)
+
+    def _ask_export_path(self, fmt: str) -> Path | None:
+        """Prompt for the figure path (remembering the folder); ``None`` on cancel."""
+        assert self._recording is not None
+        prefs = preferences.load_preferences(preferences_path)
+        start_dir = prefs.get("eeg_last_export_dir") or str(self._recording.path.parent)
+        default = str(Path(start_dir) / f"{self._recording.path.stem}.{fmt}")
+        chosen, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Export figure", default, f"{fmt.upper()} (*.{fmt})"
+        )
+        if not chosen:
+            return None
+        target = Path(chosen)
+        if target.suffix.lower() != f".{fmt}":
+            target = target.with_name(f"{target.name}.{fmt}")
+        preferences.update_preferences(
+            preferences_path, {"eeg_last_export_dir": str(target.parent)}
+        )
+        return target
 
     def _on_cursor_moved(self, seconds: float) -> None:
         if self._recording is None:

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -53,6 +53,8 @@ DEFAULTS: dict[str, Any] = {
     "eeg_last_dir": None,
     # The folder the EEG review tool last saved/loaded a view profile from (#177).
     "eeg_last_profile_dir": None,
+    # The folder the EEG review tool last exported a figure to (#180).
+    "eeg_last_export_dir": None,
 }
 
 _logger = logging.getLogger("smacc")

--- a/tests/test_eeg_export.py
+++ b/tests/test_eeg_export.py
@@ -1,0 +1,189 @@
+"""Tests for the publication figure export (#180) — pure, headless, no Qt.
+
+Snapshots are built by hand from numpy arrays (no view, no MNE) and rendered
+through matplotlib's Agg/PDF/SVG backends, mirroring the pure style of
+``test_eeg_profiles``. ``build_figure`` is the introspection seam: assert on the
+artists without writing a file.
+"""
+
+from __future__ import annotations
+
+import io
+import xml.etree.ElementTree as ET
+
+import numpy as np
+import pytest
+
+pytest.importorskip("matplotlib")  # ships with the eeg extra; skip a bare env
+
+from smacc.eeg import export  # noqa: E402
+from smacc.eeg.snapshot import (  # noqa: E402
+    Snapshot,
+    SnapshotEpoch,
+    SnapshotMark,
+    SnapshotTrace,
+)
+
+N = 600
+
+
+def _snapshot(**overrides) -> Snapshot:
+    times = np.linspace(0.0, 30.0, N)
+    base = dict(
+        times=times,
+        window_seconds=30.0,
+        traces=(
+            SnapshotTrace("C3", "eeg", 0, 0.4 * np.sin(times), 100.0),
+            SnapshotTrace("EMG", "emg", 1, 0.1 * np.cos(times), 200.0),
+        ),
+        marks=(
+            SnapshotMark(12.0, 0.0, "LRLR"),
+            SnapshotMark(20.0, 3.0, "spindle"),
+        ),
+        epochs=(SnapshotEpoch(10.0, "2"), SnapshotEpoch(20.0, "3")),
+        time_ticks=tuple((float(x), f"{int(x)}") for x in (0, 10, 20, 30)),
+        time_axis_label="time (s)",
+    )
+    base.update(overrides)
+    return Snapshot(**base)
+
+
+def _png_width(data: bytes) -> int:
+    assert data[:8] == b"\x89PNG\r\n\x1a\n", "not a PNG"
+    return int.from_bytes(data[16:20], "big")  # IHDR width, big-endian
+
+
+def _trace_lines(figure):
+    return [ln for ln in figure.axes[0].lines if ln.get_zorder() == -10]
+
+
+# ----- file output (requirement d) --------------------------------------------------
+
+
+def test_png_pixel_width_tracks_dpi(tmp_path):
+    widths = {}
+    for dpi in (150, 300):
+        path = tmp_path / f"f{dpi}.png"
+        export.render(_snapshot(), export.ExportOptions(fmt="png", dpi=dpi), path)
+        data = path.read_bytes()
+        widths[dpi] = _png_width(data)
+        assert widths[dpi] == round(10.0 * dpi)  # default width_in is 10
+    assert widths[300] > widths[150]
+
+
+def test_pdf_has_a_pdf_header(tmp_path):
+    path = tmp_path / "f.pdf"
+    export.render(_snapshot(), export.ExportOptions(fmt="pdf", dpi=150), path)
+    assert path.read_bytes()[:5] == b"%PDF-"
+
+
+def test_svg_keeps_clean_labels_as_editable_text(tmp_path):
+    path = tmp_path / "f.svg"
+    export.render(
+        _snapshot(), export.ExportOptions(fmt="svg", svg_text_as_text=True), path
+    )
+    text = path.read_text(encoding="utf-8")
+    # svg.fonttype="none" → labels are real <text>, searchable and editable.
+    texts = [el.text for el in ET.fromstring(text).iter() if el.tag.endswith("}text")]
+    flat = " ".join(t for t in texts if t)
+    assert "spindle" in flat and "LRLR" in flat
+
+
+def test_relabeling_replaces_the_technical_text(tmp_path):
+    snap = _snapshot(marks=(SnapshotMark(12.0, 0.0, "two-way comms"),))
+    path = tmp_path / "f.svg"
+    export.render(snap, export.ExportOptions(fmt="svg"), path)
+    text = path.read_text(encoding="utf-8")
+    assert "two-way comms".replace(" ", "") in text.replace(" ", "")  # tspan-split safe
+    assert "Cue started" not in text
+
+
+def test_unknown_format_raises(tmp_path):
+    with pytest.raises(ValueError, match="format"):
+        export.render(
+            _snapshot(), export.ExportOptions(fmt="tiff"), tmp_path / "f.tiff"
+        )
+
+
+def test_empty_snapshot_renders_without_crashing(tmp_path):
+    snap = Snapshot(times=np.empty(0), window_seconds=30.0, traces=())
+    path = tmp_path / "empty.png"
+    export.render(snap, export.ExportOptions(fmt="png", dpi=100), path)
+    assert path.stat().st_size > 0
+
+
+# ----- content options (requirements a/b/c) -----------------------------------------
+
+
+def test_one_trace_line_per_channel_at_the_set_weight():
+    fig = export.build_figure(_snapshot(), export.ExportOptions(line_width_pt=1.4))
+    lines = _trace_lines(fig)
+    assert len(lines) == 2  # C3, EMG
+    assert all(ln.get_linewidth() == 1.4 for ln in lines)
+
+
+def test_epoch_grid_toggle_controls_the_numbers():
+    on = export.build_figure(_snapshot(), export.ExportOptions(show_epoch_grid=True))
+    off = export.build_figure(_snapshot(), export.ExportOptions(show_epoch_grid=False))
+    assert "2" in [t.get_text() for t in on.axes[0].texts]
+    assert "2" not in [t.get_text() for t in off.axes[0].texts]
+
+
+def test_shading_toggle_controls_the_span_patch():
+    on = export.build_figure(_snapshot(), export.ExportOptions(show_mark_shading=True))
+    off = export.build_figure(
+        _snapshot(), export.ExportOptions(show_mark_shading=False)
+    )
+    assert len(on.axes[0].patches) == 1  # one span mark in the sample
+    assert len(off.axes[0].patches) == 0
+
+
+def test_mark_labels_toggle():
+    on = export.build_figure(_snapshot(), export.ExportOptions(show_mark_labels=True))
+    off = export.build_figure(_snapshot(), export.ExportOptions(show_mark_labels=False))
+    assert "spindle" in [t.get_text() for t in on.axes[0].texts]
+    assert "spindle" not in [t.get_text() for t in off.axes[0].texts]
+
+
+def test_point_mark_is_a_vertical_line_at_its_onset():
+    fig = export.build_figure(_snapshot(), export.ExportOptions())
+    verticals = [
+        ln
+        for ln in fig.axes[0].lines
+        if ln.get_zorder() == 2 and ln.get_xdata()[0] == ln.get_xdata()[-1]
+    ]
+    assert any(v.get_xdata()[0] == 12.0 for v in verticals)  # the point mark at 12 s
+
+
+def test_channel_labels_toggle():
+    on = export.build_figure(
+        _snapshot(), export.ExportOptions(show_channel_labels=True)
+    )
+    off = export.build_figure(
+        _snapshot(), export.ExportOptions(show_channel_labels=False)
+    )
+    assert [t.get_text() for t in on.axes[0].get_yticklabels()] == ["C3", "EMG"]
+    assert off.axes[0].get_yticks().tolist() == []
+
+
+# ----- vector trace handling --------------------------------------------------------
+
+
+def test_rasterized_traces_embed_one_image_not_many_paths():
+    raster = _render_svg(export.ExportOptions(fmt="svg", rasterize_traces=True))
+    vector = _render_svg(export.ExportOptions(fmt="svg", rasterize_traces=False))
+    assert "<image" in raster  # the dense trace layer flattens to one bitmap
+    assert "<image" not in vector
+
+
+def test_svg_is_reproducible(tmp_path):
+    # A fixed hashsalt + suppressed date → byte-identical re-render (no git churn).
+    first = _render_svg(export.ExportOptions(fmt="svg"))
+    second = _render_svg(export.ExportOptions(fmt="svg"))
+    assert first == second
+
+
+def _render_svg(options) -> str:
+    buffer = io.BytesIO()
+    export.render(_snapshot(), options, buffer)
+    return buffer.getvalue().decode("utf-8")

--- a/tests/test_eeg_view.py
+++ b/tests/test_eeg_view.py
@@ -546,3 +546,61 @@ def test_effective_spec_and_scale_fall_back_to_the_base(loaded):
     assert view.effective_spec("eeg") == view.spec  # base
     view.set_type_spec("eog", dsp.FilterSpec(notch=50.0))
     assert view.effective_spec("eog") == dsp.FilterSpec(notch=50.0)
+
+
+# ----- snapshot for figure export (#180) ------------------------------------------
+
+
+def test_lane_traces_match_exactly_what_the_curves_draw(loaded):
+    # The export reuses _lane_traces, so this parity is the guard that the
+    # refactor kept the on-screen picture byte-for-byte.
+    view, _ = loaded
+    times, lanes = view._lane_traces()
+    assert len(lanes) == len(view._curves)
+    for entry in lanes:
+        x, y = view._curves[entry.lane].getData()
+        assert np.allclose(x, times)
+        assert np.allclose(y, -entry.lane + entry.values)
+
+
+def test_build_snapshot_traces_match_the_visible_channels(loaded):
+    view, _ = loaded
+    view.set_visible_channels([0, 3])  # C3 (eeg), EMG (emg)
+    snap = view.build_snapshot(marks=[], show_epochs=False)
+    assert [t.name for t in snap.traces] == ["C3", "EMG"]
+    assert [t.lane for t in snap.traces] == [0, 1]
+    assert [t.ch_type for t in snap.traces] == ["eeg", "emg"]
+    # C3 50 µV on the 100 µV base → +0.5; EMG 50 µV on its 200 µV lane → +0.25.
+    assert np.allclose(snap.traces[0].values, 0.5)
+    assert np.allclose(snap.traces[1].values, 0.25)
+    assert (snap.traces[0].scale_uv, snap.traces[1].scale_uv) == (100.0, 200.0)
+
+
+def test_build_snapshot_marks_are_window_relative_and_relabeled(loaded):
+    view, _ = loaded
+    view.set_window_start(20.0)  # window 20–50
+    snap = view.build_snapshot(marks=[(25.0, 2.0, "clean")], show_epochs=False)
+    assert len(snap.marks) == 1
+    assert snap.marks[0].onset == pytest.approx(5.0)  # 25 − 20
+    assert snap.marks[0].duration == 2.0
+    assert snap.marks[0].label == "clean"
+    assert snap.times[0] == pytest.approx(0.0)  # times window-relative too
+
+
+def test_build_snapshot_epochs_follow_the_toggle(loaded):
+    view, _ = loaded  # 30 s epochs, anchor 0, window 0–30
+    assert view.build_snapshot(marks=[], show_epochs=False).epochs == ()
+    on = view.build_snapshot(marks=[], show_epochs=True)
+    assert [(e.x, e.number) for e in on.epochs] == [(0.0, "1"), (30.0, "2")]
+
+
+def test_build_snapshot_time_axis_label_follows_mode(loaded):
+    view, _ = loaded
+    snap = view.build_snapshot(marks=[], show_epochs=False)
+    assert snap.time_axis_label == "time (s)"  # no origin → elapsed
+    assert len(snap.time_ticks) == 7
+    view.set_time_origin(datetime(2026, 6, 5, 22, 0, 0))
+    view.set_time_axis_mode("clock")
+    assert (
+        view.build_snapshot(marks=[], show_epochs=False).time_axis_label == "clock time"
+    )

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -704,6 +704,84 @@ def test_load_profile_skips_channels_not_in_the_recording(
     assert window.view.visible_channels == ["C4", "C3"]  # NOSUCH skipped
 
 
+# ----- figure export (#180) --------------------------------------------------------
+
+
+def test_export_dialog_collects_marks_and_options(qtbot):
+    from smacc.eeg.window import ExportDialog
+
+    dialog = ExportDialog(
+        None, ["C3", "C4"], [0, 1], [(12.0, 0.0, "tech-A"), (20.0, 3.0, "tech-B")]
+    )
+    qtbot.addWidget(dialog)
+    dialog.annoTable.item(0, 1).setText("LRLR x3")  # relabel the first mark
+    dialog.annoTable.item(1, 0).setCheckState(
+        QtCore.Qt.CheckState.Unchecked
+    )  # drop 2nd
+    dialog.formatCombo.setCurrentIndex(2)  # SVG
+    dialog.epochGridCheck.setChecked(True)
+    options, marks, channels = dialog.result_values()
+    assert options.fmt == "svg"
+    assert options.show_epoch_grid is True
+    assert marks == [(12.0, 0.0, "LRLR x3")]  # second mark excluded
+    assert channels is None  # the picker was not opened
+
+
+def test_export_figure_renders_with_the_dialog_choices(
+    window, recording_path, tmp_path, monkeypatch
+):
+    from smacc.eeg import export as export_mod
+
+    window._load(recording_path)
+    _answer_label(monkeypatch, ("Cue response", False))
+    window._on_region_drawn(10.0, 14.0)  # an in-window span annotation
+    options = export_mod.ExportOptions(fmt="png", show_epoch_grid=False)
+    monkeypatch.setattr(
+        window_mod.ExportDialog,
+        "get_export",
+        staticmethod(lambda *a, **k: (options, [(10.0, 4.0, "two-way comms")], None)),
+    )
+    out = tmp_path / "figure.png"
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog, "getSaveFileName", lambda *a, **k: (str(out), "")
+    )
+    captured: dict = {}
+    real_render = export_mod.render
+
+    def spy_render(snapshot, opts, path):
+        captured["snapshot"] = snapshot
+        real_render(snapshot, opts, path)
+
+    monkeypatch.setattr(export_mod, "render", spy_render)
+    window._export_figure()
+    assert out.is_file()
+    snap = captured["snapshot"]
+    assert [m.label for m in snap.marks] == ["two-way comms"]  # the relabel reached it
+    assert snap.marks[0].onset == pytest.approx(10.0)  # window starts at 0
+    prefs = preferences.load_preferences(window._prefs_path)
+    assert prefs["eeg_last_export_dir"] == str(out.parent)
+
+
+def test_export_figure_appends_a_missing_suffix(
+    window, recording_path, tmp_path, monkeypatch
+):
+    from smacc.eeg import export as export_mod
+
+    window._load(recording_path)
+    options = export_mod.ExportOptions(fmt="pdf")
+    monkeypatch.setattr(
+        window_mod.ExportDialog,
+        "get_export",
+        staticmethod(lambda *a, **k: (options, [], None)),
+    )
+    bare = tmp_path / "figure"  # no extension typed
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog, "getSaveFileName", lambda *a, **k: (str(bare), "")
+    )
+    window._export_figure()
+    assert (tmp_path / "figure.pdf").is_file()
+
+
 # ----- label dialog / entry point -----------------------------------------------------
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1668,6 +1668,7 @@ docs = [
     { name = "mkdocs-material" },
 ]
 eeg = [
+    { name = "matplotlib" },
     { name = "mne" },
     { name = "pyqtgraph" },
 ]
@@ -1675,6 +1676,7 @@ eeg = [
 [package.metadata]
 requires-dist = [
     { name = "blinkstick", marker = "sys_platform == 'win32'" },
+    { name = "matplotlib", marker = "extra == 'eeg'", specifier = ">=3.7" },
     { name = "mdformat", marker = "extra == 'docs'" },
     { name = "mdformat-frontmatter", marker = "extra == 'docs'" },
     { name = "mdformat-gfm", marker = "extra == 'docs'" },


### PR DESCRIPTION
Closes #180. Export the current review window as a clean, publication-ready figure instead of a screenshot.

- **Export figure…** button opens a dialog: channel selection (reuses the #177 picker), per-trace line weight, toggles for epoch gridlines and annotation shading, an editable per-annotation label table (relabel technical marks), and format/DPI/width.
- **PNG** (selectable DPI), **PDF**, and **SVG** (editable text). Dense traces flatten to one rasterized layer at the chosen DPI while axes, marks, and labels stay crisp vector — keeping vector files small.
- The figure is **faithful to what's on screen**: same channels/order/filters/scaling as the live view (real-µV + calibration bars is deferred to a follow-up; the snapshot already carries `ch_type`/`scale_uv` so it slots in additively).

Design (matplotlib backend; faithful-rendering default) came from a backend spike + design panel; matplotlib already ships with the bundle via MNE.

Structure:
- New pure `smacc/eeg/snapshot.py` (numpy-only data contract) and `smacc/eeg/export.py` (numpy + matplotlib, headless Agg/PDF/SVG) — mirroring the `dsp`/`profiles` pure-module pattern, no Qt.
- `view.py`: extracted `_lane_traces`/`_epoch_boundaries` (shared by the live draw and `build_snapshot`, guarded by a parity test) and added `TraceView.build_snapshot`.
- `--selftest` now renders PNG/PDF/SVG so a missing matplotlib backend in the frozen exe is caught.
- `matplotlib>=3.7` pinned in the `eeg` extra; new `eeg_last_export_dir` preference.

889 tests pass (22 new); ruff + mypy clean. matplotlib stays out of window startup (lazy import, verified).