### PR TITLE
feat: add a show/hide-by-rater overlay to the EEG annotator

### DIFF
--- a/docs/eeg-review.md
+++ b/docs/eeg-review.md
@@ -83,6 +83,13 @@ save under an id confirms it (so a forgotten id is caught). Leave it blank for
 an ordinary single-rater review. See the
 [annotations file reference](reference/annotations-file.md#multiple-raters).
 
+Once several raters have scored a recording, opening it shows the **other
+raters** as a read-only overlay — each rater's marks in their own colour behind
+your editable ones — with a show/hide checkbox per rater in the **Other raters**
+list. Only your own marks are clickable and editable; the overlay is for
+comparison. (Overlays are off during a blind review, so a blind rater never sees
+their peers.)
+
 ## Blind-rater mode
 
 Objective scoring asks raters to judge the EEG without seeing what was already

--- a/src/smacc/eeg/annotations.py
+++ b/src/smacc/eeg/annotations.py
@@ -169,6 +169,42 @@ def rater_autosave_path(source: str | Path, rater_id: str) -> Path:
     return Path(source).with_suffix(f".annotations.{rater}.autosave.tsv")
 
 
+def rater_id_from_sidecar(source: str | Path, path: str | Path) -> str | None:
+    """Return the rater id ``path`` encodes for ``source``, or ``None``.
+
+    Recognizes only a canonical per-rater sidecar
+    (``night1.annotations.<id>.tsv``); the plain sidecar, an autosave
+    (``…<id>.autosave.tsv``), and unrelated files all read as ``None``. A real
+    rater id never contains a dot (see :func:`sanitize_rater_id`), so a dotted
+    middle segment marks a compound/autosave name and is rejected.
+    """
+    stem = Path(source).stem
+    name = Path(path).name
+    prefix = f"{stem}.annotations."
+    if not name.startswith(prefix) or not name.endswith(".tsv"):
+        return None
+    middle = name[len(prefix) : -len(".tsv")]
+    if not middle or "." in middle:  # plain sidecar, or an autosave/compound name
+        return None
+    return middle
+
+
+def discover_rater_sidecars(source: str | Path) -> dict[str, Path]:
+    """Return ``{rater_id: sidecar path}`` for every per-rater sidecar of ``source``.
+
+    Scans the recording's folder for ``night1.annotations.<id>.tsv`` files
+    (skipping autosaves and the plain sidecar), sorted by rater id — the input
+    to the show/hide-by-rater overlay. Missing folder yields an empty mapping.
+    """
+    src = Path(source)
+    out: dict[str, Path] = {}
+    for path in sorted(src.parent.glob(f"{src.stem}.annotations.*.tsv")):
+        rater_id = rater_id_from_sidecar(src, path)
+        if rater_id is not None:
+            out[rater_id] = path
+    return out
+
+
 def write_annotations_tsv(annotations: list[Annotation], path: str | Path) -> None:
     """Write ``annotations`` (sorted) to ``path`` as a tab-separated values file."""
     with Path(path).open("w", encoding="utf-8", newline="") as stream:

--- a/src/smacc/eeg/view.py
+++ b/src/smacc/eeg/view.py
@@ -64,12 +64,40 @@ _REGION_PEN = (70, 130, 180, 160)
 _LINE_PEN = (178, 34, 34, 160)  # firebrick for instantaneous marks
 _LINE_PEN_SELECTED = (178, 34, 34, 255)
 
+# Other raters' marks (#181d) are drawn read-only *behind* the editable layer,
+# one distinct colour per rater (Okabe–Ito, chosen to avoid the steel-blue/
+# firebrick of the operator's own marks and to stay colourblind-distinguishable).
+OVERLAY_COLORS: tuple[tuple[int, int, int], ...] = (
+    (230, 159, 0),  # orange
+    (0, 158, 115),  # bluish green
+    (204, 121, 167),  # reddish purple
+    (213, 94, 0),  # vermillion
+    (86, 180, 233),  # sky blue
+    (240, 228, 66),  # yellow
+)
+# Read-only overlay marks sit above the curves/epochs but below the editable
+# layer (z 10), so a rater's own marks always render on top of their peers'.
+_OVERLAY_Z = 5
+
 # Epoch gridlines: a faint dashed grey so the boundaries read as background
 # scaffolding behind the traces, never competing with the firebrick marks.
 _EPOCH_PEN = pg.mkPen((128, 128, 128, 110), width=1, style=QtCore.Qt.PenStyle.DashLine)
 _EPOCH_LABEL_COLOR = (128, 128, 128, 200)
 # The standard polysomnography scoring epoch; the sleep default everywhere.
 DEFAULT_EPOCH_SECONDS = 30.0
+
+
+class RaterOverlay(NamedTuple):
+    """One other rater's marks drawn read-only behind the editable layer (#181d).
+
+    ``color`` is the rater's legend colour (RGB); ``visible`` lets the window
+    show/hide a rater without rebuilding the data.
+    """
+
+    rater_id: str
+    annotations: list[Annotation]
+    color: tuple[int, int, int]
+    visible: bool = True
 
 
 class TimeAxis(pg.AxisItem):
@@ -256,6 +284,9 @@ class TraceView(pg.PlotWidget):
         self._annotations: list[Annotation] = []
         self._selected = -1
         self._annotation_items: list[pg.LinearRegionItem | pg.InfiniteLine] = []
+        # Other raters' read-only marks, drawn behind the editable layer (#181d).
+        self._overlays: list[RaterOverlay] = []
+        self._overlay_items: list[pg.LinearRegionItem | pg.InfiniteLine] = []
         self._curves: list[pg.PlotDataItem] = []
 
         self._viewbox.dragFinished.connect(self._on_drag_finished)
@@ -306,6 +337,7 @@ class TraceView(pg.PlotWidget):
         self._provider = provider
         self._window_start = 0.0
         self._epoch_anchor = 0.0  # a new recording starts epoch 1 at its start
+        self._overlays = []  # peers belong to the previous recording; window reloads
         # Show every channel in file order by default; a profile may narrow this.
         self._visible = list(range(len(provider.ch_names))) if provider else []
         self._build_curves()
@@ -540,6 +572,15 @@ class TraceView(pg.PlotWidget):
         self._selected = selected
         self._refresh_annotations()
 
+    def set_overlays(self, overlays: list[RaterOverlay]) -> None:
+        """Replace the other-rater overlays drawn behind the editable layer (#181d).
+
+        Read-only and never selectable — clicks only ever hit the editable
+        annotations — so a peer rater's marks are visible context, not editable.
+        """
+        self._overlays = list(overlays)
+        self._refresh_overlays()
+
     # ----- interaction ---------------------------------------------------------
 
     def _on_drag_finished(self, lo: float, hi: float) -> None:
@@ -727,6 +768,48 @@ class TraceView(pg.PlotWidget):
             item.setZValue(10)
             plot_item.addItem(item)
             self._annotation_items.append(item)
+        self._refresh_overlays()  # peers redraw with the editable layer on scroll
+
+    def _refresh_overlays(self) -> None:
+        """Redraw the read-only other-rater overlays for the visible window (#181d).
+
+        Each visible rater's marks paint in that rater's colour, below the
+        editable layer and with no selection styling — visible context only.
+        """
+        plot_item = self.getPlotItem()
+        assert plot_item is not None
+        for old in self._overlay_items:
+            plot_item.removeItem(old)
+        self._overlay_items = []
+        if self._provider is None:
+            return
+        lo = self._window_start
+        hi = self._window_start + self._window_seconds
+        for overlay in self._overlays:
+            if not overlay.visible:
+                continue
+            red, green, blue = overlay.color
+            brush = (red, green, blue, 45)
+            pen = (red, green, blue, 200)
+            for a in overlay.annotations:
+                if a.onset + a.duration < lo or a.onset > hi:
+                    continue
+                item: pg.LinearRegionItem | pg.InfiniteLine
+                if a.duration > 0:
+                    item = pg.LinearRegionItem(
+                        values=(a.onset, a.onset + a.duration),
+                        movable=False,
+                        brush=brush,
+                        pen=pen,
+                    )
+                else:
+                    item = pg.InfiniteLine(
+                        pos=a.onset, angle=90, movable=False, pen=pg.mkPen(pen, width=1)
+                    )
+                item.setToolTip(f"{overlay.rater_id}: {a.description}")
+                item.setZValue(_OVERLAY_Z)
+                plot_item.addItem(item)
+                self._overlay_items.append(item)
 
     def _refresh_epochs(self) -> None:
         """Redraw the epoch boundary gridlines for the visible window.

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -36,6 +36,7 @@ from . import blind, dsp, io
 from .annotations import (
     Annotation,
     autosave_path,
+    discover_rater_sidecars,
     insert,
     rater_autosave_path,
     rater_sidecar_paths,
@@ -49,7 +50,7 @@ from .annotations import (
 )
 from .profiles import FILE_FILTER as PROFILE_FILE_FILTER
 from .profiles import PROFILE_SUFFIX, ViewProfile, read_view_profile, write_view_profile
-from .view import DEFAULT_EPOCH_SECONDS, TraceView
+from .view import DEFAULT_EPOCH_SECONDS, OVERLAY_COLORS, RaterOverlay, TraceView
 
 if TYPE_CHECKING:  # matplotlib is heavy: import the export module only on demand
     from .export import ExportOptions
@@ -598,6 +599,13 @@ class EegReviewWindow(QtWidgets.QMainWindow):
                 self._blind = blind.resolve_blind(blind_spec)
             except (OSError, ValueError) as exc:
                 self._blind_error = str(exc)
+        # Other raters' sidecars overlaid read-only for comparison (#181d): the
+        # discovered (rater_id, marks, colour) layers and which are hidden. Only
+        # ever populated in a non-blind review (a blind rater sees no peers).
+        self._rater_layers: list[
+            tuple[str, list[Annotation], tuple[int, int, int]]
+        ] = []
+        self._hidden_raters: set[str] = set()
         # Annotations recovered from an autosave, held until the user restores or
         # dismisses them (#176).
         self._recovery_annotations: list[Annotation] | None = None
@@ -1058,6 +1066,13 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         buttons.addWidget(self.editButton)
         buttons.addWidget(self.deleteButton)
         panel.addLayout(buttons)
+        # Other raters (#181d): a legend of show/hide toggles for the read-only
+        # overlays. Hidden until peer sidecars are found (and never in blind mode).
+        self.ratersGroup = QtWidgets.QGroupBox("Other raters", self)
+        self.ratersLayout = QtWidgets.QVBoxLayout(self.ratersGroup)
+        self.ratersGroup.setVisible(False)
+        self._rater_checks: list[QtWidgets.QCheckBox] = []
+        panel.addWidget(self.ratersGroup)
         return panel
 
     def _build_shortcuts(self) -> None:
@@ -1213,6 +1228,76 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         )
         self._set_blind(config)
 
+    # ----- other-rater overlays (#181) -------------------------------------------
+
+    def _load_overlays(self) -> None:
+        """Discover peer rater sidecars and overlay them read-only (#181d).
+
+        Never in a blind review — a blind rater must not see their peers — and
+        the rater's own file is excluded (it is the editable layer). A peer file
+        that won't parse is skipped, not fatal.
+        """
+        self._clear_rater_toggles()
+        self._rater_layers = []
+        self._hidden_raters = set()
+        if self._recording is None or self._blind is not None:
+            self.ratersGroup.setVisible(False)
+            self.view.set_overlays([])
+            return
+        siblings = discover_rater_sidecars(self._recording.path)
+        siblings.pop(self._rater_id or "", None)  # never overlay our own file
+        for index, (rater_id, sidecar) in enumerate(siblings.items()):
+            try:
+                marks = read_annotations_tsv(sidecar)
+            except (OSError, ValueError):
+                continue
+            color = OVERLAY_COLORS[index % len(OVERLAY_COLORS)]
+            self._rater_layers.append((rater_id, marks, color))
+        self._build_rater_toggles()
+        self._apply_overlays()
+
+    def _apply_overlays(self) -> None:
+        """Push the current (visible) overlay layers to the view."""
+        self.view.set_overlays(
+            [
+                RaterOverlay(
+                    rater_id, marks, color, rater_id not in self._hidden_raters
+                )
+                for rater_id, marks, color in self._rater_layers
+            ]
+        )
+
+    def _build_rater_toggles(self) -> None:
+        """Rebuild the legend of colored show/hide checkboxes, one per peer rater."""
+        self._clear_rater_toggles()
+        for rater_id, marks, color in self._rater_layers:
+            check = QtWidgets.QCheckBox(f"{rater_id} ({len(marks)})", self)
+            check.setChecked(rater_id not in self._hidden_raters)
+            check.setStatusTip(f"Show or hide rater {rater_id}'s marks.")
+            red, green, blue = color
+            check.setStyleSheet(f"color: rgb({red}, {green}, {blue});")
+            check.toggled.connect(
+                lambda on, name=rater_id: self._toggle_rater(name, on)
+            )
+            self.ratersLayout.addWidget(check)
+            self._rater_checks.append(check)
+        self.ratersGroup.setVisible(bool(self._rater_layers))
+
+    def _clear_rater_toggles(self) -> None:
+        while self.ratersLayout.count():
+            item = self.ratersLayout.takeAt(0)
+            widget = item.widget() if item is not None else None
+            if widget is not None:
+                widget.deleteLater()
+        self._rater_checks = []
+
+    def _toggle_rater(self, rater_id: str, visible: bool) -> None:
+        if visible:
+            self._hidden_raters.discard(rater_id)
+        else:
+            self._hidden_raters.add(rater_id)
+        self._apply_overlays()
+
     # ----- opening a recording ---------------------------------------------------
 
     def open_file(self) -> None:
@@ -1300,6 +1385,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             f"{path.name} — {len(recording.ch_names)} ch · "
             f"{recording.sfreq:g} Hz · {recording.duration:.0f} s{clock}"
         )
+        self._load_overlays()
         self._check_for_recovery(tsv_path)
 
     def _fresh_annotations(

--- a/tests/test_eeg_annotations.py
+++ b/tests/test_eeg_annotations.py
@@ -133,6 +133,43 @@ def test_rater_autosave_path_is_distinct_from_the_sidecar():
     assert auto != tsv
 
 
+def test_rater_id_from_sidecar_reads_the_id():
+    src = Path("/data/night1.edf")
+    assert ann.rater_id_from_sidecar(
+        src, Path("/data/night1.annotations.alice.tsv")
+    ) == ("alice")
+
+
+def test_rater_id_from_sidecar_rejects_non_rater_files():
+    src = Path("/data/night1.edf")
+    cases = [
+        "/data/night1.annotations.tsv",  # the plain sidecar (no id)
+        "/data/night1.annotations.alice.autosave.tsv",  # an autosave (dotted middle)
+        "/data/night1.annotations.alice.json",  # not a TSV
+        "/data/other.annotations.alice.tsv",  # a different recording
+    ]
+    assert all(ann.rater_id_from_sidecar(src, Path(c)) is None for c in cases)
+
+
+def test_discover_rater_sidecars_finds_only_rater_tsvs(tmp_path):
+    src = tmp_path / "night1.edf"
+    for name in (
+        "night1.annotations.alice.tsv",
+        "night1.annotations.bob.tsv",
+        "night1.annotations.tsv",  # plain sidecar — excluded
+        "night1.annotations.alice.autosave.tsv",  # autosave — excluded
+        "night1.annotations.bob.json",  # JSON — excluded
+    ):
+        (tmp_path / name).write_text("onset\tduration\tdescription\n", encoding="utf-8")
+    found = ann.discover_rater_sidecars(src)
+    assert sorted(found) == ["alice", "bob"]
+    assert found["alice"].name == "night1.annotations.alice.tsv"
+
+
+def test_discover_rater_sidecars_empty_when_none(tmp_path):
+    assert ann.discover_rater_sidecars(tmp_path / "night1.edf") == {}
+
+
 # ----- TSV round-trip -------------------------------------------------------
 
 

--- a/tests/test_eeg_view.py
+++ b/tests/test_eeg_view.py
@@ -16,7 +16,7 @@ from PyQt6 import QtCore, QtGui
 
 from smacc.eeg import dsp
 from smacc.eeg.annotations import Annotation
-from smacc.eeg.view import DEFAULT_TYPE_SCALES, TimeAxis, TraceView
+from smacc.eeg.view import DEFAULT_TYPE_SCALES, RaterOverlay, TimeAxis, TraceView
 
 SFREQ = 100.0
 DURATION = 60.0
@@ -175,6 +175,58 @@ def test_point_annotations_get_click_tolerance(loaded):
     tolerance = view.window_seconds * 0.005
     assert view._annotation_at(10.0 + tolerance / 2) == 0
     assert view._annotation_at(10.0 + tolerance * 3) == -1
+
+
+# ----- other-rater overlays (#181d) -----------------------------------------
+
+
+def test_overlays_draw_only_visible_layers_in_window(loaded):
+    view, _ = loaded
+    view.set_overlays(
+        [
+            RaterOverlay(
+                "alice",
+                [Annotation(5.0, 2.0, "a"), Annotation(55.0, 0.0, "offscreen")],
+                (230, 159, 0),
+                True,
+            ),
+            RaterOverlay("bob", [Annotation(8.0, 0.0, "b")], (0, 158, 115), False),
+        ]
+    )
+    # Only alice's in-window region: her offscreen mark and hidden bob are skipped.
+    assert len(view._overlay_items) == 1
+    assert isinstance(view._overlay_items[0], pg.LinearRegionItem)
+
+
+def test_overlays_are_not_click_selectable(loaded):
+    view, _ = loaded
+    view.set_annotations([Annotation(20.0, 0.0, "mine")])
+    view.set_overlays(
+        [RaterOverlay("alice", [Annotation(10.0, 0.0, "theirs")], (230, 159, 0), True)]
+    )
+    assert view._annotation_at(10.0) == -1  # a peer's mark selects nothing
+    assert view._annotation_at(20.0) == 0  # the editable mark still selectable
+
+
+def test_overlays_redraw_on_scroll(loaded):
+    view, _ = loaded
+    view.set_overlays(
+        [RaterOverlay("alice", [Annotation(40.0, 0.0, "late")], (230, 159, 0), True)]
+    )
+    assert view._overlay_items == []  # 40 s mark is outside the 0–30 s window
+    view.set_window_start(35.0)
+    assert len(view._overlay_items) == 1  # now in view
+
+
+def test_set_provider_clears_overlays(loaded):
+    view, _ = loaded
+    view.set_overlays(
+        [RaterOverlay("alice", [Annotation(5.0, 0.0, "x")], (230, 159, 0), True)]
+    )
+    assert view._overlay_items
+    view.set_provider(FakeProvider())
+    assert view._overlays == []
+    assert view._overlay_items == []
 
 
 def test_click_selects_and_signals(loaded):

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -1422,3 +1422,58 @@ def test_bad_blind_spec_opens_unblinded(make_window, silence_dialogs):
     win = make_window(blind_spec="not-a-preset")
     assert win._blind is None
     assert win._blind_error is not None
+
+
+# ----- other-rater overlays (#181) ------------------------------------------
+
+
+def _write_rater(recording_path, rater_id, marks):
+    tsv, _ = rater_sidecar_paths(recording_path, rater_id)
+    write_annotations_tsv(marks, tsv)
+
+
+def test_overlays_load_peers_excluding_own(make_window, recording_path):
+    _write_rater(recording_path, "alice", [Annotation(5.0, 0.0, "x")])
+    _write_rater(recording_path, "bob", [Annotation(6.0, 0.0, "y")])
+    _write_rater(recording_path, "carol", [Annotation(7.0, 0.0, "z")])
+    win = make_window("alice")
+    win._load(recording_path)
+    assert [rid for rid, _, _ in win._rater_layers] == ["bob", "carol"]  # own excluded
+    assert win.ratersGroup.isVisible()
+    assert len(win._rater_checks) == 2
+
+
+def test_single_rater_coordinator_sees_all_peers(make_window, recording_path):
+    _write_rater(recording_path, "alice", [Annotation(5.0, 0.0, "x")])
+    _write_rater(recording_path, "bob", [Annotation(6.0, 0.0, "y")])
+    win = make_window()  # no rater id — editing the plain truth file
+    win._load(recording_path)
+    assert [rid for rid, _, _ in win._rater_layers] == ["alice", "bob"]
+
+
+def test_overlays_are_hidden_in_blind_mode(make_window, recording_path):
+    _write_rater(recording_path, "bob", [Annotation(6.0, 0.0, "y")])
+    win = make_window("alice")
+    win._blind = blind.preset_config(blind.PRESET_NAIVE)
+    win._load(recording_path)
+    assert win._rater_layers == []  # a blind rater must not see peers
+    assert not win.ratersGroup.isVisible()
+
+
+def test_toggling_a_rater_hides_its_overlay(make_window, recording_path):
+    _write_rater(recording_path, "bob", [Annotation(6.0, 0.0, "y")])
+    win = make_window("alice")
+    win._load(recording_path)
+    assert any(o.rater_id == "bob" and o.visible for o in win.view._overlays)
+    win._toggle_rater("bob", False)
+    assert "bob" in win._hidden_raters
+    assert all(not o.visible for o in win.view._overlays if o.rater_id == "bob")
+
+
+def test_corrupt_peer_sidecar_is_skipped(make_window, recording_path):
+    _write_rater(recording_path, "bob", [Annotation(6.0, 0.0, "y")])
+    carol_tsv, _ = rater_sidecar_paths(recording_path, "carol")
+    carol_tsv.write_text("not\ta\tsidecar\n", encoding="utf-8")
+    win = make_window("alice")
+    win._load(recording_path)
+    assert [rid for rid, _, _ in win._rater_layers] == ["bob"]  # carol skipped


### PR DESCRIPTION
Closes #181 (4 of 4). Stacked on #210 — review/merge that first.

The last piece: once several raters have scored a recording, their marks show as a read-only overlay for comparison. Each rater's marks paint in a distinct colour behind the editable layer, with a per-rater show/hide legend; only your own marks are clickable and editable.

- `eeg/view.py`: `RaterOverlay` + `set_overlays`/`_refresh_overlays`, drawn below the editable layer; click hit-testing still only hits your own marks.
- `eeg/annotations.py`: `discover_rater_sidecars`/`rater_id_from_sidecar` (skip the plain sidecar, autosaves, and your own file).
- Window: discovers peer sidecars on open, an "Other raters" toggle legend; overlays are off during a blind review, so a blind rater never sees peers.

Verified: ruff + mypy + the offscreen pytest-qt suite green (962 across the repo).