### PR TITLE
feat: add a quick-mark palette to the EEG annotator

### DIFF
--- a/docs/eeg-review.md
+++ b/docs/eeg-review.md
@@ -58,6 +58,11 @@ night opens in seconds and scrolling stays smooth regardless of file size.
     `night1.edf` → `night1.annotations.tsv` (+ a small `.json` describing it).
     Unsaved changes star the title and prompt before closing.
 
+For fast signal scoring, the **Quick marks** row drops a labeled point mark at
+the cursor in one click — or press **1–9** for the first nine. Use **Edit
+palette…** to set the buttons; the palette defaults to the lucid eye-signal
+vocabulary (LRLR, LRLRx2, LRLRx3, IEIE).
+
 Events already stored **inside** the recording — amp markers, SMACC's own
 trigger codes — are imported automatically the *first* time a file is
 reviewed, so your cues appear on the traces alongside your new marks. Once a

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -281,6 +281,98 @@ class ChannelPickerDialog(QtWidgets.QDialog):
         return dialog.result_indices() or None
 
 
+class PaletteEditorDialog(QtWidgets.QDialog):
+    """Edit the quick-mark palette: a reorderable list of labels (#181).
+
+    The list order is the button order (and the first nine map to keys 1–9).
+    Items rename in place (double-click); Add appends a new label. Labels are
+    whitespace-normalized and blanks dropped, matching the annotation model.
+    """
+
+    def __init__(self, parent: QtWidgets.QWidget | None, labels: list[str]) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Quick-mark palette")
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(
+            QtWidgets.QLabel(
+                "Quick-mark buttons, top to bottom (the first nine get keys 1–9):",
+                self,
+            )
+        )
+        body = QtWidgets.QHBoxLayout()
+        self.listWidget = QtWidgets.QListWidget(self)
+        self.listWidget.setMinimumWidth(220)
+        for label in labels:
+            self._append_item(label)
+        body.addWidget(self.listWidget, 1)
+        column = QtWidgets.QVBoxLayout()
+        addButton = QtWidgets.QPushButton("Add…", self)
+        addButton.clicked.connect(self._add)
+        removeButton = QtWidgets.QPushButton("Remove", self)
+        removeButton.clicked.connect(self._remove)
+        upButton = QtWidgets.QPushButton("Up", self)
+        upButton.clicked.connect(lambda: self._move(-1))
+        downButton = QtWidgets.QPushButton("Down", self)
+        downButton.clicked.connect(lambda: self._move(1))
+        for button in (addButton, removeButton, upButton, downButton):
+            column.addWidget(button)
+        column.addStretch(1)
+        body.addLayout(column)
+        layout.addLayout(body)
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _append_item(self, label: str) -> None:
+        item = QtWidgets.QListWidgetItem(label)
+        item.setFlags(item.flags() | QtCore.Qt.ItemFlag.ItemIsEditable)
+        self.listWidget.addItem(item)
+
+    def _add(self) -> None:
+        text, ok = QtWidgets.QInputDialog.getText(self, "Add quick mark", "Label:")
+        if ok and text.strip():
+            self._append_item(text.strip())
+            self.listWidget.setCurrentRow(self.listWidget.count() - 1)
+
+    def _remove(self) -> None:
+        row = self.listWidget.currentRow()
+        if row >= 0:
+            self.listWidget.takeItem(row)
+
+    def _move(self, delta: int) -> None:
+        row = self.listWidget.currentRow()
+        target = row + delta
+        if row < 0 or not 0 <= target < self.listWidget.count():
+            return
+        item = self.listWidget.takeItem(row)
+        self.listWidget.insertItem(target, item)
+        self.listWidget.setCurrentRow(target)
+
+    def result_labels(self) -> list[str]:
+        out: list[str] = []
+        for row in range(self.listWidget.count()):
+            item = self.listWidget.item(row)
+            text = " ".join(item.text().split()) if item is not None else ""
+            if text:
+                out.append(text)
+        return out
+
+    @staticmethod
+    def get_palette(
+        parent: QtWidgets.QWidget | None, labels: list[str]
+    ) -> list[str] | None:
+        """Run the dialog; return the edited label list, or ``None`` on cancel."""
+        dialog = PaletteEditorDialog(parent, labels)
+        if dialog.exec() != QtWidgets.QDialog.DialogCode.Accepted:
+            return None
+        return dialog.result_labels()
+
+
 class ExportDialog(QtWidgets.QDialog):
     """Choose what to export and how, for a publication figure (#180).
 
@@ -634,6 +726,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         layout.addWidget(self._build_recovery_banner())
         layout.addLayout(self._build_controls_row())
         layout.addLayout(self._build_epoch_row())
+        layout.addLayout(self._build_palette_row())
 
         body = QtWidgets.QHBoxLayout()
         viewColumn = QtWidgets.QVBoxLayout()
@@ -854,6 +947,28 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         row.addWidget(self.exportButton)
         return row
 
+    def _build_palette_row(self) -> QtWidgets.QLayout:
+        """The quick-mark palette (#181): one-click labels dropped at the cursor.
+
+        A configurable row of buttons, each inserting a labeled point mark with no
+        dialog — the fast path for a rater scoring signals. The first nine also
+        answer to number keys 1–9 (see :meth:`_handle_palette_key`)."""
+        row = QtWidgets.QHBoxLayout()
+        row.addWidget(QtWidgets.QLabel("Quick marks:", self))
+        self.paletteButtonsLayout = QtWidgets.QHBoxLayout()
+        self.paletteButtonsLayout.setSpacing(4)
+        self._palette_buttons: list[QtWidgets.QPushButton] = []
+        row.addLayout(self.paletteButtonsLayout)
+        row.addStretch(1)
+        self.editPaletteButton = QtWidgets.QPushButton("Edit palette…", self)
+        self.editPaletteButton.setStatusTip(
+            "Choose the quick-mark buttons (each drops its label at the cursor)."
+        )
+        self.editPaletteButton.clicked.connect(self._edit_palette)
+        row.addWidget(self.editPaletteButton)
+        self._rebuild_palette_buttons()
+        return row
+
     def _build_contract_caption(self) -> QtWidgets.QLabel:
         """A quiet, always-visible reminder of the tool's safety contract (#175)."""
         caption = QtWidgets.QLabel(
@@ -943,6 +1058,47 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             self.exportButton,
         ):
             widget.setEnabled(loaded)
+        for button in self._palette_buttons:  # no recording → nothing to mark
+            button.setEnabled(loaded)
+
+    # ----- quick-mark palette (#181) ---------------------------------------------
+
+    def _palette_labels(self) -> list[str]:
+        """The configured quick-mark labels (falls back to the seed labels)."""
+        prefs = preferences.load_preferences(preferences_path)
+        labels = prefs.get("eeg_palette_labels")
+        if not isinstance(labels, list):
+            return list(SEED_LABELS)
+        return [s for s in labels if isinstance(s, str) and s.strip()]
+
+    def _rebuild_palette_buttons(self) -> None:
+        """Recreate the quick-mark buttons from the saved palette."""
+        while self.paletteButtonsLayout.count():
+            item = self.paletteButtonsLayout.takeAt(0)
+            widget = item.widget() if item is not None else None
+            if widget is not None:
+                widget.deleteLater()
+        self._palette_buttons = []
+        for index, label in enumerate(self._palette_labels()):
+            button = QtWidgets.QPushButton(label, self)
+            hint = "Drop this label at the cursor"
+            if index < 9:  # the first nine answer to number keys 1–9
+                hint += f" (key {index + 1})"
+            button.setStatusTip(hint + ".")
+            button.clicked.connect(
+                lambda _checked=False, text=label: self._insert_label_at_cursor(text)
+            )
+            button.setEnabled(self._recording is not None)
+            self.paletteButtonsLayout.addWidget(button)
+            self._palette_buttons.append(button)
+
+    def _edit_palette(self) -> None:
+        """Edit and persist the quick-mark palette, then rebuild the buttons."""
+        result = PaletteEditorDialog.get_palette(self, self._palette_labels())
+        if result is None:
+            return
+        preferences.update_preferences(preferences_path, {"eeg_palette_labels": result})
+        self._rebuild_palette_buttons()
 
     # ----- opening a recording ---------------------------------------------------
 
@@ -1042,25 +1198,48 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         """
         if self._recording is None:
             return
-        seconds = min(max(0.0, seconds), self._recording.duration)
         result = LabelDialog.get_label(self, self._recent_labels(), offer_instant=False)
         if result is None:
             return
         label, _ = result
+        self._insert_point_mark(seconds, label)
+
+    def _insert_label_at_cursor(self, label: str) -> None:
+        """Drop ``label`` as a point mark at the cursor (a quick-mark button/key).
+
+        No dialog: the label is already chosen, so a rater scoring signals places
+        the mark in one action, at the last cursor time (or the view center if the
+        mouse never entered the traces).
+        """
+        if self._recording is None:
+            return
+        self._insert_point_mark(self._cursor_or_center(), label)
+
+    def _insert_point_mark(self, seconds: float, label: str) -> None:
+        """Insert a clamped zero-duration mark, select it, and mark the review dirty.
+
+        The shared tail of every point-mark path: ctrl-click/M (which prompt for a
+        label first) and the quick-mark palette (which already has one).
+        """
+        assert self._recording is not None
+        seconds = min(max(0.0, seconds), self._recording.duration)
         annotation = Annotation(seconds, 0.0, label)
         self._annotations = insert(self._annotations, annotation)
         self._remember_label(label)
         self._mark_dirty()
         self._select(self._annotations.index(annotation))
 
+    def _cursor_or_center(self) -> float:
+        """The last cursor time over the traces, or the view center if never set."""
+        if self._cursor_seconds is not None:
+            return self._cursor_seconds
+        return self.view.window_start + self.view.window_seconds / 2
+
     def _mark_at_cursor(self) -> None:
         """Mark at the last cursor position, or the view's center if unknown."""
         if self._recording is None:
             return
-        seconds = self._cursor_seconds
-        if seconds is None:  # the mouse never entered the traces
-            seconds = self.view.window_start + self.view.window_seconds / 2
-        self._add_point_mark(seconds)
+        self._add_point_mark(self._cursor_or_center())
 
     def edit_selected(self) -> None:
         index = self.annotationList.currentRow()
@@ -1336,10 +1515,34 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             and event.type() == QtCore.QEvent.Type.KeyPress
             and self.isActiveWindow()
             and self._recording is not None
-            and self._handle_nav_key(event)
+            and (self._handle_nav_key(event) or self._handle_palette_key(event))
         ):
             return True
         return super().eventFilter(obj, event)
+
+    def _handle_palette_key(self, event: QtGui.QKeyEvent) -> bool:
+        """Drop the n-th quick mark on a bare digit 1–9; return whether consumed.
+
+        Yields the digit to any text/number entry that has focus (so typing a
+        scale or a label is never hijacked) and ignores it when a modifier other
+        than the numeric keypad is held.
+        """
+        key = event.key()
+        if not QtCore.Qt.Key.Key_1 <= key <= QtCore.Qt.Key.Key_9:
+            return False
+        if event.modifiers() & ~QtCore.Qt.KeyboardModifier.KeypadModifier:
+            return False  # only a bare digit (keypad ok), not Ctrl/Alt/Shift+digit
+        focus = QtWidgets.QApplication.focusWidget()
+        if isinstance(
+            focus,
+            QtWidgets.QAbstractSpinBox | QtWidgets.QLineEdit | QtWidgets.QComboBox,
+        ):
+            return False
+        index = key - QtCore.Qt.Key.Key_1
+        if index >= len(self._palette_buttons):
+            return False
+        self._insert_label_at_cursor(self._palette_buttons[index].text())
+        return True
 
     def _focus_wants(self, key: int) -> bool:
         """True if the focused widget should keep ``key`` for its own editing/nav.

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -59,6 +59,10 @@ DEFAULTS: dict[str, Any] = {
     # save to a per-rater sidecar (night1.annotations.<id>.tsv); None means an
     # ordinary single-rater review writing the plain sidecar.
     "eeg_rater_id": None,
+    # The EEG review tool's quick-mark palette (#181): one-click buttons that drop
+    # a labeled point mark at the cursor. Defaults to the lucid eye-signal
+    # vocabulary; editable in the tool, and the first nine get number keys 1–9.
+    "eeg_palette_labels": ["LRLR", "LRLRx2", "LRLRx3", "IEIE"],
 }
 
 _logger = logging.getLogger("smacc")

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -1179,3 +1179,110 @@ def test_single_rater_save_never_prompts_for_identity(
     plain_tsv, _ = sidecar_paths(recording_path)
     assert read_annotations_tsv(plain_tsv) == [Annotation(10.0, 4.0, "LRLR")]
     assert not win._dirty
+
+
+# ----- quick-mark palette (#181) --------------------------------------------
+
+DEFAULT_PALETTE = ["LRLR", "LRLRx2", "LRLRx3", "IEIE"]
+
+
+def test_palette_seeds_buttons_from_the_pref(window):
+    assert [b.text() for b in window._palette_buttons] == DEFAULT_PALETTE
+
+
+def test_palette_buttons_disabled_until_a_recording_loads(window, recording_path):
+    assert all(not b.isEnabled() for b in window._palette_buttons)
+    window._load(recording_path)
+    assert all(b.isEnabled() for b in window._palette_buttons)
+
+
+def test_palette_button_drops_a_labeled_mark_at_the_cursor(window, recording_path):
+    window._load(recording_path)
+    window._on_cursor_moved(33.0)
+    window._palette_buttons[0].click()  # "LRLR" — no dialog
+    assert window._annotations == [Annotation(33.0, 0.0, "LRLR")]
+    assert window._dirty
+    # The palette label also lands in the recents that seed the label dialog.
+    assert window._recent_labels()[0] == "LRLR"
+
+
+def test_palette_button_falls_back_to_the_view_center(window, recording_path):
+    window._load(recording_path)  # cursor never moved; 0–30 window → center 15
+    window._palette_buttons[1].click()  # "LRLRx2"
+    assert window._annotations == [Annotation(15.0, 0.0, "LRLRx2")]
+
+
+def test_palette_number_key_inserts_the_nth_label(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    window._on_cursor_moved(40.0)
+    monkeypatch.setattr(
+        QtWidgets.QApplication, "focusWidget", staticmethod(lambda: None)
+    )
+    event = QtGui.QKeyEvent(
+        QtCore.QEvent.Type.KeyPress,
+        QtCore.Qt.Key.Key_2,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    assert window._handle_palette_key(event)  # consumed
+    assert window._annotations == [Annotation(40.0, 0.0, "LRLRx2")]  # 2nd label
+
+
+def test_palette_number_key_yields_to_text_entry(window, recording_path, monkeypatch):
+    window._load(recording_path)
+    monkeypatch.setattr(
+        QtWidgets.QApplication, "focusWidget", staticmethod(lambda: window.scaleSpin)
+    )
+    event = QtGui.QKeyEvent(
+        QtCore.QEvent.Type.KeyPress,
+        QtCore.Qt.Key.Key_1,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    assert not window._handle_palette_key(event)  # the spin box keeps the digit
+    assert window._annotations == []
+
+
+def test_palette_number_key_past_the_end_is_ignored(
+    window, recording_path, monkeypatch
+):
+    window._load(recording_path)
+    monkeypatch.setattr(
+        QtWidgets.QApplication, "focusWidget", staticmethod(lambda: None)
+    )
+    event = QtGui.QKeyEvent(  # only four palette buttons; 9 has no target
+        QtCore.QEvent.Type.KeyPress,
+        QtCore.Qt.Key.Key_9,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    assert not window._handle_palette_key(event)
+    assert window._annotations == []
+
+
+def test_editing_the_palette_persists_and_rebuilds(window, monkeypatch):
+    monkeypatch.setattr(
+        window_mod.PaletteEditorDialog,
+        "get_palette",
+        staticmethod(lambda *a, **k: ["Sniff", "Frown"]),
+    )
+    window._edit_palette()
+    assert [b.text() for b in window._palette_buttons] == ["Sniff", "Frown"]
+    prefs = preferences.load_preferences(window._prefs_path)
+    assert prefs["eeg_palette_labels"] == ["Sniff", "Frown"]
+
+
+def test_cancelling_the_palette_editor_changes_nothing(window, monkeypatch):
+    monkeypatch.setattr(
+        window_mod.PaletteEditorDialog,
+        "get_palette",
+        staticmethod(lambda *a, **k: None),  # cancelled
+    )
+    window._edit_palette()
+    assert [b.text() for b in window._palette_buttons] == DEFAULT_PALETTE
+
+
+def test_palette_editor_reorders_and_normalizes_labels(qtbot):
+    dialog = window_mod.PaletteEditorDialog(None, ["A", "B", "   "])
+    qtbot.addWidget(dialog)
+    dialog.listWidget.setCurrentRow(1)
+    dialog._move(-1)  # B moves above A
+    # Reordered, whitespace-normalized, and the blank entry dropped.
+    assert dialog.result_labels() == ["B", "A"]


### PR DESCRIPTION
Part of #181 (2 of 4). Stacked on #208 — review/merge that first.

A configurable quick-mark palette: one-click buttons that drop a labeled point mark at the cursor with no dialog — the fast path for scoring signals. The first nine also answer to number keys 1–9 (yielding to text fields).

- A "Quick marks" row plus an Edit-palette editor; an `eeg_palette_labels` preference (defaults to the lucid eye-signal vocabulary).
- The point-mark paths were refactored to share one insert helper.

Independent of the rest of #181, and also improves the everyday isolated-marker flow.

Verified: ruff + mypy + the offscreen pytest-qt suite green.