### PR TITLE
feat: inspect a session log standalone and hand it off from Analyze

### DIFF
--- a/docs/eeg-review.md
+++ b/docs/eeg-review.md
@@ -77,12 +77,18 @@ The sidecar format is documented in the
 Load the night's SMACC session [`.log`](reference/session-log.md) onto the
 timeline as a **read-only reference track** — every marker, cue, dream report,
 and survey shown where it happened, so you see what SMACC *did* alongside the
-EEG. Click **Load session log…** in the **Session log** panel (a recording must
-be open; the log aligns to *its* clock). Ticks appear in a thin lane across the
-top, coloured by log level, with the full message on hover. The per-level
-checkboxes show or hide levels just like the live preview — `DEBUG` (raw-trigger
-and volume-edit noise) is off by default. The log is reference context only: it
-is never editable and never saved into your annotations.
+EEG. Click **Load session log…** in the **Session log** panel. Ticks appear in a
+thin lane across the top, coloured by log level, with the full message on hover.
+The per-level checkboxes show or hide levels just like the live preview —
+`DEBUG` (raw-trigger and volume-edit noise) is off by default. The log is
+reference context only: it is never editable and never saved into your
+annotations.
+
+You can load a log **with or without a recording open**. With one, it overlays
+and aligns to *that* recording's clock. With none, it opens **standalone** on a
+bare time axis — for inspecting a log on its own (the **Analyze** window's *Open
+log in EEG annotator* hands a session off this way). Opening a recording while a
+standalone log is shown switches to the overlaid view.
 
 **Aligning the log.** The log's timestamps come from the recording PC while the
 EEG's clock comes from the amplifier, so the two can differ by seconds or more.

--- a/src/smacc/analyze.py
+++ b/src/smacc/analyze.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from . import bids, preferences, settings, windowstate
+from . import bids, eeg, preferences, settings, windowstate
 from .dialogs import ask_initial_or_final
 from .panels.base import make_section_title
 from .paths import DEFAULT_DATA_DIR, LOGO_PATH, preferences_path
@@ -137,7 +137,20 @@ class AnalyzeWindow(ToolWindow):
         self.revealButton = QtWidgets.QPushButton("Open session folder", self)
         self.revealButton.setStatusTip("Open the session's folder in the file browser.")
         self.revealButton.clicked.connect(self.reveal_folder)
-        for button in (self.exportButton, self.recoverButton, self.revealButton):
+        # Hand the session to the EEG annotator, which overlays this log on the
+        # timeline (#125). Shown only where the annotator component is available.
+        self.annotateButton = QtWidgets.QPushButton("Open log in EEG annotator", self)
+        self.annotateButton.setStatusTip(
+            "Open this session log in the EEG annotator (overlaid on a recording, "
+            "or on its own time axis)."
+        )
+        self.annotateButton.clicked.connect(self.open_in_annotator)
+        for button in (
+            self.exportButton,
+            self.recoverButton,
+            self.revealButton,
+            self.annotateButton,
+        ):
             layout.addWidget(button)
 
         self.statusBar()
@@ -151,6 +164,8 @@ class AnalyzeWindow(ToolWindow):
         """Enable the action buttons only once a session has been loaded."""
         for button in (self.exportButton, self.recoverButton, self.revealButton):
             button.setEnabled(loaded)
+        # The annotator handoff also needs the optional EEG component installed.
+        self.annotateButton.setEnabled(loaded and eeg.available())
 
     # ----- opening a session ------------------------------------------------
 
@@ -296,6 +311,40 @@ class AnalyzeWindow(ToolWindow):
             QtGui.QDesktopServices.openUrl(
                 QtCore.QUrl.fromLocalFile(str(self._base_dir))
             )
+
+    def open_in_annotator(self) -> None:
+        """Hand this session's log to the EEG annotator as its own process (#125).
+
+        Analyze stays the no-EEG summary/BIDS tool; the annotator is where the log
+        is seen on a timeline (overlaid on a recording, or standalone). Launched
+        detached, like the launcher's Review-EEG button.
+        """
+        if self._log_path is None:
+            return
+        if not eeg.launch(["--log", str(self._log_for_handoff())]):
+            self._error(
+                "Could not start the EEG annotator.",
+                "Re-running the SMACC installer and selecting the EEG Review "
+                "Tools component may fix this.",
+            )
+
+    def _log_for_handoff(self) -> Path:
+        """A log path that outlives this window — copied out of a zip extraction.
+
+        The annotator reads the file later, in its own detached process; a
+        zip-extracted log lives under a temp dir this window deletes on close
+        (``closeEvent``), so it is copied to a directory the cleanup never
+        touches. A log opened directly (its own ``.log`` or a folder) is passed
+        through unchanged.
+        """
+        assert self._log_path is not None
+        in_temp = any(tmp in self._log_path.parents for tmp in self._temp_dirs)
+        if not in_temp:
+            return self._log_path
+        # A fresh temp dir deliberately *not* tracked in _temp_dirs, so closeEvent
+        # leaves it for the annotator (and the OS) to own.
+        keep = Path(tempfile.mkdtemp(prefix="smacc-handoff-"))
+        return Path(shutil.copy(self._log_path, keep / self._log_path.name))
 
     # ----- helpers / lifecycle ----------------------------------------------
 

--- a/src/smacc/eeg/__init__.py
+++ b/src/smacc/eeg/__init__.py
@@ -51,20 +51,23 @@ def available() -> bool:
     return find_spec("mne") is not None and find_spec("pyqtgraph") is not None
 
 
-def launch() -> bool:
+def launch(args: list[str] | None = None) -> bool:
     """Start the EEG review tool as its own detached process; True if started.
 
     Detached on purpose: the viewer outlives the launcher (or a session) and
     never shares a process with them — see the isolation rationale above. The
     development path runs ``python -m smacc.eeg`` with the current
-    interpreter, the packaged path runs the installed exe.
+    interpreter, the packaged path runs the installed exe. ``args`` are extra
+    command-line arguments (e.g. ``["--log", path]`` for the Analyze handoff),
+    appended after the module/exe so both paths receive them identically.
     """
     from PyQt6 import QtCore  # deferred: keep this module import-light
 
+    extra = list(args) if args else []
     if getattr(sys, "frozen", False):
-        started, _pid = QtCore.QProcess.startDetached(str(component_exe()), [])
+        started, _pid = QtCore.QProcess.startDetached(str(component_exe()), extra)
     else:
         started, _pid = QtCore.QProcess.startDetached(
-            sys.executable, ["-m", "smacc.eeg"]
+            sys.executable, ["-m", "smacc.eeg", *extra]
         )
     return started

--- a/src/smacc/eeg/__main__.py
+++ b/src/smacc/eeg/__main__.py
@@ -29,7 +29,7 @@ from ..config import VERSION
 from .window import EegReviewWindow
 
 # Flags that take a following value, so the recording-path scan skips that value.
-_VALUE_FLAGS = ("--rater", "--blind")
+_VALUE_FLAGS = ("--rater", "--blind", "--log")
 
 
 def pick_recording_path(args: list[str]) -> str | None:
@@ -85,6 +85,17 @@ def pick_blind_spec(args: list[str]) -> str | None:
     surfaced as a dialog after the window opens, not as a vanishing process.
     """
     return _flag_value(args, "--blind")
+
+
+def pick_log_path(args: list[str]) -> str | None:
+    """Return the ``--log`` value (a SMACC session log to overlay/show), or ``None``.
+
+    Lets the Analyze window hand a session off to the annotator
+    (``SMACC-EEG.exe --log night1.log``): with no recording the log opens
+    standalone, with one it overlays. Read/parse errors surface as a dialog after
+    the window opens, not as a vanishing process.
+    """
+    return _flag_value(args, "--log")
 
 
 def selftest() -> int:
@@ -170,6 +181,7 @@ def main() -> None:
         pick_recording_path(sys.argv),
         rater_id=pick_rater_id(sys.argv),
         blind_spec=pick_blind_spec(sys.argv),
+        log_path=pick_log_path(sys.argv),
     )
     window.show()
     sys.exit(app.exec())

--- a/src/smacc/eeg/view.py
+++ b/src/smacc/eeg/view.py
@@ -390,6 +390,9 @@ class TraceView(pg.PlotWidget):
         # Pick mode: a click reports its time (to pair a log entry to an EEG
         # feature) instead of selecting an annotation.
         self._pick_mode = False
+        # Whether the log lane may be slid to align — off in standalone mode,
+        # which has no recording clock to reconcile against (#125d).
+        self._log_alignable = True
         self._curves: list[pg.PlotDataItem] = []
 
         self._viewbox.dragFinished.connect(self._on_drag_finished)
@@ -421,6 +424,21 @@ class TraceView(pg.PlotWidget):
     @property
     def window_seconds(self) -> float:
         return self._window_seconds
+
+    @property
+    def has_provider(self) -> bool:
+        """Whether something is loaded to scroll — a recording or a log timeline."""
+        return self._provider is not None
+
+    @property
+    def duration(self) -> float:
+        """The loaded provider's length in seconds (0 when nothing is loaded).
+
+        Lets the window size its scrollbar from whatever is shown — a recording
+        or the standalone log timeline (#125) — without reaching into a recording
+        it may not have.
+        """
+        return self._provider.duration if self._provider is not None else 0.0
 
     @property
     def annotations(self) -> list[Annotation]:
@@ -698,12 +716,23 @@ class TraceView(pg.PlotWidget):
 
         Marks are kept sorted by time so each scroll redraws only the handful in
         view (an overnight log has thousands of entries). A non-empty list arms
-        the top-lane slide, so a drag up there aligns the log instead of drawing
-        a span; an empty list disarms it.
+        the top-lane slide (so a drag up there aligns the log) *when alignment is
+        enabled* — standalone log mode has no second clock to correct, so it
+        disables it; an empty list always disarms.
         """
         self._log_marks = sorted(marks, key=lambda m: m.seconds)
-        self._viewbox.set_log_lane_active(bool(self._log_marks))
+        self._viewbox.set_log_lane_active(bool(self._log_marks) and self._log_alignable)
         self._refresh_log_marks()
+
+    def set_log_alignable(self, enabled: bool) -> None:
+        """Allow (or forbid) sliding the log lane — off when there is no recording.
+
+        Aligning reconciles the log clock with the recording's; with no recording
+        loaded (standalone mode) there is only one clock, so a slide would only
+        push the ticks off their own axis labels. The window disables it there.
+        """
+        self._log_alignable = enabled
+        self._viewbox.set_log_lane_active(bool(self._log_marks) and enabled)
 
     def set_pick_mode(self, enabled: bool) -> None:
         """In pick mode a click reports its time via ``timePicked`` (for pairing).

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -589,6 +589,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         file_path: str | Path | None = None,
         rater_id: str | None = None,
         blind_spec: str | None = None,
+        log_path: str | Path | None = None,
     ) -> None:
         super().__init__()
         self._recording: io.Recording | None = None
@@ -672,6 +673,12 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             # After the event loop starts, so the window is up before any
             # open-error dialog (and a long load doesn't block the first paint).
             QtCore.QTimer.singleShot(0, lambda: self._load(Path(file_path)))
+        if log_path is not None:
+            # Open a session log too (or on its own, standalone — the Analyze
+            # window's "open in annotator" handoff uses this). Deferred for the
+            # same reason; runs after the recording load so it overlays when both
+            # are given.
+            QtCore.QTimer.singleShot(0, lambda: self.load_session_log(Path(log_path)))
 
     # ----- rater identity (#181) ----------------------------------------------
 
@@ -1321,6 +1328,13 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         # cue ticks on screen under a blind preset.
         if config is not None:
             self._clear_log_overlay()
+            # A standalone log (no recording) has no _load to fall through to, so
+            # tear its bare timeline down here too — otherwise the empty axis and
+            # the "log only · N entries" label would leak that a log was loaded.
+            if self._recording is None:
+                self.view.set_provider(None)
+                self.fileInfoLabel.clear()
+                self._set_loaded(False)
         if self._recording is not None:
             self._load(self._recording.path)  # re-resolve marks under the new mode
         self._update_log_controls()  # the Load-log button follows the blind state
@@ -1422,42 +1436,43 @@ class EegReviewWindow(QtWidgets.QMainWindow):
     # ----- session-log overlay (#125) --------------------------------------------
 
     def _can_overlay_log(self) -> bool:
-        """True when a log may be overlaid: a recording is open and not blinded.
+        """True when a log may be overlaid on a recording (one is open, not blind).
 
         A blind review never shows the log — it records every cue and portcode,
         which would unblind the rater (the same invariant as the peer overlays).
         """
         return self._recording is not None and self._blind is None
 
-    def _load_session_log(self) -> None:
-        """Pick a SMACC ``.log`` and overlay its parsed entries (#125)."""
-        if not self._can_overlay_log():
-            return
-        prefs = preferences.load_preferences(preferences_path)
-        start_dir = prefs.get("eeg_last_log_dir") or (
-            str(self._recording.path.parent)
-            if self._recording is not None
-            else str(Path.home())
-        )
-        path, _ = QtWidgets.QFileDialog.getOpenFileName(
-            self, "Open session log", str(start_dir), "SMACC log (*.log);;All files (*)"
-        )
-        if not path:
-            return
+    def _can_load_log(self) -> bool:
+        """True when a log may be loaded at all — i.e. not in a blind review.
+
+        With a recording open it overlays; with none it opens *standalone* on a
+        bare time axis (#125), for inspecting a log on its own. Both are refused
+        while blind (the log carries the cue markers).
+        """
+        return self._blind is None
+
+    def load_session_log(self, path: str | Path) -> bool:
+        """Load and show ``path`` as the overlay (or standalone) log; True on success.
+
+        The programmatic entry point behind both the button and the ``--log``
+        launch flag. Overlays the open recording, or — with none — shows the log
+        standalone on a bare time axis. Returns False (after an error dialog) when
+        the file can't be read or holds no timestamped entries, or when blinded.
+        """
+        if not self._can_load_log():
+            return False
         try:
             entries = sessionlog.read_session_log(path)
         except OSError as exc:
             self._error("Could not read the session log.", str(exc))
-            return
+            return False
         if not entries:
             self._error(
                 "That log has no timestamped entries.",
                 "It may be empty or not a SMACC session log.",
             )
-            return
-        preferences.update_preferences(
-            preferences_path, {"eeg_last_log_dir": str(Path(path).parent)}
-        )
+            return False
         # A pairing armed against the previous log would otherwise hijack the
         # next click with a stale entry; cancel it before swapping logs.
         self._end_pairing()
@@ -1471,12 +1486,62 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.logOffsetSpin.setValue(0.0)
         self.logOffsetSpin.blockSignals(False)
         self._alignment = None
+        if self._recording is None:
+            self._show_standalone_log()  # bare time axis, view-only
         self._rebuild_log_level_checks()
         self._refresh_log_overlay()
         self._update_log_controls()
         # Try to place the log automatically against the amp's embedded triggers;
-        # a confident fit applies, otherwise the manual gestures take over.
+        # a confident fit applies, otherwise the manual gestures take over. A
+        # standalone log (no recording) has nothing to match, so this is a no-op.
         self._auto_align(announce=False)
+        return True
+
+    def _load_session_log(self) -> None:
+        """Pick a SMACC ``.log`` and load it (button handler)."""
+        if not self._can_load_log():
+            return
+        prefs = preferences.load_preferences(preferences_path)
+        start_dir = prefs.get("eeg_last_log_dir") or (
+            str(self._recording.path.parent)
+            if self._recording is not None
+            else str(Path.home())
+        )
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Open session log", str(start_dir), "SMACC log (*.log);;All files (*)"
+        )
+        if not path:
+            return
+        if self.load_session_log(path):
+            preferences.update_preferences(
+                preferences_path, {"eeg_last_log_dir": str(Path(path).parent)}
+            )
+
+    def _show_standalone_log(self) -> None:
+        """Show the log on a bare time axis with no recording loaded (#125).
+
+        The trace view's channel/overlay split means a log-only display is just
+        the same widget driven by a zero-channel :class:`~smacc.eeg.sessionlog.
+        LogTimeline` provider: no curves, the log ticks drawn by the overlay
+        layer, the axis and scrollbar sized to the log's span. Annotation and
+        save stay disabled (there is no recording to annotate); scrolling, the
+        epoch grid, and the log controls work.
+        """
+        timeline = sessionlog.LogTimeline(self._log_entries)
+        self.view.set_provider(timeline)
+        started = self._log_entries[0].timestamp
+        self.view.set_time_origin(started)
+        self.axisModeCombo.blockSignals(True)
+        self.axisModeCombo.setCurrentIndex(0)  # clock time, anchored at entry 1
+        self.axisModeCombo.blockSignals(False)
+        self.view.set_time_axis_mode("clock")
+        self._set_loaded(False)  # no recording: no annotate/save/channels/export
+        self.scrollBar.setEnabled(True)  # the log timeline still scrolls
+        self._configure_scrollbar()
+        self._update_epoch_readout()
+        self.fileInfoLabel.setText(
+            f"(no recording) · log only · {len(self._log_entries)} entries"
+        )
 
     def _log_has_level(self, level: str) -> bool:
         return any(e.level == level for e in self._log_entries)
@@ -1555,6 +1620,9 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._visible_log = [
             e for e in self._log_entries if e.level in self._log_levels
         ]
+        # The lane is draggable only with a recording to align against (standalone
+        # has a single clock — a slide would only push the ticks off their labels).
+        self.view.set_log_alignable(self._recording is not None)
         if origin is None:
             self.view.set_log_marks([])
         else:
@@ -1781,16 +1849,19 @@ class EegReviewWindow(QtWidgets.QMainWindow):
     def _update_log_controls(self) -> None:
         """Enable the log controls by state (recording open, log loaded, blind)."""
         has_log = bool(self._log_entries)
-        self.loadLogButton.setEnabled(self._can_overlay_log())
+        # Aligning reconciles the log clock with the recording's, so every skew
+        # control needs a recording; standalone log mode (no recording) shows the
+        # log but offers no alignment — there is only one clock.
+        can_align = has_log and self._recording is not None
+        self.loadLogButton.setEnabled(self._can_load_log())
         self.logList.setEnabled(has_log)
-        self.logOffsetSpin.setEnabled(has_log)
+        self.logOffsetSpin.setEnabled(can_align)
         self.logAlignButton.setEnabled(
-            has_log and 0 <= self.logList.currentRow() < len(self._visible_log)
+            can_align and 0 <= self.logList.currentRow() < len(self._visible_log)
         )
-        # Auto-align needs a start time to align against; without one only the
-        # manual gestures apply.
+        # Auto-align additionally needs a start time to align against.
         self.autoAlignButton.setEnabled(
-            has_log
+            can_align
             and self._recording is not None
             and self._recording.meas_date is not None
         )
@@ -1936,6 +2007,8 @@ class EegReviewWindow(QtWidgets.QMainWindow):
     # ----- annotation editing -----------------------------------------------------
 
     def _on_region_drawn(self, lo: float, hi: float) -> None:
+        if self._recording is None:
+            return  # standalone log view has no recording to annotate
         result = LabelDialog.get_label(self, self._recent_labels())
         if result is None:
             return
@@ -2205,8 +2278,9 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._sync_scrollbar(self.view.window_start)
 
     def _configure_scrollbar(self) -> None:
-        duration = self._recording.duration if self._recording else 0.0
-        span = max(0.0, duration - self.view.window_seconds)
+        # The loaded provider's length — a recording, or the standalone log
+        # timeline (#125) — so the bar sizes itself in either mode.
+        span = max(0.0, self.view.duration - self.view.window_seconds)
         self.scrollBar.blockSignals(True)
         self.scrollBar.setRange(0, int(span * _SCROLL_TICKS_PER_SECOND))
         self.scrollBar.setPageStep(
@@ -2246,7 +2320,9 @@ class EegReviewWindow(QtWidgets.QMainWindow):
 
     def _update_epoch_readout(self) -> None:
         """Show the epoch number at the left edge of the view in the status bar."""
-        if self._recording is None:
+        # Drive off the provider, not the recording, so the readout matches the
+        # epoch grid (which a standalone log timeline also draws).
+        if not self.view.has_provider:
             self.epochLabel.clear()
             return
         number = (
@@ -2283,9 +2359,12 @@ class EegReviewWindow(QtWidgets.QMainWindow):
                 if status_bar is not None:
                     status_bar.showMessage("Alignment cancelled.", 3000)
                 return True
-            if self._recording is not None and (
-                self._handle_nav_key(event) or self._handle_palette_key(event)
-            ):
+            # Navigation works whenever something is loaded (a recording, or the
+            # standalone log timeline); the quick-mark palette needs a recording
+            # to annotate.
+            if self.view.has_provider and self._handle_nav_key(event):
+                return True
+            if self._recording is not None and self._handle_palette_key(event):
                 return True
         return super().eventFilter(obj, event)
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -1,12 +1,14 @@
-"""Tests for the analyze-window pure helpers (no GUI required)."""
+"""Tests for the analyze window — its pure helpers and the annotator handoff."""
 
 from __future__ import annotations
 
+import shutil
 import zipfile
+from pathlib import Path
 
 import pytest
 
-from smacc import analyze
+from smacc import analyze, eeg
 
 
 def test_format_duration_drops_leading_zero_units():
@@ -60,3 +62,79 @@ def test_extract_zip_rejects_path_traversal(tmp_path):
     with pytest.raises(ValueError):
         analyze.extract_zip(zip_path, dest)
     assert not (tmp_path / "escape.txt").exists()
+
+
+# ----- the EEG annotator handoff (#125d) ------------------------------------
+
+A_LOG = (
+    "2026-06-05 22:00:00.000-0500, INFO, Opened SMACC v0.0.7\n"
+    "2026-06-05 22:00:05.000-0500, INFO, Lights off - portcode 47\n"
+)
+
+
+@pytest.fixture
+def analyze_window(qtbot, tmp_path, monkeypatch):
+    """An AnalyzeWindow with isolated prefs."""
+    monkeypatch.setattr(analyze, "preferences_path", tmp_path / "prefs.yaml")
+    win = analyze.AnalyzeWindow()
+    qtbot.addWidget(win)
+    return win
+
+
+def test_open_in_annotator_launches_with_the_log(analyze_window, tmp_path, monkeypatch):
+    monkeypatch.setattr(eeg, "available", lambda: True)
+    calls: list[list[str] | None] = []
+    monkeypatch.setattr(eeg, "launch", lambda args=None: calls.append(args) or True)
+    log = tmp_path / "smacc-x.log"
+    log.write_text(A_LOG, encoding="utf-8")
+    analyze_window._load_log(log, log.parent)
+    assert analyze_window.annotateButton.isEnabled()
+    analyze_window.open_in_annotator()
+    assert calls == [["--log", str(log)]]
+
+
+def test_annotate_button_disabled_without_the_eeg_component(
+    analyze_window, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(eeg, "available", lambda: False)
+    log = tmp_path / "smacc-y.log"
+    log.write_text(A_LOG, encoding="utf-8")
+    analyze_window._load_log(log, log.parent)
+    assert not analyze_window.annotateButton.isEnabled()  # component absent
+
+
+def test_handoff_copies_a_zip_extracted_log_out_of_temp(
+    analyze_window, tmp_path, monkeypatch
+):
+    # A zip-extracted log lives under a temp dir Analyze deletes on close; the
+    # detached annotator reads it later, so the handoff must pass a copy that
+    # survives that cleanup, not the temp path.
+    monkeypatch.setattr(eeg, "available", lambda: True)
+    launched: list[list[str] | None] = []
+    monkeypatch.setattr(eeg, "launch", lambda args=None: launched.append(args) or True)
+    temp = tmp_path / "smacc-analyze-xyz"
+    temp.mkdir()
+    log = temp / "smacc-x.log"
+    log.write_text(A_LOG, encoding="utf-8")
+    analyze_window._load_log(log, temp)
+    analyze_window._temp_dirs.append(temp)  # as _load_zip records it
+    analyze_window.open_in_annotator()
+    passed = Path(launched[0][1])  # the --log value
+    assert passed != log  # a copy, not the temp path
+    assert passed.read_text(encoding="utf-8") == A_LOG
+    shutil.rmtree(temp, ignore_errors=True)  # Analyze's cleanup
+    assert passed.is_file()  # the handed-off copy survives it
+    shutil.rmtree(passed.parent, ignore_errors=True)
+
+
+def test_handoff_passes_a_real_log_path_through_unchanged(
+    analyze_window, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(eeg, "available", lambda: True)
+    launched: list[list[str] | None] = []
+    monkeypatch.setattr(eeg, "launch", lambda args=None: launched.append(args) or True)
+    log = tmp_path / "smacc-z.log"
+    log.write_text(A_LOG, encoding="utf-8")
+    analyze_window._load_log(log, log.parent)  # not under a temp dir
+    analyze_window.open_in_annotator()
+    assert launched[0] == ["--log", str(log)]  # passed through, no copy

--- a/tests/test_eeg_launch.py
+++ b/tests/test_eeg_launch.py
@@ -71,6 +71,20 @@ def test_launch_frozen_runs_the_component_exe(spawned, tmp_path, monkeypatch):
     assert spawned == [(str(tmp_path / eeg.EXE_NAME), [])]
 
 
+def test_launch_forwards_extra_args_in_development(spawned):
+    # The Analyze "open in annotator" handoff passes --log; it must reach the
+    # module after the -m smacc.eeg invocation.
+    assert eeg.launch(["--log", "night1.log"])
+    assert spawned == [(sys.executable, ["-m", "smacc.eeg", "--log", "night1.log"])]
+
+
+def test_launch_forwards_extra_args_when_frozen(spawned, tmp_path, monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "executable", str(tmp_path / "SMACC.exe"))
+    assert eeg.launch(["--log", "night1.log"])
+    assert spawned == [(str(tmp_path / eeg.EXE_NAME), ["--log", "night1.log"])]
+
+
 # ----- the launcher button ----------------------------------------------------------
 
 

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -25,7 +25,12 @@ from smacc import preferences
 from smacc.config import VERSION
 from smacc.eeg import align, blind, dsp
 from smacc.eeg import window as window_mod
-from smacc.eeg.__main__ import pick_blind_spec, pick_rater_id, pick_recording_path
+from smacc.eeg.__main__ import (
+    pick_blind_spec,
+    pick_log_path,
+    pick_rater_id,
+    pick_recording_path,
+)
 from smacc.eeg.annotations import (
     Annotation,
     autosave_path,
@@ -922,7 +927,7 @@ def test_pick_recording_path_takes_the_last_non_flag_argument():
 
 
 def test_pick_recording_path_skips_value_flag_values(tmp_path):
-    # --rater/--blind values must not be mistaken for the recording.
+    # --rater/--blind/--log values must not be mistaken for the recording.
     assert (
         pick_recording_path(["exe", "--rater", "alice", "night1.edf"]) == "night1.edf"
     )
@@ -935,6 +940,16 @@ def test_pick_recording_path_skips_value_flag_values(tmp_path):
         pick_recording_path(["exe", "--rater", "a", "--blind", "naive", "n.edf"])
         == "n.edf"
     )
+    # --log night1.log opens standalone (no recording): the log path is not it.
+    assert pick_recording_path(["exe", "--log", "night1.log"]) is None
+    assert pick_recording_path(["exe", "--log", "n.log", "rec.edf"]) == "rec.edf"
+
+
+def test_pick_log_path_reads_both_forms():
+    assert pick_log_path(["exe", "--log", "night1.log"]) == "night1.log"
+    assert pick_log_path(["exe", "--log=night1.log", "rec.edf"]) == "night1.log"
+    assert pick_log_path(["exe", "rec.edf"]) is None
+    assert pick_log_path(["exe", "--log"]) is None  # dangling flag, no value
 
 
 def test_pick_rater_id_reads_both_forms():
@@ -1791,3 +1806,101 @@ def test_new_recording_re_reads_embedded_triggers(
     other.write_bytes(b"")
     window._load(other)
     assert window._embedded_triggers is None  # invalidated for the new recording
+
+
+# ----- standalone log view (#125d) -------------------------------------------
+
+
+def _standalone_log(window, monkeypatch, tmp_path, text=LOG_TEXT):
+    """Load a log into a window that has no recording open."""
+    log = tmp_path / "standalone.log"
+    log.write_text(text, encoding="utf-8")
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog, "getOpenFileName", lambda *a, **k: (str(log), "")
+    )
+    window._load_session_log()
+    return log
+
+
+def test_standalone_log_shows_on_a_bare_timeline(window, monkeypatch, tmp_path):
+    # No recording is open: loading a log installs a zero-channel timeline and
+    # draws the log ticks, with annotation/save off but scrolling on.
+    assert window._recording is None
+    _standalone_log(window, monkeypatch, tmp_path)
+    assert window.view.has_provider  # a LogTimeline is now the provider
+    assert window.view.channel_names == []  # no channels
+    assert len(window.view._log_marks) == 3  # the INFO entries (DEBUG hidden)
+    assert not window.saveButton.isEnabled()  # nothing to annotate/save
+    assert window.scrollBar.isEnabled()  # but the timeline scrolls
+    # The timeline spans the log (22:00:00 → 22:00:20 = 20 s).
+    assert window.view.duration == pytest.approx(20.0)
+
+
+def test_standalone_then_opening_a_recording_switches_to_overlay(
+    window, recording_path, monkeypatch, tmp_path
+):
+    _standalone_log(window, monkeypatch, tmp_path)
+    assert window.view.channel_names == []
+    window._load(recording_path)  # open a real recording
+    assert window._recording is not None
+    assert window.view.channel_names == ["C3", "C4", "EOG", "EMG"]  # real channels
+    assert window._log_entries == []  # the standalone log was dropped
+    assert window.saveButton.isEnabled()
+
+
+def test_standalone_drag_below_lane_makes_no_annotation(window, monkeypatch, tmp_path):
+    # With no recording there is nothing to annotate; a region draw is a no-op.
+    _standalone_log(window, monkeypatch, tmp_path)
+    before = list(window._annotations)
+    window._on_region_drawn(1.0, 3.0)
+    assert window._annotations == before  # unchanged, no dialog, no mark
+
+
+def test_load_button_enabled_without_a_recording(window):
+    # Standalone loading is allowed (the button is live before any recording).
+    assert window._recording is None
+    assert window.loadLogButton.isEnabled()
+
+
+def test_constructor_log_path_loads_standalone(qtbot, tmp_path, monkeypatch):
+    monkeypatch.setattr(window_mod, "preferences_path", tmp_path / "prefs.yaml")
+    monkeypatch.setattr(window_mod.io, "recorded_trigger_events", lambda rec: [])
+    log = tmp_path / "boot.log"
+    log.write_text(LOG_TEXT, encoding="utf-8")
+    win = EegReviewWindow(log_path=log)
+    qtbot.addWidget(win)
+    win.show()
+    qtbot.waitUntil(lambda: bool(win._log_entries), timeout=2000)  # deferred load
+    assert win._log_path == log
+    assert win.view.has_provider
+
+
+def test_standalone_disables_the_alignment_controls(window, monkeypatch, tmp_path):
+    # With no recording there is one clock, so the skew controls (offset, pair,
+    # auto-align, lane drag) are off; viewing controls stay on.
+    _standalone_log(window, monkeypatch, tmp_path)
+    assert not window.logOffsetSpin.isEnabled()
+    assert not window.autoAlignButton.isEnabled()
+    window.logList.setCurrentRow(1)
+    assert not window.logAlignButton.isEnabled()
+    assert window.view._viewbox._log_lane_active is False  # lane not draggable
+    assert window.logList.isEnabled()  # the list still works (jump/highlight)
+
+
+def test_standalone_shows_the_epoch_readout(window, monkeypatch, tmp_path):
+    # The bare timeline draws the epoch grid, so the readout must match it.
+    _standalone_log(window, monkeypatch, tmp_path)
+    assert "Epoch" in window.epochLabel.text()
+
+
+def test_entering_blind_tears_down_a_standalone_log(make_window, monkeypatch, tmp_path):
+    # A standalone log has no _load to fall through to, so entering blind must
+    # tear the bare timeline down itself — no residual "log only" leak.
+    win = make_window("alice")
+    assert win._recording is None
+    _standalone_log(win, monkeypatch, tmp_path)
+    assert win.view.has_provider
+    win._set_blind(blind.preset_config(blind.PRESET_NAIVE))
+    assert win._log_entries == []
+    assert not win.view.has_provider  # the timeline is gone
+    assert win.fileInfoLabel.text() == ""  # and its "log only" label


### PR DESCRIPTION
Fourth PR of the #125 stack — **stacked on #218**. Adds the standalone log view and the Analyze→annotator handoff.

- **Standalone mode.** Load a SMACC `.log` with no recording open and it shows on a bare time axis — the same trace widget driven by a zero-channel `LogTimeline` provider, so the log ticks, level filter, epoch grid, and scrolling all work with no EEG. Annotation and save stay off (nothing to annotate); the skew-alignment controls are off too (standalone has a single clock — sliding would only push the ticks off their own labels). Opening a recording switches to the overlaid view.
- **Handoff.** Analyze gains **Open log in EEG annotator**, which launches the annotator (`--log <path>`, via `eeg.launch(args)`) with the session's log — overlaid if a recording is opened there, standalone otherwise. Analyze stays the no-EEG summary/BIDS tool.

An adversarial review of the mode transitions caught and this PR fixes: the skew controls being live (and meaningless) standalone; a **blind-safety leak** where entering blind from a standalone log left the bare timeline and a "log only · N entries" label on screen; an epoch-grid-vs-readout inconsistency; and a **zip-extraction race** where Analyze deleted the temp log before the detached annotator read it (now copied to a dir the cleanup doesn't touch). All with regression tests. 1043 tests pass; ruff + mypy + mdformat clean.

Refs #125.
