### PR TITLE
feat: play and reveal dream-report artifacts from the log overlay

### DIFF
--- a/docs/eeg-review.md
+++ b/docs/eeg-review.md
@@ -90,6 +90,12 @@ bare time axis — for inspecting a log on its own (the **Analyze** window's *Op
 log in EEG annotator* hands a session off this way). Opening a recording while a
 standalone log is shown switches to the overlaid view.
 
+**Artifacts.** Selecting a dream-report entry lets you **Play** its recorded
+audio (`report-NN.wav`, beside the log in the session folder) — press again to
+stop — and **Reveal file** opens that folder in the file browser. Playback is
+disabled for an entry with no audio (a marker, or a log opened away from its
+recordings).
+
 **Aligning the log.** The log's timestamps come from the recording PC while the
 EEG's clock comes from the amplifier, so the two can differ by seconds or more.
 Slide the whole log along the EEG to line them up, three ways — all adjusting one

--- a/src/smacc/eeg/__main__.py
+++ b/src/smacc/eeg/__main__.py
@@ -165,6 +165,43 @@ def selftest() -> int:
             out = Path(tmp) / f"selftest.{fmt}"
             render(figure_snapshot, ExportOptions(fmt=fmt, dpi=100), out)
             assert out.stat().st_size > 0, fmt
+        # Session-log overlay (#125): round-trip a log through the parser, the
+        # auto-aligner, and the report-WAV resolver — pure, but it proves the
+        # smacc.bids/yaml chain the overlay imports is bundled.
+        from . import align, sessionlog
+
+        log = Path(tmp) / "smacc-selftest.log"
+        log.write_text(
+            "2026-06-05 22:00:00.000-0500, INFO, Opened SMACC\n"
+            "2026-06-05 22:00:05.000-0500, INFO, Lights off - portcode 47\n"
+            "2026-06-05 22:00:20.000-0500, INFO, Dream report started: report-01 "
+            "- portcode 201\n",
+            encoding="utf-8",
+        )
+        entries = sessionlog.read_session_log(log)
+        assert [e.kind for e in entries] == [
+            sessionlog.OTHER,
+            sessionlog.MARKER,
+            sessionlog.REPORT,
+        ], entries
+        origin = entries[0].timestamp
+        log_events = [
+            (sessionlog.seconds_at(e, origin, 0.0), e.code)
+            for e in entries
+            if e.code is not None
+        ]
+        result = align.estimate_offset(
+            log_events, [(8.0, 47), (23.0, 201)], duration=100.0
+        )
+        assert result.offset == 3.0, result
+        (Path(tmp) / "report-01.wav").write_bytes(b"RIFF")
+        report = next(e for e in entries if e.kind == sessionlog.REPORT)
+        assert sessionlog.report_wav(report, tmp) == Path(tmp) / "report-01.wav"
+        # Dream-report playback (#125e): QtMultimedia must be in the frozen bundle
+        # (a missed module only surfaces when the viewer tries to play a report).
+        from PyQt6.QtMultimedia import QAudioOutput, QMediaPlayer
+
+        assert QMediaPlayer is not None and QAudioOutput is not None
     print("selftest ok")
     return 0
 

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import math
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
@@ -642,6 +642,13 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         # "aligned"/"unverified" badge only ever describes the current offset.
         self._embedded_triggers: list[tuple[float, int]] | None = None
         self._alignment: align.Alignment | None = None
+        # Dream-report audio playback (#125e, folds in #179). Created lazily on
+        # first play and kept alive on the window so it isn't GC'd mid-clip.
+        # QtMultimedia, never sounddevice/PortAudio — the frozen SMACC-EEG.exe
+        # ships no live-session audio stack.
+        self._player: Any = None
+        self._audio_output: Any = None
+        self._playing_wav: Path | None = None
         # Annotations recovered from an autosave, held until the user restores or
         # dismisses them (#176).
         self._recovery_annotations: list[Annotation] | None = None
@@ -1191,6 +1198,24 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.autoAlignButton.clicked.connect(lambda: self._auto_align(announce=True))
         box.addWidget(self.autoAlignButton)
 
+        # Artifact actions on the selected entry (#125e, folds in #179): play the
+        # dream-report audio, or reveal the file the entry points at.
+        artifactRow = QtWidgets.QHBoxLayout()
+        self.logPlayButton = QtWidgets.QPushButton("Play report", self)
+        self.logPlayButton.setStatusTip(
+            "Play the selected dream report's recorded audio (report-NN.wav)."
+        )
+        self.logPlayButton.clicked.connect(self._play_or_stop_report)
+        self.logRevealButton = QtWidgets.QPushButton("Reveal file", self)
+        self.logRevealButton.setStatusTip(
+            "Show the selected entry's file (or its session folder) in the file "
+            "browser."
+        )
+        self.logRevealButton.clicked.connect(self._reveal_log_artifact)
+        artifactRow.addWidget(self.logPlayButton)
+        artifactRow.addWidget(self.logRevealButton)
+        box.addLayout(artifactRow)
+
         self.logGroup = group
         return group
 
@@ -1549,6 +1574,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
     def _clear_log_overlay(self) -> None:
         """Drop the overlaid log (a new recording, or a blind switch)."""
         self._end_pairing()
+        self._stop_player()  # the report being played belongs to this log
         self._log_entries = []
         self._log_path = None
         self._visible_log = []
@@ -1846,6 +1872,87 @@ class EegReviewWindow(QtWidgets.QMainWindow):
                 "feature).",
             )
 
+    # ----- artifact actions (#125e, folds in #179) -------------------------------
+
+    def _selected_log_entry(self) -> LogEntry | None:
+        """The log entry highlighted in the list, or ``None``."""
+        row = self.logList.currentRow()
+        return self._visible_log[row] if 0 <= row < len(self._visible_log) else None
+
+    def _selected_report_wav(self) -> Path | None:
+        """The ``report-NN.wav`` the selected entry points at, if it exists.
+
+        Resolved beside the log (the session folder); ``None`` for any entry that
+        is not a dream report, or whose audio file is missing — e.g. a log handed
+        over on its own, away from its recordings.
+        """
+        entry = self._selected_log_entry()
+        if entry is None or self._log_path is None:
+            return None
+        return sessionlog.report_wav(entry, self._log_path.parent)
+
+    def _play_or_stop_report(self) -> None:
+        """Play the selected dream report's audio, or stop it if it's playing.
+
+        QtMultimedia, never the live-session audio stack: the annotator runs as
+        the frozen ``SMACC-EEG.exe``, which ships no sounddevice/PortAudio.
+        """
+        from PyQt6.QtMultimedia import QMediaPlayer
+
+        wav = self._selected_report_wav()
+        if wav is None:
+            return
+        self._ensure_player()
+        assert self._player is not None
+        playing = (
+            self._player.playbackState() == QMediaPlayer.PlaybackState.PlayingState
+        )
+        if playing and self._playing_wav == wav:
+            self._player.stop()  # second press on the same clip stops it
+            return
+        self._player.setSource(QtCore.QUrl.fromLocalFile(str(wav)))
+        self._player.play()
+        self._playing_wav = wav
+
+    def _ensure_player(self) -> None:
+        """Create the QtMultimedia player on first use (kept alive on the window)."""
+        if self._player is not None:
+            return
+        from PyQt6.QtMultimedia import QAudioOutput, QMediaPlayer
+
+        self._audio_output = QAudioOutput(self)
+        self._player = QMediaPlayer(self)
+        self._player.setAudioOutput(self._audio_output)
+        self._player.playbackStateChanged.connect(self._on_playback_state)
+
+    def _on_playback_state(self, state: Any) -> None:
+        """Reflect play/stop on the button label and forget a finished clip."""
+        from PyQt6.QtMultimedia import QMediaPlayer
+
+        playing = state == QMediaPlayer.PlaybackState.PlayingState
+        self.logPlayButton.setText("Stop" if playing else "Play report")
+        if not playing:
+            self._playing_wav = None
+
+    def _stop_player(self) -> None:
+        """Stop any playback (on clearing the log, or closing the window)."""
+        if self._player is not None:
+            self._player.stop()
+        self._playing_wav = None
+
+    def _reveal_log_artifact(self) -> None:
+        """Open the selected entry's session folder in the file browser.
+
+        The dream-report WAV and survey-response files live there beside the log,
+        so the folder is the reliable target across entry kinds; the file-browser
+        opens to it (the report's audio is also one click via Play).
+        """
+        if self._log_path is None:
+            return
+        QtGui.QDesktopServices.openUrl(
+            QtCore.QUrl.fromLocalFile(str(self._log_path.parent))
+        )
+
     def _update_log_controls(self) -> None:
         """Enable the log controls by state (recording open, log loaded, blind)."""
         has_log = bool(self._log_entries)
@@ -1865,6 +1972,10 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             and self._recording is not None
             and self._recording.meas_date is not None
         )
+        # Artifact actions (#125e): Play needs the selected entry to resolve to a
+        # report WAV; Reveal needs only a loaded log (it opens its folder).
+        self.logPlayButton.setEnabled(self._selected_report_wav() is not None)
+        self.logRevealButton.setEnabled(has_log and self._log_path is not None)
 
     def _update_log_status(self) -> None:
         """Show the loaded log, its offset, and any alignment grade in the status."""
@@ -2733,6 +2844,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         # recover, so drop the recovery file and stop the autosave timer.
         self._autosave_timer.stop()
         self._clear_autosave()
+        self._stop_player()  # don't leave a report playing after the window closes
         # Drop the app-level key filter before this window goes away, so a stray
         # late event can never reach a half-deleted window.
         app = QtWidgets.QApplication.instance()

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -1904,3 +1904,101 @@ def test_entering_blind_tears_down_a_standalone_log(make_window, monkeypatch, tm
     assert win._log_entries == []
     assert not win.view.has_provider  # the timeline is gone
     assert win.fileInfoLabel.text() == ""  # and its "log only" label
+
+
+# ----- artifact actions: play / reveal (#125e, folds in #179) ----------------
+
+# A log with a dream-report entry that resolves to report-01.wav.
+REPORT_LOG = (
+    "2026-06-05 22:00:00.000-0500, INFO, Opened SMACC v0.0.7\n"
+    "2026-06-05 22:00:05.000-0500, INFO, Lights off - portcode 47\n"
+    "2026-06-05 22:31:00.000-0500, INFO, "
+    "Dream report started: report-01, t+00:31:00 - portcode 201\n"
+)
+
+
+class _FakePlayer:
+    """Stand-in for QMediaPlayer that records the calls _play_or_stop_report makes."""
+
+    def __init__(self):
+        self.source = None
+        self.played = False
+        self.stopped = False
+
+    def playbackState(self):
+        return None  # never the PlayingState enum, so a press always plays
+
+    def setSource(self, url):
+        self.source = url
+
+    def play(self):
+        self.played = True
+
+    def stop(self):
+        self.stopped = True
+
+
+def test_play_button_enabled_only_for_a_report_with_audio(
+    window, recording_path, monkeypatch, tmp_path
+):
+    window._load(recording_path)
+    (tmp_path / "report-01.wav").write_bytes(b"RIFF")  # the report's audio, by the log
+    _overlay_log(window, monkeypatch, tmp_path, REPORT_LOG)
+    window.logList.setCurrentRow(2)  # the dream-report entry
+    window._update_log_controls()
+    assert window.logPlayButton.isEnabled()
+    window.logList.setCurrentRow(1)  # a plain marker — no audio
+    window._update_log_controls()
+    assert not window.logPlayButton.isEnabled()
+
+
+def test_play_button_disabled_when_the_wav_is_missing(
+    window, recording_path, monkeypatch, tmp_path
+):
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path, REPORT_LOG)  # no report-01.wav written
+    window.logList.setCurrentRow(2)
+    window._update_log_controls()
+    assert window._selected_report_wav() is None
+    assert not window.logPlayButton.isEnabled()
+
+
+def test_play_report_plays_the_resolved_wav(
+    window, recording_path, monkeypatch, tmp_path
+):
+    window._load(recording_path)
+    wav = tmp_path / "report-01.wav"
+    wav.write_bytes(b"RIFF")
+    _overlay_log(window, monkeypatch, tmp_path, REPORT_LOG)
+    window.logList.setCurrentRow(2)
+    window._player = _FakePlayer()  # pre-set, so _ensure_player makes no real player
+    window._play_or_stop_report()
+    assert window._player.played
+    assert window._player.source.toLocalFile().endswith("report-01.wav")
+    assert window._playing_wav == wav
+
+
+def test_reveal_opens_the_session_folder(window, recording_path, monkeypatch, tmp_path):
+    window._load(recording_path)
+    _overlay_log(window, monkeypatch, tmp_path, REPORT_LOG)
+    opened = []
+    monkeypatch.setattr(
+        window_mod.QtGui.QDesktopServices,
+        "openUrl",
+        lambda url: opened.append(url.toLocalFile()),
+    )
+    window._reveal_log_artifact()
+    assert [Path(p) for p in opened] == [tmp_path]  # the log's session folder
+
+
+def test_clearing_the_log_stops_playback(window, recording_path, monkeypatch, tmp_path):
+    window._load(recording_path)
+    (tmp_path / "report-01.wav").write_bytes(b"RIFF")
+    _overlay_log(window, monkeypatch, tmp_path, REPORT_LOG)
+    window._player = _FakePlayer()
+    window.logList.setCurrentRow(2)
+    window._play_or_stop_report()
+    other = tmp_path / "night2.edf"
+    other.write_bytes(b"")
+    window._load(other)  # opening a new recording clears the log
+    assert window._player.stopped


### PR DESCRIPTION
Final PR of the #125 stack — **stacked on #219**. Adds the artifact actions on a log entry, closing #179 (play recorded dream-report audio from a marker).

- **Play report.** Selecting a dream-report entry enables **Play**, which plays its `report-NN.wav` (resolved beside the log by the session's naming convention); pressing again stops. Playback uses **QtMultimedia** (`QMediaPlayer`/`QAudioOutput`) — never sounddevice/PortAudio, which the frozen `SMACC-EEG.exe` doesn't ship. The player is created lazily and kept on the window; playback stops on clearing the log or closing.
- **Reveal file.** Opens the entry's session folder (where the WAV and survey responses live) in the file browser.
- Play is disabled for an entry with no audio (a plain marker, or a log opened away from its recordings); both actions are unreachable in a blind review (no log there).
- `--selftest` now round-trips a synthetic log through the parser, the auto-aligner, and the report-WAV resolver, and import-checks QtMultimedia — so the release smoke test fails fast if the module isn't bundled.

1048 tests pass; ruff + mypy + mdformat clean. **Closes #179.**

Caveat for validation: the `--selftest` import-check proves QtMultimedia is bundled, but the media backend *plugin* that actually decodes a WAV can only be confirmed by playing a real `report-NN.wav` from the built `SMACC-EEG.exe` — worth a manual check before release (same class as the MNE-bundling traps from #136). Refs #125.
