### PR TITLE
feat: parse the SMACC session log for the EEG annotator overlay

### DIFF
--- a/docs/reference/bids-export.md
+++ b/docs/reference/bids-export.md
@@ -12,7 +12,7 @@ Tab-separated, one header row plus one row per marker:
 ```text
 onset	duration	trial_type	value
 5.5	n/a	Lights off	47
-283.9	n/a	Dream report started	201
+1810.25	n/a	REM detected	41
 ```
 
 | Column       | Type             | Meaning                                                                |

--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -11,24 +11,31 @@ and two embedded snapshots of the full settings the run used. The study *designe
 Each line is three comma-separated fields:
 
 ```text
-YYYY-MM-DD HH:MM:SS.mmm, LEVEL, message
+YYYY-MM-DD HH:MM:SS.mmm±HHMM, LEVEL, message
 ```
 
-- **timestamp** — local wall-clock, millisecond precision.
+- **timestamp** — local wall-clock, millisecond precision, with the machine's UTC
+    offset (e.g. `-0500`). The offset lets a reader place the night on an absolute
+    timeline — for example when overlaying the log on an EEG recording whose clock
+    sits in another zone. Logs written before SMACC recorded the offset are
+    timezone-naive (no `±HHMM`); both forms are read back the same way.
 - **LEVEL** — a Python logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or
     `CRITICAL`. The file records every level; the live on-screen preview shows only a
     configurable subset.
 - **message** — the log text. An **event-marker** line ends in `" - portcode N"`:
 
 ```text
-2026-06-09 22:14:01.003, INFO, Opened SMACC v0.0.7
-2026-06-09 22:14:05.221, INFO, Lights off - portcode 47
-2026-06-09 22:18:30.880, INFO, Dream report started - portcode 201
-2026-06-09 22:19:02.114, INFO, Cue volume set to 0.40
+2026-06-09 22:14:01.003-0500, INFO, Opened SMACC v0.0.7
+2026-06-09 22:14:05.221-0500, INFO, Lights off - portcode 47
+2026-06-09 22:18:30.880-0500, INFO, Dream report started: report-01, t+00:04:29 - portcode 201
+2026-06-09 22:19:02.114-0500, INFO, Cue volume set to 0.40
 ```
 
 A marker line is `"{label} - portcode {code}"` when the event drives a trigger, or
-just `"{label}"` when it does not. The code-to-event map is the study's
+just `"{label}"` when it does not. A dream-report start names its recording
+(`report-NN`, matching `report-NN.wav` in the run folder) and its time since the
+recording-start marker, so the entry can be tied back to both its audio and its
+place in the EEG. The code-to-event map is the study's
 [`event_codes`](settings-file.md#event_codes) registry; see the
 [default code catalog](../triggers.md#default-event-codes).
 
@@ -56,8 +63,8 @@ marker lines up with the sound rather than SMACC's buffer (see
 `DEBUG` line:
 
 ```text
-2026-06-09 22:18:30.858, DEBUG, Cue started: Piano cue: software trigger at 22:18:30.858, marker advanced +22.0 ms to estimated onset (output latency)
-2026-06-09 22:18:30.880, INFO, Cue started: Piano cue - portcode 60
+2026-06-09 22:18:30.858-0500, DEBUG, Cue started: Piano cue: software trigger at 22:18:30.858, marker advanced +22.0 ms to estimated onset (output latency)
+2026-06-09 22:18:30.880-0500, INFO, Cue started: Piano cue - portcode 60
 ```
 
 That `DEBUG` line is deliberately **not** a `" - portcode N"` line, so the
@@ -70,8 +77,8 @@ line, one per message — in the file for the record, out of the live preview an
 the BIDS export by default:
 
 ```text
-2026-06-09 23:41:12.402, DEBUG, Chat to participant: Are you comfortable?
-2026-06-09 23:41:35.118, DEBUG, Chat from participant: yes
+2026-06-09 23:41:12.402-0500, DEBUG, Chat to participant: Are you comfortable?
+2026-06-09 23:41:35.118-0500, DEBUG, Chat from participant: yes
 ```
 
 If a study flips the chat events' triggers on, the marker lines fire alongside —

--- a/src/smacc/bids.py
+++ b/src/smacc/bids.py
@@ -17,10 +17,38 @@ from typing import Any
 
 import yaml
 
-_LOG_DATETIME_FMT = "%Y-%m-%d %H:%M:%S.%f"
 _PORTCODE_RE = re.compile(r"^(?P<label>.*) - portcode (?P<code>\d+)$")
 
 EVENT_COLUMNS = ["onset", "duration", "trial_type", "value"]
+
+
+def parse_timestamp(text: str) -> datetime | None:
+    """Parse a SMACC log timestamp, or ``None`` if it isn't one.
+
+    Accepts both the timezone-naive form older logs use
+    (``2026-06-05 22:00:00.000``) and the offset-aware form new logs write
+    (``2026-06-05 22:00:00.000-0500``, #215). ``datetime.fromisoformat`` reads
+    either, returning a naive or an aware datetime accordingly; a caller mixing
+    the two normalizes before subtracting (see :mod:`smacc.eeg.sessionlog`).
+    """
+    try:
+        return datetime.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def parse_marker(message: str) -> tuple[str, int] | None:
+    """Return ``(label, code)`` for an event-marker line, or ``None``.
+
+    A marker line ends in ``" - portcode N"``; the label is everything before
+    it. Shared by :func:`log_to_events` and the annotator's log overlay (#125)
+    so both recognize markers — and split off the label — identically.
+    """
+    match = _PORTCODE_RE.match(message)
+    if not match:
+        return None
+    return match.group("label"), int(match.group("code"))
+
 
 # Sentinels fencing a settings front-matter block embedded in the log. The block
 # records the config a session ran with so it can be recovered later. Every line
@@ -39,9 +67,8 @@ def parse_log(log_text: str) -> list[tuple[datetime, str, str]]:
         if len(parts) != 3:
             continue
         timestamp, level, message = parts
-        try:
-            when = datetime.strptime(timestamp, _LOG_DATETIME_FMT)
-        except ValueError:
+        when = parse_timestamp(timestamp)
+        if when is None:
             continue
         rows.append((when, level, message))
     return rows
@@ -59,15 +86,16 @@ def log_to_events(log_text: str) -> list[dict[str, Any]]:
     t0 = rows[0][0]
     events: list[dict[str, Any]] = []
     for when, _level, message in rows:
-        match = _PORTCODE_RE.match(message)
-        if not match:
+        marker = parse_marker(message)
+        if marker is None:
             continue
+        label, code = marker
         events.append(
             {
                 "onset": round((when - t0).total_seconds(), 3),
                 "duration": "n/a",
-                "trial_type": match.group("label"),
-                "value": int(match.group("code")),
+                "trial_type": label,
+                "value": code,
             }
         )
     return events

--- a/src/smacc/eeg/sessionlog.py
+++ b/src/smacc/eeg/sessionlog.py
@@ -1,0 +1,210 @@
+"""Parse a SMACC session log into timeline entries for the annotator overlay (#125).
+
+The EEG annotator can overlay a past session's ``.log`` on its timeline as a
+read-only reference track: every marker, cue, dream report, and survey shown
+where it happened, so a reviewer sees what SMACC *did* alongside the EEG. This
+module is the pure model behind that overlay — no GUI, no MNE — so it is
+directly unit-testable and safe to import in the frozen ``SMACC-EEG.exe``. It
+builds on the log parsers in :mod:`smacc.bids` (shared with the Analyze window),
+adding the per-entry classification, dream-report numbering, and the wall-clock
+placement math the overlay needs.
+
+**Placement.** A log line carries a wall-clock timestamp (the recording PC's
+clock); the EEG carries data-seconds from its own start. To draw a log entry on
+the EEG timeline it is placed at ``(entry_time - origin) + offset`` seconds,
+where ``origin`` is the recording's data-second-0 wall time (from
+:func:`smacc.eeg.window.wall_time`, which owns the per-format clock rule) and
+``offset`` is the manual/auto clock-skew correction. Both sides are compared as
+naive *wall-clock readings* (:func:`wall_clock_naive`): a new offset-aware log
+(#215) and an old naive one place identically, and a tz-aware origin never
+raises against a naive log.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+
+from ..bids import parse_log, parse_marker
+
+# Entry kinds. A marker line ("… - portcode N") is one of REPORT/SURVEY/MARKER
+# by what it points at; any other parseable log line is OTHER (a soft
+# interaction or a system line), carried so the overlay's per-level filter can
+# show it.
+MARKER = "marker"
+REPORT = "report"  # a dream-report start — points at report-NN.wav
+SURVEY = "survey"  # a survey opened/submitted — points at a response file
+OTHER = "other"
+
+# App-defined marker labels (from smacc.events) whose entries carry a session
+# artifact, matched against the label parsed off a "… - portcode N" line. Kept
+# as literals so this pure model needn't import the live event registry; the
+# labels are app-defined and stable (a study overrides codes/routing, not
+# labels — see the portcodes reference).
+_REPORT_LABEL = "Dream report started"
+_SURVEY_LABELS = ("Survey opened", "Survey submitted")
+# The report's file stem as written into the log line by the recording panel
+# ("Dream report started: report-02, t+…"); lets an entry resolve report-NN.wav
+# directly, robust to a saturated increment band or a dropped entry.
+_REPORT_NUMBER_RE = re.compile(r"report-(\d+)")
+
+
+@dataclass(frozen=True)
+class LogEntry:
+    """One parseable line of a session log, classified for the overlay.
+
+    ``timestamp`` is the line's wall clock (naive for an old log, offset-aware
+    for a new one). ``code``/``label`` are filled for a marker line (the label
+    is the message minus its ``" - portcode N"`` suffix), ``None`` otherwise.
+    ``kind`` is one of :data:`MARKER`/:data:`REPORT`/:data:`SURVEY`/:data:`OTHER`;
+    ``report_number`` is the resolved ``report-NN`` index for a :data:`REPORT`
+    entry (explicit from the line, else its 1-based order among reports), and
+    ``None`` for every other kind.
+    """
+
+    timestamp: datetime
+    level: str
+    message: str
+    code: int | None
+    label: str | None
+    kind: str
+    report_number: int | None
+
+
+def parse_session_log(log_text: str) -> list[LogEntry]:
+    """Classify every parseable line of ``log_text`` into :class:`LogEntry` rows.
+
+    Order is the log's own (chronological). Marker lines are recognized via
+    :func:`smacc.bids.parse_marker`; dream reports are numbered in order, taking
+    the explicit ``report-NN`` from the line when present and falling back to
+    their 1-based position so an old log (no number in the line) still resolves.
+    """
+    entries: list[LogEntry] = []
+    report_index = 0
+    for when, level, message in parse_log(log_text):
+        marker = parse_marker(message)
+        if marker is None:
+            entries.append(LogEntry(when, level, message, None, None, OTHER, None))
+            continue
+        label, code = marker
+        kind = _classify(label)
+        number: int | None = None
+        if kind == REPORT:
+            report_index += 1
+            match = _REPORT_NUMBER_RE.search(message)
+            number = int(match.group(1)) if match else report_index
+        entries.append(LogEntry(when, level, message, code, label, kind, number))
+    return entries
+
+
+def read_session_log(path: str | Path) -> list[LogEntry]:
+    """Read a ``.log`` file and parse it into :class:`LogEntry` rows.
+
+    Raises:
+        OSError: if the file can't be read.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    return parse_session_log(text)
+
+
+def _classify(label: str) -> str:
+    """Map a marker label to its artifact-bearing kind (or plain :data:`MARKER`)."""
+    if label.startswith(_REPORT_LABEL):
+        return REPORT
+    if any(label.startswith(prefix) for prefix in _SURVEY_LABELS):
+        return SURVEY
+    return MARKER
+
+
+def wall_clock_naive(when: datetime) -> datetime:
+    """Return ``when`` as a naive wall-clock reading (drop any UTC offset).
+
+    The log's timestamps and the EEG origin are compared as the clock *readings*
+    they show, not as absolute instants: a log written ``22:00:00-0500`` reads
+    22:00 on the recording-PC clock, and dropping the offset keeps that — never
+    converting it into the reviewer's zone. The origin from
+    :func:`smacc.eeg.window.wall_time` already applies the per-format rule (a
+    true-UTC FIF ``meas_date`` is localized there; an EDF/BrainVision wall-clock
+    stamp is left as-is), so stripping here is the matching, format-agnostic step.
+    """
+    return when.replace(tzinfo=None) if when.tzinfo is not None else when
+
+
+def seconds_at(entry: LogEntry, origin: datetime, offset: float = 0.0) -> float:
+    """Data-seconds where ``entry`` lands: ``(entry - origin) + offset``.
+
+    ``origin`` is the recording's data-second-0 wall time; ``offset`` is the
+    clock-skew correction (manual drag/pair or an auto estimate). Both sides are
+    reduced to wall-clock readings first, so a naive and an offset-aware log
+    place identically and the subtraction never mixes aware with naive.
+    """
+    delta = wall_clock_naive(entry.timestamp) - wall_clock_naive(origin)
+    return delta.total_seconds() + offset
+
+
+def log_span(entries: list[LogEntry]) -> tuple[datetime, datetime] | None:
+    """Return ``(first, last)`` entry timestamps, or ``None`` for an empty log."""
+    if not entries:
+        return None
+    return entries[0].timestamp, entries[-1].timestamp
+
+
+def report_wav(entry: LogEntry, folder: str | Path) -> Path | None:
+    """Return the ``report-NN.wav`` a dream-report entry points at, if it exists.
+
+    Resolved by the session's own naming convention (``report-02.wav`` beside the
+    log); ``None`` for a non-report entry, an unnumbered one, or a missing file.
+    The audio half of #179 plays exactly this file.
+    """
+    if entry.kind != REPORT or entry.report_number is None:
+        return None
+    wav = Path(folder) / f"report-{entry.report_number:02d}.wav"
+    return wav if wav.is_file() else None
+
+
+class LogTimeline:
+    """A zero-channel :class:`~smacc.eeg.view.SliceProvider` for standalone mode.
+
+    Lets the trace view show a log on a bare time axis with no EEG loaded (#125):
+    the view's channel/overlay split means a log-only display is the same widget
+    with a provider that has no channels and no samples — its only real datum is
+    the duration the log spans, so the axis and scrollbar size themselves. The
+    log marks are drawn by the overlay layer, not fetched through ``get_slice``.
+    """
+
+    def __init__(self, entries: list[LogEntry]) -> None:
+        self._entries = list(entries)
+
+    @property
+    def ch_names(self) -> list[str]:
+        return []
+
+    @property
+    def ch_types(self) -> list[str]:
+        return []
+
+    @property
+    def sfreq(self) -> float:
+        return 1.0
+
+    @property
+    def duration(self) -> float:
+        """Seconds from the first to the last log entry (0 for an empty log)."""
+        span = log_span(self._entries)
+        if span is None:
+            return 0.0
+        first, last = span
+        return (wall_clock_naive(last) - wall_clock_naive(first)).total_seconds()
+
+    @property
+    def meas_date(self) -> datetime | None:
+        """The first entry's timestamp — data-second 0 for standalone placement."""
+        return self._entries[0].timestamp if self._entries else None
+
+    def get_slice(self, start_s: float, stop_s: float) -> tuple[np.ndarray, np.ndarray]:
+        """No channels, so every slice is empty (the view draws no curves)."""
+        return np.empty(0), np.empty((0, 0))

--- a/src/smacc/panels/recording.py
+++ b/src/smacc/panels/recording.py
@@ -151,14 +151,17 @@ class RecordingWindow(PanelWindow):
                     self.surveyComboBox.currentText(),
                     report_number=self.n_report_counter,
                 )
-            # Stamp the report with the time since the "Start recording" marker so
-            # it can be found in the EEG file later (#60). With no marker yet, still
-            # log the report right away, then tell the user it's untimed. When the
-            # registry's increment flag is on, each start also advances its code
-            # (201, 202, …) automatically, so reports stay individually findable.
+            # Stamp the report with its file name (report-NN) and the time since
+            # the "Start recording" marker, so a later reviewer can tie the log
+            # entry to both its WAV and its place in the EEG (#60, #125). The
+            # number is the WAV's (set in _start_recording just above); naming it
+            # in the line lets the annotator resolve report-NN.wav even when the
+            # increment band saturates or an entry is dropped. With no marker yet,
+            # still log the report right away, then tell the user it's untimed.
+            report = f"report-{self.n_report_counter:02d}"
             elapsed = self.session.elapsed_since_recording()
             if elapsed is None:
-                self.session.emit_event("DreamReportStarted")
+                self.session.emit_event("DreamReportStarted", detail=report)
                 self.session.show_info_popup(
                     "Recording start not marked.",
                     "This dream report was logged, but the “Start recording” "
@@ -168,7 +171,8 @@ class RecordingWindow(PanelWindow):
                 )
             else:
                 self.session.emit_event(
-                    "DreamReportStarted", detail=f"t+{format_elapsed(elapsed)}"
+                    "DreamReportStarted",
+                    detail=f"{report}, t+{format_elapsed(elapsed)}",
                 )
         else:
             self._stop_recording()

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -38,6 +38,33 @@ def make_session_dir(base: Path, now: datetime) -> Path:
     return session_dir
 
 
+class _LogFormatter(logging.Formatter):
+    """Format a log line as ``YYYY-MM-DD HH:MM:SS.mmm±HHMM, LEVEL, message``.
+
+    The timezone offset (#215) stamps each line with the machine's local UTC
+    offset, so a later reader can place the night on an absolute timeline —
+    notably when overlaying the log onto an EEG recording whose clock may sit in
+    a different zone (#125). Older logs are timezone-naive;
+    :func:`smacc.bids.parse_log` reads both forms.
+
+    The whole timestamp (date, time, milliseconds, offset) is built in
+    :meth:`formatTime` rather than split across ``datefmt`` + a ``%(msecs)03d``
+    field, because the offset has to land after the milliseconds and ``asctime``
+    would otherwise emit it in the middle. ``record.created``/``record.msecs``
+    stay the source of truth, so an onset-corrected marker (which sets both by
+    hand in ``_log_marker``) still stamps at its estimated onset. Only the time
+    field is overridden, so the base formatter still appends an ``exc_info``
+    traceback to a CRITICAL line.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(fmt="%(asctime)s, %(levelname)s, %(message)s")
+
+    def formatTime(self, record: logging.LogRecord, datefmt: str | None = None) -> str:
+        when = datetime.fromtimestamp(record.created).astimezone()
+        return f"{when:%Y-%m-%d %H:%M:%S}.{int(record.msecs):03d}{when:%z}"
+
+
 class SmaccSession:
     """Shared session context: run folder, optional metadata, logger, LSL outlet.
 
@@ -153,11 +180,7 @@ class SmaccSession:
         # Per-run folders are unique, so a plain "w" never clobbers another run.
         fh = logging.FileHandler(log_path, mode="w", encoding="utf-8")
         fh.setLevel(logging.DEBUG)  # the file always records every level
-        formatter = logging.Formatter(
-            fmt="%(asctime)s.%(msecs)03d, %(levelname)s, %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
-        fh.setFormatter(formatter)
+        fh.setFormatter(_LogFormatter())
         self.logger.addHandler(fh)
         self._file_handler = fh
 

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -1,6 +1,7 @@
 """Tests for the BIDS events exporter (no GUI required)."""
 
 import csv
+from datetime import datetime, timedelta, timezone
 
 from smacc import bids, settings
 
@@ -9,6 +10,48 @@ SAMPLE_LOG = """2026-06-05 22:00:00.000, INFO, Opened SMACC v0.0.7
 2026-06-05 22:30:10.250, INFO, Note [saw a light] - portcode 201
 2026-06-05 22:45:00.000, INFO, Program closed
 """
+
+# The same session as SAMPLE_LOG, written by a newer SMACC that stamps each
+# line with the machine's UTC offset (#215).
+AWARE_LOG = """2026-06-05 22:00:00.000-0500, INFO, Opened SMACC v0.0.7
+2026-06-05 22:00:05.500-0500, INFO, Lights off - portcode 47
+2026-06-05 22:30:10.250-0500, INFO, Note [saw a light] - portcode 201
+2026-06-05 22:45:00.000-0500, INFO, Program closed
+"""
+
+
+def test_parse_timestamp_reads_naive_and_offset_aware():
+    naive = bids.parse_timestamp("2026-06-05 22:00:00.000")
+    assert naive == datetime(2026, 6, 5, 22, 0, 0)
+    assert naive.tzinfo is None
+    aware = bids.parse_timestamp("2026-06-05 22:00:00.000-0500")
+    assert aware.tzinfo is not None
+    assert aware.utcoffset() == timedelta(hours=-5)
+    assert aware == datetime(2026, 6, 5, 22, 0, 0, tzinfo=timezone(timedelta(hours=-5)))
+
+
+def test_parse_timestamp_rejects_non_timestamps():
+    assert bids.parse_timestamp("Program closed") is None
+    assert bids.parse_timestamp("") is None
+
+
+def test_parse_marker_splits_label_and_code():
+    assert bids.parse_marker("Lights off - portcode 47") == ("Lights off", 47)
+    assert bids.parse_marker("Cue started: Piano - portcode 60") == (
+        "Cue started: Piano",
+        60,
+    )
+
+
+def test_parse_marker_rejects_non_marker_lines():
+    assert bids.parse_marker("Opened SMACC v0.0.7") is None
+    assert bids.parse_marker("Cue volume set to 0.40") is None
+
+
+def test_log_to_events_handles_offset_aware_timestamps():
+    # A new offset-aware log yields the same data-relative onsets as the old
+    # naive one: onsets are deltas within one log, so the offset cancels out.
+    assert bids.log_to_events(AWARE_LOG) == bids.log_to_events(SAMPLE_LOG)
 
 
 def test_log_to_events_extracts_only_portcode_lines():

--- a/tests/test_eeg_sessionlog.py
+++ b/tests/test_eeg_sessionlog.py
@@ -1,0 +1,148 @@
+"""Tests for the session-log overlay model (#125, no GUI, no MNE)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from smacc.eeg import sessionlog as sl
+
+# A small but representative night: an open line, a marker, two dream reports
+# (the second's recording-start untimed-style line), a survey, and a soft DEBUG
+# line — covering every entry kind the overlay distinguishes.
+SAMPLE_LOG = """2026-06-05 22:00:00.000-0500, INFO, Opened SMACC v0.0.7
+2026-06-05 22:05:00.000-0500, INFO, Lights off - portcode 47
+2026-06-05 22:30:00.000-0500, DEBUG, Cue volume set to 0.40
+2026-06-05 22:31:00.000-0500, INFO, Dream report started: report-01, t+00:26:00 - portcode 201
+2026-06-05 22:32:00.000-0500, INFO, Survey opened: DLQ - portcode 67
+2026-06-05 23:10:00.000-0500, INFO, Dream report started: report-02, t+01:05:00 - portcode 202
+"""
+
+
+def _entry(entries, code):
+    return next(e for e in entries if e.code == code)
+
+
+# ----- parsing & classification ---------------------------------------------
+
+
+def test_parse_session_log_returns_every_parseable_line():
+    entries = sl.parse_session_log(SAMPLE_LOG)
+    assert len(entries) == 6  # incl. the open line and the DEBUG soft line
+    assert [e.level for e in entries].count("DEBUG") == 1
+
+
+def test_non_marker_lines_are_other_with_no_code():
+    entries = sl.parse_session_log(SAMPLE_LOG)
+    opened = entries[0]
+    assert opened.kind == sl.OTHER
+    assert opened.code is None and opened.label is None and opened.report_number is None
+
+
+def test_marker_line_carries_label_and_code():
+    lights = _entry(sl.parse_session_log(SAMPLE_LOG), 47)
+    assert lights.kind == sl.MARKER
+    assert lights.label == "Lights off"
+    assert lights.code == 47
+
+
+def test_dream_reports_classified_and_numbered_from_the_line():
+    entries = sl.parse_session_log(SAMPLE_LOG)
+    reports = [e for e in entries if e.kind == sl.REPORT]
+    assert [e.report_number for e in reports] == [1, 2]
+    assert [e.code for e in reports] == [201, 202]
+
+
+def test_survey_line_classified():
+    survey = _entry(sl.parse_session_log(SAMPLE_LOG), 67)
+    assert survey.kind == sl.SURVEY
+
+
+def test_report_number_falls_back_to_order_for_old_logs():
+    # An older log whose dream-report lines carry no "report-NN" token still
+    # numbers the reports by their order, matching report-01.wav / report-02.wav.
+    old = (
+        "2026-06-05 22:00:00.000, INFO, Opened SMACC\n"
+        "2026-06-05 22:31:00.000, INFO, Dream report started: t+00:31:00 - portcode 201\n"
+        "2026-06-05 23:10:00.000, INFO, Dream report started: t+01:10:00 - portcode 202\n"
+    )
+    reports = [e for e in sl.parse_session_log(old) if e.kind == sl.REPORT]
+    assert [e.report_number for e in reports] == [1, 2]
+
+
+# ----- placement math -------------------------------------------------------
+
+
+def test_seconds_at_places_relative_to_origin():
+    entries = sl.parse_session_log(SAMPLE_LOG)
+    origin = entries[0].timestamp  # the open line, 22:00:00
+    lights = _entry(entries, 47)  # 22:05:00, five minutes later
+    assert sl.seconds_at(lights, origin) == 300.0
+
+
+def test_seconds_at_applies_the_offset():
+    entries = sl.parse_session_log(SAMPLE_LOG)
+    origin = entries[0].timestamp
+    lights = _entry(entries, 47)
+    assert sl.seconds_at(lights, origin, offset=12.5) == 312.5
+
+
+def test_seconds_at_compares_wall_clock_readings_across_awareness():
+    # A naive origin (an EDF wall-clock meas_date) vs an offset-aware log entry:
+    # both are read as their wall-clock face value, so placement matches the
+    # naive case and the subtraction never raises on mixed awareness.
+    entries = sl.parse_session_log(SAMPLE_LOG)
+    aware_lights = _entry(entries, 47)  # 22:05:00-0500
+    naive_origin = datetime(2026, 6, 5, 22, 0, 0)  # 22:00, no tzinfo
+    assert sl.seconds_at(aware_lights, naive_origin) == 300.0
+
+
+def test_wall_clock_naive_strips_without_converting_zones():
+    aware = datetime(2026, 6, 5, 22, 0, 0, tzinfo=timezone(timedelta(hours=-5)))
+    stripped = sl.wall_clock_naive(aware)
+    assert stripped == datetime(2026, 6, 5, 22, 0, 0)  # 22:00 as written, not 03:00Z
+    assert stripped.tzinfo is None
+
+
+# ----- span / artifacts / standalone provider -------------------------------
+
+
+def test_log_span_returns_first_and_last_timestamps():
+    entries = sl.parse_session_log(SAMPLE_LOG)
+    span = sl.log_span(entries)
+    assert span == (entries[0].timestamp, entries[-1].timestamp)
+    assert sl.log_span([]) is None
+
+
+def test_report_wav_resolves_existing_file(tmp_path):
+    (tmp_path / "report-02.wav").write_bytes(b"RIFF")
+    entries = sl.parse_session_log(SAMPLE_LOG)
+    report2 = _entry(entries, 202)
+    assert sl.report_wav(report2, tmp_path) == tmp_path / "report-02.wav"
+    # report-01.wav was not written, so it resolves to None (missing file).
+    report1 = _entry(entries, 201)
+    assert sl.report_wav(report1, tmp_path) is None
+
+
+def test_report_wav_none_for_non_report_entry(tmp_path):
+    (tmp_path / "report-01.wav").write_bytes(b"RIFF")
+    lights = _entry(sl.parse_session_log(SAMPLE_LOG), 47)
+    assert sl.report_wav(lights, tmp_path) is None
+
+
+def test_log_timeline_is_a_zero_channel_provider():
+    entries = sl.parse_session_log(SAMPLE_LOG)
+    timeline = sl.LogTimeline(entries)
+    assert timeline.ch_names == []
+    assert timeline.ch_types == []
+    # 22:00:00 -> 23:10:00 is 70 minutes of span.
+    assert timeline.duration == 70 * 60
+    assert timeline.meas_date == entries[0].timestamp
+    times, data = timeline.get_slice(0.0, 30.0)
+    assert times.size == 0
+    assert data.shape == (0, 0)
+
+
+def test_log_timeline_empty_log():
+    timeline = sl.LogTimeline([])
+    assert timeline.duration == 0.0
+    assert timeline.meas_date is None

--- a/tests/test_panels_recording.py
+++ b/tests/test_panels_recording.py
@@ -79,6 +79,28 @@ def test_record_start_to_stop_writes_the_report_wav(
     window.cleanup()
 
 
+def test_dream_report_marker_names_its_recording(
+    qtbot, live_session, monkeypatch, silence_dialogs
+):
+    # The DreamReportStarted line carries its WAV name (report-NN), so the EEG
+    # annotator can tie the log entry back to report-NN.wav (#125). With no
+    # recording-start marker, the detail is just the report name (untimed).
+    _stub_recorder(monkeypatch)
+    live_session.devices.bindings["bedroom_mic_1"] = "Mic (Test)"
+    window = RecordingWindow(live_session)
+    qtbot.addWidget(window)
+    emitted = []
+    monkeypatch.setattr(
+        live_session,
+        "emit_event",
+        lambda key, detail=None, **k: emitted.append((key, detail)),
+    )
+    window.micrecordButton.setChecked(True)
+    window.start_or_stop_recording()
+    assert emitted == [("DreamReportStarted", "report-01")]
+    window.cleanup()
+
+
 def test_failed_start_reverts_button_and_leaves_no_numbering_gap(
     qtbot, live_session, monkeypatch, silence_dialogs
 ):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,11 +1,30 @@
 """Tests for the session-folder helper and emit_event routing (no LSL/GUI needed)."""
 
 import logging
+import re
 from dataclasses import replace
 from datetime import datetime
 
-from smacc import events, triggers
-from smacc.session import SmaccSession, make_session_dir
+from smacc import bids, events, triggers
+from smacc.session import SmaccSession, _LogFormatter, make_session_dir
+
+
+def test_log_formatter_stamps_offset_and_round_trips_through_parse_log():
+    # Each line carries the machine's UTC offset (#215) in a form bids.parse_log
+    # reads back, so the annotator can place the night on an absolute timeline.
+    record = logging.LogRecord(
+        "smacc", logging.INFO, "(smacc)", 0, "Lights off - portcode 47", (), None
+    )
+    line = _LogFormatter().format(record)
+    timestamp, level, message = line.split(", ", 2)
+    assert level == "INFO"
+    assert message == "Lights off - portcode 47"
+    # YYYY-MM-DD HH:MM:SS.mmm±HHMM — millisecond precision, then the offset.
+    assert re.fullmatch(
+        r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{4}", timestamp
+    )
+    when = bids.parse_timestamp(timestamp)
+    assert when is not None and when.tzinfo is not None
 
 
 def test_make_session_dir_uses_timestamp_stem(tmp_path):


### PR DESCRIPTION
First PR of the #125 stack (overlay the session log on the EEG annotator timeline). This one lands the shared log contract and the pure overlay model; no UI yet.

- Session-log timestamps now carry the machine's UTC offset (`…-0500`), so a reader can place the night on an absolute timeline when aligning the log to an EEG recording in another zone. Folds in the capture half of #215; `bids.parse_log` reads both the new offset-aware and the old naive form.
- `bids.parse_marker` becomes the single definition of an event-marker line, shared by the BIDS exporter and the new overlay model.
- The `DreamReportStarted` log line names its recording (`report-NN`), so a log entry resolves to `report-NN.wav` robustly (the linkage #179 needs).
- New pure `smacc.eeg.sessionlog` (no GUI, no MNE): `LogEntry`, classification, dream-report numbering, wall-clock placement math, `report_wav`, and the zero-channel `LogTimeline` provider that backs standalone mode.

Verified: `pytest` (984 pass, incl. new `test_eeg_sessionlog` and additions to `test_bids`/`test_session`/`test_panels_recording`), ruff + mypy + mdformat clean. Design rationale and the alignment plan are on the issue: https://github.com/remrama/smacc/issues/125#issuecomment-4693708321

Refs #125, #215, #179.
