### PR TITLE
feat: add per-rater annotation sidecars to the EEG annotator

### DIFF
--- a/docs/eeg-review.md
+++ b/docs/eeg-review.md
@@ -67,6 +67,17 @@ duplicated).
 The sidecar format is documented in the
 [annotations file reference](reference/annotations-file.md).
 
+## Multiple raters
+
+For blind, multi-rater scoring, give each reviewer a **rater id** — click the
+**Rater** button, or launch with `--rater <id>`. Their annotations then save to
+a per-rater sidecar (`night1.annotations.alice.tsv`) instead of the plain one,
+so several raters can score the same recording without overwriting each other.
+The active id shows in the window title and on the Rater button, and the first
+save under an id confirms it (so a forgotten id is caught). Leave it blank for
+an ordinary single-rater review. See the
+[annotations file reference](reference/annotations-file.md#multiple-raters).
+
 ## For developers
 
 Run it from a source checkout with the `eeg` extra:

--- a/docs/reference/annotations-file.md
+++ b/docs/reference/annotations-file.md
@@ -51,13 +51,35 @@ Documents each column (BIDS-style) and records provenance:
   "description": {"Description": "Annotation label as entered by the reviewer."},
   "SourceFile": "night1.edf",
   "MeasurementDate": "2026-06-05T22:00:00+00:00",
+  "Rater": null,
   "GeneratedBy": {"Name": "SMACC", "Version": "1.0.0"}
 }
 ```
 
 `MeasurementDate` is the recording's start as stored in the file — combined
 with the data-relative onsets it reconstructs clock time. It is `null` when
-the format or anonymization dropped it.
+the format or anonymization dropped it. `Rater` names the reviewer for a
+per-rater sidecar (see below) and is `null` for an ordinary single-rater review.
+
+## Multiple raters
+
+Objective signal scoring often uses several reviewers. Give each a **rater id**
+— from the Rater button, or by launching with `--rater <id>` — and that
+reviewer's annotations save to a sidecar keyed by the id, so several raters can
+score one recording without overwriting each other:
+
+```
+night1.annotations.tsv          ← single-rater review (no id)
+night1.annotations.alice.tsv    ← rater "alice"
+night1.annotations.bob.tsv      ← rater "bob"
+```
+
+Each rater writes a different path, so cross-rater clobbering is impossible and
+the coordinator's marks in the plain `night1.annotations.tsv` stay untouched.
+The id is reduced to a filesystem-safe token (letters, digits, dash,
+underscore), and each rater gets their own crash-recovery autosave
+(`night1.annotations.alice.autosave.tsv`). Downstream analysis attributes and
+compares marks by reading the JSON `Rater` field.
 
 ## Precedence
 

--- a/src/smacc/eeg/__main__.py
+++ b/src/smacc/eeg/__main__.py
@@ -34,10 +34,39 @@ def pick_recording_path(args: list[str]) -> str | None:
 
     The last non-flag argument wins, mirroring the base app's settings-file
     handling; existence and format errors are left to the window so the user
-    sees a dialog, not a vanishing process.
+    sees a dialog, not a vanishing process. The value of ``--rater <id>`` is
+    skipped so a coordinator's ``--rater alice night1.edf`` opens the recording,
+    not the rater id.
     """
-    candidates = [arg for arg in args[1:] if not arg.startswith("-")]
+    candidates: list[str] = []
+    skip = False
+    for arg in args[1:]:
+        if skip:  # the value consumed by a preceding "--rater"
+            skip = False
+            continue
+        if arg == "--rater":
+            skip = True
+            continue
+        if arg.startswith("-"):  # any flag, incl. "--rater=alice"
+            continue
+        candidates.append(arg)
     return candidates[-1] if candidates else None
+
+
+def pick_rater_id(args: list[str]) -> str | None:
+    """Return the ``--rater`` value from CLI args, or ``None``.
+
+    Accepts both ``--rater alice`` and ``--rater=alice`` so a coordinator can
+    hand out a one-click command (``SMACC-EEG.exe --rater alice night1.edf``).
+    Sanitizing/validation is the window's job — an empty or unusable id falls
+    back to single-rater there rather than failing the launch.
+    """
+    for index, arg in enumerate(args):
+        if arg == "--rater" and index + 1 < len(args):
+            return args[index + 1]
+        if arg.startswith("--rater="):
+            return arg.split("=", 1)[1]
+    return None
 
 
 def selftest() -> int:
@@ -104,7 +133,9 @@ def main() -> None:
         sys.exit(selftest())
     app = QApplication(sys.argv)
     app.setApplicationName("SMACC EEG review")
-    window = EegReviewWindow(pick_recording_path(sys.argv))
+    window = EegReviewWindow(
+        pick_recording_path(sys.argv), rater_id=pick_rater_id(sys.argv)
+    )
     window.show()
     sys.exit(app.exec())
 

--- a/src/smacc/eeg/annotations.py
+++ b/src/smacc/eeg/annotations.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import csv
 import json
+import re
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
@@ -39,6 +40,11 @@ JSON_SUFFIX = ".annotations.json"
 # Crash-recovery autosave, kept distinct from the canonical sidecar so autosave
 # can never clobber a deliberate save ("night1.edf" → the .autosave.tsv).
 AUTOSAVE_SUFFIX = ".annotations.autosave.tsv"
+
+# A rater id becomes part of a sidecar's filename ("night1.annotations.<id>.tsv"),
+# so it is reduced to a filesystem-safe token: anything outside this class
+# collapses to a single underscore (see sanitize_rater_id).
+_RATER_ID_UNSAFE = re.compile(r"[^A-Za-z0-9_-]+")
 
 # Onsets/durations are written with millisecond precision: finer than any human
 # click on a plot, and exact for every sample at the rates sleep labs record.
@@ -121,6 +127,48 @@ def autosave_path(source: str | Path) -> Path:
     return Path(source).with_suffix(AUTOSAVE_SUFFIX)
 
 
+def sanitize_rater_id(raw: str) -> str:
+    """Reduce a rater id to a filesystem-safe token (alnum, dash, underscore).
+
+    The rater id *is* the sidecar's path selector
+    (``night1.annotations.<id>.tsv``), so any run of other characters collapses
+    to a single underscore and the ends are trimmed. Raises ``ValueError`` when
+    nothing usable remains — silently yielding an empty token would route a
+    rater's marks to the plain single-rater sidecar and mix two reviewers' work.
+    """
+    token = _RATER_ID_UNSAFE.sub("_", str(raw).strip()).strip("_-")
+    if not token:
+        raise ValueError(f"Rater id {raw!r} has no filename-safe characters")
+    return token
+
+
+def rater_sidecar_paths(source: str | Path, rater_id: str) -> tuple[Path, Path]:
+    """Return the (TSV, JSON) sidecar paths for one rater's review.
+
+    Mirrors :func:`sidecar_paths` with the rater id woven into the stem
+    (``night1.edf`` → ``night1.annotations.alice.tsv``), so each rater of one
+    recording writes a different path and cross-rater clobbering is structurally
+    impossible. The id is sanitized to a safe filename token first.
+    """
+    rater = sanitize_rater_id(rater_id)
+    src = Path(source)
+    return (
+        src.with_suffix(f".annotations.{rater}.tsv"),
+        src.with_suffix(f".annotations.{rater}.json"),
+    )
+
+
+def rater_autosave_path(source: str | Path, rater_id: str) -> Path:
+    """Return the crash-recovery autosave path for one rater's review.
+
+    The rater-keyed counterpart of :func:`autosave_path` (``night1.edf`` →
+    ``night1.annotations.alice.autosave.tsv``), so a rater's recovery file is
+    kept apart both from the canonical per-rater sidecar and from other raters.
+    """
+    rater = sanitize_rater_id(rater_id)
+    return Path(source).with_suffix(f".annotations.{rater}.autosave.tsv")
+
+
 def write_annotations_tsv(annotations: list[Annotation], path: str | Path) -> None:
     """Write ``annotations`` (sorted) to ``path`` as a tab-separated values file."""
     with Path(path).open("w", encoding="utf-8", newline="") as stream:
@@ -175,12 +223,17 @@ def read_annotations_tsv(path: str | Path) -> list[Annotation]:
     return sorted(annotations)
 
 
-def annotations_sidecar(source_name: str, meas_date: datetime | None) -> dict[str, Any]:
+def annotations_sidecar(
+    source_name: str, meas_date: datetime | None, rater_id: str | None = None
+) -> dict[str, Any]:
     """Return the JSON sidecar payload documenting the TSV columns and provenance.
 
     ``MeasurementDate`` (the recording's absolute start, when the file carries
     one) is what lets a reader reconstruct clock time from the data-relative
-    onsets; ``null`` when the format/anonymization dropped it.
+    onsets; ``null`` when the format/anonymization dropped it. ``Rater`` names
+    the reviewer when this is a per-rater sidecar, and is ``null`` for an
+    ordinary single-rater review — so downstream analysis can attribute and
+    compare marks across raters by reading one stable field.
     """
     return {
         "onset": {
@@ -195,13 +248,18 @@ def annotations_sidecar(source_name: str, meas_date: datetime | None) -> dict[st
         "description": {"Description": "Annotation label as entered by the reviewer."},
         "SourceFile": source_name,
         "MeasurementDate": meas_date.isoformat() if meas_date else None,
+        "Rater": rater_id,
         "GeneratedBy": {"Name": "SMACC", "Version": VERSION},
     }
 
 
 def write_annotations_json(
-    path: str | Path, *, source_name: str, meas_date: datetime | None
+    path: str | Path,
+    *,
+    source_name: str,
+    meas_date: datetime | None,
+    rater_id: str | None = None,
 ) -> None:
     """Write the JSON sidecar to ``path``."""
-    payload = annotations_sidecar(source_name, meas_date)
+    payload = annotations_sidecar(source_name, meas_date, rater_id)
     Path(path).write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -37,9 +37,12 @@ from .annotations import (
     Annotation,
     autosave_path,
     insert,
+    rater_autosave_path,
+    rater_sidecar_paths,
     read_annotations_tsv,
     remove,
     replace,
+    sanitize_rater_id,
     sidecar_paths,
     write_annotations_json,
     write_annotations_tsv,
@@ -471,7 +474,9 @@ class ExportDialog(QtWidgets.QDialog):
 class EegReviewWindow(QtWidgets.QMainWindow):
     """Review and annotate one recording; the EEG component's main window."""
 
-    def __init__(self, file_path: str | Path | None = None) -> None:
+    def __init__(
+        self, file_path: str | Path | None = None, rater_id: str | None = None
+    ) -> None:
         super().__init__()
         self._recording: io.Recording | None = None
         self._annotations: list[Annotation] = []
@@ -480,6 +485,14 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         # True once this review's annotations live in the canonical sidecar (we
         # loaded it, or we have saved at least once); gates the overwrite prompt.
         self._owns_sidecar = False
+        # The rater whose sidecar this review reads and writes (#181): None is an
+        # ordinary single-rater review on the plain sidecar; a value routes every
+        # save/load/autosave to a per-rater path. Resolved arg → pref → none (no
+        # prompt — a solo reviewer is never nagged).
+        self._rater_id: str | None = self._resolve_rater_id(rater_id)
+        # Rater ids confirmed at save this session, so the confirm-before-save
+        # prompt fires once per id, not on every save.
+        self._confirmed_raters: set[str] = set()
         # Annotations recovered from an autosave, held until the user restores or
         # dismisses them (#176).
         self._recovery_annotations: list[Annotation] | None = None
@@ -502,6 +515,112 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             # After the event loop starts, so the window is up before any
             # open-error dialog (and a long load doesn't block the first paint).
             QtCore.QTimer.singleShot(0, lambda: self._load(Path(file_path)))
+
+    # ----- rater identity (#181) ----------------------------------------------
+
+    def _resolve_rater_id(self, rater_id: str | None) -> str | None:
+        """Pick the active rater id: explicit arg, else the saved pref, else none.
+
+        Deliberately no prompt for the bare default — a solo reviewer keeps the
+        plain sidecar and is never asked; a rater id only appears when one was
+        passed (``--rater``) or set in a prior session. An unusable saved/passed
+        id falls back to single-rater rather than failing to open.
+        """
+        if rater_id is None:
+            prefs = preferences.load_preferences(preferences_path)
+            rater_id = prefs.get("eeg_rater_id")
+        if not rater_id:
+            return None
+        try:
+            return sanitize_rater_id(rater_id)
+        except ValueError:
+            return None
+
+    def _sidecar_for(self, source: str | Path) -> tuple[Path, Path]:
+        """The (TSV, JSON) sidecar paths for the active rater (plain if none)."""
+        if self._rater_id is None:
+            return sidecar_paths(source)
+        return rater_sidecar_paths(source, self._rater_id)
+
+    def _autosave_for(self, source: str | Path) -> Path:
+        """The crash-recovery autosave path for the active rater (plain if none)."""
+        if self._rater_id is None:
+            return autosave_path(source)
+        return rater_autosave_path(source, self._rater_id)
+
+    def _refresh_rater_button(self) -> None:
+        """Keep the rater button (and so the toolbar) showing the active id."""
+        self.raterButton.setText(
+            f"Rater: {self._rater_id}" if self._rater_id else "Rater…"
+        )
+
+    def _set_rater_id(self) -> None:
+        """Prompt for the rater id and switch to it (blank clears it)."""
+        text, ok = QtWidgets.QInputDialog.getText(
+            self,
+            "Rater id",
+            "Rater id (annotations save to a per-rater sidecar; "
+            "leave blank for a single-rater review):",
+            text=self._rater_id or "",
+        )
+        if not ok:
+            return
+        text = text.strip()
+        if not text:
+            self._apply_rater_id(None)
+            return
+        try:
+            self._apply_rater_id(sanitize_rater_id(text))
+        except ValueError:
+            self._error(
+                "That rater id can't be used.",
+                "A rater id needs at least one letter, digit, dash, or underscore.",
+            )
+
+    def _apply_rater_id(self, new_id: str | None) -> None:
+        """Switch the active rater id, re-pointing this review's output to it.
+
+        A correction, not a merge (#181): the current marks are *this* rater's,
+        so the previous id's autosave is dropped (it was misattributed) and the
+        marks now save under ``new_id``. We have not loaded the new id's sidecar,
+        so ``_owns_sidecar`` re-arms — the first save into an existing foreign
+        file then prompts via the usual overwrite guard.
+        """
+        if new_id == self._rater_id:
+            return
+        self._autosave_timer.stop()
+        self._clear_autosave()  # uses the *old* id (still current here)
+        self._rater_id = new_id
+        self._owns_sidecar = False
+        # Re-confirm the new id on its next save (discard is a no-op for None).
+        self._confirmed_raters.discard(new_id)
+        preferences.update_preferences(preferences_path, {"eeg_rater_id": new_id})
+        self._refresh_rater_button()
+        if self._recording is not None and self._annotations:
+            self._mark_dirty()  # unsaved work now belongs to the new id
+        self._refresh_title()
+
+    def _confirm_rater_identity(self) -> bool:
+        """Confirm the active rater id once per id per session before its first save.
+
+        A single-rater review (no id) never prompts; once an id is confirmed it
+        stays confirmed until it changes, so routine saves are silent. The rater
+        button stays visible to fix a wrong id without saving.
+        """
+        if self._rater_id is None or self._rater_id in self._confirmed_raters:
+            return True
+        button = QtWidgets.QMessageBox.question(
+            self,
+            "Confirm rater",
+            f"Save these annotations as rater '{self._rater_id}'?\n\n"
+            "Use the Rater button to change it.",
+            QtWidgets.QMessageBox.StandardButton.Save
+            | QtWidgets.QMessageBox.StandardButton.Cancel,
+        )
+        if button == QtWidgets.QMessageBox.StandardButton.Save:
+            self._confirmed_raters.add(self._rater_id)
+            return True
+        return False
 
     # ----- UI construction ----------------------------------------------------
 
@@ -635,6 +754,17 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         row.addWidget(self.scaleSpin)
 
         row.addStretch(1)
+        # Rater identity (#181): blank for a single-rater review; set it and every
+        # save/load/autosave routes to a per-rater sidecar. Always enabled — the id
+        # can be set before a recording is open and persists for next launch.
+        self.raterButton = QtWidgets.QPushButton(self)
+        self.raterButton.setStatusTip(
+            "Set the rater id; annotations then save to a per-rater sidecar "
+            "(night1.annotations.<id>.tsv). Blank means a single-rater review."
+        )
+        self.raterButton.clicked.connect(self._set_rater_id)
+        self._refresh_rater_button()
+        row.addWidget(self.raterButton)
         self.saveButton = QtWidgets.QPushButton("Save annotations", self)
         self.saveButton.setStatusTip(
             "Write the annotation sidecar next to the recording; the recording "
@@ -837,7 +967,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         # recovery file (the user already saved or discarded it via open_file).
         self._autosave_timer.stop()
         self._clear_autosave()
-        tsv_path, _ = sidecar_paths(path)
+        tsv_path, _ = self._sidecar_for(path)
         if tsv_path.is_file():
             # Resume a previous review. A sidecar that exists but won't parse
             # aborts the open: it is the reviewer's data, and proceeding would
@@ -968,7 +1098,11 @@ class EegReviewWindow(QtWidgets.QMainWindow):
     def save_annotations(self) -> None:
         if self._recording is None:
             return
-        tsv_path, json_path = sidecar_paths(self._recording.path)
+        # In a per-rater review, confirm the identity once before its first save,
+        # so a forgotten/stale rater id is caught before it writes a file.
+        if not self._confirm_rater_identity():
+            return
+        tsv_path, json_path = self._sidecar_for(self._recording.path)
         # Guard the one case where a save would silently clobber someone else's
         # work: a sidecar we did not open (a fresh review, or one that appeared
         # while we worked). A sidecar we loaded — or already saved — is ours.
@@ -981,6 +1115,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
                 json_path,
                 source_name=self._recording.path.name,
                 meas_date=self._recording.meas_date,
+                rater_id=self._rater_id,
             )
         except OSError as exc:
             self._error("Could not save the annotations.", str(exc))
@@ -1040,8 +1175,9 @@ class EegReviewWindow(QtWidgets.QMainWindow):
 
     def _refresh_title(self) -> None:
         name = f" — {self._recording.path.name}" if self._recording else ""
+        rater = f" · rater {self._rater_id}" if self._rater_id else ""
         star = " *" if self._dirty else ""
-        self.setWindowTitle(f"SMACC — EEG review{name}{star}")
+        self.setWindowTitle(f"SMACC — EEG review{name}{rater}{star}")
 
     def _recent_labels(self) -> list[str]:
         prefs = preferences.load_preferences(preferences_path)
@@ -1060,7 +1196,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         """Write the recovery file (best-effort, atomic); fired by the debounce timer."""
         if self._recording is None or not self._dirty:
             return
-        path = autosave_path(self._recording.path)
+        path = self._autosave_for(self._recording.path)
         tmp = path.with_suffix(".tmp")  # write-then-rename so a crash never half-writes
         try:
             write_annotations_tsv(self._annotations, tmp)
@@ -1069,9 +1205,9 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             pass  # autosave must never interrupt the review
 
     def _clear_autosave(self) -> None:
-        """Delete the current recording's recovery file, if any."""
+        """Delete the active rater's recovery file for this recording, if any."""
         if self._recording is not None:
-            autosave_path(self._recording.path).unlink(missing_ok=True)
+            self._autosave_for(self._recording.path).unlink(missing_ok=True)
 
     def _check_for_recovery(self, tsv_path: Path) -> None:
         """On open, offer to restore a recovery file newer than the saved sidecar."""
@@ -1079,7 +1215,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._recovery_annotations = None
         if self._recording is None:
             return
-        recovery = autosave_path(self._recording.path)
+        recovery = self._autosave_for(self._recording.path)
         if not recovery.is_file():
             return
         # A recovery file with a clean save strictly newer than it is stale — the

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -55,6 +55,10 @@ DEFAULTS: dict[str, Any] = {
     "eeg_last_profile_dir": None,
     # The folder the EEG review tool last exported a figure to (#180).
     "eeg_last_export_dir": None,
+    # The rater id the EEG review tool saves under (#181): when set, annotations
+    # save to a per-rater sidecar (night1.annotations.<id>.tsv); None means an
+    # ordinary single-rater review writing the plain sidecar.
+    "eeg_rater_id": None,
 }
 
 _logger = logging.getLogger("smacc")

--- a/tests/test_eeg_annotations.py
+++ b/tests/test_eeg_annotations.py
@@ -83,6 +83,56 @@ def test_sidecar_paths_keep_bids_style_stems_intact():
     assert tsv.name == "sub-01_task-sleep_eeg.annotations.tsv"
 
 
+# ----- rater-keyed sidecars (#181) ------------------------------------------
+
+
+def test_sanitize_rater_id_keeps_safe_tokens():
+    assert ann.sanitize_rater_id("alice") == "alice"
+    assert ann.sanitize_rater_id("rater_1") == "rater_1"
+    assert ann.sanitize_rater_id("RM-2") == "RM-2"
+
+
+def test_sanitize_rater_id_collapses_unsafe_runs_and_trims():
+    # The id becomes part of a filename, so spaces/punctuation collapse to a
+    # single underscore and the ends are trimmed.
+    assert ann.sanitize_rater_id("  rater one!! ") == "rater_one"
+    assert ann.sanitize_rater_id("a@@@b") == "a_b"
+    assert ann.sanitize_rater_id("rater.01") == "rater_01"  # no dots in the suffix
+
+
+def test_sanitize_rater_id_rejects_an_empty_token():
+    # A blank id must fail loudly rather than silently fall back to the plain
+    # single-rater sidecar (which would mix two reviewers' marks).
+    for raw in ("", "   ", "!!!", "__"):
+        with pytest.raises(ValueError, match="filename-safe"):
+            ann.sanitize_rater_id(raw)
+
+
+def test_rater_sidecar_paths_weave_the_id_into_the_stem():
+    tsv, js = ann.rater_sidecar_paths(Path("C:/data/night1.edf"), "alice")
+    assert tsv.name == "night1.annotations.alice.tsv"
+    assert js.name == "night1.annotations.alice.json"
+
+
+def test_rater_sidecar_paths_sanitize_the_id():
+    tsv, _ = ann.rater_sidecar_paths(Path("night1.edf"), "Rater One")
+    assert tsv.name == "night1.annotations.Rater_One.tsv"
+
+
+def test_rater_paths_differ_per_rater_so_they_cannot_clobber():
+    a, _ = ann.rater_sidecar_paths(Path("night1.edf"), "alice")
+    b, _ = ann.rater_sidecar_paths(Path("night1.edf"), "bob")
+    plain, _ = ann.sidecar_paths(Path("night1.edf"))
+    assert len({a, b, plain}) == 3
+
+
+def test_rater_autosave_path_is_distinct_from_the_sidecar():
+    auto = ann.rater_autosave_path(Path("night1.edf"), "alice")
+    tsv, _ = ann.rater_sidecar_paths(Path("night1.edf"), "alice")
+    assert auto.name == "night1.annotations.alice.autosave.tsv"
+    assert auto != tsv
+
+
 # ----- TSV round-trip -------------------------------------------------------
 
 
@@ -186,3 +236,17 @@ def test_json_sidecar_handles_a_missing_meas_date(tmp_path):
     path = tmp_path / "x.json"
     ann.write_annotations_json(path, source_name="x.fif", meas_date=None)
     assert json.loads(path.read_text(encoding="utf-8"))["MeasurementDate"] is None
+
+
+def test_json_sidecar_records_the_rater_when_set(tmp_path):
+    path = tmp_path / "night1.annotations.alice.json"
+    ann.write_annotations_json(
+        path, source_name="night1.edf", meas_date=None, rater_id="alice"
+    )
+    assert json.loads(path.read_text(encoding="utf-8"))["Rater"] == "alice"
+
+
+def test_json_sidecar_rater_is_null_for_a_single_rater_review(tmp_path):
+    path = tmp_path / "night1.annotations.json"
+    ann.write_annotations_json(path, source_name="night1.edf", meas_date=None)
+    assert json.loads(path.read_text(encoding="utf-8"))["Rater"] is None

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -9,6 +9,7 @@ touches the machine's real ``preferences.yaml``.
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -24,10 +25,12 @@ from smacc import preferences
 from smacc.config import VERSION
 from smacc.eeg import dsp
 from smacc.eeg import window as window_mod
-from smacc.eeg.__main__ import pick_recording_path
+from smacc.eeg.__main__ import pick_rater_id, pick_recording_path
 from smacc.eeg.annotations import (
     Annotation,
     autosave_path,
+    rater_autosave_path,
+    rater_sidecar_paths,
     read_annotations_tsv,
     sidecar_paths,
     write_annotations_tsv,
@@ -913,6 +916,22 @@ def test_pick_recording_path_takes_the_last_non_flag_argument():
     assert pick_recording_path(["exe", "a.edf", "b.fif"]) == "b.fif"
 
 
+def test_pick_recording_path_skips_the_rater_value(tmp_path):
+    # --rater alice night1.edf must open the recording, not the rater id.
+    assert (
+        pick_recording_path(["exe", "--rater", "alice", "night1.edf"]) == "night1.edf"
+    )
+    assert pick_recording_path(["exe", "--rater", "alice"]) is None
+    assert pick_recording_path(["exe", "--rater=alice", "night1.edf"]) == "night1.edf"
+
+
+def test_pick_rater_id_reads_both_forms():
+    assert pick_rater_id(["exe", "--rater", "alice", "night1.edf"]) == "alice"
+    assert pick_rater_id(["exe", "--rater=bob", "night1.edf"]) == "bob"
+    assert pick_rater_id(["exe", "night1.edf"]) is None
+    assert pick_rater_id(["exe", "--rater"]) is None  # dangling flag, no value
+
+
 # ----- wall-clock display ---------------------------------------------------------
 
 
@@ -987,3 +1006,176 @@ def test_selftest_round_trips_through_mne():
     )
     assert proc.returncode == 0, proc.stderr
     assert "selftest ok" in proc.stdout
+
+
+# ----- rater identity (#181) ------------------------------------------------
+
+
+@pytest.fixture
+def make_window(qtbot, tmp_path, monkeypatch):
+    """Build EegReviewWindows (optionally with a rater id) over the faked IO,
+    isolated prefs, and auto-answered dialogs the ``window`` fixture uses."""
+    monkeypatch.setattr(window_mod, "preferences_path", tmp_path / "prefs.yaml")
+    monkeypatch.setattr(window_mod.io, "open_recording", FakeRecording)
+    monkeypatch.setattr(window_mod.io, "embedded_annotations", lambda rec: [])
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: QtWidgets.QMessageBox.StandardButton.Discard,
+    )
+
+    def build(rater_id: str | None = None) -> EegReviewWindow:
+        win = EegReviewWindow(rater_id=rater_id)
+        qtbot.addWidget(win)
+        win.show()
+        win._prefs_path = tmp_path / "prefs.yaml"  # test convenience handle
+        return win
+
+    return build
+
+
+def test_constructor_resolves_rater_from_the_pref(make_window, tmp_path):
+    preferences.update_preferences(tmp_path / "prefs.yaml", {"eeg_rater_id": "carol"})
+    win = make_window()  # no explicit arg → falls back to the saved pref
+    assert win._rater_id == "carol"
+
+
+def test_explicit_rater_arg_beats_the_pref(make_window, tmp_path):
+    preferences.update_preferences(tmp_path / "prefs.yaml", {"eeg_rater_id": "carol"})
+    assert make_window("alice")._rater_id == "alice"
+
+
+def test_unusable_rater_falls_back_to_single_rater(make_window, tmp_path):
+    preferences.update_preferences(tmp_path / "prefs.yaml", {"eeg_rater_id": "!!!"})
+    assert make_window()._rater_id is None  # nothing safe → plain sidecar, no crash
+
+
+def test_rater_button_shows_the_active_id(make_window):
+    win = make_window("alice")
+    assert win.raterButton.text() == "Rater: alice"
+    win._apply_rater_id(None)
+    assert win.raterButton.text() == "Rater…"
+
+
+def test_title_shows_the_rater(make_window, recording_path):
+    win = make_window("alice")
+    win._load(recording_path)
+    assert "rater alice" in win.windowTitle()
+
+
+def test_rater_save_writes_the_rater_sidecar_only(
+    make_window, recording_path, monkeypatch
+):
+    win = make_window("alice")
+    win._confirmed_raters.add("alice")  # identity confirmed (tested separately)
+    win._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    win._on_region_drawn(10.0, 14.0)
+    win.save_annotations()
+    rater_tsv, rater_json = rater_sidecar_paths(recording_path, "alice")
+    plain_tsv, _ = sidecar_paths(recording_path)
+    assert read_annotations_tsv(rater_tsv) == [Annotation(10.0, 4.0, "LRLR")]
+    assert json.loads(rater_json.read_text(encoding="utf-8"))["Rater"] == "alice"
+    assert not plain_tsv.exists()  # the single-rater/truth sidecar is untouched
+
+
+def test_rater_load_resumes_from_the_rater_sidecar(
+    make_window, recording_path, monkeypatch
+):
+    saved = [Annotation(5.0, 2.0, "REM period")]
+    rater_tsv, _ = rater_sidecar_paths(recording_path, "alice")
+    write_annotations_tsv(saved, rater_tsv)
+    # A second rater must not see alice's marks: their fresh review imports the
+    # embedded events instead, against their own (absent) sidecar.
+    monkeypatch.setattr(
+        window_mod.io,
+        "embedded_annotations",
+        lambda rec: [Annotation(1.0, 0.0, "Cue")],
+    )
+    alice = make_window("alice")
+    alice._load(recording_path)
+    assert alice._annotations == saved
+    bob = make_window("bob")
+    bob._load(recording_path)
+    assert alice._annotations == saved  # alice's review is unaffected
+    assert bob._annotations == [Annotation(1.0, 0.0, "Cue")]  # bob starts fresh
+
+
+def test_rater_autosave_uses_the_rater_path(make_window, recording_path, monkeypatch):
+    win = make_window("alice")
+    win._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    win._on_region_drawn(10.0, 14.0)  # marks dirty
+    win._write_autosave()
+    assert rater_autosave_path(recording_path, "alice").is_file()
+    assert not autosave_path(recording_path).exists()  # not the plain autosave
+
+
+def test_switching_rater_repoints_output_and_drops_the_old_autosave(
+    make_window, recording_path, monkeypatch
+):
+    win = make_window()  # single-rater to start
+    win._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    win._on_region_drawn(10.0, 14.0)
+    win._write_autosave()
+    assert autosave_path(recording_path).is_file()  # the plain autosave exists
+    win._apply_rater_id("alice")
+    assert win._rater_id == "alice"
+    assert win._dirty  # the marks now belong to alice, unsaved
+    assert not autosave_path(recording_path).exists()  # misattributed autosave gone
+    assert preferences.load_preferences(win._prefs_path)["eeg_rater_id"] == "alice"
+    win._confirmed_raters.add("alice")
+    win.save_annotations()
+    rater_tsv, _ = rater_sidecar_paths(recording_path, "alice")
+    assert read_annotations_tsv(rater_tsv) == [Annotation(10.0, 4.0, "LRLR")]
+
+
+def test_save_confirm_fires_once_per_rater(make_window, recording_path, monkeypatch):
+    calls: list[int] = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: calls.append(1) or QtWidgets.QMessageBox.StandardButton.Save,
+    )
+    win = make_window("alice")
+    win._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    win._on_region_drawn(10.0, 14.0)
+    win.save_annotations()  # first save under "alice" → confirms
+    win._on_region_drawn(20.0, 21.0)
+    win.save_annotations()  # already confirmed → silent
+    assert len(calls) == 1
+    assert "alice" in win._confirmed_raters
+
+
+def test_save_confirm_cancel_blocks_the_save(make_window, recording_path, monkeypatch):
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "question",
+        lambda *a, **k: QtWidgets.QMessageBox.StandardButton.Cancel,
+    )
+    win = make_window("alice")
+    win._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    win._on_region_drawn(10.0, 14.0)
+    win.save_annotations()
+    rater_tsv, _ = rater_sidecar_paths(recording_path, "alice")
+    assert not rater_tsv.exists()  # cancelled before any write
+    assert win._dirty
+    win._dirty = False  # let teardown close cleanly under the Cancel patch
+
+
+def test_single_rater_save_never_prompts_for_identity(
+    make_window, recording_path, monkeypatch
+):
+    # The fixture answers QMessageBox.question with Discard; a single-rater save
+    # must still succeed, proving it never reaches the identity prompt.
+    win = make_window()  # no rater id
+    win._load(recording_path)
+    _answer_label(monkeypatch, ("LRLR", False))
+    win._on_region_drawn(10.0, 14.0)
+    win.save_annotations()
+    plain_tsv, _ = sidecar_paths(recording_path)
+    assert read_annotations_tsv(plain_tsv) == [Annotation(10.0, 4.0, "LRLR")]
+    assert not win._dirty


### PR DESCRIPTION
Part of #181 (1 of 4, stacked). The foundation for blind-rater scoring.

A rater identity routes annotations to a per-rater sidecar (`night1.annotations.<id>.tsv`), so several raters can score one recording without overwriting each other — cross-rater clobbering becomes structurally impossible, which also removes the Save-As/overwrite coupling raised in the issue.

- `eeg/annotations.py`: `rater_sidecar_paths`, `rater_autosave_path`, `sanitize_rater_id`, and a `Rater` field in the JSON sidecar.
- Window: rater resolved arg → pref → none (no prompt for a solo reviewer); load/save/autosave routed per rater; a Rater button to set or correct it mid-session; a once-per-id save confirmation.
- `--rater <id>` CLI and an `eeg_rater_id` preference.

Verified: ruff + mypy + the offscreen pytest-qt suite green; `--selftest` round-trips a rater sidecar through MNE.