### PR TITLE
feat: overlay the SMACC session log on the EEG annotator timeline

### DIFF
--- a/docs/eeg-review.md
+++ b/docs/eeg-review.md
@@ -72,6 +72,42 @@ duplicated).
 The sidecar format is documented in the
 [annotations file reference](reference/annotations-file.md).
 
+## Session log overlay
+
+Load the night's SMACC session [`.log`](reference/session-log.md) onto the
+timeline as a **read-only reference track** — every marker, cue, dream report,
+and survey shown where it happened, so you see what SMACC *did* alongside the
+EEG. Click **Load session log…** in the **Session log** panel (a recording must
+be open; the log aligns to *its* clock). Ticks appear in a thin lane across the
+top, coloured by log level, with the full message on hover. The per-level
+checkboxes show or hide levels just like the live preview — `DEBUG` (raw-trigger
+and volume-edit noise) is off by default. The log is reference context only: it
+is never editable and never saved into your annotations.
+
+**Aligning the log.** The log's timestamps come from the recording PC while the
+EEG's clock comes from the amplifier, so the two can differ by seconds or more.
+Slide the whole log along the EEG to line them up, three ways — all adjusting one
+offset:
+
+- **Drag the log lane.** A left-drag that starts in the top lane slides the log
+    (a drag anywhere else still draws an annotation). On release it snaps onto a
+    nearby mark of yours, so a clapper lands exactly on the artifact it made.
+- **Pair an entry to a feature.** Select a log entry, click **Align entry to
+    feature…**, then click the EEG feature it produced — useful when the two are
+    far apart to drag. (Esc cancels.)
+- **Nudge the offset.** The **Offset** box is the exact value, and the fine
+    control.
+
+The classic clapper workflow fits directly: press **Clapper** on the SMACC PC at
+the same instant as a manual trigger on the recording system, then pair (or drag)
+the logged clapper onto the marker it left in the EEG. Clapping at both lights-off
+and lights-on gives two reference points. A recording with no start time
+(anonymized) has no absolute anchor, so the log starts at its first entry and you
+align it entirely by hand.
+
+The log is **never shown in a blind review** — it records every cue and portcode,
+which would unblind the rater.
+
 ## Multiple raters
 
 For blind, multi-rater scoring, give each reviewer a **rater id** — click the

--- a/src/smacc/eeg/view.py
+++ b/src/smacc/eeg/view.py
@@ -23,6 +23,7 @@ no MNE and nothing from the wider app.
 
 from __future__ import annotations
 
+import bisect
 import math
 from datetime import datetime, timedelta
 from typing import Any, NamedTuple, Protocol
@@ -85,6 +86,40 @@ _EPOCH_PEN = pg.mkPen((128, 128, 128, 110), width=1, style=QtCore.Qt.PenStyle.Da
 _EPOCH_LABEL_COLOR = (128, 128, 128, 200)
 # The standard polysomnography scoring epoch; the sleep default everywhere.
 DEFAULT_EPOCH_SECONDS = 30.0
+
+# Session-log overlay (#125): the parsed log is drawn as a read-only reference
+# track in a thin lane across the top of the plot, kept clear of the traces and
+# the editable/peer marks below it. A log mark is an instantaneous tick spanning
+# only this lane (the top _LOG_LANE_FRAC..1.0 of the viewbox height), so a
+# left-drag that starts up here slides the whole log instead of drawing a span.
+_LOG_LANE_FRAC = 0.92
+# Per-level tick colour, keyed by logging level name. Markers (INFO) are the
+# common case and read in a calm slate; warnings/errors escalate to amber/red so
+# a mid-session fault stands out even as reference context. z below the peer
+# overlays (5) and editable marks (10), above the epoch grid (2).
+_LOG_LEVEL_COLORS: dict[str, tuple[int, int, int]] = {
+    "DEBUG": (150, 150, 150),
+    "INFO": (70, 90, 130),
+    "WARNING": (200, 150, 0),
+    "ERROR": (200, 60, 60),
+    "CRITICAL": (200, 60, 60),
+}
+_LOG_DEFAULT_COLOR = (70, 90, 130)
+_LOG_Z = 4
+
+
+class LogMark(NamedTuple):
+    """One session-log entry placed on the EEG timeline for the overlay (#125).
+
+    ``seconds`` is the data-second the entry aligns to (the window computes it
+    from the log time, the recording origin, and the clock-skew offset);
+    ``level`` selects the tick colour; ``tooltip`` is the hover text (clock time,
+    level, and the log message). Read-only — the view never selects or edits it.
+    """
+
+    seconds: float
+    level: str
+    tooltip: str
 
 
 class RaterOverlay(NamedTuple):
@@ -182,18 +217,66 @@ class _AnnotateViewBox(pg.ViewBox):
     dragFinished = QtCore.pyqtSignal(float, float)  # span in data seconds
     clicked = QtCore.pyqtSignal(float)  # click time in data seconds
     markRequested = QtCore.pyqtSignal(float)  # ctrl-click: drop a point mark here
+    logSlideStarted = QtCore.pyqtSignal()  # a log-lane drag began (#125)
+    logSlideMoved = QtCore.pyqtSignal(float)  # live log-lane drag delta (seconds)
+    logSlideFinished = QtCore.pyqtSignal(float)  # log-lane drag released (seconds)
 
     def __init__(self) -> None:
         super().__init__(enableMouse=False, enableMenu=False)
         self._preview: pg.LinearRegionItem | None = None
+        # When a session log is overlaid (#125), a drag that *starts* in its top
+        # lane slides the log instead of drawing a span. Off by default, so with
+        # no log loaded the whole plot draws annotations as before.
+        self._log_lane_active = False
+        self._sliding = False
+        # Pick mode (#125 manual alignment): every gesture only reports a time
+        # to pair with a log entry — no span is drawn, no mark dropped — so an
+        # accidental drag while aiming can't edit the rater's own annotations.
+        self._pick_active = False
+
+    def set_log_lane_active(self, active: bool) -> None:
+        """Enable the top-lane log slide (only while a log overlay is loaded)."""
+        self._log_lane_active = active
+        if not active:
+            self._sliding = False  # never strand a slide when the lane is dropped
+
+    def set_pick_active(self, active: bool) -> None:
+        """Enter/leave pick mode: gestures only pick a time, never edit marks."""
+        self._pick_active = active
+
+    def _in_log_lane(self, local_pos: Any) -> bool:
+        """True if ``local_pos`` (item coords) is in the top log lane."""
+        rect = self.boundingRect()
+        return (local_pos.y() - rect.top()) <= rect.height() * (1.0 - _LOG_LANE_FRAC)
 
     def mouseDragEvent(self, ev: Any, axis: int | None = None) -> None:
         if ev.button() != QtCore.Qt.MouseButton.LeftButton:
             ev.ignore()
             return
         ev.accept()
+        # In pick mode a drag must not draw a span or slide — the whole gesture
+        # is reserved for picking a time (the click path reports it). Swallow it.
+        if self._pick_active:
+            return
         start = float(self.mapToView(ev.buttonDownPos()).x())
         current = float(self.mapToView(ev.pos()).x())
+        # Decide the gesture once, at the drag's start, and hold it: a drag that
+        # began in the log lane slides the log for its whole duration even as the
+        # cursor leaves the lane.
+        if ev.isStart():
+            self._sliding = self._log_lane_active and self._in_log_lane(
+                ev.buttonDownPos()
+            )
+            if self._sliding:
+                self.logSlideStarted.emit()  # the window re-bases its offset here
+        if self._sliding:
+            delta = current - start
+            if ev.isFinish():
+                self._sliding = False
+                self.logSlideFinished.emit(delta)
+            else:
+                self.logSlideMoved.emit(delta)
+            return
         lo, hi = sorted((start, current))
         if self._preview is None:
             self._preview = pg.LinearRegionItem(
@@ -213,6 +296,11 @@ class _AnnotateViewBox(pg.ViewBox):
             return
         ev.accept()
         seconds = float(self.mapToView(ev.pos()).x())
+        # In pick mode every click (modifier or not) just reports its time; the
+        # ctrl-modifier never drops a mark while the rater is aiming an alignment.
+        if self._pick_active:
+            self.clicked.emit(seconds)
+            return
         # Ctrl+click drops a point mark; a plain click selects. The modifier
         # keeps the frequent selection-click from ever creating stray markers.
         if ev.modifiers() & QtCore.Qt.KeyboardModifier.ControlModifier:
@@ -248,6 +336,10 @@ class TraceView(pg.PlotWidget):
       window can sync its scrollbar.
     * ``cursorMoved(seconds)`` — mouse position, for the status-bar clock.
     * ``pointMarkRequested(seconds)`` — ctrl-click asked for a point mark here.
+    * ``logSlideMoved/Finished(delta)`` — a drag in the log lane is sliding/has
+      slid the overlay by ``delta`` seconds (#125 manual alignment).
+    * ``timePicked(seconds)`` — a click while in pick mode chose this time (used
+      to pair a log entry with the EEG feature it produced).
     """
 
     regionDrawn = QtCore.pyqtSignal(float, float)
@@ -255,6 +347,10 @@ class TraceView(pg.PlotWidget):
     windowChanged = QtCore.pyqtSignal(float)
     cursorMoved = QtCore.pyqtSignal(float)
     pointMarkRequested = QtCore.pyqtSignal(float)
+    logSlideStarted = QtCore.pyqtSignal()
+    logSlideMoved = QtCore.pyqtSignal(float)
+    logSlideFinished = QtCore.pyqtSignal(float)
+    timePicked = QtCore.pyqtSignal(float)
 
     def __init__(self) -> None:
         self._viewbox = _AnnotateViewBox()
@@ -287,11 +383,21 @@ class TraceView(pg.PlotWidget):
         # Other raters' read-only marks, drawn behind the editable layer (#181d).
         self._overlays: list[RaterOverlay] = []
         self._overlay_items: list[pg.LinearRegionItem | pg.InfiniteLine] = []
+        # Session-log overlay (#125): read-only ticks in the top lane, kept sorted
+        # by time so only the visible window is drawn on each scroll.
+        self._log_marks: list[LogMark] = []
+        self._log_items: list[pg.InfiniteLine] = []
+        # Pick mode: a click reports its time (to pair a log entry to an EEG
+        # feature) instead of selecting an annotation.
+        self._pick_mode = False
         self._curves: list[pg.PlotDataItem] = []
 
         self._viewbox.dragFinished.connect(self._on_drag_finished)
         self._viewbox.clicked.connect(self._on_clicked)
         self._viewbox.markRequested.connect(self._on_mark_requested)
+        self._viewbox.logSlideStarted.connect(self.logSlideStarted)
+        self._viewbox.logSlideMoved.connect(self.logSlideMoved)
+        self._viewbox.logSlideFinished.connect(self.logSlideFinished)
         # Keyboard navigation is owned by the window (a single app-level filter,
         # so it works without first clicking the traces — see window.py); the
         # view only exposes the navigation primitives it drives.
@@ -338,12 +444,15 @@ class TraceView(pg.PlotWidget):
         self._window_start = 0.0
         self._epoch_anchor = 0.0  # a new recording starts epoch 1 at its start
         self._overlays = []  # peers belong to the previous recording; window reloads
+        self._log_marks = []  # the log belongs to the previous recording too
+        self._viewbox.set_log_lane_active(False)
         # Show every channel in file order by default; a profile may narrow this.
         self._visible = list(range(len(provider.ch_names))) if provider else []
         self._build_curves()
         self._refresh_data()
         self._refresh_annotations()
         self._refresh_epochs()
+        self._refresh_log_marks()
 
     def set_spec(self, spec: dsp.FilterSpec) -> None:
         self._spec = spec
@@ -444,6 +553,7 @@ class TraceView(pg.PlotWidget):
         self._refresh_data()
         self._refresh_annotations()
         self._refresh_epochs()
+        self._refresh_log_marks()
 
     def build_snapshot(
         self,
@@ -515,6 +625,7 @@ class TraceView(pg.PlotWidget):
         self._refresh_data()
         self._refresh_annotations()
         self._refresh_epochs()
+        self._refresh_log_marks()
 
     def set_window_start(self, seconds: float) -> None:
         self._window_start = seconds
@@ -522,6 +633,7 @@ class TraceView(pg.PlotWidget):
         self._refresh_data()
         self._refresh_annotations()
         self._refresh_epochs()
+        self._refresh_log_marks()
 
     def set_epoch_seconds(self, seconds: float) -> None:
         """Set the scoring-epoch length (≥ 1 s); redraws the epoch grid."""
@@ -581,6 +693,29 @@ class TraceView(pg.PlotWidget):
         self._overlays = list(overlays)
         self._refresh_overlays()
 
+    def set_log_marks(self, marks: list[LogMark]) -> None:
+        """Replace the read-only session-log overlay in the top lane (#125).
+
+        Marks are kept sorted by time so each scroll redraws only the handful in
+        view (an overnight log has thousands of entries). A non-empty list arms
+        the top-lane slide, so a drag up there aligns the log instead of drawing
+        a span; an empty list disarms it.
+        """
+        self._log_marks = sorted(marks, key=lambda m: m.seconds)
+        self._viewbox.set_log_lane_active(bool(self._log_marks))
+        self._refresh_log_marks()
+
+    def set_pick_mode(self, enabled: bool) -> None:
+        """In pick mode a click reports its time via ``timePicked`` (for pairing).
+
+        While enabled a plain click does not select an annotation — it answers
+        the "click the EEG feature this log entry caused" prompt — and a drag or
+        ctrl-click can't slip through to edit a mark either (the viewbox swallows
+        them), so the manual alignment never disturbs the rater's own work.
+        """
+        self._pick_mode = bool(enabled)
+        self._viewbox.set_pick_active(self._pick_mode)
+
     # ----- interaction ---------------------------------------------------------
 
     def _on_drag_finished(self, lo: float, hi: float) -> None:
@@ -599,6 +734,13 @@ class TraceView(pg.PlotWidget):
         self.pointMarkRequested.emit(seconds)
 
     def _on_clicked(self, seconds: float) -> None:
+        # Pick mode (manual log alignment): the click chooses a time to pair with
+        # a log entry, not an annotation to select.
+        if self._pick_mode:
+            if self._provider is not None:
+                clamped = min(max(0.0, seconds), self._provider.duration)
+                self.timePicked.emit(clamped)
+            return
         index = self._annotation_at(seconds)
         self._selected = index
         self._refresh_annotations()
@@ -810,6 +952,40 @@ class TraceView(pg.PlotWidget):
                 item.setZValue(_OVERLAY_Z)
                 plot_item.addItem(item)
                 self._overlay_items.append(item)
+
+    def _refresh_log_marks(self) -> None:
+        """Redraw the session-log overlay ticks in the top lane (#125).
+
+        Each mark is an instantaneous tick spanning only the top lane, coloured
+        by its log level. The marks are time-sorted, so a binary search bounds
+        the redraw to the entries inside the visible window — cheap on scroll
+        even for an all-night log with thousands of entries.
+        """
+        plot_item = self.getPlotItem()
+        assert plot_item is not None
+        for old in self._log_items:
+            plot_item.removeItem(old)
+        self._log_items = []
+        if self._provider is None or not self._log_marks:
+            return
+        lo = self._window_start
+        hi = self._window_start + self._window_seconds
+        seconds = [m.seconds for m in self._log_marks]
+        start = bisect.bisect_left(seconds, lo)
+        stop = bisect.bisect_right(seconds, hi)
+        for mark in self._log_marks[start:stop]:
+            color = _LOG_LEVEL_COLORS.get(mark.level, _LOG_DEFAULT_COLOR)
+            line = pg.InfiniteLine(
+                pos=mark.seconds,
+                angle=90,
+                movable=False,
+                pen=pg.mkPen(color, width=2),
+                span=(_LOG_LANE_FRAC, 1.0),  # the top lane only
+            )
+            line.setToolTip(mark.tooltip)
+            line.setZValue(_LOG_Z)
+            plot_item.addItem(line)
+            self._log_items.append(line)
 
     def _refresh_epochs(self) -> None:
         """Redraw the epoch boundary gridlines for the visible window.

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -32,7 +32,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import preferences, windowstate
 from ..paths import LOGO_PATH, preferences_path
-from . import blind, dsp, io
+from . import blind, dsp, io, sessionlog
 from .annotations import (
     Annotation,
     autosave_path,
@@ -50,7 +50,14 @@ from .annotations import (
 )
 from .profiles import FILE_FILTER as PROFILE_FILE_FILTER
 from .profiles import PROFILE_SUFFIX, ViewProfile, read_view_profile, write_view_profile
-from .view import DEFAULT_EPOCH_SECONDS, OVERLAY_COLORS, RaterOverlay, TraceView
+from .sessionlog import LogEntry
+from .view import (
+    DEFAULT_EPOCH_SECONDS,
+    OVERLAY_COLORS,
+    LogMark,
+    RaterOverlay,
+    TraceView,
+)
 
 if TYPE_CHECKING:  # matplotlib is heavy: import the export module only on demand
     from .export import ExportOptions
@@ -76,6 +83,16 @@ _SCROLL_TICKS_PER_SECOND = 10
 # Autosave (#176) is debounced: each annotation change restarts this timer, so a
 # burst of edits writes the recovery file once, shortly after the last of them.
 _AUTOSAVE_DEBOUNCE_MS = 2000
+
+# Session-log overlay (#125). The level checkboxes default to the live preview's
+# gate (INFO and up); DEBUG is off so the lane isn't swamped by the raw-trigger
+# and volume-edit lines. The tuple fixes the checkbox order.
+_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
+_LOG_DEFAULT_LEVELS = frozenset({"INFO", "WARNING", "ERROR", "CRITICAL"})
+# On a log-lane drag release, a mark within this many seconds of one of the
+# reviewer's marks snaps onto it, so a clapper lands exactly (mark-on-mark)
+# instead of by eye.
+_LOG_SNAP_SECONDS = 0.5
 
 # Keyboard navigation (#174). Plain Left/Right page by one epoch; Shift nudges a
 # second to peek across a boundary. Up/Down step the amplitude multiplicatively
@@ -606,6 +623,18 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             tuple[str, list[Annotation], tuple[int, int, int]]
         ] = []
         self._hidden_raters: set[str] = set()
+        # Session-log overlay (#125): the parsed entries, the source path, the
+        # manual clock-skew offset (seconds added to the wall-clock placement),
+        # and which levels are shown. Empty until a log is loaded; never loaded in
+        # a blind review (the log carries the cue markers a blind rater must not
+        # see). ``_visible_log`` is the level-filtered subset shown in the list.
+        self._log_entries: list[LogEntry] = []
+        self._log_path: Path | None = None
+        self._log_offset = 0.0
+        self._log_levels: set[str] = set(_LOG_DEFAULT_LEVELS)
+        self._visible_log: list[LogEntry] = []
+        self._log_slide_base: float | None = None  # offset captured at drag start
+        self._pairing_entry: LogEntry | None = None  # entry awaiting a paired click
         # Annotations recovered from an autosave, held until the user restores or
         # dismisses them (#176).
         self._recovery_annotations: list[Annotation] | None = None
@@ -766,6 +795,10 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.view.windowChanged.connect(self._sync_scrollbar)
         self.view.cursorMoved.connect(self._on_cursor_moved)
         self.view.pointMarkRequested.connect(self._add_point_mark)
+        self.view.logSlideStarted.connect(self._on_log_slide_started)
+        self.view.logSlideMoved.connect(self._on_log_slide_moved)
+        self.view.logSlideFinished.connect(self._on_log_slide_finished)
+        self.view.timePicked.connect(self._on_time_picked)
         viewColumn.addWidget(self.view, 1)
         self.scrollBar = QtWidgets.QScrollBar(QtCore.Qt.Orientation.Horizontal, self)
         self.scrollBar.setStatusTip("Scroll through the recording.")
@@ -781,10 +814,13 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         # the normal message area.
         self.epochLabel = QtWidgets.QLabel("", self)
         self.epochLabel.setStatusTip("The epoch at the left edge of the view.")
+        self.logInfoLabel = QtWidgets.QLabel("", self)
+        self.logInfoLabel.setStatusTip("The overlaid session log and its offset.")
         self.fileInfoLabel = QtWidgets.QLabel("", self)
         status_bar = self.statusBar()
         assert status_bar is not None
         status_bar.addPermanentWidget(self.epochLabel)
+        status_bar.addPermanentWidget(self.logInfoLabel)
         status_bar.addPermanentWidget(self.fileInfoLabel)
 
         self._build_shortcuts()
@@ -1073,7 +1109,68 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.ratersGroup.setVisible(False)
         self._rater_checks: list[QtWidgets.QCheckBox] = []
         panel.addWidget(self.ratersGroup)
+        panel.addWidget(self._build_log_group())
         return panel
+
+    def _build_log_group(self) -> QtWidgets.QWidget:
+        """The session-log overlay controls (#125): load, filter, list, align.
+
+        The log is a read-only reference track on the timeline — what SMACC did
+        during the night, laid over the EEG. Loading needs a recording open (the
+        log aligns to *its* clock) and is refused in a blind review (the log
+        carries the cue markers). Alignment is manual here (#125b): drag the lane,
+        pair an entry to a feature, or nudge the offset; #125c adds auto-align.
+        """
+        group = QtWidgets.QGroupBox("Session log", self)
+        box = QtWidgets.QVBoxLayout(group)
+        self.loadLogButton = QtWidgets.QPushButton("Load session log…", self)
+        self.loadLogButton.setStatusTip(
+            "Overlay a SMACC session .log on the timeline as a read-only track."
+        )
+        self.loadLogButton.clicked.connect(self._load_session_log)
+        box.addWidget(self.loadLogButton)
+
+        # Per-level show/hide (the live preview's model), built on load from the
+        # levels the log actually contains.
+        self.logLevelsLayout = QtWidgets.QHBoxLayout()
+        self.logLevelsLayout.setSpacing(6)
+        self._log_level_checks: dict[str, QtWidgets.QCheckBox] = {}
+        box.addLayout(self.logLevelsLayout)
+
+        self.logList = QtWidgets.QListWidget(self)
+        self.logList.setMinimumWidth(230)
+        self.logList.setStatusTip(
+            "Log entries shown on the timeline; double-click to jump there."
+        )
+        self.logList.currentRowChanged.connect(self._on_log_list_selection)
+        self.logList.itemDoubleClicked.connect(lambda _item: self._go_to_log_entry())
+        box.addWidget(self.logList, 1)
+
+        offsetRow = QtWidgets.QHBoxLayout()
+        offsetRow.addWidget(QtWidgets.QLabel("Offset:", self))
+        self.logOffsetSpin = QtWidgets.QDoubleSpinBox(self)
+        self.logOffsetSpin.setRange(-86400.0, 86400.0)  # ±24 h covers any skew
+        self.logOffsetSpin.setDecimals(2)
+        self.logOffsetSpin.setSingleStep(0.5)
+        self.logOffsetSpin.setSuffix(" s")
+        self.logOffsetSpin.setStatusTip(
+            "Slide the whole log along the EEG to correct clock skew between "
+            "the recording PC and the amplifier."
+        )
+        self.logOffsetSpin.valueChanged.connect(self._on_log_offset_changed)
+        offsetRow.addWidget(self.logOffsetSpin, 1)
+        box.addLayout(offsetRow)
+
+        self.logAlignButton = QtWidgets.QPushButton("Align entry to feature…", self)
+        self.logAlignButton.setStatusTip(
+            "Select a log entry, then click the EEG feature it produced to align "
+            "the log (e.g. a clapper on the artifact it made)."
+        )
+        self.logAlignButton.clicked.connect(self._align_selected_log_entry)
+        box.addWidget(self.logAlignButton)
+
+        self.logGroup = group
+        return group
 
     def _build_shortcuts(self) -> None:
         """Window-wide paging on PageUp/PageDown, plus M to drop a point mark.
@@ -1107,6 +1204,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             widget.setEnabled(loaded)
         for button in self._palette_buttons:  # no recording → nothing to mark
             button.setEnabled(loaded)
+        self._update_log_controls()  # log loading is gated on a recording too
 
     # ----- quick-mark palette (#181) ---------------------------------------------
 
@@ -1201,8 +1299,16 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._blind = config
         self._refresh_blind_button()
         self._rebuild_palette_buttons()  # a config may carry its own palette
+        # Drop the log overlay the instant blind is entered, before the reload —
+        # a blind review must never show the cue/portcode log, and _load only
+        # clears it at the very end, after several early-return points (a moved
+        # recording, an unreadable truth sidecar) that would otherwise leave the
+        # cue ticks on screen under a blind preset.
+        if config is not None:
+            self._clear_log_overlay()
         if self._recording is not None:
             self._load(self._recording.path)  # re-resolve marks under the new mode
+        self._update_log_controls()  # the Load-log button follows the blind state
         self._refresh_title()
 
     def _load_blind_config(self) -> None:
@@ -1298,6 +1404,298 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             self._hidden_raters.add(rater_id)
         self._apply_overlays()
 
+    # ----- session-log overlay (#125) --------------------------------------------
+
+    def _can_overlay_log(self) -> bool:
+        """True when a log may be overlaid: a recording is open and not blinded.
+
+        A blind review never shows the log — it records every cue and portcode,
+        which would unblind the rater (the same invariant as the peer overlays).
+        """
+        return self._recording is not None and self._blind is None
+
+    def _load_session_log(self) -> None:
+        """Pick a SMACC ``.log`` and overlay its parsed entries (#125)."""
+        if not self._can_overlay_log():
+            return
+        prefs = preferences.load_preferences(preferences_path)
+        start_dir = prefs.get("eeg_last_log_dir") or (
+            str(self._recording.path.parent)
+            if self._recording is not None
+            else str(Path.home())
+        )
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Open session log", str(start_dir), "SMACC log (*.log);;All files (*)"
+        )
+        if not path:
+            return
+        try:
+            entries = sessionlog.read_session_log(path)
+        except OSError as exc:
+            self._error("Could not read the session log.", str(exc))
+            return
+        if not entries:
+            self._error(
+                "That log has no timestamped entries.",
+                "It may be empty or not a SMACC session log.",
+            )
+            return
+        preferences.update_preferences(
+            preferences_path, {"eeg_last_log_dir": str(Path(path).parent)}
+        )
+        # A pairing armed against the previous log would otherwise hijack the
+        # next click with a stale entry; cancel it before swapping logs.
+        self._end_pairing()
+        self._log_entries = entries
+        self._log_path = Path(path)
+        self._log_offset = 0.0
+        self._log_levels = {
+            level for level in _LOG_DEFAULT_LEVELS if self._log_has_level(level)
+        } or {e.level for e in entries}
+        self.logOffsetSpin.blockSignals(True)
+        self.logOffsetSpin.setValue(0.0)
+        self.logOffsetSpin.blockSignals(False)
+        self._rebuild_log_level_checks()
+        self._refresh_log_overlay()
+        self._update_log_controls()
+
+    def _log_has_level(self, level: str) -> bool:
+        return any(e.level == level for e in self._log_entries)
+
+    def _clear_log_overlay(self) -> None:
+        """Drop the overlaid log (a new recording, or a blind switch)."""
+        self._end_pairing()
+        self._log_entries = []
+        self._log_path = None
+        self._visible_log = []
+        self._log_slide_base = None
+        self.logList.blockSignals(True)
+        self.logList.clear()
+        self.logList.blockSignals(False)
+        self._rebuild_log_level_checks()
+        self.view.set_log_marks([])
+        self._update_log_controls()
+        self._update_log_status()  # clear the stale "log: …" status label
+
+    def _log_origin(self) -> datetime | None:
+        """The wall-clock instant of data-second 0, for placing log entries.
+
+        The recording's start (format-aware, via :func:`wall_time`) when it has
+        one; otherwise the log's own first entry, so the overlay still draws and
+        the manual offset slides it into place (no absolute anchor exists).
+        """
+        if self._recording is not None:
+            started = wall_time(self._recording, 0.0)
+            if started is not None:
+                return started
+        return self._log_entries[0].timestamp if self._log_entries else None
+
+    def _rebuild_log_level_checks(self) -> None:
+        """Rebuild the per-level checkboxes from the levels present in the log."""
+        while self.logLevelsLayout.count():
+            item = self.logLevelsLayout.takeAt(0)
+            widget = item.widget() if item is not None else None
+            if widget is not None:
+                widget.deleteLater()
+        self._log_level_checks = {}
+        if not self._log_entries:
+            return
+        for level in _LOG_LEVELS:
+            if not self._log_has_level(level):
+                continue
+            check = QtWidgets.QCheckBox(level.title(), self)
+            check.setChecked(level in self._log_levels)
+            check.setStatusTip(f"Show or hide {level} log entries.")
+            check.toggled.connect(
+                lambda on, name=level: self._on_log_level_toggled(name, on)
+            )
+            self.logLevelsLayout.addWidget(check)
+            self._log_level_checks[level] = check
+        self.logLevelsLayout.addStretch(1)
+
+    def _on_log_level_toggled(self, level: str, on: bool) -> None:
+        if on:
+            self._log_levels.add(level)
+        else:
+            self._log_levels.discard(level)
+        self._refresh_log_overlay()
+
+    def _refresh_log_overlay(self) -> None:
+        """Recompute the overlay marks and the entry list from the current offset.
+
+        Filters by the enabled levels, places each entry on the EEG timeline via
+        the recording origin and the manual offset, and pushes the result to the
+        view; the list mirrors the same filtered, placed entries.
+        """
+        origin = self._log_origin()
+        self._visible_log = [
+            e for e in self._log_entries if e.level in self._log_levels
+        ]
+        if origin is None:
+            self.view.set_log_marks([])
+        else:
+            self.view.set_log_marks(
+                [
+                    LogMark(
+                        sessionlog.seconds_at(entry, origin, self._log_offset),
+                        entry.level,
+                        self._log_tooltip(entry),
+                    )
+                    for entry in self._visible_log
+                ]
+            )
+        self._refresh_log_list()
+        self._update_log_status()
+
+    def _log_tooltip(self, entry: LogEntry) -> str:
+        """Hover text for a log mark: clock time, level, and the message."""
+        clock = entry.timestamp.strftime("%H:%M:%S")
+        return f"{clock} · {entry.level} · {entry.message}"
+
+    def _refresh_log_list(self) -> None:
+        self.logList.blockSignals(True)
+        self.logList.clear()
+        for entry in self._visible_log:
+            clock = entry.timestamp.strftime("%H:%M:%S")
+            self.logList.addItem(f"{clock}  {entry.message}")
+        self.logList.blockSignals(False)
+
+    def _on_log_list_selection(self, _row: int) -> None:
+        self._update_log_controls()
+
+    def _go_to_log_entry(self) -> None:
+        """Jump the view so the selected log entry sits a quarter-window in."""
+        row = self.logList.currentRow()
+        origin = self._log_origin()
+        if origin is None or not 0 <= row < len(self._visible_log):
+            return
+        seconds = sessionlog.seconds_at(
+            self._visible_log[row], origin, self._log_offset
+        )
+        self._jump_to(seconds - self.view.window_seconds / 4)
+
+    # ----- manual alignment: offset, drag, pairing -------------------------------
+
+    def _set_log_offset(self, value: float) -> None:
+        """Set the clock-skew offset, syncing the spin box and the overlay."""
+        self._log_offset = value
+        self.logOffsetSpin.blockSignals(True)
+        self.logOffsetSpin.setValue(value)
+        self.logOffsetSpin.blockSignals(False)
+        self._refresh_log_overlay()
+
+    def _on_log_offset_changed(self, value: float) -> None:
+        self._log_offset = value
+        self._refresh_log_overlay()
+
+    def _on_log_slide_started(self) -> None:
+        """Capture the offset each gesture starts from (every drag re-bases here).
+
+        Keying the base to the drag's *start* — rather than to ``base is None``
+        on the first move — means a dropped finish (a lost release event) can
+        never strand a stale base into the next slide: the next gesture always
+        re-bases from the current offset.
+        """
+        self._log_slide_base = self._log_offset
+
+    def _on_log_slide_moved(self, delta: float) -> None:
+        """Live feedback while dragging the log lane: slide by ``delta`` seconds."""
+        base = (
+            self._log_offset if self._log_slide_base is None else self._log_slide_base
+        )
+        self._set_log_offset(base + delta)
+
+    def _on_log_slide_finished(self, delta: float) -> None:
+        """On release, settle the dragged offset and snap to a nearby mark."""
+        base = (
+            self._log_offset if self._log_slide_base is None else self._log_slide_base
+        )
+        self._log_slide_base = None
+        self._set_log_offset(self._snap_offset(base + delta))
+
+    def _snap_offset(self, offset: float) -> float:
+        """Snap ``offset`` so a visible log mark lands on a nearby reviewer mark.
+
+        Considers only entries and annotations inside the current window, so a
+        clapper dragged near the artifact it produced clicks exactly onto it;
+        nothing within tolerance leaves the offset untouched.
+        """
+        origin = self._log_origin()
+        if origin is None or not self._annotations:
+            return offset
+        lo = self.view.window_start
+        hi = lo + self.view.window_seconds
+        onsets = [a.onset for a in self._annotations if lo <= a.onset <= hi]
+        if not onsets:
+            return offset
+        best: float | None = None
+        for entry in self._visible_log:
+            placed = sessionlog.seconds_at(entry, origin, offset)
+            if not lo <= placed <= hi:
+                continue
+            for onset in onsets:
+                gap = onset - placed
+                if best is None or abs(gap) < abs(best):
+                    best = gap
+        if best is not None and abs(best) <= _LOG_SNAP_SECONDS:
+            return offset + best
+        return offset
+
+    def _align_selected_log_entry(self) -> None:
+        """Begin pairing: the next click on the traces aligns the selected entry."""
+        row = self.logList.currentRow()
+        if not 0 <= row < len(self._visible_log):
+            self._error(
+                "Select a log entry first.",
+                "Pick the entry in the list whose EEG feature you'll click.",
+            )
+            return
+        self._pairing_entry = self._visible_log[row]
+        self.view.set_pick_mode(True)
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.showMessage(
+            "Click the EEG feature this entry produced to align the log "
+            "(Esc to cancel)."
+        )
+
+    def _on_time_picked(self, seconds: float) -> None:
+        """Finish pairing: offset the log so the paired entry lands at ``seconds``."""
+        entry = self._pairing_entry
+        origin = self._log_origin()
+        self._end_pairing()
+        if entry is None or origin is None:
+            return
+        # Solve for the offset that puts this entry at the clicked time.
+        self._set_log_offset(seconds - sessionlog.seconds_at(entry, origin, 0.0))
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.showMessage("Log aligned to the clicked feature.", 4000)
+
+    def _end_pairing(self) -> None:
+        """Leave pairing mode (paired, cancelled, or a new log loaded)."""
+        self._pairing_entry = None
+        self.view.set_pick_mode(False)
+
+    def _update_log_controls(self) -> None:
+        """Enable the log controls by state (recording open, log loaded, blind)."""
+        has_log = bool(self._log_entries)
+        self.loadLogButton.setEnabled(self._can_overlay_log())
+        self.logList.setEnabled(has_log)
+        self.logOffsetSpin.setEnabled(has_log)
+        self.logAlignButton.setEnabled(
+            has_log and 0 <= self.logList.currentRow() < len(self._visible_log)
+        )
+
+    def _update_log_status(self) -> None:
+        """Show the loaded log and its offset in the permanent status area."""
+        if not self._log_entries or self._log_path is None:
+            self.logInfoLabel.clear()
+            return
+        self.logInfoLabel.setText(
+            f"log: {self._log_path.name} · offset {self._log_offset:+.2f} s"
+        )
+
     # ----- opening a recording ---------------------------------------------------
 
     def open_file(self) -> None:
@@ -1386,6 +1784,10 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             f"{recording.sfreq:g} Hz · {recording.duration:.0f} s{clock}"
         )
         self._load_overlays()
+        # A loaded log belonged to the previous recording (its origin/offset no
+        # longer apply, and the view already dropped its marks); the reviewer
+        # re-loads it for the new file if wanted.
+        self._clear_log_overlay()
         self._check_for_recovery(tsv_path)
 
     def _fresh_annotations(
@@ -1749,17 +2151,29 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         """Route epoch/amplitude keys to the view regardless of which child has focus.
 
         Installed on the application so the keys work without first clicking the
-        traces; scoped to this window being active (so a modal dialog keeps them)
-        and to a recording being loaded.
+        traces; scoped to this window being the active window — a modal dialog
+        becomes active instead, so the keys are deliberately yielded to it — and
+        (for the nav/palette keys) to a recording being loaded.
         """
         if (
             isinstance(event, QtGui.QKeyEvent)
             and event.type() == QtCore.QEvent.Type.KeyPress
             and self.isActiveWindow()
-            and self._recording is not None
-            and (self._handle_nav_key(event) or self._handle_palette_key(event))
         ):
-            return True
+            # Esc cancels an in-progress log-entry pairing before anything else.
+            if (
+                event.key() == QtCore.Qt.Key.Key_Escape
+                and self._pairing_entry is not None
+            ):
+                self._end_pairing()
+                status_bar = self.statusBar()
+                if status_bar is not None:
+                    status_bar.showMessage("Alignment cancelled.", 3000)
+                return True
+            if self._recording is not None and (
+                self._handle_nav_key(event) or self._handle_palette_key(event)
+            ):
+                return True
         return super().eventFilter(obj, event)
 
     def _handle_palette_key(self, event: QtGui.QKeyEvent) -> bool:

--- a/tests/test_eeg_view.py
+++ b/tests/test_eeg_view.py
@@ -229,6 +229,140 @@ def test_set_provider_clears_overlays(loaded):
     assert view._overlay_items == []
 
 
+# ----- session-log overlay (#125) -------------------------------------------
+
+
+def _log_mark(seconds, level="INFO", tooltip="x"):
+    from smacc.eeg.view import LogMark
+
+    return LogMark(seconds, level, tooltip)
+
+
+def test_log_marks_draw_only_inside_the_window(loaded):
+    view, _ = loaded
+    view.set_log_marks([_log_mark(5.0), _log_mark(15.0), _log_mark(45.0, "WARNING")])
+    # The 0–30 s window holds the first two; the 45 s mark is offscreen.
+    assert len(view._log_items) == 2
+    assert all(isinstance(item, pg.InfiniteLine) for item in view._log_items)
+
+
+def test_log_marks_redraw_on_scroll(loaded):
+    view, _ = loaded
+    view.set_log_marks([_log_mark(45.0)])
+    assert view._log_items == []  # outside the 0–30 s window
+    view.set_window_start(35.0)
+    assert len(view._log_items) == 1
+
+
+def test_log_marks_are_not_click_selectable(loaded):
+    view, _ = loaded
+    view.set_annotations([Annotation(20.0, 0.0, "mine")])
+    view.set_log_marks([_log_mark(10.0)])
+    # A log mark is read-only context: a click near it selects no annotation.
+    assert view._annotation_at(10.0) == -1
+    assert view._annotation_at(20.0) == 0
+
+
+def test_set_log_marks_arms_the_lane_slide(loaded):
+    view, _ = loaded
+    assert view._viewbox._log_lane_active is False
+    view.set_log_marks([_log_mark(5.0)])
+    assert view._viewbox._log_lane_active is True
+    view.set_log_marks([])  # cleared → slide disarmed
+    assert view._viewbox._log_lane_active is False
+
+
+def test_set_provider_clears_log_marks(loaded):
+    view, _ = loaded
+    view.set_log_marks([_log_mark(5.0)])
+    assert view._log_items
+    view.set_provider(FakeProvider())
+    assert view._log_marks == []
+    assert view._log_items == []
+
+
+def test_pick_mode_emits_time_instead_of_selecting(loaded):
+    view, _ = loaded
+    view.set_annotations([Annotation(6.0, 0.0, "mine")])
+    picked: list[float] = []
+    selections: list[int] = []
+    view.timePicked.connect(picked.append)
+    view.annotationSelected.connect(selections.append)
+    view.set_pick_mode(True)
+    view._on_clicked(6.0)
+    assert picked == [6.0]
+    assert selections == []  # no annotation selection while picking
+    assert view.selected == -1
+    view.set_pick_mode(False)
+    view._on_clicked(6.0)
+    assert selections == [0]  # normal selection resumes
+
+
+def test_pick_mode_swallows_drags_and_ctrl_clicks(exposed):
+    # A drag or ctrl-click while aiming an alignment must not edit the rater's
+    # marks: pick mode swallows both (no region, no point mark).
+    view, _ = exposed
+    drawn: list[tuple[float, float]] = []
+    marks: list[float] = []
+    view.regionDrawn.connect(lambda lo, hi: drawn.append((lo, hi)))
+    view.pointMarkRequested.connect(marks.append)
+    view.set_pick_mode(True)
+    viewbox = view._viewbox
+    viewbox.mouseDragEvent(
+        _FakeMouseEvent(viewbox, 5.0, 8.0, start=True, finish=False, down_y=-1.0)
+    )
+    viewbox.mouseDragEvent(_FakeMouseEvent(viewbox, 5.0, 8.0, finish=True, down_y=-1.0))
+    assert drawn == []  # no stray annotation while pairing
+    ctrl = _FakeMouseEvent(
+        viewbox, 6.0, 6.0, modifiers=QtCore.Qt.KeyboardModifier.ControlModifier
+    )
+    picked: list[float] = []
+    view.timePicked.connect(picked.append)
+    viewbox.mouseClickEvent(ctrl)
+    assert marks == []  # ctrl-click drops no mark in pick mode
+    assert picked == [pytest.approx(6.0, abs=0.05)]  # it picks the time instead
+
+
+def test_disarming_the_lane_clears_a_stale_slide_flag(loaded):
+    view, _ = loaded
+    view.set_log_marks([_log_mark(5.0)])
+    view._viewbox._sliding = True  # as if a finish were lost mid-drag
+    view.set_log_marks([])  # disarming the lane must reset the flag
+    assert view._viewbox._sliding is False
+
+
+def test_lane_drag_slides_the_log_not_a_region(exposed):
+    view, _ = exposed
+    view.set_log_marks([_log_mark(5.0)])
+    slid: list[float] = []
+    drawn: list[tuple[float, float]] = []
+    view.logSlideFinished.connect(slid.append)
+    view.regionDrawn.connect(lambda lo, hi: drawn.append((lo, hi)))
+    viewbox = view._viewbox
+    # A drag starting in the top log lane (down_y near the 0.6 top of the range)
+    # slides the log by the dragged seconds; no region is drawn.
+    viewbox.mouseDragEvent(
+        _FakeMouseEvent(viewbox, 5.0, 9.0, start=True, finish=False, down_y=0.55)
+    )
+    viewbox.mouseDragEvent(_FakeMouseEvent(viewbox, 5.0, 9.0, finish=True, down_y=0.55))
+    assert drawn == []
+    assert len(slid) == 1
+    assert slid[0] == pytest.approx(4.0, abs=0.1)  # dragged +4 s
+
+
+def test_drag_below_the_lane_still_draws_a_region(exposed):
+    view, _ = exposed
+    view.set_log_marks([_log_mark(5.0)])  # lane armed, but the drag starts below it
+    drawn: list[tuple[float, float]] = []
+    view.regionDrawn.connect(lambda lo, hi: drawn.append((lo, hi)))
+    viewbox = view._viewbox
+    viewbox.mouseDragEvent(
+        _FakeMouseEvent(viewbox, 5.0, 8.0, start=True, finish=False, down_y=-1.0)
+    )
+    viewbox.mouseDragEvent(_FakeMouseEvent(viewbox, 5.0, 8.0, finish=True, down_y=-1.0))
+    assert len(drawn) == 1  # ordinary annotation drag, not a slide
+
+
 def test_click_selects_and_signals(loaded):
     view, _ = loaded
     view.set_annotations([Annotation(5.0, 2.0, "region")])
@@ -305,13 +439,16 @@ class _FakeMouseEvent:
         x: float,
         *,
         finish=True,
+        start=False,
+        down_y: float = 0.0,
         button=None,
         modifiers=None,
     ):
         self._button = button or QtCore.Qt.MouseButton.LeftButton
-        self._down = viewbox.mapFromView(pg.Point(down_x, 0.0))
-        self._pos = viewbox.mapFromView(pg.Point(x, 0.0))
+        self._down = viewbox.mapFromView(pg.Point(down_x, down_y))
+        self._pos = viewbox.mapFromView(pg.Point(x, down_y))
         self._finish = finish
+        self._start = start
         self._modifiers = modifiers or QtCore.Qt.KeyboardModifier.NoModifier
         self.accepted = False
         self.ignored = False
@@ -330,6 +467,9 @@ class _FakeMouseEvent:
 
     def isFinish(self):
         return self._finish
+
+    def isStart(self):
+        return self._start
 
     def accept(self):
         self.accepted = True

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -1477,3 +1477,209 @@ def test_corrupt_peer_sidecar_is_skipped(make_window, recording_path):
     win = make_window("alice")
     win._load(recording_path)
     assert [rid for rid, _, _ in win._rater_layers] == ["bob"]  # carol skipped
+
+
+# ----- session-log overlay (#125) -------------------------------------------
+
+# Entries placed against the recording's 22:00:00 start (FakeRecording.meas_date):
+# Opened at 0 s, Lights off at 5 s, a DEBUG soft line at 10 s, REM at 20 s.
+LOG_TEXT = (
+    "2026-06-05 22:00:00.000-0500, INFO, Opened SMACC v0.0.7\n"
+    "2026-06-05 22:00:05.000-0500, INFO, Lights off - portcode 47\n"
+    "2026-06-05 22:00:10.000-0500, DEBUG, Cue volume set to 0.40\n"
+    "2026-06-05 22:00:20.000-0500, INFO, REM detected - portcode 41\n"
+)
+
+
+def _overlay_log(window, monkeypatch, tmp_path, text=LOG_TEXT):
+    """Write ``text`` to a .log and load it through the file-dialog flow."""
+    log = tmp_path / "session.log"
+    log.write_text(text, encoding="utf-8")
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog, "getOpenFileName", lambda *a, **k: (str(log), "")
+    )
+    window._load_session_log()
+    return log
+
+
+def test_load_log_overlays_placed_marks(window, recording_path, monkeypatch, tmp_path):
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path)
+    # INFO is on by default, DEBUG off: Opened (0 s), Lights off (5 s), REM (20 s).
+    placed = [m.seconds for m in window.view._log_marks]
+    assert placed == [0.0, 5.0, 20.0]
+    assert "session.log" in window.logInfoLabel.text()
+    assert "+0.00 s" in window.logInfoLabel.text()
+
+
+def test_log_level_filter_toggles_debug(window, recording_path, monkeypatch, tmp_path):
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path)
+    assert len(window.view._log_marks) == 3  # DEBUG hidden by default
+    window._log_level_checks["DEBUG"].setChecked(True)
+    assert len(window.view._log_marks) == 4  # the 10 s soft line appears
+    assert 10.0 in [m.seconds for m in window.view._log_marks]
+
+
+def test_offset_slides_every_mark(window, recording_path, monkeypatch, tmp_path):
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path)
+    window._set_log_offset(2.5)
+    assert [m.seconds for m in window.view._log_marks] == [2.5, 7.5, 22.5]
+    assert "+2.50 s" in window.logInfoLabel.text()
+    assert window.logOffsetSpin.value() == pytest.approx(2.5)
+
+
+def test_pair_entry_aligns_log_to_clicked_feature(
+    window, recording_path, monkeypatch, tmp_path
+):
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path)
+    # Select "Lights off" (row 1, placed at 5 s) and pair it to a feature at 12 s.
+    window.logList.setCurrentRow(1)
+    window._align_selected_log_entry()
+    assert window._pairing_entry is not None
+    window._on_time_picked(12.0)
+    # The whole log shifts +7 s so that entry lands on the clicked feature.
+    assert window._log_offset == pytest.approx(7.0)
+    assert [m.seconds for m in window.view._log_marks] == [7.0, 12.0, 27.0]
+    assert window._pairing_entry is None  # pairing ended
+
+
+def test_lane_drag_finish_snaps_to_a_nearby_mark(
+    window, recording_path, monkeypatch, tmp_path
+):
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path)
+    # A reviewer mark at 5.3 s; dragging the log +0.1 s leaves "Lights off" (5 s)
+    # at 5.1 s, within snap tolerance of 5.3 → it clicks onto 5.3.
+    window._annotations = [Annotation(5.3, 0.0, "clap artifact")]
+    window._on_log_slide_moved(0.1)
+    window._on_log_slide_finished(0.1)
+    assert window._log_offset == pytest.approx(0.3)  # snapped, not 0.1
+    assert window._log_slide_base is None
+
+
+def test_slide_finish_without_move_preserves_the_offset(
+    window, recording_path, monkeypatch, tmp_path
+):
+    # A minimal lane drag can finish without an intervening move; it must not
+    # reset a previously-set offset to ~0.
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path)
+    window._set_log_offset(5.0)
+    window._on_log_slide_finished(0.0)  # finish with no preceding moved + no delta
+    assert window._log_offset == pytest.approx(5.0)
+
+
+def test_blind_review_refuses_the_log_overlay(
+    make_window, recording_path, monkeypatch, tmp_path
+):
+    win = make_window("alice")
+    win._blind = blind.preset_config(blind.PRESET_NAIVE)
+    win._load(recording_path)
+    assert not win._can_overlay_log()  # the log carries the cues
+    assert not win.loadLogButton.isEnabled()
+
+
+def test_entering_blind_clears_a_loaded_log(
+    make_window, recording_path, monkeypatch, tmp_path
+):
+    win = make_window("alice")
+    win._load(recording_path)
+    _overlay_log(win, monkeypatch, tmp_path)
+    assert win._log_entries
+    win._set_blind(blind.preset_config(blind.PRESET_NAIVE))
+    assert win._log_entries == []  # dropped on entering blind
+    assert win.view._log_marks == []
+    assert win.logInfoLabel.text() == ""  # no stale "log: …" status
+
+
+def test_entering_blind_clears_the_log_even_if_reload_fails(
+    make_window, recording_path, monkeypatch, tmp_path, silence_dialogs
+):
+    # Blind safety: the overlay must be gone the instant blind is entered, even
+    # when _load early-returns (here: an unreadable coordinator truth sidecar,
+    # which pops a silenced error dialog), so the cue/portcode ticks can never
+    # survive under a blind preset.
+    win = make_window("alice")
+    win._load(recording_path)
+    _overlay_log(win, monkeypatch, tmp_path)
+    assert win._log_entries
+    truth_tsv, _ = sidecar_paths(recording_path)
+    truth_tsv.write_text("not\ta\tsidecar\n", encoding="utf-8")  # makes _load abort
+    win._set_blind(blind.preset_config(blind.PRESET_NAIVE))
+    assert win._log_entries == []  # cleared before the failing reload
+    assert win.view._log_marks == []
+    assert win.view._viewbox._log_lane_active is False  # lane disarmed, not draggable
+
+
+def test_opening_a_new_recording_clears_the_log(
+    window, recording_path, monkeypatch, tmp_path
+):
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path)
+    assert window._log_entries
+    other = tmp_path / "night2.edf"
+    other.write_bytes(b"")
+    window._load(other)
+    assert window._log_entries == []
+    assert window.view._log_marks == []
+    assert window.logInfoLabel.text() == ""  # no stale "log: …" status
+
+
+def test_loading_a_new_log_cancels_a_pending_pairing(
+    window, recording_path, monkeypatch, tmp_path
+):
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path)
+    window.logList.setCurrentRow(1)
+    window._align_selected_log_entry()
+    assert window._pairing_entry is not None
+    # Loading a different log mid-pairing must cancel it — else the next click
+    # would align a stale entry from the old log.
+    _overlay_log(window, monkeypatch, tmp_path)
+    assert window._pairing_entry is None
+    assert not window.view._pick_mode
+
+
+def test_slide_rebases_each_gesture_even_after_a_dropped_finish(
+    window, recording_path, monkeypatch, tmp_path
+):
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path)
+    # Gesture 1 starts and moves but its finish is lost (no _on_log_slide_finished).
+    window._on_log_slide_started()
+    window._on_log_slide_moved(5.0)
+    assert window._log_offset == pytest.approx(5.0)
+    # Gesture 2 re-bases from the current offset (5.0), not a stale base.
+    window._on_log_slide_started()
+    window._on_log_slide_moved(2.0)
+    assert window._log_offset == pytest.approx(7.0)
+
+
+def test_double_click_log_entry_jumps_the_view(
+    window, recording_path, monkeypatch, tmp_path
+):
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path)
+    window.logList.setCurrentRow(2)  # REM detected, placed at 20 s
+    window._go_to_log_entry()
+    # Jumps so the entry sits a quarter-window in (20 - 30/4 = 12.5 s).
+    assert window.view.window_start == pytest.approx(12.5)
+
+
+def test_esc_cancels_pairing(window, recording_path, monkeypatch, tmp_path):
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path)
+    window.logList.setCurrentRow(0)
+    window._align_selected_log_entry()
+    assert window._pairing_entry is not None
+    esc = QtGui.QKeyEvent(
+        QtCore.QEvent.Type.KeyPress,
+        QtCore.Qt.Key.Key_Escape,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+    window.eventFilter(window, esc)
+    assert window._pairing_entry is None
+    assert not window.view._pick_mode


### PR DESCRIPTION
Second PR of the #125 stack — **stacked on #216** (review/merge that first). Adds the read-only session-log overlay and manual alignment to the EEG annotator.

- **Overlay track.** Load a SMACC `.log` (Session log panel) and its entries draw as a read-only tick lane across the top of the timeline, coloured by log level, with the message on hover. Per-level checkboxes show/hide levels (DEBUG off by default, like the live preview). Time-sorted with a binary search, so an all-night log redraws cheaply on scroll.
- **Manual alignment** (one offset, three ways): drag the top lane to slide the whole log (snaps onto a nearby mark of yours, so a clapper lands exactly); select an entry and click the EEG feature it produced (pairing, Esc to cancel); or set the Offset box directly. Placement is `(log_time − recording_origin) + offset`, origin from the format-aware `wall_time`.
- **Blind-safe.** The log carries every cue/portcode, so it is never shown in a blind review — refused at load and dropped the instant blind mode is entered (even if the re-load early-returns).

Pure model from #216 (`smacc.eeg.sessionlog`) does the parsing/placement; this PR is the view + window wiring. 1008 tests pass (18 new view/window tests covering placement, level filter, drag-slide + snap, pairing, pick-mode gesture isolation, and the blind exclusion); ruff + mypy + mdformat clean. An adversarial multi-agent review of the diff surfaced 7 issues (a stale status label, a mid-pairing reload hijack, stray-annotation drags in pick mode, a dropped-drag base, and two blind-safety holes) — all fixed with regression tests.

Manual GUI check on a real recording still wanted before relying on the drag feel and overlay rendering. Refs #125.
