### PR TITLE
feat: add blind-rater presets to the EEG annotator

### DIFF
--- a/docs/eeg-review.md
+++ b/docs/eeg-review.md
@@ -83,6 +83,37 @@ save under an id confirms it (so a forgotten id is caught). Leave it blank for
 an ordinary single-rater review. See the
 [annotations file reference](reference/annotations-file.md#multiple-raters).
 
+## Blind-rater mode
+
+Objective scoring asks raters to judge the EEG without seeing what was already
+marked. The **Blind** button (or `--blind`) filters annotations **before they
+are ever shown**, so a rater cannot glimpse what is hidden, with three presets:
+
+- **Fully naive** — every mark is hidden; the rater scrolls a clean recording.
+- **Reports visible** — only dream-report markers are shown; detected signals
+    and cues are hidden.
+- **Signal-present (classify only)** — signal *positions* are shown with their
+    labels blanked (a `?`), so the rater sees *where* a signal is and classifies
+    *what* it is.
+
+Blind mode **requires a rater id** — a blind review seeds from the coordinator's
+truth sidecar (`night1.annotations.tsv`) but saves to the rater's own
+(`night1.annotations.alice.tsv`), so the truth file is never overwritten and
+each rater's judgements stay separate for later comparison. Reopening a rater's
+own file resumes their work unfiltered.
+
+A coordinator can save a preset (plus the visible/signal label lists and a
+quick-mark palette) as a shareable `study.smacc-blind.json` and hand out a
+one-click command:
+
+```sh
+SMACC-EEG.exe --rater alice --blind study.smacc-blind.json night1.edf
+```
+
+Blinding is a workflow aid, not a security boundary: the guarantee is that the
+app never *renders* a hidden label. Someone with file access can still read the
+recording or the truth sidecar directly.
+
 ## For developers
 
 Run it from a source checkout with the `eeg` extra:

--- a/src/smacc/eeg/__main__.py
+++ b/src/smacc/eeg/__main__.py
@@ -28,29 +28,43 @@ from ..config import VERSION
 # test — a lazy import would make it pass on a bundle that can't open a file).
 from .window import EegReviewWindow
 
+# Flags that take a following value, so the recording-path scan skips that value.
+_VALUE_FLAGS = ("--rater", "--blind")
+
 
 def pick_recording_path(args: list[str]) -> str | None:
     """Return the recording to open from CLI args, or ``None``.
 
     The last non-flag argument wins, mirroring the base app's settings-file
     handling; existence and format errors are left to the window so the user
-    sees a dialog, not a vanishing process. The value of ``--rater <id>`` is
-    skipped so a coordinator's ``--rater alice night1.edf`` opens the recording,
+    sees a dialog, not a vanishing process. A value following ``--rater`` or
+    ``--blind`` is skipped, so ``--rater alice night1.edf`` opens the recording,
     not the rater id.
     """
     candidates: list[str] = []
     skip = False
     for arg in args[1:]:
-        if skip:  # the value consumed by a preceding "--rater"
+        if skip:  # the value consumed by a preceding value-flag
             skip = False
             continue
-        if arg == "--rater":
+        if arg in _VALUE_FLAGS:
             skip = True
             continue
         if arg.startswith("-"):  # any flag, incl. "--rater=alice"
             continue
         candidates.append(arg)
     return candidates[-1] if candidates else None
+
+
+def _flag_value(args: list[str], flag: str) -> str | None:
+    """Return the value of ``flag`` (``--flag v`` or ``--flag=v``), or ``None``."""
+    prefix = f"{flag}="
+    for index, arg in enumerate(args):
+        if arg == flag and index + 1 < len(args):
+            return args[index + 1]
+        if arg.startswith(prefix):
+            return arg.split("=", 1)[1]
+    return None
 
 
 def pick_rater_id(args: list[str]) -> str | None:
@@ -61,12 +75,16 @@ def pick_rater_id(args: list[str]) -> str | None:
     Sanitizing/validation is the window's job — an empty or unusable id falls
     back to single-rater there rather than failing the launch.
     """
-    for index, arg in enumerate(args):
-        if arg == "--rater" and index + 1 < len(args):
-            return args[index + 1]
-        if arg.startswith("--rater="):
-            return arg.split("=", 1)[1]
-    return None
+    return _flag_value(args, "--rater")
+
+
+def pick_blind_spec(args: list[str]) -> str | None:
+    """Return the ``--blind`` value (a preset name or a config path), or ``None``.
+
+    Validation is the window's job: an unknown preset or unreadable config is
+    surfaced as a dialog after the window opens, not as a vanishing process.
+    """
+    return _flag_value(args, "--blind")
 
 
 def selftest() -> int:
@@ -107,6 +125,21 @@ def selftest() -> int:
         tsv = Path(tmp) / "selftest.annotations.tsv"
         write_annotations_tsv([Annotation(1.0, 0.5, "selftest")], tsv)
         assert read_annotations_tsv(tsv) == [Annotation(1.0, 0.5, "selftest")]
+        # Rater-keyed + blind-rater (#181): round-trip a per-rater sidecar and a
+        # blind config, and exercise the filter, so the frozen bundle proves them.
+        from . import blind
+        from .annotations import rater_sidecar_paths
+
+        rater_tsv, _ = rater_sidecar_paths(fif, "selftest")
+        write_annotations_tsv([Annotation(1.0, 0.0, "SignalObserved")], rater_tsv)
+        assert read_annotations_tsv(rater_tsv) == [
+            Annotation(1.0, 0.0, "SignalObserved")
+        ]
+        blind_path = Path(tmp) / f"selftest{blind.BLIND_SUFFIX}"
+        blind.write_blind_config(blind.preset_config(blind.PRESET_CLASSIFY), blind_path)
+        config = blind.read_blind_config(blind_path)
+        hidden = blind.apply_blind([Annotation(1.0, 0.0, "SignalObserved")], config)
+        assert hidden == [Annotation(1.0, 0.0, "?")], hidden
         # Figure export (#180): prove matplotlib's PNG/PDF/SVG backends are bundled
         # — a missed backend only surfaces when one actually writes a file.
         from .export import ExportOptions, render
@@ -134,7 +167,9 @@ def main() -> None:
     app = QApplication(sys.argv)
     app.setApplicationName("SMACC EEG review")
     window = EegReviewWindow(
-        pick_recording_path(sys.argv), rater_id=pick_rater_id(sys.argv)
+        pick_recording_path(sys.argv),
+        rater_id=pick_rater_id(sys.argv),
+        blind_spec=pick_blind_spec(sys.argv),
     )
     window.show()
     sys.exit(app.exec())

--- a/src/smacc/eeg/blind.py
+++ b/src/smacc/eeg/blind.py
@@ -1,0 +1,215 @@
+"""Blind-rater presets for the EEG annotator (#181).
+
+Objective signal scoring uses blind judges, and labs differ on how blind: a
+fully naive scroll-through, a review that may see dream-report markers but not
+detected signals, or one shown only that *a* signal exists and asked to classify
+it. This module is the pure core of that: a :class:`BlindConfig` (which labels a
+rater may see, which are blanked, the quick-mark palette) and :func:`apply_blind`,
+a single rule the window runs **before any annotation is shown** so a rater can
+never glimpse what is meant to be hidden.
+
+The three presets are just named ``(visible_labels, signal_labels)`` pairs over
+the annotation's free-text ``description`` — no annotation-category schema is
+needed (the shipped model has none). Matching is normalized and prefix-based, so
+``DreamReportStarted``/``Dream report 1`` and ``SignalObserved: LRLR`` all match
+their configured stem despite increments and detail suffixes.
+
+A config can be saved as a standalone ``<study>.smacc-blind.json`` — the same
+envelope pattern as :mod:`smacc.eeg.profiles` — so a coordinator defines the
+blinding once and hands it out. Pure dataclasses + JSON I/O, no GUI and no MNE.
+
+Note: blinding is *procedural integrity*, not a security boundary. The guarantee
+is that the app never renders a hidden label; a rater with filesystem access can
+always read the source recording or the coordinator's sidecar directly.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..config import VERSION
+from .annotations import Annotation
+
+# JSON envelope: a stable kind + schema version so a stray file is rejected
+# rather than half-applied (mirrors smacc.eeg.profiles).
+KIND = "smacc/eeg-blind-config"
+SCHEMA_VERSION = 1
+
+BLIND_SUFFIX = ".smacc-blind.json"
+FILE_FILTER = "SMACC blind config (*.smacc-blind.json);;All files (*)"
+
+# Built-in presets (canonical names; the window shows friendlier labels).
+PRESET_NAIVE = "naive"  # hide every mark
+PRESET_REPORTS = "reports"  # show only dream-report markers
+PRESET_CLASSIFY = "classify"  # show signal positions, blank their labels
+PRESET_CUSTOM = "custom"  # an explicit visible/signal pairing from a file
+PRESET_NAMES = (PRESET_NAIVE, PRESET_REPORTS, PRESET_CLASSIFY)
+
+# Defaults seeding the report/signal allow-lists. Matched as normalized prefixes
+# (see _matches), so these catch the key form, the human label, and increment or
+# detail suffixes. SignalObserved is SMACC's lucidity-signal marker (events.py);
+# DreamReport* are the dream-report markers. Labs extend these in the config —
+# adding more is pure data, no code change.
+DEFAULT_SIGNAL_LABELS = ("SignalObserved",)
+DEFAULT_REPORT_LABELS = ("DreamReport",)
+
+# Stand-in shown for a blanked signal in classify-only. Configurable; never empty
+# (the annotation model rejects empty descriptions, so a literal blank is out).
+DEFAULT_PLACEHOLDER = "?"
+
+
+@dataclass(frozen=True)
+class BlindConfig:
+    """A blinding rule: which labels a rater sees, which are blanked, the palette.
+
+    ``visible_labels`` are shown verbatim; ``signal_labels`` are shown at their
+    original time but with the label replaced by ``classify_placeholder`` (the
+    "a signal is here — classify it" case); everything else is dropped. ``preset``
+    is a human tag for the UI. ``palette`` optionally overrides the operator's
+    quick-mark buttons so a coordinator ships the classification vocabulary too.
+    """
+
+    preset: str = PRESET_CUSTOM
+    visible_labels: tuple[str, ...] = ()
+    signal_labels: tuple[str, ...] = ()
+    palette: tuple[str, ...] = ()
+    classify_placeholder: str = DEFAULT_PLACEHOLDER
+
+    def __post_init__(self) -> None:
+        if not self.classify_placeholder.strip():
+            raise ValueError("classify_placeholder must not be empty")
+
+
+def _normalize(text: str) -> str:
+    """Lower-case and strip non-alphanumerics, for tolerant label matching."""
+    return re.sub(r"[^a-z0-9]+", "", text.lower())
+
+
+def _matches(description: str, patterns: tuple[str, ...]) -> bool:
+    """True if ``description`` normalized starts with any pattern normalized.
+
+    Prefix (not equality) so a configured ``SignalObserved`` matches
+    ``SignalObserved: LRLR`` and ``DreamReport`` matches ``DreamReportStarted-2``.
+    """
+    norm = _normalize(description)
+    return any(norm.startswith(p) for p in (_normalize(x) for x in patterns) if p)
+
+
+def apply_blind(annotations: list[Annotation], config: BlindConfig) -> list[Annotation]:
+    """Return the rater-visible annotations under ``config`` (input untouched).
+
+    The one rule behind every preset: a mark whose label is in
+    ``visible_labels`` is kept verbatim; one in ``signal_labels`` is kept at its
+    time with the label blanked to ``classify_placeholder``; anything else is
+    dropped. Naive is the empty/empty case (everything dropped); reports-visible
+    fills ``visible_labels``; classify-only fills ``signal_labels``.
+    """
+    out: list[Annotation] = []
+    for a in annotations:
+        if _matches(a.description, config.visible_labels):
+            out.append(a)
+        elif _matches(a.description, config.signal_labels):
+            out.append(Annotation(a.onset, a.duration, config.classify_placeholder))
+        # else: hidden from the rater
+    return sorted(out)
+
+
+def preset_config(
+    preset: str,
+    *,
+    signal_labels: tuple[str, ...] = DEFAULT_SIGNAL_LABELS,
+    report_labels: tuple[str, ...] = DEFAULT_REPORT_LABELS,
+    palette: tuple[str, ...] = (),
+    placeholder: str = DEFAULT_PLACEHOLDER,
+) -> BlindConfig:
+    """Build a :class:`BlindConfig` for a built-in preset.
+
+    Raises:
+        ValueError: for an unknown preset name.
+    """
+    if preset == PRESET_NAIVE:
+        return BlindConfig(PRESET_NAIVE, (), (), palette, placeholder)
+    if preset == PRESET_REPORTS:
+        return BlindConfig(
+            PRESET_REPORTS, tuple(report_labels), (), palette, placeholder
+        )
+    if preset == PRESET_CLASSIFY:
+        return BlindConfig(
+            PRESET_CLASSIFY, (), tuple(signal_labels), palette, placeholder
+        )
+    raise ValueError(
+        f"Unknown blind preset {preset!r} (known: {', '.join(PRESET_NAMES)})"
+    )
+
+
+def blind_payload(config: BlindConfig) -> dict[str, Any]:
+    """Return the JSON-serializable envelope for ``config``."""
+    return {
+        "kind": KIND,
+        "schema_version": SCHEMA_VERSION,
+        "preset": config.preset,
+        "visible_labels": list(config.visible_labels),
+        "signal_labels": list(config.signal_labels),
+        "palette": list(config.palette),
+        "classify_placeholder": config.classify_placeholder,
+        "generated_by": {"name": "SMACC", "version": VERSION},
+    }
+
+
+def write_blind_config(config: BlindConfig, path: str | Path) -> None:
+    """Write ``config`` to ``path`` as JSON."""
+    Path(path).write_text(json.dumps(blind_payload(config), indent=2), encoding="utf-8")
+
+
+def _str_tuple(payload: Any, field_name: str) -> tuple[str, ...]:
+    if not isinstance(payload, list) or not all(isinstance(s, str) for s in payload):
+        raise ValueError(f"{field_name!r} must be a list of strings")
+    return tuple(payload)
+
+
+def read_blind_config(path: str | Path) -> BlindConfig:
+    """Read a blind config back, raising on a file that is not one.
+
+    Raises:
+        OSError: if the file can't be read.
+        ValueError: on a wrong/missing ``kind`` or an unparseable field — better
+            to refuse than to silently apply a half-understood blinding.
+    """
+    text = Path(path).read_text(encoding="utf-8-sig")  # tolerate a Notepad BOM
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict) or payload.get("kind") != KIND:
+        raise ValueError(f"Not a SMACC blind config (kind={payload.get('kind')!r})")
+    placeholder = payload.get("classify_placeholder", DEFAULT_PLACEHOLDER)
+    if not isinstance(placeholder, str):
+        raise ValueError("'classify_placeholder' must be a string")
+    try:
+        return BlindConfig(
+            preset=str(payload.get("preset", PRESET_CUSTOM)),
+            visible_labels=_str_tuple(
+                payload.get("visible_labels", []), "visible_labels"
+            ),
+            signal_labels=_str_tuple(payload.get("signal_labels", []), "signal_labels"),
+            palette=_str_tuple(payload.get("palette", []), "palette"),
+            classify_placeholder=placeholder,
+        )
+    except ValueError as exc:
+        raise ValueError(f"Invalid blind config: {exc}") from exc
+
+
+def resolve_blind(spec: str) -> BlindConfig:
+    """Resolve a ``--blind`` value: a built-in preset name, or a config file path.
+
+    Raises:
+        OSError: if a config-file path can't be read.
+        ValueError: for an unknown preset or an invalid config file.
+    """
+    if spec in PRESET_NAMES:
+        return preset_config(spec)
+    return read_blind_config(spec)

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -32,7 +32,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import preferences, windowstate
 from ..paths import LOGO_PATH, preferences_path
-from . import dsp, io
+from . import blind, dsp, io
 from .annotations import (
     Annotation,
     autosave_path,
@@ -567,7 +567,10 @@ class EegReviewWindow(QtWidgets.QMainWindow):
     """Review and annotate one recording; the EEG component's main window."""
 
     def __init__(
-        self, file_path: str | Path | None = None, rater_id: str | None = None
+        self,
+        file_path: str | Path | None = None,
+        rater_id: str | None = None,
+        blind_spec: str | None = None,
     ) -> None:
         super().__init__()
         self._recording: io.Recording | None = None
@@ -585,6 +588,16 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         # Rater ids confirmed at save this session, so the confirm-before-save
         # prompt fires once per id, not on every save.
         self._confirmed_raters: set[str] = set()
+        # Blind-rater mode (#181): a filter applied at load so a rater never sees
+        # hidden marks. None is an ordinary review. A bad --blind value is held
+        # and surfaced after the window shows (see the deferred error below).
+        self._blind: blind.BlindConfig | None = None
+        self._blind_error: str | None = None
+        if blind_spec:
+            try:
+                self._blind = blind.resolve_blind(blind_spec)
+            except (OSError, ValueError) as exc:
+                self._blind_error = str(exc)
         # Annotations recovered from an autosave, held until the user restores or
         # dismisses them (#176).
         self._recovery_annotations: list[Annotation] | None = None
@@ -603,6 +616,15 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         app = QtWidgets.QApplication.instance()
         if app is not None:
             app.installEventFilter(self)
+        if self._blind_error is not None:
+            # A bad --blind value: warn once the window is up (a constructor-time
+            # dialog would race the first paint), then proceed unblinded.
+            QtCore.QTimer.singleShot(
+                0,
+                lambda: self._error(
+                    "Could not apply the blind config.", self._blind_error
+                ),
+            )
         if file_path is not None:
             # After the event loop starts, so the window is up before any
             # open-error dialog (and a long load doesn't block the first paint).
@@ -847,6 +869,16 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         row.addWidget(self.scaleSpin)
 
         row.addStretch(1)
+        # Blind-rater mode (#181): hide/blank marks before they render, for blind
+        # scoring. Needs a rater id (so marks save to the rater's own sidecar).
+        self.blindButton = QtWidgets.QPushButton(self)
+        self.blindButton.setStatusTip(
+            "Blind-rater mode: hide or blank marks before they are shown "
+            "(needs a rater id)."
+        )
+        self.blindButton.clicked.connect(self._choose_blind_mode)
+        self._refresh_blind_button()
+        row.addWidget(self.blindButton)
         # Rater identity (#181): blank for a single-rater review; set it and every
         # save/load/autosave routes to a per-rater sidecar. Always enabled — the id
         # can be set before a recording is open and persists for next launch.
@@ -1064,7 +1096,14 @@ class EegReviewWindow(QtWidgets.QMainWindow):
     # ----- quick-mark palette (#181) ---------------------------------------------
 
     def _palette_labels(self) -> list[str]:
-        """The configured quick-mark labels (falls back to the seed labels)."""
+        """The active quick-mark labels: a blind config's palette wins, else prefs.
+
+        A loaded blind config can ship its own classification vocabulary so a
+        coordinator hands out the buttons too; otherwise the operator's saved
+        palette applies (falling back to the seed labels if it is unreadable).
+        """
+        if self._blind is not None and self._blind.palette:
+            return list(self._blind.palette)
         prefs = preferences.load_preferences(preferences_path)
         labels = prefs.get("eeg_palette_labels")
         if not isinstance(labels, list):
@@ -1100,6 +1139,80 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         preferences.update_preferences(preferences_path, {"eeg_palette_labels": result})
         self._rebuild_palette_buttons()
 
+    # ----- blind-rater mode (#181) -----------------------------------------------
+
+    def _refresh_blind_button(self) -> None:
+        """Keep the Blind button showing the active preset (or off)."""
+        self.blindButton.setText(
+            f"Blind: {self._blind.preset}" if self._blind is not None else "Blind: off"
+        )
+
+    def _choose_blind_mode(self) -> None:
+        """Pop up the blind-mode menu: a preset, a config file, or off."""
+        menu = QtWidgets.QMenu(self)
+        menu.addAction("Off", lambda: self._set_blind(None))
+        menu.addAction(
+            "Fully naive",
+            lambda: self._set_blind(blind.preset_config(blind.PRESET_NAIVE)),
+        )
+        menu.addAction(
+            "Reports visible",
+            lambda: self._set_blind(blind.preset_config(blind.PRESET_REPORTS)),
+        )
+        menu.addAction(
+            "Signal-present (classify only)",
+            lambda: self._set_blind(blind.preset_config(blind.PRESET_CLASSIFY)),
+        )
+        menu.addSeparator()
+        menu.addAction("Load config file…", self._load_blind_config)
+        menu.exec(self.blindButton.mapToGlobal(self.blindButton.rect().bottomLeft()))
+
+    def _set_blind(self, config: blind.BlindConfig | None) -> None:
+        """Switch the blind mode, re-resolving the open recording through it.
+
+        Blinding needs a rater id (so marks save to the rater's own sidecar, never
+        the coordinator's truth). Changing the view re-reads the recording from
+        the data boundary, discarding in-progress edits, so confirm first.
+        """
+        if config is not None and self._rater_id is None:
+            self._error(
+                "Blind review needs a rater id.",
+                "Set a rater id with the Rater button first, so the rater's marks "
+                "save to their own sidecar.",
+            )
+            return
+        if self._recording is not None and not self._confirm_discard():
+            return
+        self._blind = config
+        self._refresh_blind_button()
+        self._rebuild_palette_buttons()  # a config may carry its own palette
+        if self._recording is not None:
+            self._load(self._recording.path)  # re-resolve marks under the new mode
+        self._refresh_title()
+
+    def _load_blind_config(self) -> None:
+        """Load a shareable .smacc-blind.json and switch to it."""
+        prefs = preferences.load_preferences(preferences_path)
+        start_dir = prefs.get("eeg_last_blind_dir") or (
+            str(self._recording.path.parent)
+            if self._recording is not None
+            else str(Path.home())
+        )
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Load blind config", str(start_dir), blind.FILE_FILTER
+        )
+        if not path:
+            return
+        try:
+            config = blind.read_blind_config(path)
+        except (OSError, ValueError) as exc:
+            self._error("Could not read the blind config.", str(exc))
+            return
+        preferences.update_preferences(
+            preferences_path, {"eeg_last_blind_dir": str(Path(path).parent)}
+        )
+        self._set_blind(config)
+
     # ----- opening a recording ---------------------------------------------------
 
     def open_file(self) -> None:
@@ -1114,6 +1227,17 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             self._load(Path(path))
 
     def _load(self, path: Path) -> None:
+        # Blind review must write to a rater's own sidecar, never the coordinator's
+        # truth file: without a rater id the resume/save would clobber the truth.
+        # Refuse before opening anything (the data-loss guard for #181c).
+        if self._blind is not None and self._rater_id is None:
+            self._error(
+                "Blind review needs a rater id.",
+                "Set a rater id (the Rater button or --rater) before a blind "
+                "review, so the rater's marks save to their own sidecar and never "
+                "overwrite the coordinator's truth file.",
+            )
+            return
         try:
             recording = io.open_recording(path)
         except (ValueError, OSError, RuntimeError) as exc:
@@ -1127,7 +1251,8 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         if tsv_path.is_file():
             # Resume a previous review. A sidecar that exists but won't parse
             # aborts the open: it is the reviewer's data, and proceeding would
-            # overwrite it with an empty list on the next save.
+            # overwrite it with an empty list on the next save. A rater's own
+            # resumed marks are theirs, so they are never re-blinded.
             try:
                 annotations = read_annotations_tsv(tsv_path)
             except (OSError, ValueError) as exc:
@@ -1138,10 +1263,10 @@ class EegReviewWindow(QtWidgets.QMainWindow):
                 )
                 return
         else:
-            # A fresh review starts from the events embedded in the recording
-            # (amp markers, SMACC's own portcodes…), so they end up in the
-            # sidecar alongside the reviewer's marks.
-            annotations = io.embedded_annotations(recording)
+            fresh = self._fresh_annotations(path, recording)
+            if fresh is None:  # a blind seed sidecar that won't parse
+                return
+            annotations = fresh
         self._recording = recording
         self._annotations = annotations
         self._dirty = False
@@ -1176,6 +1301,36 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             f"{recording.sfreq:g} Hz · {recording.duration:.0f} s{clock}"
         )
         self._check_for_recovery(tsv_path)
+
+    def _fresh_annotations(
+        self, path: Path, recording: io.Recording
+    ) -> list[Annotation] | None:
+        """Annotations to start a fresh review from; ``None`` on a read error.
+
+        A plain review starts from the events embedded in the recording (amp
+        markers, SMACC's own portcodes…). A blind review instead seeds from the
+        coordinator's truth sidecar (the plain one) when it exists — so the
+        blinding hides *its* marks — falling back to the embedded events, and
+        runs the blind filter before anything is shown. This is the load-time
+        safety invariant (#181c): the filter covers both fresh sources, so a
+        naive rater never glimpses the recording's cue/portcode markers.
+        """
+        if self._blind is None:
+            return io.embedded_annotations(recording)
+        truth_tsv, _ = sidecar_paths(path)
+        if truth_tsv.is_file():
+            try:
+                seed = read_annotations_tsv(truth_tsv)
+            except (OSError, ValueError) as exc:
+                self._error(
+                    "Could not read the coordinator's annotations sidecar.",
+                    f"{truth_tsv.name}: {exc}\n\nFix or rename it, then open the "
+                    "recording again.",
+                )
+                return None
+        else:
+            seed = io.embedded_annotations(recording)
+        return blind.apply_blind(seed, self._blind)
 
     # ----- annotation editing -----------------------------------------------------
 
@@ -1355,8 +1510,9 @@ class EegReviewWindow(QtWidgets.QMainWindow):
     def _refresh_title(self) -> None:
         name = f" — {self._recording.path.name}" if self._recording else ""
         rater = f" · rater {self._rater_id}" if self._rater_id else ""
+        blinded = f" · blind:{self._blind.preset}" if self._blind is not None else ""
         star = " *" if self._dirty else ""
-        self.setWindowTitle(f"SMACC — EEG review{name}{rater}{star}")
+        self.setWindowTitle(f"SMACC — EEG review{name}{rater}{blinded}{star}")
 
     def _recent_labels(self) -> list[str]:
         prefs = preferences.load_preferences(preferences_path)

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -63,6 +63,8 @@ DEFAULTS: dict[str, Any] = {
     # a labeled point mark at the cursor. Defaults to the lucid eye-signal
     # vocabulary; editable in the tool, and the first nine get number keys 1–9.
     "eeg_palette_labels": ["LRLR", "LRLRx2", "LRLRx3", "IEIE"],
+    # The folder the EEG review tool last loaded a blind config from (#181).
+    "eeg_last_blind_dir": None,
 }
 
 _logger = logging.getLogger("smacc")

--- a/tests/test_eeg_blind.py
+++ b/tests/test_eeg_blind.py
@@ -1,0 +1,148 @@
+"""Tests for the blind-rater presets and config file (#181, no GUI)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from smacc.eeg import blind
+from smacc.eeg.annotations import Annotation
+
+
+def _marks() -> list[Annotation]:
+    return [
+        Annotation(10.0, 0.0, "SignalObserved"),
+        Annotation(20.0, 0.0, "DreamReportStarted"),
+        Annotation(30.0, 0.0, "Cue started: Piano"),
+        Annotation(40.0, 0.0, "Arousal"),
+    ]
+
+
+# ----- the filter -----------------------------------------------------------
+
+
+def test_naive_hides_every_mark():
+    assert blind.apply_blind(_marks(), blind.preset_config(blind.PRESET_NAIVE)) == []
+
+
+def test_reports_visible_keeps_only_report_marks():
+    out = blind.apply_blind(_marks(), blind.preset_config(blind.PRESET_REPORTS))
+    assert [a.description for a in out] == ["DreamReportStarted"]
+
+
+def test_classify_only_blanks_signals_and_drops_the_rest():
+    out = blind.apply_blind(_marks(), blind.preset_config(blind.PRESET_CLASSIFY))
+    # Only the signal survives, at its time, with the label blanked.
+    assert out == [Annotation(10.0, 0.0, "?")]
+
+
+def test_classify_placeholder_is_configurable():
+    config = blind.BlindConfig(
+        preset="custom",
+        signal_labels=("SignalObserved",),
+        classify_placeholder="(classify)",
+    )
+    assert blind.apply_blind(_marks(), config) == [Annotation(10.0, 0.0, "(classify)")]
+
+
+def test_matching_is_prefix_and_normalized():
+    # Increment suffixes, detail tags, and the spaced human label all match.
+    marks = [
+        Annotation(1.0, 0.0, "DreamReportStarted-2"),
+        Annotation(2.0, 0.0, "Dream report started"),
+        Annotation(3.0, 0.0, "SignalObserved: LRLR conf 3"),
+    ]
+    config = blind.BlindConfig(
+        preset="custom",
+        visible_labels=("DreamReport",),
+        signal_labels=("SignalObserved",),
+    )
+    out = blind.apply_blind(marks, config)
+    assert [a.description for a in out] == [
+        "DreamReportStarted-2",
+        "Dream report started",
+        "?",
+    ]
+
+
+def test_apply_blind_leaves_the_input_untouched():
+    marks = _marks()
+    blind.apply_blind(marks, blind.preset_config(blind.PRESET_NAIVE))
+    assert len(marks) == 4  # pure: caller's list unchanged
+
+
+def test_preset_config_rejects_an_unknown_preset():
+    with pytest.raises(ValueError, match="Unknown blind preset"):
+        blind.preset_config("bogus")
+
+
+def test_blind_config_rejects_an_empty_placeholder():
+    with pytest.raises(ValueError, match="placeholder"):
+        blind.BlindConfig(preset="custom", classify_placeholder="   ")
+
+
+# ----- config file round-trip -----------------------------------------------
+
+
+def test_config_round_trip_preserves_fields(tmp_path):
+    config = blind.BlindConfig(
+        preset="classify",
+        signal_labels=("SignalObserved", "Sniff"),
+        palette=("LRLR", "Sniff"),
+        classify_placeholder="?",
+    )
+    path = tmp_path / "study.smacc-blind.json"
+    blind.write_blind_config(config, path)
+    assert blind.read_blind_config(path) == config
+
+
+def test_config_envelope_has_kind_and_version(tmp_path):
+    path = tmp_path / "x.smacc-blind.json"
+    blind.write_blind_config(blind.preset_config(blind.PRESET_NAIVE), path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["kind"] == blind.KIND
+    assert payload["schema_version"] == blind.SCHEMA_VERSION
+
+
+def test_read_rejects_a_foreign_file(tmp_path):
+    path = tmp_path / "x.json"
+    path.write_text('{"kind": "something-else"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="Not a SMACC blind config"):
+        blind.read_blind_config(path)
+
+
+def test_read_rejects_non_string_labels(tmp_path):
+    path = tmp_path / "x.smacc-blind.json"
+    path.write_text(
+        json.dumps({"kind": blind.KIND, "schema_version": 1, "signal_labels": [1, 2]}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="signal_labels"):
+        blind.read_blind_config(path)
+
+
+def test_read_tolerates_a_notepad_bom(tmp_path):
+    path = tmp_path / "x.smacc-blind.json"
+    payload = blind.blind_payload(blind.preset_config(blind.PRESET_NAIVE))
+    path.write_bytes(b"\xef\xbb\xbf" + json.dumps(payload).encode("utf-8"))
+    assert blind.read_blind_config(path).preset == "naive"
+
+
+# ----- resolve (CLI --blind) ------------------------------------------------
+
+
+def test_resolve_blind_accepts_preset_names():
+    assert blind.resolve_blind("naive").preset == "naive"
+    assert blind.resolve_blind("classify").signal_labels == blind.DEFAULT_SIGNAL_LABELS
+
+
+def test_resolve_blind_reads_a_config_path(tmp_path):
+    path = tmp_path / "study.smacc-blind.json"
+    blind.write_blind_config(blind.preset_config(blind.PRESET_REPORTS), path)
+    assert blind.resolve_blind(str(path)).preset == "reports"
+
+
+def test_resolve_blind_rejects_an_unknown_spec():
+    with pytest.raises((ValueError, OSError)):
+        blind.resolve_blind("not-a-preset-or-file")

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -23,9 +23,9 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from smacc import preferences
 from smacc.config import VERSION
-from smacc.eeg import dsp
+from smacc.eeg import blind, dsp
 from smacc.eeg import window as window_mod
-from smacc.eeg.__main__ import pick_rater_id, pick_recording_path
+from smacc.eeg.__main__ import pick_blind_spec, pick_rater_id, pick_recording_path
 from smacc.eeg.annotations import (
     Annotation,
     autosave_path,
@@ -916,13 +916,20 @@ def test_pick_recording_path_takes_the_last_non_flag_argument():
     assert pick_recording_path(["exe", "a.edf", "b.fif"]) == "b.fif"
 
 
-def test_pick_recording_path_skips_the_rater_value(tmp_path):
-    # --rater alice night1.edf must open the recording, not the rater id.
+def test_pick_recording_path_skips_value_flag_values(tmp_path):
+    # --rater/--blind values must not be mistaken for the recording.
     assert (
         pick_recording_path(["exe", "--rater", "alice", "night1.edf"]) == "night1.edf"
     )
     assert pick_recording_path(["exe", "--rater", "alice"]) is None
     assert pick_recording_path(["exe", "--rater=alice", "night1.edf"]) == "night1.edf"
+    assert (
+        pick_recording_path(["exe", "--blind", "naive", "night1.edf"]) == "night1.edf"
+    )
+    assert (
+        pick_recording_path(["exe", "--rater", "a", "--blind", "naive", "n.edf"])
+        == "n.edf"
+    )
 
 
 def test_pick_rater_id_reads_both_forms():
@@ -930,6 +937,14 @@ def test_pick_rater_id_reads_both_forms():
     assert pick_rater_id(["exe", "--rater=bob", "night1.edf"]) == "bob"
     assert pick_rater_id(["exe", "night1.edf"]) is None
     assert pick_rater_id(["exe", "--rater"]) is None  # dangling flag, no value
+
+
+def test_pick_blind_spec_reads_both_forms():
+    assert pick_blind_spec(["exe", "--blind", "naive", "night1.edf"]) == "naive"
+    assert pick_blind_spec(["exe", "--blind=study.smacc-blind.json"]) == (
+        "study.smacc-blind.json"
+    )
+    assert pick_blind_spec(["exe", "night1.edf"]) is None
 
 
 # ----- wall-clock display ---------------------------------------------------------
@@ -1024,8 +1039,10 @@ def make_window(qtbot, tmp_path, monkeypatch):
         lambda *a, **k: QtWidgets.QMessageBox.StandardButton.Discard,
     )
 
-    def build(rater_id: str | None = None) -> EegReviewWindow:
-        win = EegReviewWindow(rater_id=rater_id)
+    def build(
+        rater_id: str | None = None, blind_spec: str | None = None
+    ) -> EegReviewWindow:
+        win = EegReviewWindow(rater_id=rater_id, blind_spec=blind_spec)
         qtbot.addWidget(win)
         win.show()
         win._prefs_path = tmp_path / "prefs.yaml"  # test convenience handle
@@ -1286,3 +1303,122 @@ def test_palette_editor_reorders_and_normalizes_labels(qtbot):
     dialog._move(-1)  # B moves above A
     # Reordered, whitespace-normalized, and the blank entry dropped.
     assert dialog.result_labels() == ["B", "A"]
+
+
+# ----- blind-rater mode (#181) ----------------------------------------------
+
+
+def test_blind_without_a_rater_id_aborts_the_open(
+    make_window, recording_path, silence_dialogs
+):
+    win = make_window()  # no rater id — blinding would clobber the truth file
+    win._blind = blind.preset_config(blind.PRESET_NAIVE)
+    win._load(recording_path)
+    assert win._recording is None  # refused before opening
+    assert not win.saveButton.isEnabled()
+
+
+def test_naive_blind_hides_embedded_marks_before_render(
+    make_window, recording_path, monkeypatch
+):
+    monkeypatch.setattr(
+        window_mod.io,
+        "embedded_annotations",
+        lambda rec: [
+            Annotation(5.0, 0.0, "SignalObserved"),
+            Annotation(8.0, 0.0, "Cue"),
+        ],
+    )
+    win = make_window("alice")
+    win._blind = blind.preset_config(blind.PRESET_NAIVE)
+    win._load(recording_path)
+    assert win._annotations == []  # nothing hidden ever reaches window state
+    assert win.annotationList.count() == 0
+
+
+def test_classify_blind_seeds_from_truth_and_blanks_signals(
+    make_window, recording_path
+):
+    # A fresh blind review seeds from the coordinator's truth (the plain sidecar).
+    truth = [Annotation(5.0, 0.0, "SignalObserved"), Annotation(8.0, 0.0, "Arousal")]
+    plain_tsv, _ = sidecar_paths(recording_path)
+    write_annotations_tsv(truth, plain_tsv)
+    win = make_window("alice")
+    win._blind = blind.preset_config(blind.PRESET_CLASSIFY)
+    win._load(recording_path)
+    # Only the signal position survives, label blanked; the arousal is hidden.
+    assert win._annotations == [Annotation(5.0, 0.0, "?")]
+
+
+def test_blind_seeds_from_truth_not_embedded(make_window, recording_path, monkeypatch):
+    truth = [Annotation(5.0, 0.0, "DreamReportStarted")]
+    plain_tsv, _ = sidecar_paths(recording_path)
+    write_annotations_tsv(truth, plain_tsv)
+    monkeypatch.setattr(
+        window_mod.io,
+        "embedded_annotations",
+        lambda rec: pytest.fail("blind seeds from the truth sidecar, not embedded"),
+    )
+    win = make_window("alice")
+    win._blind = blind.preset_config(blind.PRESET_REPORTS)
+    win._load(recording_path)
+    assert win._annotations == truth  # the report is visible
+
+
+def test_rater_resume_is_not_reblinded(make_window, recording_path):
+    # Alice already saved her classifications; reopening blind shows them as-is —
+    # naive would wipe them if resume were (wrongly) re-filtered.
+    alice_marks = [Annotation(5.0, 0.0, "LRLR"), Annotation(8.0, 0.0, "?")]
+    rater_tsv, _ = rater_sidecar_paths(recording_path, "alice")
+    write_annotations_tsv(alice_marks, rater_tsv)
+    win = make_window("alice")
+    win._blind = blind.preset_config(blind.PRESET_NAIVE)
+    win._load(recording_path)
+    assert win._annotations == alice_marks  # her own marks survive, unfiltered
+
+
+def test_blind_save_writes_rater_path_and_leaves_truth(make_window, recording_path):
+    truth = [Annotation(5.0, 0.0, "SignalObserved")]
+    plain_tsv, _ = sidecar_paths(recording_path)
+    write_annotations_tsv(truth, plain_tsv)
+    win = make_window("alice")
+    win._confirmed_raters.add("alice")
+    win._blind = blind.preset_config(blind.PRESET_CLASSIFY)
+    win._load(recording_path)  # alice sees the blanked signal
+    win.save_annotations()
+    rater_tsv, _ = rater_sidecar_paths(recording_path, "alice")
+    assert read_annotations_tsv(rater_tsv) == [Annotation(5.0, 0.0, "?")]
+    assert read_annotations_tsv(plain_tsv) == truth  # truth untouched
+
+
+def test_blind_button_reflects_the_mode(make_window):
+    win = make_window("alice")
+    assert win.blindButton.text() == "Blind: off"
+    win._set_blind(blind.preset_config(blind.PRESET_CLASSIFY))
+    assert win.blindButton.text() == "Blind: classify"
+
+
+def test_set_blind_without_a_rater_is_refused(make_window, silence_dialogs):
+    win = make_window()  # no rater id
+    win._set_blind(blind.preset_config(blind.PRESET_NAIVE))
+    assert win._blind is None  # refused
+
+
+def test_blind_config_palette_overrides_the_buttons(make_window):
+    win = make_window("alice")
+    win._set_blind(
+        blind.BlindConfig(
+            preset="custom",
+            signal_labels=("SignalObserved",),
+            palette=("LRLR", "Sniff"),
+        )
+    )
+    assert [b.text() for b in win._palette_buttons] == ["LRLR", "Sniff"]
+
+
+def test_bad_blind_spec_opens_unblinded(make_window, silence_dialogs):
+    # An unknown --blind value must not crash the launch; it records a (deferred)
+    # error and the window opens with blinding off.
+    win = make_window(blind_spec="not-a-preset")
+    assert win._blind is None
+    assert win._blind_error is not None


### PR DESCRIPTION
Part of #181 (3 of 4). Stacked on #209 — review/merge that first.

The blind-rater core. A filter applied at load, before any annotation renders, so a rater cannot glimpse what is hidden. Three presets over the free-text label (no annotation-category field needed): fully naive, reports-visible, and signal-present (classify-only, which blanks signal labels to a placeholder).

- New pure module `eeg/blind.py`: the one-rule filter and a shareable `<study>.smacc-blind.json` config (same envelope as view profiles).
- Blind mode requires a rater id — a fresh blind review seeds from the coordinator's truth sidecar and saves to the rater's own, so the truth file is never overwritten; a rater's own resume is not re-filtered.
- A Blind menu (preset or config file) and a `--blind <preset-or-path>` CLI; `--selftest` extended to exercise the filter.

Note: embedded LSL marks are numeric codes, so out-of-the-box matching targets the coordinator's labeled truth file; raw-recording reviews add codes to the config (documented).

Verified: ruff + mypy + offscreen pytest-qt green; `--selftest` round-trips the blind path through MNE.