### PR TITLE
feat: auto-align the session log to the EEG by matching trigger codes

### DIFF
--- a/docs/eeg-review.md
+++ b/docs/eeg-review.md
@@ -98,6 +98,19 @@ offset:
 - **Nudge the offset.** The **Offset** box is the exact value, and the fine
     control.
 
+**Auto-align to triggers.** When the amplifier itself recorded SMACC's trigger
+codes — a hardware-TTL rig, where the codes are embedded events in the EEG file —
+**Auto-align to triggers** estimates the offset by matching the log's markers to
+them. It anchors only on *rare* codes (a clapper, a dream report, the
+recording-start marker), never the periodic cue codes that could line up at the
+wrong firing, and grades the result: a confident match is applied silently, a
+low-confidence one is applied but marked *unverified* in the status bar, and an
+unreliable or contradictory one (too few matches, or two clusters from a clock
+jump or the wrong log) is refused so you align by hand instead. It runs
+automatically when a log is loaded, and the button re-runs it. An LSL-only rig
+records markers only to its side file, not the EEG, so there is nothing embedded
+to match — use the manual gestures.
+
 The classic clapper workflow fits directly: press **Clapper** on the SMACC PC at
 the same instant as a manual trigger on the recording system, then pair (or drag)
 the logged clapper onto the marker it left in the EEG. Clapping at both lights-off

--- a/src/smacc/eeg/align.py
+++ b/src/smacc/eeg/align.py
@@ -1,0 +1,258 @@
+"""Estimate the clock-skew offset that aligns a session log to an EEG recording (#125).
+
+When the recording carries the same trigger codes SMACC sent (hardware TTL wired
+into the amplifier), the log's marker events can be matched to the recording's
+*embedded* events to estimate the constant offset that slides the log onto the
+EEG — the manual drag/pair of #125b done automatically. This is opportunistic:
+an LSL-only rig leaves no triggers in the file, so there is nothing to match and
+the manual path stays primary.
+
+Pure, no GUI and no MNE, so the algorithm is unit-testable. The hard part is not
+the arithmetic but *not trusting a wrong fit*: an overnight log repeats cue codes
+every few seconds, two PC clocks can disagree or jump (NTP, DST), and the wrong
+log can be loaded entirely. The estimator therefore:
+
+* anchors only on **rare** codes (a clapper, a dream report, a recording-start),
+  never the periodic cue codes that would alias to a neighbour and fit tightly
+  but wrongly;
+* matches one-to-one (each embedded event consumed once);
+* grades the result — :data:`GREEN` (apply silently), :data:`AMBER` (apply but
+  flag), :data:`RED` (refuse; the deltas are too few, too scattered, or split
+  into two clusters, i.e. a clock jump or the wrong log) — so the caller never
+  silently applies a confident-but-wrong offset.
+
+Inputs are ``(seconds, code)`` lists in **recording data-seconds**: the log
+events placed at offset 0 against the recording origin (so a correct fit has the
+two streams already roughly coincident), the embedded events at their own
+data-seconds. The returned ``offset`` is what to add to the log placement.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import median
+
+# Alignment quality tiers.
+GREEN = "green"  # confident — apply silently
+AMBER = "amber"  # low-confidence — apply but flag as unverified
+RED = "red"  # unreliable or contradictory — refuse, fall back to manual
+
+# A code anchors the fit only if it occurs at most this many times in the
+# overlap window on *each* side — i.e. it is rare enough to pair unambiguously.
+# Periodic cue codes (dozens of firings) are excluded from anchoring and only
+# admitted to the refine pass, where the fixed coarse offset prevents aliasing.
+_ANCHOR_MAX_COUNT = 2
+# Anchor nearest-neighbour search half-window around the meas_date prior. Widened
+# once if every anchor sits beyond it (a large but consistent clock skew).
+_CAPTURE_SECONDS = 90.0
+_CAPTURE_SECONDS_WIDE = 300.0
+# Refine half-window once the coarse offset is fixed: << the seconds-scale cue
+# spacing, so a periodic code can't wrap onto the wrong firing.
+_REFINE_SECONDS = 0.5
+
+# Codes excluded from matching entirely: 0 (a return-to-baseline / non-event) and
+# 255 (the incrementing-band clamp collision — many distinct reports pile onto it,
+# so it is not a unique anchor; see events.runtime_code).
+_EXCLUDED_CODES = frozenset({0, 255})
+
+# Tier thresholds.
+_GREEN_MIN_ANCHORS = 3
+_GREEN_MIN_FRACTION = 0.6
+_GREEN_MAX_MAD = 0.25
+_AMBER_MIN_FRACTION = 0.3
+_AMBER_MAX_MAD = 1.0
+
+
+@dataclass(frozen=True)
+class Alignment:
+    """The estimated offset and the evidence behind it.
+
+    ``offset`` is seconds to add to the log placement; ``tier`` is
+    :data:`GREEN`/:data:`AMBER`/:data:`RED`. The rest is the evidence a caller
+    shows or logs: how many anchor and total matches, the matched fraction, the
+    residual spread (median absolute deviation), whether the deltas split into
+    two clusters (a clock jump or the wrong log), and a one-line ``reason``.
+    """
+
+    offset: float
+    tier: str
+    n_anchor: int
+    n_matched: int
+    match_fraction: float
+    residual_mad: float
+    bimodal: bool
+    reason: str
+
+
+def _in_window(events: list[tuple[float, int]], lo: float, hi: float):
+    """Events whose time falls in ``[lo, hi]`` and whose code is matchable."""
+    return [(t, c) for t, c in events if c not in _EXCLUDED_CODES and lo <= t <= hi]
+
+
+def _counts(events: list[tuple[float, int]]) -> dict[int, int]:
+    counts: dict[int, int] = {}
+    for _t, code in events:
+        counts[code] = counts.get(code, 0) + 1
+    return counts
+
+
+def _match_one_to_one(
+    log_secs: list[float], emb_secs: list[float], tol: float
+) -> list[float]:
+    """Greedy one-to-one match within ``tol``; return ``emb - log`` per pair.
+
+    Candidate pairs are taken smallest-gap first, each log and embedded time
+    consumed at most once — so duplicate-code events can't double-assign and
+    inflate the match count.
+    """
+    pairs = sorted(
+        (abs(e - lg), i, j)
+        for i, lg in enumerate(log_secs)
+        for j, e in enumerate(emb_secs)
+        if abs(e - lg) <= tol
+    )
+    used_log: set[int] = set()
+    used_emb: set[int] = set()
+    deltas: list[float] = []
+    for _gap, i, j in pairs:
+        if i in used_log or j in used_emb:
+            continue
+        used_log.add(i)
+        used_emb.add(j)
+        deltas.append(emb_secs[j] - log_secs[i])
+    return deltas
+
+
+def _mad(values: list[float], center: float) -> float:
+    """Median absolute deviation of ``values`` about ``center``."""
+    return median([abs(v - center) for v in values]) if values else 0.0
+
+
+def _is_bimodal(deltas: list[float]) -> bool:
+    """True if the sorted deltas split into two clusters with a wide gap between.
+
+    A clock step (NTP), a DST rollback, or the wrong log produces two groups of
+    matches an offset apart; a single constant offset must not be medianed across
+    them. Split at the widest gap and compare it to the spread *within* the two
+    sides (not the overall spread, which the split itself inflates and would
+    mask): a clean jump leaves each side tight, so the gap dwarfs ``6·MAD`` of
+    the tighter-bounded cluster. Needs real support (≥2) on both sides.
+    """
+    if len(deltas) < 4:
+        return False
+    ordered = sorted(deltas)
+    gaps = [(ordered[i + 1] - ordered[i], i) for i in range(len(ordered) - 1)]
+    widest, split = max(gaps)
+    left, right = ordered[: split + 1], ordered[split + 1 :]
+    if len(left) < 2 or len(right) < 2:
+        return False
+    within = max(_mad(left, median(left)), _mad(right, median(right)))
+    return widest > max(1.0, 6.0 * within)
+
+
+def estimate_offset(
+    log_events: list[tuple[float, int]],
+    embedded_events: list[tuple[float, int]],
+    *,
+    duration: float,
+) -> Alignment:
+    """Estimate the clock-skew offset aligning the log to the embedded events.
+
+    ``log_events`` and ``embedded_events`` are ``(data_seconds, code)`` with the
+    log already placed against the recording origin (offset 0). ``duration`` is
+    the recording length. Returns an :class:`Alignment`; a :data:`RED` tier means
+    no offset should be applied automatically (``offset`` is 0.0 there).
+    """
+    if not embedded_events:
+        return Alignment(0.0, RED, 0, 0, 0.0, 0.0, False, "no embedded triggers")
+
+    # Coarse pass: anchor only on codes that are rare on both sides, searching a
+    # capture window around the prior. The window is widened once for a large
+    # skew — including the case where the narrow window catches nothing on a side
+    # because every event sits beyond it, so an empty narrow window must retry the
+    # wide one (not refuse) before concluding the log truly does not overlap.
+    log_in: list[tuple[float, int]] = []
+    emb_in: list[tuple[float, int]] = []
+    anchor_deltas: list[float] = []
+    any_in_window = False
+    for capture in (_CAPTURE_SECONDS, _CAPTURE_SECONDS_WIDE):
+        log_in = _in_window(log_events, -capture, duration + capture)
+        emb_in = _in_window(embedded_events, -capture, duration + capture)
+        if not log_in or not emb_in:
+            continue
+        any_in_window = True
+        log_counts = _counts(log_in)
+        emb_counts = _counts(emb_in)
+        anchor_codes = {
+            code
+            for code in log_counts
+            if log_counts[code] <= _ANCHOR_MAX_COUNT
+            and emb_counts.get(code, 0) <= _ANCHOR_MAX_COUNT
+            and code in emb_counts
+        }
+        anchor_deltas = []
+        for code in anchor_codes:
+            log_secs = [t for t, c in log_in if c == code]
+            emb_secs = [t for t, c in emb_in if c == code]
+            anchor_deltas.extend(_match_one_to_one(log_secs, emb_secs, capture))
+        if anchor_deltas:
+            break
+
+    if not any_in_window:
+        return Alignment(0.0, RED, 0, 0, 0.0, 0.0, False, "log does not overlap")
+    n_anchor = len(anchor_deltas)
+    if n_anchor == 0:
+        return Alignment(
+            0.0, RED, 0, 0, 0.0, 0.0, False, "no rare anchor codes matched"
+        )
+
+    r0 = median(anchor_deltas)
+    # Refine: with the coarse offset fixed, match each code one-to-one in a tight
+    # window — *per code*, so a sparse code never pairs with an unrelated code
+    # that merely coincides in time (which would skew the offset and inflate the
+    # match count). The r0 shift brings true same-code pairs within ±0.5 s.
+    refine: list[float] = []
+    emb_by_code: dict[int, list[float]] = {}
+    for time, code in emb_in:
+        emb_by_code.setdefault(code, []).append(time)
+    log_by_code: dict[int, list[float]] = {}
+    for time, code in log_in:
+        log_by_code.setdefault(code, []).append(time + r0)
+    for code, log_secs in log_by_code.items():
+        if code in emb_by_code:
+            refine.extend(
+                _match_one_to_one(log_secs, emb_by_code[code], _REFINE_SECONDS)
+            )
+    residuals = refine if refine else [0.0]
+    offset = r0 + median(residuals)
+    mad = _mad(residuals, median(residuals))
+    n_matched = len(refine)
+    denominator = min(len(log_in), len(emb_in))
+    match_fraction = n_matched / denominator if denominator else 0.0
+    bimodal = _is_bimodal(anchor_deltas)
+
+    tier, reason = _grade(n_anchor, match_fraction, mad, bimodal)
+    if tier == RED:
+        return Alignment(
+            0.0, RED, n_anchor, n_matched, match_fraction, mad, bimodal, reason
+        )
+    return Alignment(
+        offset, tier, n_anchor, n_matched, match_fraction, mad, bimodal, reason
+    )
+
+
+def _grade(
+    n_anchor: int, match_fraction: float, mad: float, bimodal: bool
+) -> tuple[str, str]:
+    """Map the evidence to a tier and a one-line reason."""
+    if bimodal:
+        return RED, "matches split into two clusters (clock jump, DST, or wrong log)"
+    if mad > _AMBER_MAX_MAD or match_fraction < _AMBER_MIN_FRACTION:
+        return RED, "too few or too scattered matches"
+    if (
+        n_anchor >= _GREEN_MIN_ANCHORS
+        and match_fraction >= _GREEN_MIN_FRACTION
+        and mad <= _GREEN_MAX_MAD
+    ):
+        return GREEN, "aligned on embedded trigger codes"
+    return AMBER, "low-confidence alignment — verify before trusting marker times"

--- a/src/smacc/eeg/io.py
+++ b/src/smacc/eeg/io.py
@@ -15,6 +15,7 @@ rate, duration, ``get_slice``); tests fake it without MNE.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -49,6 +50,12 @@ FILE_FILTER = (
 # the Annotation model rejects empty descriptions, and inventing nothing is
 # worse than naming the gap.
 _UNLABELED = "unlabeled"
+
+# First run of digits in an embedded event description — the trigger code. SMACC
+# sends an integer byte; the amp records it as a bare "47" (Neuroscan/EEGLAB/EDF
+# TAL) or inside a label ("Stimulus/S 47", BrainVision). Amp-native events with
+# no number ("New Segment") yield nothing and are dropped (see recorded_trigger_events).
+_TRIGGER_CODE_RE = re.compile(r"\d+")
 
 
 class Recording:
@@ -135,14 +142,17 @@ def embedded_annotations(recording: Recording) -> list[Annotation]:
     new marks. Converted to this package's model so they save into the sidecar
     like any other annotation.
 
-    MNE's onsets are relative to ``orig_time`` when one is set (so the data
-    offset ``first_time`` must come off) and data-relative when it is ``None``
-    — the documented ``mne.Annotations`` semantics. Events that land outside
-    the data span after correction (possible on cropped files) are dropped.
+    MNE bakes the data offset ``first_time`` into the stored onsets, so it comes
+    off to recover the data-relative time — unconditionally, the way MNE's own
+    ``_sync_onset`` does it (``onset - first_time``). A conditional on
+    ``orig_time`` is wrong: an anonymized file (``meas_date`` stripped to
+    ``None``) keeps a non-zero ``first_samp`` but a ``None`` ``orig_time``, and
+    the offset is baked in regardless. Events that land outside the data span
+    after correction (possible on cropped files) are dropped.
     """
     raw = recording._raw
     duration = recording.duration
-    shift = raw.first_time if raw.annotations.orig_time is not None else 0.0
+    shift = raw.first_time
     out: list[Annotation] = []
     for onset, length, description in zip(
         raw.annotations.onset,
@@ -159,3 +169,74 @@ def embedded_annotations(recording: Recording) -> list[Annotation]:
         label = " ".join(str(description).split()) or _UNLABELED
         out.append(Annotation(data_onset, float(length), label))
     return sorted(out)
+
+
+def recorded_trigger_events(recording: Recording) -> list[tuple[float, int]]:
+    """Return ``(data_seconds, code)`` for every trigger the amp recorded.
+
+    The raw material for auto-aligning the session log to the EEG (#125): when a
+    hardware-TTL transport was wired into the amplifier, SMACC's portcodes land
+    in the recording as events, and matching them to the log's markers estimates
+    the clock-skew offset. Two sources are combined — codes parsed from
+    ``raw.annotations`` (BrainVision/Neuroscan/EEGLAB and EDF+ TAL) and codes on
+    a stim channel read with ``mne.find_events`` (FIF/EDF status) — covering the
+    formats sleep-lab amps produce. Empty when the file carries no triggers (an
+    LSL-only rig records markers only to its XDF, never the amp's native file),
+    in which case the aligner has nothing to match and the manual path stays.
+
+    Onsets are data-relative (the annotation/stim timebase), so they line up with
+    the log placement the aligner compares against.
+    """
+    raw = recording._raw
+    duration = recording.duration
+    out: list[tuple[float, int]] = []
+    # Annotation-borne codes. The data offset is baked into the stored onsets, so
+    # it comes off unconditionally — the same correction embedded_annotations
+    # makes, matching MNE's _sync_onset (and keeping these codes on the same
+    # data-relative timebase as the stim-channel codes below, even on an
+    # anonymized file with first_samp > 0 and no orig_time).
+    shift = raw.first_time
+    for onset, description in zip(
+        raw.annotations.onset, raw.annotations.description, strict=True
+    ):
+        match = _TRIGGER_CODE_RE.search(str(description))
+        if match is None:
+            continue
+        data_onset = float(onset) - shift
+        if 0.0 <= data_onset <= duration:
+            out.append((data_onset, int(match.group())))
+    out.extend(_stim_channel_events(recording))
+    return sorted(out)
+
+
+def _stim_channel_events(recording: Recording) -> list[tuple[float, int]]:
+    """Trigger codes on a stim channel (FIF/EDF status), or ``[]`` if there is none.
+
+    Guarded on a stim channel existing so an annotation-only file never pays
+    ``find_events``' full-length channel read or hits its "no stim channel"
+    error. Codes are read at their onset; the return-to-baseline 0 is dropped.
+    """
+    import mne
+
+    raw = recording._raw
+    if "stim" not in raw.get_channel_types():
+        return []
+    try:
+        # No stim_channel arg: find_events auto-detects (STI101 → STI 014 → the
+        # first stim-typed channel), which is what amp recordings carry.
+        # consecutive=True so a code written directly over a held one (SMACC's
+        # set-and-hold mode) is still reported even when it is numerically lower
+        # than the code it replaced; identical to the default for pulsed codes
+        # that return to baseline between events.
+        events = mne.find_events(
+            raw, shortest_event=1, consecutive=True, verbose="error"
+        )
+    except (ValueError, RuntimeError):
+        return []
+    sfreq = recording.sfreq
+    first = raw.first_samp
+    return [
+        (float(sample - first) / sfreq, int(code))
+        for sample, _prev, code in events
+        if int(code) > 0
+    ]

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -32,7 +32,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import preferences, windowstate
 from ..paths import LOGO_PATH, preferences_path
-from . import blind, dsp, io, sessionlog
+from . import align, blind, dsp, io, sessionlog
 from .annotations import (
     Annotation,
     autosave_path,
@@ -635,6 +635,12 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._visible_log: list[LogEntry] = []
         self._log_slide_base: float | None = None  # offset captured at drag start
         self._pairing_entry: LogEntry | None = None  # entry awaiting a paired click
+        # Auto-alignment (#125c): the recording's embedded trigger events (cached
+        # per recording; None until first needed) and the last estimate. The
+        # estimate is dropped the moment the offset is touched by hand, so its
+        # "aligned"/"unverified" badge only ever describes the current offset.
+        self._embedded_triggers: list[tuple[float, int]] | None = None
+        self._alignment: align.Alignment | None = None
         # Annotations recovered from an autosave, held until the user restores or
         # dismisses them (#176).
         self._recovery_annotations: list[Annotation] | None = None
@@ -1169,6 +1175,15 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.logAlignButton.clicked.connect(self._align_selected_log_entry)
         box.addWidget(self.logAlignButton)
 
+        self.autoAlignButton = QtWidgets.QPushButton("Auto-align to triggers", self)
+        self.autoAlignButton.setStatusTip(
+            "Estimate the offset by matching the log's markers to trigger codes "
+            "the amplifier recorded (needs a recording start time and embedded "
+            "triggers)."
+        )
+        self.autoAlignButton.clicked.connect(lambda: self._auto_align(announce=True))
+        box.addWidget(self.autoAlignButton)
+
         self.logGroup = group
         return group
 
@@ -1455,9 +1470,13 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.logOffsetSpin.blockSignals(True)
         self.logOffsetSpin.setValue(0.0)
         self.logOffsetSpin.blockSignals(False)
+        self._alignment = None
         self._rebuild_log_level_checks()
         self._refresh_log_overlay()
         self._update_log_controls()
+        # Try to place the log automatically against the amp's embedded triggers;
+        # a confident fit applies, otherwise the manual gestures take over.
+        self._auto_align(announce=False)
 
     def _log_has_level(self, level: str) -> bool:
         return any(e.level == level for e in self._log_entries)
@@ -1469,6 +1488,11 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._log_path = None
         self._visible_log = []
         self._log_slide_base = None
+        self._alignment = None
+        self._log_offset = 0.0  # don't carry one log's offset into the next
+        self.logOffsetSpin.blockSignals(True)
+        self.logOffsetSpin.setValue(0.0)
+        self.logOffsetSpin.blockSignals(False)
         self.logList.blockSignals(True)
         self.logList.clear()
         self.logList.blockSignals(False)
@@ -1585,8 +1609,13 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._refresh_log_overlay()
 
     def _on_log_offset_changed(self, value: float) -> None:
+        self._clear_alignment_estimate()  # a hand-set offset is no longer the estimate
         self._log_offset = value
         self._refresh_log_overlay()
+
+    def _clear_alignment_estimate(self) -> None:
+        """Forget the auto-alignment grade (the offset is being set by hand now)."""
+        self._alignment = None
 
     def _on_log_slide_started(self) -> None:
         """Capture the offset each gesture starts from (every drag re-bases here).
@@ -1596,6 +1625,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         never strand a stale base into the next slide: the next gesture always
         re-bases from the current offset.
         """
+        self._clear_alignment_estimate()  # a hand-dragged offset isn't the estimate
         self._log_slide_base = self._log_offset
 
     def _on_log_slide_moved(self, delta: float) -> None:
@@ -1666,6 +1696,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._end_pairing()
         if entry is None or origin is None:
             return
+        self._clear_alignment_estimate()  # a hand-paired offset isn't the estimate
         # Solve for the offset that puts this entry at the clicked time.
         self._set_log_offset(seconds - sessionlog.seconds_at(entry, origin, 0.0))
         status_bar = self.statusBar()
@@ -1677,6 +1708,76 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._pairing_entry = None
         self.view.set_pick_mode(False)
 
+    # ----- auto-alignment (#125c) ------------------------------------------------
+
+    def _auto_align(self, *, announce: bool) -> None:
+        """Estimate and apply the offset by matching the log to embedded triggers.
+
+        Opportunistic: it works only when the amp recorded SMACC's trigger codes
+        (a hardware-TTL rig) and the file carries a start time. A confident
+        (green) fit is applied silently; a low-confidence (amber) one is applied
+        but flagged; an unreliable or contradictory (red) one is refused, leaving
+        the offset for the manual path. ``announce`` adds a dialog (the user
+        pressed the button and wants to know what happened).
+        """
+        if self._recording is None or not self._log_entries:
+            return
+        if self._recording.meas_date is None:
+            self._alignment = None
+            self._refresh_log_overlay()
+            if announce:
+                self._error(
+                    "No recording start time.",
+                    "This recording has no start time to align against, so the "
+                    "log can only be aligned by hand (drag the lane, or pair an "
+                    "entry to a feature).",
+                )
+            return
+        if self._embedded_triggers is None:
+            self._embedded_triggers = io.recorded_trigger_events(self._recording)
+        origin = self._log_origin()
+        assert origin is not None  # meas_date present → wall_time gives an origin
+        log_events = [
+            (sessionlog.seconds_at(entry, origin, 0.0), entry.code)
+            for entry in self._log_entries
+            if entry.code is not None
+        ]
+        result = align.estimate_offset(
+            log_events, self._embedded_triggers, duration=self._recording.duration
+        )
+        self._alignment = result
+        if result.tier == align.RED:
+            self._refresh_log_overlay()  # offset unchanged; status reflects the miss
+        else:
+            self._set_log_offset(result.offset)  # also refreshes the overlay/status
+        if announce:
+            self._announce_alignment(result)
+
+    def _announce_alignment(self, result: align.Alignment) -> None:
+        """Report an explicit Auto-align press: what matched and what was applied."""
+        if result.tier == align.GREEN:
+            QtWidgets.QMessageBox.information(
+                self,
+                "Log aligned",
+                f"Aligned on {result.n_anchor} anchor markers "
+                f"({result.n_matched} matched, ±{result.residual_mad:.2f} s). "
+                f"Offset set to {self._log_offset:+.2f} s.",
+            )
+        elif result.tier == align.AMBER:
+            self._error(
+                "Low-confidence alignment.",
+                f"{result.reason.capitalize()}. The offset was applied "
+                f"({self._log_offset:+.2f} s) but is marked unverified — check it "
+                "against a known event before trusting marker times.",
+            )
+        else:
+            self._error(
+                "Could not auto-align the log.",
+                f"{result.reason.capitalize()}. The offset was left unchanged; "
+                "align the log by hand (drag the lane, or pair an entry to a "
+                "feature).",
+            )
+
     def _update_log_controls(self) -> None:
         """Enable the log controls by state (recording open, log loaded, blind)."""
         has_log = bool(self._log_entries)
@@ -1686,15 +1787,26 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.logAlignButton.setEnabled(
             has_log and 0 <= self.logList.currentRow() < len(self._visible_log)
         )
+        # Auto-align needs a start time to align against; without one only the
+        # manual gestures apply.
+        self.autoAlignButton.setEnabled(
+            has_log
+            and self._recording is not None
+            and self._recording.meas_date is not None
+        )
 
     def _update_log_status(self) -> None:
-        """Show the loaded log and its offset in the permanent status area."""
+        """Show the loaded log, its offset, and any alignment grade in the status."""
         if not self._log_entries or self._log_path is None:
             self.logInfoLabel.clear()
             return
-        self.logInfoLabel.setText(
-            f"log: {self._log_path.name} · offset {self._log_offset:+.2f} s"
-        )
+        text = f"log: {self._log_path.name} · offset {self._log_offset:+.2f} s"
+        result = self._alignment
+        if result is not None and result.tier == align.GREEN:
+            text += f" · aligned ({result.n_matched} marks)"
+        elif result is not None and result.tier == align.AMBER:
+            text += " · alignment unverified"
+        self.logInfoLabel.setText(text)
 
     # ----- opening a recording ---------------------------------------------------
 
@@ -1753,6 +1865,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._recording = recording
         self._annotations = annotations
         self._dirty = False
+        self._embedded_triggers = None  # belong to the previous recording; re-read
         # We own the sidecar when we loaded from it; a fresh review does not yet,
         # so its first save guards against overwriting one that appeared meanwhile.
         self._owns_sidecar = tsv_path.is_file()

--- a/tests/test_eeg_align.py
+++ b/tests/test_eeg_align.py
@@ -1,0 +1,129 @@
+"""Tests for the log↔EEG auto-alignment estimator (#125, pure, no GUI/MNE)."""
+
+from __future__ import annotations
+
+import pytest
+
+from smacc.eeg import align
+
+
+def _shift(events, by):
+    """Move every (seconds, code) event later by ``by`` seconds."""
+    return [(t + by, c) for t, c in events]
+
+
+# Three rare anchor codes (clapper 49, two dream reports) plus a periodic cue
+# code 60 firing every 2 s — the realistic shape the matcher must handle.
+ANCHORS = [(100.0, 49), (500.0, 201), (1500.0, 202)]
+CUES = [(float(t), 60) for t in range(200, 260, 2)]  # 30 firings, 2 s apart
+EMBEDDED = sorted(ANCHORS + CUES)
+
+
+def test_clean_offset_is_recovered_green():
+    # The EEG carries the same codes 3 s after where the log places them.
+    log = _shift(EMBEDDED, -3.0)
+    result = align.estimate_offset(log, EMBEDDED, duration=2000.0)
+    assert result.tier == align.GREEN
+    assert result.offset == 3.0
+    assert result.n_anchor == 3
+    assert result.residual_mad <= 0.25
+
+
+def test_periodic_cue_codes_do_not_alias_the_offset():
+    # The same fit, but the meas_date prior is off by ~one cue period (2 s). A
+    # naive nearest-neighbour on the cue code would snap to a neighbour and fit
+    # tightly but wrongly; anchoring only on the rare codes keeps it correct.
+    log = _shift(EMBEDDED, -3.0)
+    result = align.estimate_offset(log, EMBEDDED, duration=2000.0)
+    # Offset is driven by the anchors, not the dense periodic code.
+    assert result.offset == 3.0
+
+
+def test_no_embedded_triggers_is_red():
+    log = _shift(EMBEDDED, -3.0)
+    result = align.estimate_offset(log, [], duration=2000.0)
+    assert result.tier == align.RED
+    assert result.offset == 0.0
+    assert "no embedded" in result.reason
+
+
+def test_only_periodic_codes_gives_no_anchor_red():
+    # Without a rare code to anchor on, the matcher refuses rather than guessing
+    # from an aliasing periodic code.
+    log = _shift(CUES, -3.0)
+    result = align.estimate_offset(log, CUES, duration=2000.0)
+    assert result.tier == align.RED
+    assert result.n_anchor == 0
+
+
+def test_clock_jump_makes_it_bimodal_red():
+    # Half the night's anchors sit at +3 s, the other half at +20 s (an NTP step
+    # mid-record). A single median would be confidently wrong; refuse instead.
+    embedded = [
+        (100.0, 49),
+        (500.0, 201),
+        (1500.0, 202),
+        (2500.0, 110),
+        (3500.0, 111),
+        (4500.0, 112),
+    ]
+    log = [
+        (97.0, 49),
+        (497.0, 201),
+        (1497.0, 202),  # +3 s cluster
+        (2480.0, 110),
+        (3480.0, 111),
+        (4480.0, 112),  # +20 s cluster
+    ]
+    result = align.estimate_offset(log, embedded, duration=5000.0)
+    assert result.bimodal is True
+    assert result.tier == align.RED
+
+
+def test_wrong_log_no_overlap_is_red():
+    # A log whose events land entirely outside the recording span (a different
+    # night) has nothing in the window to match.
+    far = _shift(EMBEDDED, 100000.0)
+    result = align.estimate_offset(far, EMBEDDED, duration=2000.0)
+    assert result.tier == align.RED
+    assert "overlap" in result.reason
+
+
+def test_excluded_codes_are_ignored():
+    # Code 0 (baseline) and 255 (the increment-band clamp collision) never anchor.
+    embedded = [(100.0, 0), (200.0, 255), (300.0, 49), (800.0, 201), (1600.0, 202)]
+    log = _shift(embedded, -2.0)
+    result = align.estimate_offset(log, embedded, duration=2000.0)
+    # Only 49/201/202 anchor; 0 and 255 are dropped (still a clean +2 s fit).
+    assert result.offset == 2.0
+    assert result.n_anchor == 3
+
+
+def test_one_to_one_match_does_not_double_assign():
+    # Two embedded code-49 events near one log code-49: only one pair forms.
+    deltas = align._match_one_to_one([10.0], [9.8, 10.3], tol=1.0)
+    assert len(deltas) == 1
+    assert abs(deltas[0]) <= 0.3  # the nearer (9.8) is chosen
+
+
+def test_wide_capture_window_recovers_a_large_skew():
+    # All anchors sit in the first minute; the log places them 200 s before the
+    # embedded events — beyond the ±90 s narrow window, so the narrow pass finds
+    # nothing in-window on the log side. The wide (±300 s) window must still be
+    # tried rather than refusing outright.
+    embedded = [(20.0, 49), (40.0, 201), (60.0, 202)]
+    log = _shift(embedded, -200.0)
+    result = align.estimate_offset(log, embedded, duration=100.0)
+    assert result.tier == align.GREEN
+    assert result.offset == pytest.approx(200.0)
+
+
+def test_refine_does_not_count_cross_code_coincidences():
+    # A log code-70 event coincides (within 0.5 s after the +3 s shift) with an
+    # embedded code-99 event. They are different codes, so the refine pass must
+    # NOT pair them — that would inflate the match count and skew the offset.
+    embedded = [(100.0, 49), (500.0, 201), (1500.0, 202), (1003.0, 99)]
+    log = [(97.0, 49), (497.0, 201), (1497.0, 202), (1000.0, 70)]
+    result = align.estimate_offset(log, embedded, duration=2000.0)
+    assert result.offset == pytest.approx(3.0)  # not pulled by the 70↔99 coincidence
+    assert result.n_matched == 3  # only the three real same-code anchors

--- a/tests/test_eeg_io.py
+++ b/tests/test_eeg_io.py
@@ -171,3 +171,63 @@ def test_embedded_annotations_never_surface_out_of_range_events(tmp_path):
     cropped.save(path, verbose="error")
     found = io.embedded_annotations(io.open_recording(path))
     assert [a.description for a in found] == ["kept"]
+
+
+# ----- recorded trigger events (#125 auto-alignment) ------------------------
+
+
+def test_recorded_trigger_events_parses_codes_from_annotations(tmp_path):
+    # Codes surface in annotations as a bare "47" (Neuroscan/EEGLAB/EDF TAL) or
+    # inside a label "Stimulus/S 60" (BrainVision); both yield the integer.
+    raw = _make_raw()
+    raw.set_annotations(
+        mne.Annotations(
+            onset=[1.0, 2.0, 3.0],
+            duration=[0.0, 0.0, 0.0],
+            description=["47", "Stimulus/S 60", "New Segment"],
+        )
+    )
+    path = tmp_path / "trig_raw.fif"
+    raw.save(path, verbose="error")
+    events = io.recorded_trigger_events(io.open_recording(path))
+    # The two numeric codes are extracted; "New Segment" (no digits) is dropped.
+    assert events == [(1.0, 47), (2.0, 60)]
+
+
+def test_recorded_trigger_events_reads_a_stim_channel(tmp_path):
+    # A FIF with a STIM channel carrying codes 5 (at 1 s) and 7 (at 2 s).
+    info = mne.create_info(["C3", "STI 014"], sfreq=SFREQ, ch_types=["eeg", "stim"])
+    data = np.zeros((2, int(3 * SFREQ)))
+    data[1, int(1.0 * SFREQ)] = 5
+    data[1, int(2.0 * SFREQ)] = 7
+    raw = mne.io.RawArray(data, info, verbose="error")
+    path = tmp_path / "stim_raw.fif"
+    raw.save(path, verbose="error")
+    events = io.recorded_trigger_events(io.open_recording(path))
+    assert (1.0, 5) in events
+    assert (2.0, 7) in events
+
+
+def test_recorded_trigger_events_empty_when_no_triggers(fif_path):
+    # The fixture's only annotation is "Arousal" (no digits) and it has no stim
+    # channel — an LSL-only-style file with nothing to match.
+    assert io.recorded_trigger_events(io.open_recording(fif_path)) == []
+
+
+def test_trigger_events_data_relative_when_anonymized_with_first_samp(tmp_path):
+    # An anonymized recording drops meas_date but keeps a non-zero first_samp;
+    # MNE bakes first_time into the stored onsets, so the data-relative time must
+    # still come off (matching the stim-channel timebase), not be left too large.
+    info = mne.create_info(["C3", "STI 014"], sfreq=SFREQ, ch_types=["eeg", "stim"])
+    data = np.zeros((2, int(5 * SFREQ)))
+    data[1, int(1.0 * SFREQ)] = 9  # a stim code at data-second 1.0
+    raw = mne.io.RawArray(data, info, first_samp=int(2.0 * SFREQ), verbose="error")
+    raw.set_annotations(
+        mne.Annotations(onset=[1.0], duration=[0.0], description=["9"])
+    )  # an annotation code at data-second 1.0 (orig_time None, meas_date None)
+    path = tmp_path / "anon_raw.fif"
+    raw.save(path, verbose="error")
+    events = io.recorded_trigger_events(io.open_recording(path))
+    # Both the annotation code and the stim code land at 1.0 s — consistent, not
+    # offset by first_time (2.0 s).
+    assert events.count((1.0, 9)) == 2

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -23,7 +23,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from smacc import preferences
 from smacc.config import VERSION
-from smacc.eeg import blind, dsp
+from smacc.eeg import align, blind, dsp
 from smacc.eeg import window as window_mod
 from smacc.eeg.__main__ import pick_blind_spec, pick_rater_id, pick_recording_path
 from smacc.eeg.annotations import (
@@ -67,6 +67,11 @@ def window(qtbot, tmp_path, monkeypatch):
     monkeypatch.setattr(window_mod, "preferences_path", tmp_path / "prefs.yaml")
     monkeypatch.setattr(window_mod.io, "open_recording", FakeRecording)
     monkeypatch.setattr(window_mod.io, "embedded_annotations", lambda rec: [])
+    # Auto-align (#125c) reads the recording's embedded triggers on every log
+    # load; the fake recording has none, so default to empty (the auto-align
+    # tests override this). Without it, recorded_trigger_events hits the fake's
+    # missing _raw.
+    monkeypatch.setattr(window_mod.io, "recorded_trigger_events", lambda rec: [])
     # Tests routinely leave unsaved annotations, and pytest-qt closes added
     # widgets in its runtest-teardown hook — *before* fixture cleanup could
     # reset any state — so a dirty close would raise a real (blocking)
@@ -1033,6 +1038,7 @@ def make_window(qtbot, tmp_path, monkeypatch):
     monkeypatch.setattr(window_mod, "preferences_path", tmp_path / "prefs.yaml")
     monkeypatch.setattr(window_mod.io, "open_recording", FakeRecording)
     monkeypatch.setattr(window_mod.io, "embedded_annotations", lambda rec: [])
+    monkeypatch.setattr(window_mod.io, "recorded_trigger_events", lambda rec: [])
     monkeypatch.setattr(
         QtWidgets.QMessageBox,
         "question",
@@ -1683,3 +1689,105 @@ def test_esc_cancels_pairing(window, recording_path, monkeypatch, tmp_path):
     window.eventFilter(window, esc)
     assert window._pairing_entry is None
     assert not window.view._pick_mode
+
+
+# ----- auto-alignment (#125c) ------------------------------------------------
+
+# A log with three rare anchor codes (lights-off 47 at 5 s, REM 41 at 20 s,
+# clapper 49 at 25 s) placed against the 22:00:00 recording start.
+ALIGN_LOG = (
+    "2026-06-05 22:00:00.000-0500, INFO, Opened SMACC v0.0.7\n"
+    "2026-06-05 22:00:05.000-0500, INFO, Lights off - portcode 47\n"
+    "2026-06-05 22:00:20.000-0500, INFO, REM detected - portcode 41\n"
+    "2026-06-05 22:00:25.000-0500, INFO, Clapper - portcode 49\n"
+)
+# The same three codes the amp recorded, 3 s later than the log places them.
+ALIGN_TRIGGERS = [(8.0, 47), (23.0, 41), (28.0, 49)]
+
+
+def test_auto_align_applies_a_green_offset_on_load(
+    window, recording_path, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        window_mod.io, "recorded_trigger_events", lambda rec: ALIGN_TRIGGERS
+    )
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path, ALIGN_LOG)
+    assert window._alignment is not None
+    assert window._alignment.tier == align.GREEN
+    assert window._log_offset == pytest.approx(3.0)  # the recovered skew
+    # Every INFO entry shifts by the offset — the "Opened" line (0 → 3) plus the
+    # three matched markers (5/20/25 → 8/23/28). Only coded markers drive the fit.
+    assert [m.seconds for m in window.view._log_marks] == [3.0, 8.0, 23.0, 28.0]
+    assert "aligned" in window.logInfoLabel.text()
+
+
+def test_auto_align_red_leaves_the_offset_unchanged(
+    window, recording_path, monkeypatch, tmp_path
+):
+    # No embedded triggers → nothing to match → red, offset stays at the
+    # wall-clock placement (0), no "aligned" badge.
+    monkeypatch.setattr(window_mod.io, "recorded_trigger_events", lambda rec: [])
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path, ALIGN_LOG)
+    assert window._alignment.tier == align.RED
+    assert window._log_offset == 0.0
+    assert "aligned" not in window.logInfoLabel.text()
+
+
+def test_auto_align_button_announces_the_result(
+    window, recording_path, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        window_mod.io, "recorded_trigger_events", lambda rec: ALIGN_TRIGGERS
+    )
+    infos = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "information",
+        lambda *a, **k: infos.append(a[2] if len(a) > 2 else ""),
+    )
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path, ALIGN_LOG)
+    window._auto_align(announce=True)
+    assert infos and "Aligned on 3 anchor" in infos[-1]
+
+
+def test_auto_align_disabled_without_a_recording_start(
+    window, recording_path, monkeypatch, tmp_path
+):
+    window._load(recording_path)
+    window._recording.meas_date = None  # anonymized recording
+    _overlay_log(window, monkeypatch, tmp_path, ALIGN_LOG)
+    assert not window.autoAlignButton.isEnabled()
+    assert window._alignment is None  # auto-align on load did nothing
+    assert window._log_offset == 0.0
+
+
+def test_manual_offset_clears_the_alignment_badge(
+    window, recording_path, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        window_mod.io, "recorded_trigger_events", lambda rec: ALIGN_TRIGGERS
+    )
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path, ALIGN_LOG)
+    assert window._alignment is not None
+    window._on_log_offset_changed(1.0)  # hand-set offset
+    assert window._alignment is None  # the estimate no longer describes the offset
+    assert "aligned" not in window.logInfoLabel.text()
+
+
+def test_new_recording_re_reads_embedded_triggers(
+    window, recording_path, monkeypatch, tmp_path
+):
+    monkeypatch.setattr(
+        window_mod.io, "recorded_trigger_events", lambda rec: ALIGN_TRIGGERS
+    )
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path, ALIGN_LOG)
+    assert window._embedded_triggers == ALIGN_TRIGGERS
+    other = tmp_path / "night2.edf"
+    other.write_bytes(b"")
+    window._load(other)
+    assert window._embedded_triggers is None  # invalidated for the new recording


### PR DESCRIPTION
Third PR of the #125 stack — **stacked on #217**. Adds opportunistic auto-alignment: when the amplifier recorded SMACC's trigger codes (a hardware-TTL rig), estimate the clock-skew offset by matching the log's markers to them.

- **Matcher** (`smacc.eeg.align`, pure): anchors only on *rare* codes (clapper, dream report, recording-start) so the periodic cue codes can't alias to the wrong firing, refines per-code one-to-one within ±0.5 s, and grades the fit — **green** (apply silently), **amber** (apply, flag *unverified*), **red** (refuse: too few/scattered matches, or two clusters from a clock jump, DST, or the wrong log). v1 is a constant offset; drift is out of scope.
- **Extraction** (`io.recorded_trigger_events`): codes from `raw.annotations` (BrainVision/Neuroscan/EEGLAB, EDF+ TAL) and from a stim channel via `find_events` (FIF/EDF status). Empty on an LSL-only rig (triggers live only in the XDF), where the manual path stays.
- **Window**: runs on log load, plus an **Auto-align to triggers** button; the status bar badges the grade, cleared the moment the offset is touched by hand.

An adversarial multi-agent review of the matcher caught and this PR fixes: a wide-capture-window short-circuit (large skews were refused), a refine pass that matched *across* codes (skewing the applied offset and inflating confidence), an onset-shift bug in `embedded_annotations`/`recorded_trigger_events` (an anonymized FIF with `meas_date=None` but `first_samp>0` was off by `first_time` — now unconditional like MNE's `_sync_onset`), and `find_events` dropping SMACC's set-and-hold codes (`consecutive=True`). All with regression tests. 1028 tests pass; ruff + mypy + mdformat clean.

Real-hardware validation still wanted (a recording with embedded SMACC triggers) before relying on a green auto-fit. Refs #125.
