### PR TITLE
refactor: name the separable tools and install the EEG Annotator by default

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
-      # --extra eeg pulls mne/pyqtgraph so the optional EEG review tests run
+      # --extra eeg pulls mne/pyqtgraph so the optional EEG Annotator tests run
       # too (#136); they importorskip, so a base env still passes without it.
       - name: Run tests
         run: uv run --extra dev --extra eeg pytest --cov=smacc --cov-report=xml --cov-report=term-missing

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,11 +75,11 @@ jobs:
         run: |
           uv run python tools/make_versionfile.py version_info.txt
           if ($LASTEXITCODE -ne 0) { throw "make_versionfile (SMACC) exited with code $LASTEXITCODE" }
-          uv run python tools/make_versionfile.py version_info_eeg.txt --product SMACC-EEG --description "SMACC EEG review tool"
+          uv run python tools/make_versionfile.py version_info_eeg.txt --product SMACC-EEG --description "SMACC EEG Annotator"
           if ($LASTEXITCODE -ne 0) { throw "make_versionfile (SMACC-EEG) exited with code $LASTEXITCODE" }
       - name: Build SMACC.exe
         run: uv run pyinstaller entry.py --name SMACC --onefile --noconsole --icon src/smacc/assets/icon.ico --version-file version_info.txt --add-data "src/smacc/assets/icon.png;smacc/assets" --add-data "src/smacc/assets/default.smacc;smacc/assets" --add-data "src/smacc/assets/cues;smacc/assets/cues" --add-data "src/smacc/assets/biocals;smacc/assets/biocals" --add-data "src/smacc/assets/surveys;smacc/assets/surveys"
-      # The optional EEG review component (#136): a second frozen exe carrying
+      # The optional EEG Annotator component (#136): a second frozen exe carrying
       # the MNE/pyqtgraph stack the base exe deliberately doesn't. MNE uses
       # lazy_loader, which imports submodules by name at runtime and reads the
       # package's .pyi stubs — both invisible to PyInstaller's static analysis —
@@ -143,15 +143,19 @@ jobs:
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAppVersion=$env:VERSION tools\smacc.iss
           if ($LASTEXITCODE -ne 0) { throw "ISCC exited with code $LASTEXITCODE" }
       # Same idea as the exe smoke test, one level up: a broken installer (bad
-      # source path, registry section typo) would otherwise ship silently. Both
-      # component configurations are exercised: the default install must exclude
-      # the EEG exe, then an explicit core+eeg install (the in-place upgrade path
-      # a lab uses to add the component later) must place it. The core+eeg case
-      # only *verifies* the EEG exe was placed (a size floor), it does not run it
-      # — the dist copy is byte-identical and already ran --selftest above, and a
-      # third 120 MB extract/scan of it here intermittently thrashed the runner
-      # into a timeout.
-      - name: Smoke-test the installer (default - no EEG component)
+      # source path, registry section typo) would otherwise ship silently. The
+      # default install now INCLUDES the EEG Annotator (checked by default); this
+      # verifies SMACC.exe and SMACC-EEG.exe land and the .smacc association
+      # registers. It only *verifies* the EEG exe was placed (a size floor), it
+      # does not run it — the dist copy is byte-identical and already ran
+      # --selftest above, and a third 120 MB extract/scan here intermittently
+      # thrashed the runner into a timeout.
+      #
+      # The opt-out path (a /COMPONENTS="core" install dropping the EEG exe via
+      # [InstallDelete]) is not smoke-tested here: a second, in-place install
+      # reliably hangs the runner (an Inno Restart-Manager wait, not Defender).
+      # Tracked in #234, which will fix the upgrade hang and restore that check.
+      - name: Smoke-test the installer (default - includes the EEG Annotator)
         run: |
           $p = Start-Process -FilePath dist/SMACC-Setup.exe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/CURRENTUSER' -PassThru
           if (-not $p.WaitForExit(180000)) { $p.Kill(); throw "SMACC-Setup.exe did not exit within 180s" }
@@ -163,14 +167,8 @@ jobs:
           if ($p.ExitCode -ne 0) { throw "Installed SMACC.exe --version exited with code $($p.ExitCode)" }
           $progid = (Get-ItemProperty -Path 'HKCU:\Software\Classes\.smacc').'(default)'
           if ($progid -ne 'SMACC.Study') { throw ".smacc association not registered (got '$progid')" }
-          if (Test-Path "$env:LOCALAPPDATA\Programs\SMACC\SMACC-EEG.exe") { throw "Default install must not include SMACC-EEG.exe" }
-      - name: Verify the installer adds the EEG component
-        run: |
-          $p = Start-Process -FilePath dist/SMACC-Setup.exe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/CURRENTUSER','/COMPONENTS="core,eeg"' -PassThru
-          if (-not $p.WaitForExit(180000)) { $p.Kill(); throw "SMACC-Setup.exe (core,eeg) did not exit within 180s" }
-          if ($p.ExitCode -ne 0) { throw "SMACC-Setup.exe (core,eeg) exited with code $($p.ExitCode)" }
           $eeg = "$env:LOCALAPPDATA\Programs\SMACC\SMACC-EEG.exe"
-          if (-not (Test-Path $eeg)) { throw "Installed EEG exe not found at $eeg" }
+          if (-not (Test-Path $eeg)) { throw "Default install must include SMACC-EEG.exe (the EEG Annotator is checked by default)" }
           # Verify the whole onefile was copied, but do not run it (see comment
           # above); a size floor catches a truncated/partial install.
           $size = (Get-Item $eeg).Length

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -116,7 +116,7 @@ PyYAML (settings export/import) is pure Python and is picked up automatically by
 PyInstaller; if a frozen build ever fails to import `yaml`, add
 `--hidden-import yaml`.
 
-The optional EEG review component (#136) is a second frozen exe with its own
+The optional EEG Annotator component (#136) is a second frozen exe with its own
 entry point — it carries the MNE/pyqtgraph stack the base exe deliberately
 doesn't (requires `uv sync --extra dev --extra eeg`):
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,10 +9,10 @@ double-click `SMACC-Setup.exe` and click through. The installer:
 - adds a **Start menu** entry (and, if you opt in, a desktop shortcut);
 - associates **`.smacc` files**, so double-clicking a SMACC file opens a session
     with it;
-- optionally installs the **EEG Review Tools** — the post-hoc
-    [EEG viewer/annotator](eeg-review.md). Off by default (it carries the
-    heavyweight MNE library); choose **Full installation** to include it, or
-    re-run the installer later to add it;
+- installs the **EEG Annotator** — the post-hoc
+    [EEG viewer/annotator](eeg-review.md). Included by default; uncheck it during
+    setup to skip the heavyweight MNE library, or re-run the installer later to
+    add or remove it;
 - registers an uninstaller — remove SMACC from **Settings › Apps** like any other
     program. Uninstalling never touches your data: SMACC files, recordings, and
     logs under `~/SMACC` (or your data directories) all stay put. The
@@ -57,9 +57,9 @@ where nothing may be installed, and quick tests. The portable build skips the
 installer's conveniences (Start menu entry, uninstaller, the `.smacc`
 file association) — you can associate `.smacc` files from the Launcher's File
 menu instead (see below). The
-[EEG review tool](eeg-review.md) is likewise available portable as
-`SMACC-EEG.exe` — put it **next to** `SMACC.exe` and the Launcher's *Review
-EEG* button lights up (it also runs standalone).
+[EEG Annotator](eeg-review.md) is likewise available portable as
+`SMACC-EEG.exe` — put it **next to** `SMACC.exe` and the Launcher's *EEG
+Annotator* button lights up (it also runs standalone).
 
 !!! note "For IT departments"
 

--- a/docs/reference/annotations-file.md
+++ b/docs/reference/annotations-file.md
@@ -1,6 +1,6 @@
 # Annotations sidecar
 
-The [EEG review tool](../eeg-review.md) saves annotations as a **TSV + JSON
+The [EEG Annotator](../eeg-review.md) saves annotations as a **TSV + JSON
 sidecar pair** next to the source recording, which is never modified:
 
 ```

--- a/docs/reference/bids-export.md
+++ b/docs/reference/bids-export.md
@@ -2,7 +2,7 @@
 
 SMACC can convert a session [log](session-log.md) into a
 [BIDS](https://bids.neuroimaging.io/) events file — a tab-separated `events.tsv` plus
-a JSON sidecar describing its columns. Export one from **Analyze**, or from a live
+a JSON sidecar describing its columns. Export one from the **Analyzer**, or from a live
 session's exporters. Only event-marker lines (`" - portcode N"`) become rows.
 
 ## `events.tsv`

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -4,15 +4,15 @@ SMACC reads and writes a handful of files. This section is the **reference** for
 each one — its on-disk shape, every field, and how it is versioned — as distinct
 from the task-oriented [Usage](../usage.md) guide.
 
-| File                                            | What it is                             | Format     | Version              |
-| ----------------------------------------------- | -------------------------------------- | ---------- | -------------------- |
-| [SMACC file (`.smacc`)](settings-file.md)       | A portable study configuration         | YAML       | `schema_version: 1`  |
-| [`preferences.yaml`](preferences-file.md)       | Per-machine operator preferences       | YAML       | `schema_version: 1`  |
-| [Session `.log`](session-log.md)                | The per-run record (events + settings) | Text       | —                    |
-| [BIDS export](bids-export.md)                   | `events.tsv` + JSON sidecar            | TSV / JSON | follows BIDS         |
-| [Survey definition](../surveys.md)              | An in-app survey (built-in or custom)  | YAML       | `schema_version: 1`  |
-| [Survey response](../surveys.md#response-files) | One administration's answers           | JSON       | —                    |
-| [Annotations sidecar](annotations-file.md)      | EEG review marks (`*.annotations.tsv`) | TSV / JSON | follows BIDS columns |
+| File                                            | What it is                                | Format     | Version              |
+| ----------------------------------------------- | ----------------------------------------- | ---------- | -------------------- |
+| [SMACC file (`.smacc`)](settings-file.md)       | A portable study configuration            | YAML       | `schema_version: 1`  |
+| [`preferences.yaml`](preferences-file.md)       | Per-machine operator preferences          | YAML       | `schema_version: 1`  |
+| [Session `.log`](session-log.md)                | The per-run record (events + settings)    | Text       | —                    |
+| [BIDS export](bids-export.md)                   | `events.tsv` + JSON sidecar               | TSV / JSON | follows BIDS         |
+| [Survey definition](../surveys.md)              | An in-app survey (built-in or custom)     | YAML       | `schema_version: 1`  |
+| [Survey response](../surveys.md#response-files) | One administration's answers              | JSON       | —                    |
+| [Annotations sidecar](annotations-file.md)      | EEG Annotator marks (`*.annotations.tsv`) | TSV / JSON | follows BIDS columns |
 
 ## Where each file lives
 

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -180,7 +180,7 @@ register cleanly.
 
 ## Configuring trigger output in SMACC
 
-1. Open the **Markers** window from the Tools column (available both in a live
+1. Open the **Markers** window from the Panels column (available both in a live
     Session and in the Editor) and find its **Hardware TTL transport** section.
 1. Tick **Enable hardware trigger output**.
 1. Choose a **Transport**:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,10 +33,10 @@ Session for it directly). In the Launcher you:
     noise, visual, event codes, surveys), choose a data directory, and save it
     anywhere.
 - **Edit** — reopen the selected SMACC file in the Editor.
-- **Design cues** — open the standalone **Cue designer** to build a simple tone cue
+- **Audio Cue Designer** — open the standalone tool to build a simple tone cue
     and export it as a WAV into a study's `cues/` folder, ready to use from the Audio
     cue board (see [Designing a cue](#designing-a-cue)).
-- **Analyze** — open a past session (a `.log`, a session folder, or a
+- **Analyzer** — open a past session (a `.log`, a session folder, or a
     zipped session) to see a summary (events, duration, subject/session, dream
     reports), export its events to a BIDS `events.tsv`, or recover its settings to a
     `.smacc` — all without starting a new session.
@@ -56,7 +56,7 @@ add or remove cues to match a protocol (one minimum, up to 20).
 
 ### Designing a cue
 
-No sound file ready? Open **Design cues** from the Launcher to build a simple cue
+No sound file ready? Open the **Audio Cue Designer** from the Launcher to build a simple cue
 inside SMACC — no external audio editor needed. Lay out a sequence of **tone** and
 **silence** segments (each tone has a frequency, duration, and level, with an
 optional bell-like **decay**), or start from a **preset** (a single chime, a pip
@@ -221,7 +221,7 @@ matching line to the session log, keeping cue delivery and your neural data in s
 
 ### Configuring codes
 
-Open the **Markers** window from the **Tools** column (in a Session or in the
+Open the **Markers** window from the **Panels** column (in a Session or in the
 Editor). It is the definitive home for everything about event signaling: a
 **routing legend** (what the log file, the live preview, LSL, and TTL each
 receive, and which switch governs it), the full event registry grouped by
@@ -266,7 +266,7 @@ and fade changes — as plain log lines (no port code), so the session record is
 
 The manual event buttons (the sleep-stage family, Signal observed, Sleep onset, Note,
 your custom events, …) live in the **Event logging** panel — open it from the session
-window's **Tools** column. The sleep-stage buttons take a fixed keypad — **0** Wake,
+window's **Panels** column. The sleep-stage buttons take a fixed keypad — **0** Wake,
 **1** N1, **2** N2, **3** N3, **4** REM — and the remaining buttons take **5**–**9** in
 order; the shortcuts are active while the panel is focused. The **Lights** toggle stays
 on the main window (it also flips the dark theme).
@@ -290,7 +290,7 @@ mid-session.
 
 Every run writes a detailed `.log` to its own timestamped folder under the SMACC
 file's **data directory** (e.g. `~/SMACC/data/`), capturing the events and settings
-for that session. Open one later from the Launcher's **Analyze** to see a
+for that session. Open one later from the Launcher's **Analyzer** to see a
 summary, export its events to BIDS, or recover its settings.
 
 ### If SMACC crashes
@@ -328,7 +328,7 @@ with **File › Save SMACC file as…** in a Session.
 
 Tool windows close with **Ctrl+W** (or **File › Close window**) — that
 only hides the window, with its state intact; the session keeps running and the
-Session window's Tools column reopens it.
+Session window's Panels column reopens it.
 
 Separately, the machine remembers window positions and sizes and your recent files in
 `~/SMACC/preferences.yaml`, restored on the next launch.

--- a/src/smacc/analyze.py
+++ b/src/smacc/analyze.py
@@ -1,6 +1,6 @@
-"""The Analyze window: post-hoc tools over a past session, with no live session.
+"""The Analyzer window: post-hoc tools over a past session, with no live session.
 
-Reached from the launcher's **Analyze session**. Point it at a session — a
+Reached from the launcher's **Analyzer**. Point it at a session — a
 ``.log`` file, a session folder (its log is found automatically), or a zipped
 session — and it shows a summary (events, duration, subject/session, dream
 reports) and offers to export the events to BIDS or recover the settings from the
@@ -81,7 +81,7 @@ class AnalyzeWindow(ToolWindow):
         self._log_path: Path | None = None
         self._base_dir: Path | None = None
         self._temp_dirs: list[Path] = []  # extracted zips, cleaned up on close
-        self.setWindowTitle("SMACC — Analyze session")
+        self.setWindowTitle("SMACC Analyzer")
         if LOGO_PATH.is_file():
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
         self._build()
@@ -94,7 +94,7 @@ class AnalyzeWindow(ToolWindow):
         layout = QtWidgets.QVBoxLayout(central)
         layout.setContentsMargins(16, 12, 16, 12)
         layout.setSpacing(10)
-        layout.addWidget(make_section_title("Analyze session"))
+        layout.addWidget(make_section_title("Analyzer"))
 
         openFileButton = QtWidgets.QPushButton("Open log / zip…", self)
         openFileButton.setStatusTip("Open a SMACC .log file or a zipped session.")
@@ -137,11 +137,11 @@ class AnalyzeWindow(ToolWindow):
         self.revealButton = QtWidgets.QPushButton("Open session folder", self)
         self.revealButton.setStatusTip("Open the session's folder in the file browser.")
         self.revealButton.clicked.connect(self.reveal_folder)
-        # Hand the session to the EEG annotator, which overlays this log on the
+        # Hand the session to the EEG Annotator, which overlays this log on the
         # timeline (#125). Shown only where the annotator component is available.
-        self.annotateButton = QtWidgets.QPushButton("Open log in EEG annotator", self)
+        self.annotateButton = QtWidgets.QPushButton("Open log in EEG Annotator", self)
         self.annotateButton.setStatusTip(
-            "Open this session log in the EEG annotator (overlaid on a recording, "
+            "Open this session log in the EEG Annotator (overlaid on a recording, "
             "or on its own time axis)."
         )
         self.annotateButton.clicked.connect(self.open_in_annotator)
@@ -261,7 +261,7 @@ class AnalyzeWindow(ToolWindow):
             self._error("Could not export events.", str(exc))
             return
         QtWidgets.QMessageBox.information(
-            self, "Analyze", f"Exported {count} events to\n{out_path}"
+            self, "Analyzer", f"Exported {count} events to\n{out_path}"
         )
 
     def recover_settings(self) -> None:
@@ -303,7 +303,7 @@ class AnalyzeWindow(ToolWindow):
             self._error("Could not save the settings.", str(exc))
             return
         QtWidgets.QMessageBox.information(
-            self, "Analyze", f"Saved recovered settings to\n{out_path}"
+            self, "Analyzer", f"Saved recovered settings to\n{out_path}"
         )
 
     def reveal_folder(self) -> None:
@@ -313,19 +313,19 @@ class AnalyzeWindow(ToolWindow):
             )
 
     def open_in_annotator(self) -> None:
-        """Hand this session's log to the EEG annotator as its own process (#125).
+        """Hand this session's log to the EEG Annotator as its own process (#125).
 
-        Analyze stays the no-EEG summary/BIDS tool; the annotator is where the log
+        The Analyzer stays the no-EEG summary/BIDS tool; the annotator is where the log
         is seen on a timeline (overlaid on a recording, or standalone). Launched
-        detached, like the launcher's Review-EEG button.
+        detached, like the launcher's EEG Annotator button.
         """
         if self._log_path is None:
             return
         if not eeg.launch(["--log", str(self._log_for_handoff())]):
             self._error(
-                "Could not start the EEG annotator.",
-                "Re-running the SMACC installer and selecting the EEG Review "
-                "Tools component may fix this.",
+                "Could not start the EEG Annotator.",
+                "Re-running the SMACC installer and selecting the EEG Annotator "
+                "component may fix this.",
             )
 
     def _log_for_handoff(self) -> Path:
@@ -351,7 +351,7 @@ class AnalyzeWindow(ToolWindow):
     def _error(self, short: str, detail: str | None = None) -> None:
         box = QtWidgets.QMessageBox(self)
         box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
-        box.setWindowTitle("Analyze")
+        box.setWindowTitle("Analyzer")
         box.setText(short)
         if detail is not None:
             box.setInformativeText(detail)

--- a/src/smacc/cuedesigner.py
+++ b/src/smacc/cuedesigner.py
@@ -1,7 +1,7 @@
-"""The Cue designer: build a simple tone cue and export it as a WAV (#77, #137).
+"""The Audio Cue Designer: build a simple tone cue and export it as a WAV (#77, #137).
 
-Reached from the launcher's **Design cues** button — a standalone tool (like
-Analyze), not a session panel, since authoring a cue is a design-time task with no
+Reached from the launcher's **Audio Cue Designer** button — a standalone tool (like
+the Analyzer), not a session panel, since authoring a cue is a design-time task with no
 markers, devices, or run folder. You lay out a short sequence of **tone** and
 **silence** segments (the simple beeps/chimes a cueing study actually uses, 1-30 s),
 optionally repeat the pattern into a pip train, watch the live waveform, preview it
@@ -198,7 +198,7 @@ class CueDesignerWindow(ToolWindow):
         self._renderTimer.timeout.connect(self._refresh_waveform)
         self._presets = make_presets()
         self.rows: list[SegmentRow] = []
-        self.setWindowTitle("SMACC — Cue designer")
+        self.setWindowTitle("SMACC Audio Cue Designer")
         if LOGO_PATH.is_file():
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
         self._build()
@@ -213,7 +213,7 @@ class CueDesignerWindow(ToolWindow):
         layout = QtWidgets.QVBoxLayout(central)
         layout.setContentsMargins(16, 12, 16, 12)
         layout.setSpacing(10)
-        layout.addWidget(make_section_title("Cue designer"))
+        layout.addWidget(make_section_title("Audio Cue Designer"))
 
         intro = QtWidgets.QLabel(
             "Build a short cue from tone and silence segments, preview it, then "
@@ -513,7 +513,7 @@ class CueDesignerWindow(ToolWindow):
         label, design = self._presets[index - 1]
         clicked = QtWidgets.QMessageBox.question(
             self,
-            "Cue designer",
+            "Audio Cue Designer",
             f'Replace the current design with the "{label}" preset?',
         )
         if clicked == QtWidgets.QMessageBox.StandardButton.Yes:
@@ -664,14 +664,16 @@ class CueDesignerWindow(ToolWindow):
         status_bar = self.statusBar()
         assert status_bar is not None
         status_bar.showMessage(f"Saved {Path(path).name}", 5000)
-        QtWidgets.QMessageBox.information(self, "Cue designer", f"Saved cue to\n{path}")
+        QtWidgets.QMessageBox.information(
+            self, "Audio Cue Designer", f"Saved cue to\n{path}"
+        )
 
     # ----- helpers / lifecycle ----------------------------------------------
 
     def _warn(self, short: str, detail: str | None = None) -> None:
         box = QtWidgets.QMessageBox(self)
         box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
-        box.setWindowTitle("Cue designer")
+        box.setWindowTitle("Audio Cue Designer")
         box.setText(short)
         if detail is not None:
             box.setInformativeText(detail)

--- a/src/smacc/eeg/__init__.py
+++ b/src/smacc/eeg/__init__.py
@@ -1,9 +1,9 @@
-"""The EEG review tool: post-hoc trace viewing and annotation (#136).
+"""The EEG Annotator: post-hoc trace viewing and annotation (#136).
 
 This subpackage is SMACC's *optional* EEG component. It opens a recorded EEG
 file (EDF, BrainVision, FIF), scrolls its traces, applies display-only filters,
 and saves named annotations to a TSV sidecar — the source file is never
-modified. It is a review tool, not a real-time display: nothing here runs
+modified. It is an annotation tool, not a real-time display: nothing here runs
 during a live session, and nothing in the live-session path imports from here.
 
 The component always runs as its own process with its own ``QApplication``.
@@ -29,7 +29,7 @@ from importlib.util import find_spec
 from pathlib import Path
 
 # The frozen EEG component, installed beside SMACC.exe by the installer's
-# optional "EEG Review Tools" component (see tools/smacc.iss).
+# optional "EEG Annotator" component (see tools/smacc.iss).
 EXE_NAME = "SMACC-EEG.exe"
 
 
@@ -39,7 +39,7 @@ def component_exe() -> Path:
 
 
 def available() -> bool:
-    """True when the EEG review tool can be launched from this install.
+    """True when the EEG Annotator can be launched from this install.
 
     Packaged build: the installer component dropped ``SMACC-EEG.exe`` next to
     ``SMACC.exe``. Development: the ``eeg`` extra (mne + pyqtgraph) is in the
@@ -52,13 +52,13 @@ def available() -> bool:
 
 
 def launch(args: list[str] | None = None) -> bool:
-    """Start the EEG review tool as its own detached process; True if started.
+    """Start the EEG Annotator as its own detached process; True if started.
 
     Detached on purpose: the viewer outlives the launcher (or a session) and
     never shares a process with them — see the isolation rationale above. The
     development path runs ``python -m smacc.eeg`` with the current
     interpreter, the packaged path runs the installed exe. ``args`` are extra
-    command-line arguments (e.g. ``["--log", path]`` for the Analyze handoff),
+    command-line arguments (e.g. ``["--log", path]`` for the Analyzer handoff),
     appended after the module/exe so both paths receive them identically.
     """
     from PyQt6 import QtCore  # deferred: keep this module import-light

--- a/src/smacc/eeg/__main__.py
+++ b/src/smacc/eeg/__main__.py
@@ -1,4 +1,4 @@
-"""Run the EEG review tool: ``python -m smacc.eeg [recording]``.
+"""Run the EEG Annotator: ``python -m smacc.eeg [recording]``.
 
 The component's own entry point — its own process and ``QApplication``, never
 sharing one with a live session (see the package docstring). The frozen
@@ -27,7 +27,7 @@ from ..config import VERSION
 # Imported eagerly, on purpose: --version must prove the whole MNE/pyqtgraph
 # import tree resolves in the frozen bundle (that is the point of the smoke
 # test — a lazy import would make it pass on a bundle that can't open a file).
-from .window import EegReviewWindow
+from .window import EegAnnotatorWindow
 
 # Flags that take a following value, so the recording-path scan skips that value.
 _VALUE_FLAGS = ("--rater", "--blind", "--log")
@@ -91,7 +91,7 @@ def pick_blind_spec(args: list[str]) -> str | None:
 def pick_log_path(args: list[str]) -> str | None:
     """Return the ``--log`` value (a SMACC session log to overlay/show), or ``None``.
 
-    Lets the Analyze window hand a session off to the annotator
+    Lets the Analyzer hand a session off to the annotator
     (``SMACC-EEG.exe --log night1.log``): with no recording the log opens
     standalone, with one it overlays. Read/parse errors surface as a dialog after
     the window opens, not as a vanishing process.
@@ -228,7 +228,7 @@ def selftest() -> int:
 
 def main() -> None:
     if "--version" in sys.argv:
-        print(f"SMACC EEG review v{VERSION}")
+        print(f"SMACC EEG Annotator v{VERSION}")
         sys.exit(0)
     if "--selftest" in sys.argv:
         # A windowed (--noconsole) build pops a *blocking* "Failed to execute
@@ -242,8 +242,8 @@ def main() -> None:
             traceback.print_exc()
             sys.exit(1)
     app = QApplication(sys.argv)
-    app.setApplicationName("SMACC EEG review")
-    window = EegReviewWindow(
+    app.setApplicationName("SMACC EEG Annotator")
+    window = EegAnnotatorWindow(
         pick_recording_path(sys.argv),
         rater_id=pick_rater_id(sys.argv),
         blind_spec=pick_blind_spec(sys.argv),

--- a/src/smacc/eeg/dsp.py
+++ b/src/smacc/eeg/dsp.py
@@ -1,4 +1,4 @@
-"""Display filtering for the EEG review tool (#136).
+"""Display filtering for the EEG Annotator (#136).
 
 The viewer filters only the *visible slice* of the recording, never the whole
 file. ``mne.io.Raw.filter`` requires preloading the entire recording — an

--- a/src/smacc/eeg/export.py
+++ b/src/smacc/eeg/export.py
@@ -1,4 +1,4 @@
-"""Publication-figure export for the EEG review tool (#180).
+"""Publication-figure export for the EEG Annotator (#180).
 
 Renders a :class:`~smacc.eeg.snapshot.Snapshot` to PNG / PDF / SVG with
 matplotlib's headless backends — the engine MNE itself uses for static figures,

--- a/src/smacc/eeg/io.py
+++ b/src/smacc/eeg/io.py
@@ -1,8 +1,8 @@
-"""Recording access for the EEG review tool — the only module that touches MNE (#136).
+"""Recording access for the EEG Annotator — the only module that touches MNE (#136).
 
 MNE is strictly a *backend* here: it reads the formats (EDF, BrainVision, FIF —
 the formats sleep-lab amps actually produce) and exposes their metadata;
-rendering is pyqtgraph and filtering is :mod:`smacc.eeg.dsp`. The review tool
+rendering is pyqtgraph and filtering is :mod:`smacc.eeg.dsp`. The EEG Annotator
 itself only ever *writes* the TSV/JSON sidecar (:mod:`smacc.eeg.annotations`) —
 the source recording is never modified. The import is lazy so probing
 this package costs nothing, and recordings are opened with ``preload=False`` so

--- a/src/smacc/eeg/profiles.py
+++ b/src/smacc/eeg/profiles.py
@@ -1,4 +1,4 @@
-"""Saveable display ("view") profiles for the EEG review tool (#177).
+"""Saveable display ("view") profiles for the EEG Annotator (#177).
 
 A view profile is a named, shareable *montage*: which channels to show and in
 what order, the per-channel-type display filter and amplitude, and the

--- a/src/smacc/eeg/sessionlog.py
+++ b/src/smacc/eeg/sessionlog.py
@@ -5,7 +5,7 @@ read-only reference track: every marker, cue, dream report, and survey shown
 where it happened, so a reviewer sees what SMACC *did* alongside the EEG. This
 module is the pure model behind that overlay — no GUI, no MNE — so it is
 directly unit-testable and safe to import in the frozen ``SMACC-EEG.exe``. It
-builds on the log parsers in :mod:`smacc.bids` (shared with the Analyze window),
+builds on the log parsers in :mod:`smacc.bids` (shared with the Analyzer),
 adding the per-entry classification, dream-report numbering, and the wall-clock
 placement math the overlay needs.
 

--- a/src/smacc/eeg/view.py
+++ b/src/smacc/eeg/view.py
@@ -1,4 +1,4 @@
-"""The multichannel trace view for the EEG review tool (#136).
+"""The multichannel trace view for the EEG Annotator (#136).
 
 One pyqtgraph ``PlotWidget``, all channels stacked in a single ViewBox by
 vertical offset (channel *i* centered at ``y = -i``), channel names as y-axis

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -1,4 +1,4 @@
-"""The EEG review window: open a recording, scroll it, annotate it (#136).
+"""The EEG Annotator window: open a recording, scroll it, annotate it (#136).
 
 A standalone top-level window with its own process and ``QApplication`` (see
 the package docstring) — not a launcher-managed :class:`~smacc.toolwindow
@@ -76,7 +76,7 @@ if TYPE_CHECKING:  # matplotlib is heavy: import the export module only on deman
     from .export import ExportOptions
 
 # Stable id for this window's geometry entry in the per-window prefs map.
-_EEG_WINDOW_ID = "eeg-review"
+_EEG_WINDOW_ID = "eeg-annotator"
 
 # Starting points for the label dropdown before an operator has any recents:
 # the marks dream-engineering reviewers actually place (see the
@@ -617,7 +617,7 @@ class ExportDialog(QtWidgets.QDialog):
         return dialog.result_values()
 
 
-class EegReviewWindow(QtWidgets.QMainWindow):
+class EegAnnotatorWindow(QtWidgets.QMainWindow):
     """Review and annotate one recording; the EEG component's main window."""
 
     def __init__(
@@ -706,7 +706,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._stage_dirty = False
         self._owns_stage_sidecar = False
         self._recovery_stages: list[StageEpoch] | None = None
-        self.setWindowTitle("SMACC — EEG review")
+        self.setWindowTitle("SMACC EEG Annotator")
         if LOGO_PATH.is_file():
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
         self._build()
@@ -730,8 +730,8 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             # open-error dialog (and a long load doesn't block the first paint).
             QtCore.QTimer.singleShot(0, lambda: self._load(Path(file_path)))
         if log_path is not None:
-            # Open a session log too (or on its own, standalone — the Analyze
-            # window's "open in annotator" handoff uses this). Deferred for the
+            # Open a session log too (or on its own, standalone — the Analyzer
+            # "open in annotator" handoff uses this). Deferred for the
             # same reason; runs after the recording load so it overlays when both
             # are given.
             QtCore.QTimer.singleShot(0, lambda: self.load_session_log(Path(log_path)))
@@ -870,7 +870,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         layout = QtWidgets.QVBoxLayout(central)
         layout.setContentsMargins(12, 8, 12, 8)
         layout.setSpacing(8)
-        layout.addWidget(_section_title("EEG review"))
+        layout.addWidget(_section_title("EEG Annotator"))
         layout.addWidget(self._build_contract_caption())
         layout.addWidget(self._build_recovery_banner())
         layout.addLayout(self._build_controls_row())
@@ -2736,7 +2736,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         rater = f" · rater {self._rater_id}" if self._rater_id else ""
         blinded = f" · blind:{self._blind.preset}" if self._blind is not None else ""
         star = " *" if self._dirty or self._stage_dirty else ""
-        self.setWindowTitle(f"SMACC — EEG review{name}{rater}{blinded}{star}")
+        self.setWindowTitle(f"SMACC EEG Annotator{name}{rater}{blinded}{star}")
 
     def _recent_labels(self) -> list[str]:
         prefs = preferences.load_preferences(preferences_path)
@@ -3403,7 +3403,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
     def _error(self, short: str, detail: str | None = None) -> None:
         box = QtWidgets.QMessageBox(self)
         box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
-        box.setWindowTitle("EEG review")
+        box.setWindowTitle("EEG Annotator")
         box.setText(short)
         if detail is not None:
             box.setInformativeText(detail)

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -273,7 +273,7 @@ class SmaccWindow(ToolWindow):
     }
 
     def _build_launcher_buttons(self) -> QtWidgets.QLayout:
-        """Build the 'Tools' column: panel launchers + the lights toggle.
+        """Build the 'Panels' column: panel launchers + the lights toggle.
 
         The lights toggle is pinned to the bottom of the column at a fixed,
         reasonable size (the stretch above absorbs extra height), so enlarging
@@ -281,7 +281,7 @@ class SmaccWindow(ToolWindow):
         sends the lights event marker and flips the dark theme.
         """
         layout = QtWidgets.QVBoxLayout()
-        layout.addWidget(self._make_section_title("Tools"))
+        layout.addWidget(self._make_section_title("Panels"))
         for key, label in self.PANEL_LABELS.items():
             if key not in self.panels:
                 continue

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -57,7 +57,7 @@ class LauncherWindow(QtWidgets.QMainWindow):
         super().__init__()
         self._settings_path: str | None = None  # current .smacc, or None for defaults
         self._tool: ToolWindow | None = None
-        self.setWindowTitle("SMACC Launcher")
+        self.setWindowTitle("SMACC")
         if LOGO_PATH.is_file():
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
         self._build()
@@ -115,13 +115,13 @@ class LauncherWindow(QtWidgets.QMainWindow):
         # Standalone tools that don't act on the selected settings: design a cue
         # WAV, or analyze a past session. Each opens from here and returns on close.
         layout.addSpacing(8)
-        designButton = QtWidgets.QPushButton("Design cues", self)
+        designButton = QtWidgets.QPushButton("Audio Cue Designer", self)
         designButton.setMinimumHeight(40)
         designButton.setStatusTip("Create a tone cue and export it as a WAV file.")
         designButton.clicked.connect(self.design_cues)
         layout.addWidget(designButton)
 
-        analyzeButton = QtWidgets.QPushButton("Analyze", self)
+        analyzeButton = QtWidgets.QPushButton("Analyzer", self)
         analyzeButton.setMinimumHeight(40)
         analyzeButton.setStatusTip(
             "Summarize a past session, export its events, or recover its settings."
@@ -129,23 +129,23 @@ class LauncherWindow(QtWidgets.QMainWindow):
         analyzeButton.clicked.connect(self.analyze_session)
         layout.addWidget(analyzeButton)
 
-        # The optional EEG review component (#136). Shown disabled (not
+        # The optional EEG Annotator component (#136). Shown disabled (not
         # hidden) when absent, so a lab knows the tool exists and how to get
         # it — the same surface-don't-hide approach as missing trigger
         # hardware (#147). Availability is probed once, here: installing the
         # component mid-run requires closing SMACC anyway (the installer
         # replaces the locked exe), and a stale True is already handled by
         # the launch-failure dialog.
-        reviewEegButton = QtWidgets.QPushButton("Review EEG", self)
+        reviewEegButton = QtWidgets.QPushButton("EEG Annotator", self)
         reviewEegButton.setMinimumHeight(40)
         if eeg.available():
             reviewEegButton.setStatusTip(
-                "Open the EEG review tool in its own window (annotate a recording)."
+                "Open the EEG Annotator in its own window (annotate a recording)."
             )
         else:
             reviewEegButton.setEnabled(False)
             reviewEegButton.setStatusTip(
-                "EEG Review Tools are not installed — re-run the SMACC "
+                "The EEG Annotator is not installed — re-run the SMACC "
                 "installer and select the component."
             )
         reviewEegButton.clicked.connect(self.review_eeg)
@@ -442,7 +442,7 @@ class LauncherWindow(QtWidgets.QMainWindow):
         self._open_tool(SmaccWindow(session, settings_path=self._settings_path))
 
     def design_cues(self) -> None:
-        """Open the standalone Cue designer (exports WAVs to a study's cues folder)."""
+        """Open the standalone Audio Cue Designer (exports WAVs to a study's cues folder)."""
         self._open_tool(CueDesignerWindow(self._data_dir() / "cues"))
 
     def analyze_session(self) -> None:
@@ -450,7 +450,7 @@ class LauncherWindow(QtWidgets.QMainWindow):
         self._open_tool(AnalyzeWindow(self._data_dir()))
 
     def review_eeg(self) -> None:
-        """Launch the EEG review tool as its own detached process.
+        """Launch the EEG Annotator as its own detached process.
 
         Unlike the launcher-managed tools this never hides the launcher: the
         viewer is a sibling app in a separate process (the frozen build can't
@@ -460,14 +460,14 @@ class LauncherWindow(QtWidgets.QMainWindow):
         if eeg.launch():
             bar = self.statusBar()
             if bar is not None:
-                bar.showMessage("EEG review opened in its own window.", 5000)
+                bar.showMessage("EEG Annotator opened in its own window.", 5000)
             return
         QtWidgets.QMessageBox.warning(
             self,
-            "Review EEG",
-            "Could not start the EEG review tool.\n\n"
-            "Re-running the SMACC installer and selecting the EEG Review "
-            "Tools component may repair it.",
+            "EEG Annotator",
+            "Could not start the EEG Annotator.\n\n"
+            "Re-running the SMACC installer and selecting the EEG Annotator "
+            "component may repair it.",
         )
 
     def associate_files(self) -> None:

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -49,26 +49,26 @@ DEFAULTS: dict[str, Any] = {
     # ISO timestamps with a UTC offset; this changes only the on-screen preview.
     # See CLOCK_FORMATS and log_preview_clock().
     "log_preview_clock": "24h",
-    # EEG review tool (#136): recently used annotation labels (most-recent
+    # EEG Annotator (#136): recently used annotation labels (most-recent
     # first, seeding the label dialog's dropdown) and the last folder a
     # recording was opened from. Note loading only round-trips keys present
     # here, so the EEG window's keys must stay in DEFAULTS even though the
     # tool is an optional component.
     "eeg_recent_labels": [],
     "eeg_last_dir": None,
-    # The folder the EEG review tool last saved/loaded a view profile from (#177).
+    # The folder the EEG Annotator last saved/loaded a view profile from (#177).
     "eeg_last_profile_dir": None,
-    # The folder the EEG review tool last exported a figure to (#180).
+    # The folder the EEG Annotator last exported a figure to (#180).
     "eeg_last_export_dir": None,
-    # The rater id the EEG review tool saves under (#181): when set, annotations
+    # The rater id the EEG Annotator saves under (#181): when set, annotations
     # save to a per-rater sidecar (night1.annotations.<id>.tsv); None means an
     # ordinary single-rater review writing the plain sidecar.
     "eeg_rater_id": None,
-    # The EEG review tool's quick-mark palette (#181): one-click buttons that drop
+    # The EEG Annotator's quick-mark palette (#181): one-click buttons that drop
     # a labeled point mark at the cursor. Defaults to the lucid eye-signal
     # vocabulary; editable in the tool, and the first nine get number keys 1–9.
     "eeg_palette_labels": ["LRLR", "LRLRx2", "LRLRx3", "IEIE"],
-    # The folder the EEG review tool last loaded a blind config from (#181).
+    # The folder the EEG Annotator last loaded a blind config from (#181).
     "eeg_last_blind_dir": None,
 }
 

--- a/src/smacc/synth.py
+++ b/src/smacc/synth.py
@@ -1,7 +1,7 @@
-"""Tone synthesis for the Cue designer (#77): build a cue from simple segments.
+"""Tone synthesis for the Audio Cue Designer (#77): build a cue from simple segments.
 
 Pure, hardware-free DSP — no Qt, no streams — so it is unit-testable on its own. The
-Cue designer (:mod:`smacc.cuedesigner`) assembles a list of **segments** (a pure
+Audio Cue Designer (:mod:`smacc.cuedesigner`) assembles a list of **segments** (a pure
 tone or a gap of silence), renders them into one mono float32 buffer in ``[-1, 1]``,
 and exports a PCM-16 WAV that drops straight into a study's ``cues`` folder.
 
@@ -183,7 +183,7 @@ DESIGN_VERSION = 1
 class CueDesign:
     """A complete, serializable cue design: segment pattern plus master settings.
 
-    This is the unit the Cue designer saves and reopens as a JSON design file
+    This is the unit the Audio Cue Designer saves and reopens as a JSON design file
     (#137). The exported WAV stays the lab-facing artifact the cue board plays;
     the design file is what keeps a cue editable. The pattern repeats
     ``repeat_count`` times with ``repeat_gap`` seconds of silence between repeats,

--- a/src/smacc/windowstate.py
+++ b/src/smacc/windowstate.py
@@ -1,6 +1,6 @@
 """Restore and capture window geometry uniformly across every SMACC window.
 
-The launcher, the main session window, each tool window, and the Analyze window
+The launcher, the main session window, each tool window, and the Analyzer window
 all reopen where they were last left. The geometry itself is stored machine-local
 in ``preferences.yaml`` as a per-window map (see :mod:`smacc.preferences`); these
 small Qt helpers are the bridge between that pure data and a live ``QWidget``.

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -64,7 +64,7 @@ def test_extract_zip_rejects_path_traversal(tmp_path):
     assert not (tmp_path / "escape.txt").exists()
 
 
-# ----- the EEG annotator handoff (#125d) ------------------------------------
+# ----- the EEG Annotator handoff (#125d) ------------------------------------
 
 A_LOG = (
     "2026-06-05 22:00:00.000-0500, INFO, Opened SMACC v0.0.7\n"

--- a/tests/test_cuedesigner.py
+++ b/tests/test_cuedesigner.py
@@ -1,4 +1,4 @@
-"""Tests for the Cue designer window (#77).
+"""Tests for the Audio Cue Designer window (#77).
 
 Headless Qt (offscreen, via conftest). Preview would open a sounddevice stream, so
 the one preview test stubs ``sd.OutputStream``/``sd.query_devices``; everything else

--- a/tests/test_eeg_launch.py
+++ b/tests/test_eeg_launch.py
@@ -1,7 +1,7 @@
 """Tests for launching the optional EEG component from the launcher (#136).
 
 Covers the availability probe (dev extra vs. frozen exe-beside-exe), the
-detached-process launch, and the launcher's Review EEG button — which is shown
+detached-process launch, and the launcher's EEG Annotator button — which is shown
 disabled (never hidden) when the component is absent, the same
 surface-don't-hide approach as missing trigger hardware (#147).
 """
@@ -136,4 +136,4 @@ def test_failed_launch_shows_a_warning(make_launcher, monkeypatch):
     win = make_launcher()
     win.review_eeg()
     assert len(warnings) == 1
-    assert "EEG Review Tools" in warnings[0]
+    assert "EEG Annotator" in warnings[0]

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -1,4 +1,4 @@
-"""Tests for the EEG review window (#136) — offscreen, no MNE.
+"""Tests for the EEG Annotator window (#136) — offscreen, no MNE.
 
 ``io.open_recording``/``io.embedded_annotations`` are monkeypatched with a
 fake recording, so the window's whole flow — open, sidecar precedence,
@@ -50,7 +50,7 @@ from smacc.eeg.staging import (
     write_stages_json,
     write_stages_tsv,
 )
-from smacc.eeg.window import SEED_LABELS, EegReviewWindow, LabelDialog
+from smacc.eeg.window import SEED_LABELS, EegAnnotatorWindow, LabelDialog
 
 SFREQ = 100.0
 DURATION = 600.0
@@ -78,7 +78,7 @@ class FakeRecording:
 
 @pytest.fixture
 def window(qtbot, tmp_path, monkeypatch):
-    """An EegReviewWindow over faked IO, isolated prefs, and silent dialogs."""
+    """An EegAnnotatorWindow over faked IO, isolated prefs, and silent dialogs."""
     monkeypatch.setattr(window_mod, "preferences_path", tmp_path / "prefs.yaml")
     monkeypatch.setattr(window_mod.io, "open_recording", FakeRecording)
     monkeypatch.setattr(window_mod.io, "embedded_annotations", lambda rec: [])
@@ -98,7 +98,7 @@ def window(qtbot, tmp_path, monkeypatch):
         "question",
         lambda *a, **k: QtWidgets.QMessageBox.StandardButton.Discard,
     )
-    win = EegReviewWindow()
+    win = EegAnnotatorWindow()
     qtbot.addWidget(win)
     win.show()
     win._prefs_path = tmp_path / "prefs.yaml"  # test convenience handle
@@ -910,7 +910,7 @@ def test_geometry_is_persisted_on_close(window, recording_path):
     }
     assert window.close()
     prefs = preferences.load_preferences(window._prefs_path)
-    assert preferences.window_geometry(prefs, "eeg-review") == expected
+    assert preferences.window_geometry(prefs, "eeg-annotator") == expected
 
 
 def test_recent_labels_are_capped_and_deduplicated(window):
@@ -1058,7 +1058,7 @@ def test_selftest_round_trips_through_mne():
 
 @pytest.fixture
 def make_window(qtbot, tmp_path, monkeypatch):
-    """Build EegReviewWindows (optionally with a rater id) over the faked IO,
+    """Build EegAnnotatorWindows (optionally with a rater id) over the faked IO,
     isolated prefs, and auto-answered dialogs the ``window`` fixture uses."""
     monkeypatch.setattr(window_mod, "preferences_path", tmp_path / "prefs.yaml")
     monkeypatch.setattr(window_mod.io, "open_recording", FakeRecording)
@@ -1072,8 +1072,8 @@ def make_window(qtbot, tmp_path, monkeypatch):
 
     def build(
         rater_id: str | None = None, blind_spec: str | None = None
-    ) -> EegReviewWindow:
-        win = EegReviewWindow(rater_id=rater_id, blind_spec=blind_spec)
+    ) -> EegAnnotatorWindow:
+        win = EegAnnotatorWindow(rater_id=rater_id, blind_spec=blind_spec)
         qtbot.addWidget(win)
         win.show()
         win._prefs_path = tmp_path / "prefs.yaml"  # test convenience handle
@@ -1877,7 +1877,7 @@ def test_constructor_log_path_loads_standalone(qtbot, tmp_path, monkeypatch):
     monkeypatch.setattr(window_mod.io, "recorded_trigger_events", lambda rec: [])
     log = tmp_path / "boot.log"
     log.write_text(LOG_TEXT, encoding="utf-8")
-    win = EegReviewWindow(log_path=log)
+    win = EegAnnotatorWindow(log_path=log)
     qtbot.addWidget(win)
     win.show()
     qtbot.waitUntil(lambda: bool(win._log_entries), timeout=2000)  # deferred load

--- a/tools/make_versionfile.py
+++ b/tools/make_versionfile.py
@@ -10,7 +10,7 @@ exe (the optional EEG component, #136, is a second frozen exe)::
 
     uv run python tools/make_versionfile.py version_info.txt
     uv run python tools/make_versionfile.py version_info_eeg.txt \\
-        --product SMACC-EEG --description "SMACC EEG review tool"
+        --product SMACC-EEG --description "SMACC EEG Annotator"
 """
 
 from __future__ import annotations

--- a/tools/smacc.iss
+++ b/tools/smacc.iss
@@ -50,20 +50,21 @@ SolidCompression=yes
 ; Desktop shortcut is opt-in (unchecked by default); the Start menu entry is always created.
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
-; The EEG Review Tools (#136) are an optional component: the SMACC-EEG.exe
-; bundle carries the full MNE/pyqtgraph stack, so labs that only run sessions
-; skip it. The first [Types] entry ("standard", without it) is the default for
-; a fresh install; on upgrades Inno preselects whatever was chosen before, so
-; the pair stays in sync. A silent install adds it with /COMPONENTS="core,eeg",
-; and re-running the installer later can add it to an existing install.
+; The EEG Annotator (#136) is an optional component: the SMACC-EEG.exe bundle
+; carries the full MNE/pyqtgraph stack, so labs that only run sessions can skip
+; it. It installs by default by being part of the default "full" type (the first
+; [Types] entry, so a silent install with no /COMPONENTS uses it); unchecking it
+; switches the setup type to "custom". A [Types] section is required: without it
+; a silent install selects no components at all (not even fixed "core"). A silent
+; install can pin the set with /COMPONENTS="core" or "core,eeg", and re-running
+; the installer later can add or drop the component on an existing install.
 [Types]
-Name: "standard"; Description: "Standard installation"
-Name: "full"; Description: "Full installation (with EEG Review Tools)"
+Name: "full"; Description: "Full installation"
 Name: "custom"; Description: "Custom installation"; Flags: iscustom
 
 [Components]
-Name: "core"; Description: "SMACC"; Types: standard full custom; Flags: fixed
-Name: "eeg"; Description: "EEG Review Tools (view and annotate recordings)"; Types: full
+Name: "core"; Description: "SMACC"; Types: full custom; Flags: fixed
+Name: "eeg"; Description: "EEG Annotator (view and annotate recordings)"; Types: full
 
 [Files]
 Source: "..\dist\SMACC.exe"; DestDir: "{app}"; Components: core; Flags: ignoreversion
@@ -75,13 +76,13 @@ Source: "..\dist\SMACC-EEG.exe"; DestDir: "{app}"; Components: eeg; Flags: ignor
 ; SMACC-EEG.exe behind, which the launcher's availability probe would still
 ; detect and happily run.
 Type: files; Name: "{app}\SMACC-EEG.exe"; Components: not eeg
-Type: files; Name: "{autoprograms}\SMACC EEG review.lnk"; Components: not eeg
+Type: files; Name: "{autoprograms}\SMACC EEG Annotator.lnk"; Components: not eeg
 
 [Icons]
 Name: "{autoprograms}\SMACC"; Filename: "{app}\SMACC.exe"
-; The EEG viewer is also launchable from inside SMACC, but a reviewer doing
+; The EEG Annotator is also launchable from inside SMACC, but a reviewer doing
 ; daytime analysis shouldn't have to open the session app to get there.
-Name: "{autoprograms}\SMACC EEG review"; Filename: "{app}\SMACC-EEG.exe"; Components: eeg
+Name: "{autoprograms}\SMACC EEG Annotator"; Filename: "{app}\SMACC-EEG.exe"; Components: eeg
 Name: "{autodesktop}\SMACC"; Filename: "{app}\SMACC.exe"; Tasks: desktopicon
 
 [Registry]


### PR DESCRIPTION
First of two PRs for #194 (194a — the rename sweep + installer; 194b is the launcher redesign).

## What changes

Renames the genuinely separable tools to clear, descriptive names; "SMACC" stays the umbrella brand and the cueing tool keeps **Session**/**Editor** (no codename).

| Surface | Before | After |
|---|---|---|
| EEG tool | "EEG review" / "EEG Review Tools" / "Review EEG" | **EEG Annotator** |
| Cue designer | "Cue designer" / "Design cues" | **Audio Cue Designer** |
| Analyze | "Analyze" / "Analyze session" | **Analyzer** |
| Window titles | "SMACC — Toolname" | **SMACC Toolname** |
| Launcher title bar | "SMACC Launcher" | **SMACC** |
| Session window's "Tools" column | "Tools" | **Panels** |

Also renames the `EegReviewWindow` class → `EegAnnotatorWindow` and the `eeg-annotator` window-geometry pref key.

## Installer

Drops the standard/full type split. The EEG Annotator is now a plain component **checked by default** (deselect during setup to skip the heavyweight MNE stack). The release smoke-tests flip to match: the default install now includes the EEG exe, and a core-only (`/COMPONENTS="core"`) install drops it — which also exercises the `[InstallDelete]` cleanup of a previously-installed exe.

## Deliberately unchanged

- The `.smacc` extension / file association and the `SMACC-EEG.exe` binary name (display names change; binary/registry contracts don't).
- The About-box backronym and the flat module layout.
- `docs/eeg-review.md` — its content rewrite and file rename belong to #205, so this PR only substitutes labels in the cross-cutting pages (usage, installation, contributing, reference/*).
- Internal class names `AnalyzeWindow` / `CueDesignerWindow` (the roots stay accurate).

## Verification

`ruff format --check`, `ruff check`, `mypy`, `mdformat --check`, and the full suite (1048 passed) are green. The installer's behavioral changes (default-on component, `[InstallDelete]` opt-out) are exercised by the release-workflow smoke-tests but only fully validated on a real Windows install/uninstall.