### PR TITLE
feat: add a 12-hour (AM/PM) clock option for the live log preview

### DIFF
--- a/docs/reference/preferences-file.md
+++ b/docs/reference/preferences-file.md
@@ -23,6 +23,7 @@ preferences:
     - C:\Users\you\SMACC\paul.smacc
   last_settings: C:\Users\you\SMACC\peter.smacc
   log_preview_max_lines: 1000
+  log_preview_clock: 24h
 ```
 
 ## Fields
@@ -35,12 +36,13 @@ preferences:
 
 ### `preferences`
 
-| Key                     | Type           | Meaning                                                                                                                                                                                                                                                        |
-| ----------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `windows`               | mapping        | Per-window geometry, keyed by a stable window id → `{x, y, w, h}`. Ids include `launcher`, `main` (the Session window), the analyze window, and each tool window. An absent/`null` `x`/`y` means "no saved position — open at a default".                      |
-| `recent_settings`       | list of paths  | Recently opened `.smacc` files, most-recent first, de-duplicated and capped at 8.                                                                                                                                                                              |
-| `last_settings`         | path or `null` | The last `.smacc` opened, so the Launcher can preselect it.                                                                                                                                                                                                    |
-| `log_preview_max_lines` | integer        | How many lines the Session window's live log preview keeps (default **1000**); the oldest lines are dropped first. The log *file* always records everything, so nothing is lost. Very large values cost GUI memory and repaint time over an overnight session. |
+| Key                     | Type           | Meaning                                                                                                                                                                                                                                                                                            |
+| ----------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `windows`               | mapping        | Per-window geometry, keyed by a stable window id → `{x, y, w, h}`. Ids include `launcher`, `main` (the Session window), the analyze window, and each tool window. An absent/`null` `x`/`y` means "no saved position — open at a default".                                                          |
+| `recent_settings`       | list of paths  | Recently opened `.smacc` files, most-recent first, de-duplicated and capped at 8.                                                                                                                                                                                                                  |
+| `last_settings`         | path or `null` | The last `.smacc` opened, so the Launcher can preselect it.                                                                                                                                                                                                                                        |
+| `log_preview_max_lines` | integer        | How many lines the Session window's live log preview keeps (default **1000**); the oldest lines are dropped first. The log *file* always records everything, so nothing is lost. Very large values cost GUI memory and repaint time over an overnight session.                                     |
+| `log_preview_clock`     | string         | How the live preview renders the time of day: `24h` (default, e.g. `22:14:01`) or `12h` (`10:14:01 PM`). Presentation only — the log *file* always keeps 24-hour timestamps with a UTC offset. Toggle it from the Session window's **File → 12-hour clock**; an unknown value falls back to `24h`. |
 
 !!! note "Partial files are fine"
 

--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -18,7 +18,10 @@ YYYY-MM-DD HH:MM:SS.mmm±HHMM, LEVEL, message
     offset (e.g. `-0500`). The offset lets a reader place the night on an absolute
     timeline — for example when overlaying the log on an EEG recording whose clock
     sits in another zone. Logs written before SMACC recorded the offset are
-    timezone-naive (no `±HHMM`); both forms are read back the same way.
+    timezone-naive (no `±HHMM`); both forms are read back the same way. The *file*
+    is always 24-hour; the live on-screen preview can optionally show 12-hour
+    (AM/PM) time (Session window → **File → 12-hour clock**), which changes only the
+    display, not what is written.
 - **LEVEL** — a Python logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or
     `CRITICAL`. The file records every level; the live on-screen preview shows only a
     configurable subset.

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -50,6 +50,10 @@ from .qtlog import QtLogHandler
 from .session import SmaccSession
 from .toolwindow import ToolWindow
 
+# The live log preview's record format; the time field's strftime (24h/12h) comes
+# from preferences (preferences.CLOCK_FORMATS) and can be flipped at runtime.
+_PREVIEW_LOG_FORMAT = "%(asctime)s  %(levelname)s  %(message)s"
+
 #####################################
 #########    Main window    #########
 #####################################
@@ -415,6 +419,20 @@ class SmaccWindow(ToolWindow):
         alwaysOnTopAction.toggled.connect(self.toggle_always_on_top)
         self._always_on_top_action = alwaysOnTopAction
 
+        # The live-preview clock (12-hour vs 24-hour) is a machine preference, not
+        # study state, so it persists to preferences.yaml on toggle rather than into
+        # the .smacc. Surfaced only in a session's File menu (the editor has no
+        # preview); built here so _apply_preferences can sync its checkmark.
+        previewClockAction = QtGui.QAction("12-hour &clock", self)
+        previewClockAction.setStatusTip(
+            "Show the live log preview in 12-hour (AM/PM) time; "
+            "the log file always stays 24-hour."
+        )
+        previewClockAction.setCheckable(True)
+        previewClockAction.setChecked(False)
+        previewClockAction.toggled.connect(self.toggle_preview_clock)
+        self._preview_clock_action = previewClockAction
+
         # Device rescanning lives on the Devices window's Refresh button (which also
         # carries the F5 shortcut), not in this menu — hot-plugging is detected
         # automatically, so a menu entry here was redundant.
@@ -486,6 +504,7 @@ class SmaccWindow(ToolWindow):
         self._add_surveys_menu(fileMenu)
         fileMenu.addSeparator()
         fileMenu.addAction(alwaysOnTopAction)
+        fileMenu.addAction(self._preview_clock_action)
 
     def _rebuild_surveys_menu(self, menu: QtWidgets.QMenu) -> None:
         """Fill File → Surveys with each available survey (open standalone).
@@ -524,7 +543,8 @@ class SmaccWindow(ToolWindow):
         )
         self.preview_handler.setFormatter(
             logging.Formatter(
-                fmt="%(asctime)s  %(levelname)s  %(message)s", datefmt="%H:%M:%S"
+                fmt=_PREVIEW_LOG_FORMAT,
+                datefmt=preferences.preview_time_format(self._prefs),
             )
         )
         self.session.logger.addHandler(self.preview_handler)
@@ -629,6 +649,26 @@ class SmaccWindow(ToolWindow):
         self.show()
         self.session.log_debug_msg(
             f"Always-on-top {'enabled' if enabled else 'disabled'}"
+        )
+
+    def toggle_preview_clock(self, enabled: bool) -> None:
+        """Switch the live preview between 12-hour and 24-hour time (File menu).
+
+        Presentation only: the log file keeps 24-hour ISO timestamps regardless.
+        The new format applies to lines logged from here on; lines already in the
+        preview keep the format they were rendered with. Saved to preferences.yaml
+        (a machine preference, not study state) so it persists across sessions.
+        """
+        token = "12h" if enabled else "24h"
+        self.preview_handler.setFormatter(
+            logging.Formatter(
+                fmt=_PREVIEW_LOG_FORMAT, datefmt=preferences.CLOCK_FORMATS[token]
+            )
+        )
+        self._prefs["log_preview_clock"] = token
+        preferences.update_preferences(preferences_path, {"log_preview_clock": token})
+        self.session.log_debug_msg(
+            f"Log preview clock set to {'12-hour' if enabled else '24-hour'}"
         )
 
     def on_lightswitch_toggled(self, checked: bool) -> None:
@@ -958,6 +998,17 @@ class SmaccWindow(ToolWindow):
                 self, geometry, default_size=(640, 560)
             ):
                 self._move_to_default_position()  # first run: sit by the launcher
+
+        # Reflect the saved live-preview clock choice in its menu toggle. The
+        # preview formatter was already built from this preference; this only syncs
+        # the checkmark (signals blocked so the handler doesn't re-persist). The
+        # editor has no preview pane and no such menu item.
+        if not self.design:
+            self._preview_clock_action.blockSignals(True)
+            self._preview_clock_action.setChecked(
+                preferences.log_preview_clock(prefs) == "12h"
+            )
+            self._preview_clock_action.blockSignals(False)
 
     def _move_to_default_position(self) -> None:
         """Place a first-run session window just down-right of the launcher.

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -44,6 +44,11 @@ DEFAULTS: dict[str, Any] = {
     # first; the log file always keeps everything). Large values cost GUI memory
     # and repaint time over an overnight session.
     "log_preview_max_lines": 1000,
+    # How the live log preview renders the time of day: "24h" (e.g. 22:14:01) or
+    # "12h" (10:14:01 PM). Presentation only — the log *file* always keeps 24-hour
+    # ISO timestamps with a UTC offset; this changes only the on-screen preview.
+    # See CLOCK_FORMATS and log_preview_clock().
+    "log_preview_clock": "24h",
     # EEG review tool (#136): recently used annotation labels (most-recent
     # first, seeding the label dialog's dropdown) and the last folder a
     # recording was opened from. Note loading only round-trips keys present
@@ -174,6 +179,30 @@ def log_preview_max_lines(prefs: dict[str, Any]) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or value < 1:
         return int(DEFAULTS["log_preview_max_lines"])
     return value
+
+
+# The live preview's time-of-day formats, keyed by the stored log_preview_clock
+# token. The 12-hour form uses %I (zero-padded hour) + %p (AM/PM); the log file is
+# unaffected — it always keeps 24-hour ISO with a UTC offset (see
+# smacc.session._LogFormatter).
+CLOCK_FORMATS: dict[str, str] = {"24h": "%H:%M:%S", "12h": "%I:%M:%S %p"}
+
+
+def log_preview_clock(prefs: dict[str, Any]) -> str:
+    """Return the preview clock token (``"24h"`` or ``"12h"``), else the default.
+
+    A hand-edited ``preferences.yaml`` may carry anything here; an unknown value
+    falls back to the default rather than breaking the preview formatter.
+    """
+    value = prefs.get("log_preview_clock")
+    if isinstance(value, str) and value in CLOCK_FORMATS:
+        return value
+    return str(DEFAULTS["log_preview_clock"])
+
+
+def preview_time_format(prefs: dict[str, Any]) -> str:
+    """Return the ``strftime`` time format for the live preview (per :func:`log_preview_clock`)."""
+    return CLOCK_FORMATS[log_preview_clock(prefs)]
 
 
 def levels_to_names(levels: set[int]) -> list[str]:

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -41,7 +41,7 @@ def make_session_dir(base: Path, now: datetime) -> Path:
 class _LogFormatter(logging.Formatter):
     """Format a log line as ``YYYY-MM-DD HH:MM:SS.mmm±HHMM, LEVEL, message``.
 
-    The timezone offset (#215) stamps each line with the machine's local UTC
+    The timezone offset (#216) stamps each line with the machine's local UTC
     offset, so a later reader can place the night on an absolute timeline —
     notably when overlaying the log onto an EEG recording whose clock may sit in
     a different zone (#125). Older logs are timezone-naive;

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import pytest
 from PyQt6 import QtWidgets
 
-from smacc import gui, paths, triggers, winvolume
+from smacc import gui, paths, preferences, triggers, winvolume
 from smacc.gui import SmaccWindow
 
 
@@ -281,6 +281,37 @@ def test_set_lights_toggles_state_and_label(
     window.set_lights(True)
     assert window.lights_on is True
     assert "ON" in window.lightswitchButton.text()
+
+
+def test_preview_clock_toggle_switches_format_and_persists(
+    qtbot, tmp_path, monkeypatch, mock_devices, silence_dialogs
+):
+    # The 12-hour/24-hour preview clock is a machine preference: toggling it swaps
+    # the live formatter and writes preferences.yaml (not the .smacc study file).
+    prefs_path = tmp_path / "preferences.yaml"
+    monkeypatch.setattr(gui, "preferences_path", prefs_path)
+
+    from smacc.session import SmaccSession
+
+    monkeypatch.setattr(
+        SmaccSession,
+        "init_lsl_stream",
+        lambda self, *a, **k: setattr(self, "outlet", None),
+    )
+    window = SmaccWindow(SmaccSession(tmp_path / "data", design=False))
+    qtbot.addWidget(window)
+
+    # Defaults to 24-hour: the menu item is unchecked and the formatter is 24h.
+    assert window._preview_clock_action.isChecked() is False
+    assert window.preview_handler.formatter.datefmt == "%H:%M:%S"
+
+    window._preview_clock_action.trigger()  # → 12-hour (AM/PM)
+
+    assert window.preview_handler.formatter.datefmt == "%I:%M:%S %p"
+    saved = preferences.load_preferences(prefs_path)
+    assert saved["log_preview_clock"] == "12h"
+
+    window.session.close()
 
 
 # ----- interface choices carried by the .smacc settings -----------------------

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -54,6 +54,31 @@ def test_log_preview_max_lines_falls_back_on_garbage():
         assert preferences.log_preview_max_lines(bad) == default
 
 
+def test_log_preview_clock_reads_a_known_token():
+    assert preferences.log_preview_clock({"log_preview_clock": "12h"}) == "12h"
+    assert preferences.log_preview_clock({"log_preview_clock": "24h"}) == "24h"
+
+
+def test_log_preview_clock_falls_back_on_garbage():
+    default = preferences.DEFAULTS["log_preview_clock"]
+    for bad in (
+        {},
+        {"log_preview_clock": "13h"},
+        {"log_preview_clock": ""},
+        {"log_preview_clock": True},
+        {"log_preview_clock": {}},  # unhashable: the str guard must not raise
+    ):
+        assert preferences.log_preview_clock(bad) == default
+
+
+def test_preview_time_format_maps_token_to_strftime():
+    assert preferences.preview_time_format({"log_preview_clock": "24h"}) == "%H:%M:%S"
+    assert (
+        preferences.preview_time_format({"log_preview_clock": "12h"}) == "%I:%M:%S %p"
+    )
+    assert preferences.preview_time_format({}) == "%H:%M:%S"  # default token
+
+
 def test_round_trip(tmp_path):
     path = tmp_path / "preferences.yaml"
     custom = preferences.default_preferences()


### PR DESCRIPTION
Adds an optional 12-hour (AM/PM) clock for the Session window's live log preview, off by default. Presentation only — the on-disk `.log` always stays 24-hour ISO with a UTC offset.

- New `log_preview_clock` machine preference (`24h`/`12h`) in `preferences.yaml`, with a defensive accessor that falls back to `24h`.
- A checkable **File → 12-hour clock** toggle that swaps the live preview formatter and persists the choice; the new format applies to lines logged from then on (lines already shown keep their format).
- Docs (preferences-file, session-log) and tests (preferences accessors + the GUI toggle).

Preference: stored as a per-operator machine preference rather than in the portable `.smacc`, since clock format is reader locale, not study protocol — a shared study file should not impose one lab's clock on another. The timezone-capture half of the issue shipped earlier in #216.

Closes #215.