### PR TITLE
chore: disable codecov PR comments, set patch to informational

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,11 +11,13 @@ coverage:
   status:
     project:
       default:
+        name: codecov/project
         # SMACC is a GUI-heavy desktop app where some glue is hard to cover
         # headlessly, so 60% is a floor to ratchet up over time, not a ceiling.
         target: 60%
         threshold: 1% # tolerate a 1% dip before the check fails (anti-flap)
     patch:
       default:
+        name: codecov/patch
         target: 60% # ~60% of the lines a PR changes should be covered
         informational: true # patch result is visible but never blocks a merge

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -5,6 +5,8 @@
 # enforced as Codecov status checks (codecov/project and codecov/patch) posted on
 # each PR after the report uploads. To make them *block* merges, add those two
 # checks as required status checks in the branch protection rule for `main`.
+comment: false # status checks replace PR comments
+
 coverage:
   status:
     project:
@@ -16,4 +18,4 @@ coverage:
     patch:
       default:
         target: 60% # ~60% of the lines a PR changes should be covered
-        # Set `informational: true` here if patch gating gets noisy on GUI PRs.
+        informational: true # patch result is visible but never blocks a merge


### PR DESCRIPTION
Closes #212.

Adds `comment: false` to suppress Codecov's auto-comment on PRs — status checks
(`codecov/project`, `codecov/patch`) already carry the same information and are
visible in the PR checks list without the noise.

Also flips `patch` to `informational: true` so patch coverage is reported but
never blocks a merge. The `project` check still enforces the 60% floor.

**Follow-up:** add `codecov/project` and `codecov/patch` as required status
checks in the branch protection ruleset for `main` to make the project gate
block merges.