### PR TITLE
feat: model sleep-stage hypnograms and their rater-keyed sidecars

### DIFF
--- a/src/smacc/eeg/staging.py
+++ b/src/smacc/eeg/staging.py
@@ -1,0 +1,389 @@
+"""The sleep-staging model and its TSV/JSON hypnogram sidecar (#182).
+
+A *hypnogram* is a partition of the recording into fixed-length epochs, each
+assigned exactly one stage from a closed vocabulary (Wake/N1/N2/N3/REM). That is
+a different shape from :mod:`smacc.eeg.annotations`, whose marks are overlapping
+free-text spans: a stage epoch always has a positive duration and there is
+exactly one stage per slot, so stages live in their own model and their own
+sidecar rather than crowding the event list. Scoring two raters of one night
+then writes two files and a κ falls straight out — the inter-rater-reliability
+workflow staging exists for.
+
+Stages save to a sidecar next to the recording — ``night1.edf`` →
+``night1.stages.tsv`` + ``night1.stages.json`` — keyed by rater id exactly like
+the annotation sidecar (``night1.stages.alice.tsv``), and the recording is never
+touched. The TSV is sparse (only scored epochs get a row; an absent row reads as
+unscored) with ``onset``/``duration``/``stage`` columns — the same shape MNE and
+BIDS use for a hypnogram-as-events, so the file doubles as interchange. The JSON
+records which scoring manual produced it (AASM vs R&K), the epoch grid, and
+provenance, so a ``.stages.tsv`` is self-describing.
+
+The scoring vocabulary is data, not code: :class:`StagingVocabulary` bundles the
+stages, their hotkeys, and their hypnogram colours, so swapping AASM for
+Rechtschaffen & Kales (which adds S3/S4 and a Movement-Time epoch) is a config
+choice. Pure functions and frozen dataclasses, no GUI and no MNE — directly
+unit-testable, mirroring :mod:`smacc.eeg.annotations`.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+from ..config import VERSION
+from .annotations import sanitize_rater_id
+
+# Shown for an epoch with no stage yet. Display-only: the sparse sidecar never
+# writes it (an absent row already means "unscored"), and the model forbids it
+# as a real stage so it can never be mistaken for one.
+UNSCORED = "?"
+
+STAGE_COLUMNS = ["onset", "duration", "stage"]
+
+# Sidecar suffixes appended to the source's stem via Path.with_suffix, so
+# "night1.edf" maps to "night1.stages.tsv" (mirrors annotations.py).
+STAGES_TSV_SUFFIX = ".stages.tsv"
+STAGES_JSON_SUFFIX = ".stages.json"
+STAGES_AUTOSAVE_SUFFIX = ".stages.autosave.tsv"
+
+# Onsets/durations carry millisecond precision, exact for every epoch boundary
+# at the rates sleep labs record (mirrors annotations.py).
+_SECONDS_DECIMALS = 3
+
+# Human labels for every stage token any shipped vocabulary uses; written into
+# the JSON sidecar's BIDS-style "Levels" map so a bare ``.stages.tsv`` is
+# self-describing without the reader knowing which manual produced it.
+STAGE_LABELS = {
+    "W": "Wake",
+    "N1": "NREM stage 1",
+    "N2": "NREM stage 2",
+    "N3": "NREM stage 3 (slow-wave sleep)",
+    "R": "REM sleep",
+    "S1": "NREM stage 1 (R&K)",
+    "S2": "NREM stage 2 (R&K)",
+    "S3": "NREM stage 3 (R&K)",
+    "S4": "NREM stage 4 (R&K)",
+    "MT": "Movement time (R&K)",
+}
+
+
+@dataclass(frozen=True)
+class StagingVocabulary:
+    """A sleep-scoring vocabulary: its stages, hotkeys, and hypnogram colours.
+
+    The single source of truth a staging session reads through, so swapping AASM
+    for R&K is a data change, not a code change. ``name`` is written to the
+    sidecar as the scoring manual; ``stages`` is the ordered partition
+    vocabulary; ``hotkeys`` maps a single upper-case character to the stage it
+    scores — plain characters, never Qt key codes, so this module stays GUI-free
+    like :mod:`smacc.eeg.annotations`; ``colors`` is an RGB per stage for the
+    hypnogram band and overview strip.
+    """
+
+    name: str
+    stages: tuple[str, ...]
+    hotkeys: dict[str, str]
+    colors: dict[str, tuple[int, int, int]]
+
+    def __post_init__(self) -> None:
+        if not self.stages:
+            raise ValueError("A staging vocabulary needs at least one stage")
+        if UNSCORED in self.stages:
+            raise ValueError(f"{UNSCORED!r} is the unscored sentinel, not a stage")
+        unknown = sorted({s for s in self.hotkeys.values() if s not in self.stages})
+        if unknown:
+            raise ValueError(f"Hotkeys map to stages not in the vocabulary: {unknown}")
+        missing = [s for s in self.stages if s not in self.colors]
+        if missing:
+            raise ValueError(f"Stages missing a colour: {missing}")
+
+    def stage_for_key(self, char: str) -> str | None:
+        """The stage a typed character scores, or ``None`` if it scores none."""
+        return self.hotkeys.get(char.upper())
+
+
+# AASM (2007+): the current clinical standard — five stages, no Movement epoch
+# (a movement is an event annotation laid over the majority stage, not a stage).
+AASM = StagingVocabulary(
+    name="AASM",
+    stages=("W", "N1", "N2", "N3", "R"),
+    hotkeys={"W": "W", "1": "N1", "2": "N2", "3": "N3", "R": "R"},
+    colors={
+        "W": (242, 201, 76),  # amber — awake
+        "N1": (130, 197, 222),  # light blue
+        "N2": (74, 144, 200),  # blue
+        "N3": (44, 80, 158),  # deep blue — slow-wave sleep
+        "R": (224, 96, 120),  # rose — REM
+    },
+)
+
+# Rechtschaffen & Kales (1968): S1–S4 instead of N1–N3, and a distinct Movement
+# Time (MT) epoch for gross movement obscuring the stage — a legitimate partition
+# member here (it is *not* one under AASM). MT is keyed off the digits so it
+# never collides with the window's M (point-mark) key.
+RK = StagingVocabulary(
+    name="R&K-1968",
+    stages=("W", "S1", "S2", "S3", "S4", "R", "MT"),
+    hotkeys={"W": "W", "1": "S1", "2": "S2", "3": "S3", "4": "S4", "R": "R", "5": "MT"},
+    colors={
+        "W": (242, 201, 76),
+        "S1": (130, 197, 222),
+        "S2": (74, 144, 200),
+        "S3": (52, 96, 170),
+        "S4": (36, 64, 130),
+        "R": (224, 96, 120),
+        "MT": (140, 140, 140),  # grey — unscorable movement
+    },
+)
+
+VOCABULARIES = {v.name: v for v in (AASM, RK)}
+DEFAULT_VOCABULARY = AASM
+
+
+def vocabulary_by_name(name: str | None) -> StagingVocabulary:
+    """Look up a vocabulary by its ``name``; the AASM default for ``None``/unknown.
+
+    Used to resolve a saved preference or a sidecar's ``ScoringManual`` back to a
+    vocabulary; an unrecognized name falls back rather than failing, so a file
+    from a future/foreign manual still opens (its stages read as free tokens).
+    """
+    if name is None:
+        return DEFAULT_VOCABULARY
+    return VOCABULARIES.get(name, DEFAULT_VOCABULARY)
+
+
+@dataclass(frozen=True, order=True)
+class StageEpoch:
+    """One scored epoch: seconds from data start, seconds long, and its stage.
+
+    A member of the hypnogram partition — unlike an
+    :class:`~smacc.eeg.annotations.Annotation` it always has a positive duration,
+    and ``set_stage`` keeps exactly one per slot. Field order gives the natural
+    sort (onset, then duration, then stage) via ``order=True``; the stage is
+    stripped and the times are rounded to millisecond precision on construction.
+    """
+
+    onset: float
+    duration: float
+    stage: str
+
+    def __post_init__(self) -> None:
+        if self.onset < 0:
+            raise ValueError(f"Stage onset must be >= 0 (got {self.onset})")
+        if self.duration <= 0:
+            raise ValueError(f"Stage duration must be > 0 (got {self.duration})")
+        stage = self.stage.strip()
+        if not stage:
+            raise ValueError("Stage must not be empty")
+        # Frozen dataclass: normalized fields go through object.__setattr__.
+        object.__setattr__(self, "stage", stage)
+        object.__setattr__(self, "onset", round(self.onset, _SECONDS_DECIMALS))
+        object.__setattr__(self, "duration", round(self.duration, _SECONDS_DECIMALS))
+
+
+def epoch_bounds(
+    anchor: float, epoch_seconds: float, seconds: float
+) -> tuple[float, float]:
+    """Return ``(onset, duration)`` of the epoch containing ``seconds`` on the grid.
+
+    The grid runs ``anchor + k·epoch_seconds`` for integer ``k`` — the same grid
+    the view draws (#173) — so scoring always lands on a boundary-aligned span
+    and re-anchoring is well defined. ``onset`` may be negative when ``seconds``
+    sits before the anchor; the caller scores only within the recording.
+    """
+    if epoch_seconds <= 0:
+        raise ValueError(f"epoch_seconds must be > 0 (got {epoch_seconds})")
+    k = math.floor((seconds - anchor) / epoch_seconds)
+    onset = anchor + k * epoch_seconds
+    return round(onset, _SECONDS_DECIMALS), round(epoch_seconds, _SECONDS_DECIMALS)
+
+
+def set_stage(epochs: list[StageEpoch], epoch: StageEpoch) -> list[StageEpoch]:
+    """Return a new sorted list with ``epoch`` scored, replacing the slot at its onset.
+
+    Insert-or-replace by onset: epochs come off one locked grid, so a matching
+    rounded onset is the same slot. This keeps the partition sorted and
+    one-stage-per-slot, and re-scoring an epoch overwrites its prior stage. The
+    input list is left untouched.
+    """
+    out = [e for e in epochs if e.onset != epoch.onset]
+    out.append(epoch)
+    return sorted(out)
+
+
+def clear_stage(epochs: list[StageEpoch], onset: float) -> list[StageEpoch]:
+    """Return a new list with the epoch at ``onset`` removed (back to unscored)."""
+    target = round(onset, _SECONDS_DECIMALS)
+    return [e for e in epochs if e.onset != target]
+
+
+def stage_at(epochs: list[StageEpoch], seconds: float) -> str | None:
+    """The stage covering ``seconds``, or ``None`` where nothing is scored.
+
+    The end boundary is exclusive (``onset <= seconds < onset + duration``), so a
+    time exactly on an epoch boundary belongs to the epoch that starts there.
+    """
+    for epoch in epochs:
+        if epoch.onset <= seconds < epoch.onset + epoch.duration:
+            return epoch.stage
+    return None
+
+
+def stages_sidecar_paths(source: str | Path) -> tuple[Path, Path]:
+    """Return the (TSV, JSON) hypnogram sidecar paths for a source recording.
+
+    The source's final suffix is replaced (``night1.edf`` →
+    ``night1.stages.tsv``), matching :func:`smacc.eeg.annotations.sidecar_paths`
+    so a recording's stages and annotations sit side by side.
+    """
+    src = Path(source)
+    return src.with_suffix(STAGES_TSV_SUFFIX), src.with_suffix(STAGES_JSON_SUFFIX)
+
+
+def rater_stages_paths(source: str | Path, rater_id: str) -> tuple[Path, Path]:
+    """Return the (TSV, JSON) hypnogram sidecar paths for one rater's staging.
+
+    The rater id is woven into the stem (``night1.edf`` →
+    ``night1.stages.alice.tsv``) so each rater of one recording writes a
+    different path and cross-rater clobbering is structurally impossible — the
+    inter-rater-reliability workflow. The id is sanitized to a filename-safe
+    token first (shared with the annotation sidecars).
+    """
+    rater = sanitize_rater_id(rater_id)
+    src = Path(source)
+    return (
+        src.with_suffix(f".stages.{rater}.tsv"),
+        src.with_suffix(f".stages.{rater}.json"),
+    )
+
+
+def stages_autosave_path(source: str | Path) -> Path:
+    """Return the crash-recovery autosave path for a hypnogram (``…stages.autosave.tsv``).
+
+    Kept distinct from the canonical sidecar so an in-progress autosave is never
+    mistaken for, and never overwrites, a deliberate save.
+    """
+    return Path(source).with_suffix(STAGES_AUTOSAVE_SUFFIX)
+
+
+def rater_stages_autosave_path(source: str | Path, rater_id: str) -> Path:
+    """Return the crash-recovery autosave path for one rater's staging."""
+    rater = sanitize_rater_id(rater_id)
+    return Path(source).with_suffix(f".stages.{rater}.autosave.tsv")
+
+
+def write_stages_tsv(epochs: list[StageEpoch], path: str | Path) -> None:
+    """Write ``epochs`` (sorted) to ``path`` as a tab-separated hypnogram file."""
+    with Path(path).open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.writer(stream, delimiter="\t", lineterminator="\n")
+        writer.writerow(STAGE_COLUMNS)
+        for epoch in sorted(epochs):
+            writer.writerow(
+                [
+                    f"{epoch.onset:.{_SECONDS_DECIMALS}f}",
+                    f"{epoch.duration:.{_SECONDS_DECIMALS}f}",
+                    epoch.stage,
+                ]
+            )
+
+
+def read_stages_tsv(path: str | Path) -> list[StageEpoch]:
+    """Read a hypnogram sidecar TSV back into a sorted list of stage epochs.
+
+    Strict on shape so a half-clobbered or hand-mangled file surfaces as an error
+    instead of silently losing epochs: the header must match
+    :data:`STAGE_COLUMNS` exactly and every row must parse. ``utf-8-sig`` so a
+    sidecar re-saved in Notepad (with a BOM) still reads.
+
+    Raises:
+        OSError: if the file can't be read.
+        ValueError: on a wrong header or an unparseable row (with its line number).
+    """
+    with Path(path).open("r", encoding="utf-8-sig", newline="") as stream:
+        reader = csv.reader(stream, delimiter="\t")
+        header = next(reader, None)
+        if header != STAGE_COLUMNS:
+            raise ValueError(
+                f"Not a stages TSV (header {header!r}, expected {STAGE_COLUMNS!r})"
+            )
+        epochs: list[StageEpoch] = []
+        for line_number, row in enumerate(reader, start=2):
+            if not row:  # a trailing blank line is not an error
+                continue
+            if len(row) != len(STAGE_COLUMNS):
+                raise ValueError(
+                    f"Line {line_number}: expected {len(STAGE_COLUMNS)} "
+                    f"columns, got {len(row)}"
+                )
+            try:
+                epoch = StageEpoch(float(row[0]), float(row[1]), row[2])
+            except ValueError as exc:
+                raise ValueError(f"Line {line_number}: {exc}") from exc
+            epochs.append(epoch)
+    return sorted(epochs)
+
+
+def stages_sidecar(
+    source_name: str,
+    meas_date: datetime | None,
+    *,
+    vocabulary: StagingVocabulary,
+    epoch_seconds: float,
+    anchor: float,
+    rater_id: str | None = None,
+) -> dict[str, object]:
+    """Return the JSON sidecar payload documenting the columns, grid, and provenance.
+
+    ``ScoringManual`` names the vocabulary so a reader knows whether ``S2`` or
+    ``N2`` was meant; ``EpochLength``/``Anchor`` record the grid the stages were
+    scored on (so an absolute-onset row can be mapped back to an epoch index);
+    ``MeasurementDate`` recovers clock time from the data-relative onsets;
+    ``Rater`` attributes a per-rater file (``null`` for a single-rater review).
+    """
+    return {
+        "onset": {
+            "Description": "Epoch onset relative to the start of the recording's data.",
+            "Units": "second",
+        },
+        "duration": {
+            "Description": "Epoch length.",
+            "Units": "second",
+        },
+        "stage": {
+            "Description": "Sleep stage scored for the epoch.",
+            "Levels": {s: STAGE_LABELS.get(s, s) for s in vocabulary.stages},
+        },
+        "ScoringManual": vocabulary.name,
+        "EpochLength": epoch_seconds,
+        "Anchor": anchor,
+        "SourceFile": source_name,
+        "MeasurementDate": meas_date.isoformat() if meas_date else None,
+        "Rater": rater_id,
+        "GeneratedBy": {"Name": "SMACC", "Version": VERSION},
+    }
+
+
+def write_stages_json(
+    path: str | Path,
+    *,
+    source_name: str,
+    meas_date: datetime | None,
+    vocabulary: StagingVocabulary,
+    epoch_seconds: float,
+    anchor: float,
+    rater_id: str | None = None,
+) -> None:
+    """Write the hypnogram JSON sidecar to ``path``."""
+    payload = stages_sidecar(
+        source_name,
+        meas_date,
+        vocabulary=vocabulary,
+        epoch_seconds=epoch_seconds,
+        anchor=anchor,
+        rater_id=rater_id,
+    )
+    Path(path).write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/tests/test_eeg_staging.py
+++ b/tests/test_eeg_staging.py
@@ -1,0 +1,258 @@
+"""Tests for the EEG sleep-staging model and its hypnogram sidecars (#182, no GUI)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from smacc.config import VERSION
+from smacc.eeg import staging
+
+# ----- the vocabulary -------------------------------------------------------
+
+
+def test_aasm_default_has_the_five_standard_stages_and_no_movement():
+    # AASM scores a movement as an event annotation over the majority stage, so
+    # the partition vocabulary is exactly W/N1/N2/N3/R — no Movement stage.
+    assert staging.AASM.stages == ("W", "N1", "N2", "N3", "R")
+    assert "MT" not in staging.AASM.stages
+    assert staging.DEFAULT_VOCABULARY is staging.AASM
+
+
+def test_rk_vocabulary_adds_s_stages_and_a_movement_token():
+    # R&K (1968) had S1-S4 and a distinct Movement-Time epoch class.
+    assert staging.RK.stages == ("W", "S1", "S2", "S3", "S4", "R", "MT")
+
+
+def test_stage_for_key_is_case_insensitive_and_misses_cleanly():
+    assert staging.AASM.stage_for_key("2") == "N2"
+    assert staging.AASM.stage_for_key("w") == "W"
+    assert staging.AASM.stage_for_key("R") == "R"
+    assert staging.AASM.stage_for_key("9") is None  # 4-9 are inert under AASM
+
+
+def test_rk_movement_key_avoids_the_window_mark_key():
+    # The window binds M to a point mark; R&K's MT must not steal it, so MT is
+    # keyed off a digit, not "M".
+    assert "M" not in staging.RK.hotkeys
+    assert staging.RK.stage_for_key("5") == "MT"
+
+
+def test_vocabulary_rejects_unscored_sentinel_as_a_stage():
+    with pytest.raises(ValueError, match="sentinel"):
+        staging.StagingVocabulary(
+            "bad", (staging.UNSCORED,), {}, {staging.UNSCORED: (0, 0, 0)}
+        )
+
+
+def test_vocabulary_rejects_hotkey_to_unknown_stage():
+    with pytest.raises(ValueError, match="not in the vocabulary"):
+        staging.StagingVocabulary("bad", ("W",), {"X": "REM"}, {"W": (0, 0, 0)})
+
+
+def test_vocabulary_rejects_stage_without_a_colour():
+    with pytest.raises(ValueError, match="colour"):
+        staging.StagingVocabulary("bad", ("W", "N1"), {}, {"W": (0, 0, 0)})
+
+
+def test_vocabulary_by_name_resolves_known_and_falls_back():
+    assert staging.vocabulary_by_name("R&K-1968") is staging.RK
+    assert staging.vocabulary_by_name(None) is staging.DEFAULT_VOCABULARY
+    assert staging.vocabulary_by_name("Martian-2099") is staging.DEFAULT_VOCABULARY
+
+
+# ----- the epoch model ------------------------------------------------------
+
+
+def test_stage_epoch_rejects_nonpositive_duration_and_negative_onset():
+    # A partition epoch is a span, never a point — unlike a free annotation.
+    with pytest.raises(ValueError, match="duration"):
+        staging.StageEpoch(0.0, 0.0, "N2")
+    with pytest.raises(ValueError, match="onset"):
+        staging.StageEpoch(-1.0, 30.0, "N2")
+
+
+def test_stage_epoch_rejects_empty_stage_and_strips_whitespace():
+    with pytest.raises(ValueError, match="empty"):
+        staging.StageEpoch(0.0, 30.0, "   ")
+    assert staging.StageEpoch(0.0, 30.0, "  N2 ").stage == "N2"
+
+
+def test_stage_epoch_rounds_times_to_milliseconds():
+    e = staging.StageEpoch(1.23456, 30.00049, "N2")
+    assert e.onset == 1.235
+    assert e.duration == 30.0
+
+
+def test_stage_epochs_sort_by_onset():
+    later = staging.StageEpoch(30.0, 30.0, "N1")
+    earlier = staging.StageEpoch(0.0, 30.0, "W")
+    assert sorted([later, earlier]) == [earlier, later]
+
+
+def test_epoch_bounds_aligns_to_the_grid_from_a_zero_anchor():
+    assert staging.epoch_bounds(0.0, 30.0, 0.0) == (0.0, 30.0)
+    assert staging.epoch_bounds(0.0, 30.0, 75.0) == (60.0, 30.0)  # 3rd epoch
+    # A time exactly on a boundary belongs to the epoch that starts there.
+    assert staging.epoch_bounds(0.0, 30.0, 30.0) == (30.0, 30.0)
+
+
+def test_epoch_bounds_honours_a_nonzero_anchor():
+    # Anchoring on a feature (#173) back/front-fills the grid from that point.
+    assert staging.epoch_bounds(5.0, 30.0, 40.0) == (35.0, 30.0)
+    assert staging.epoch_bounds(5.0, 30.0, 5.0) == (5.0, 30.0)
+
+
+def test_epoch_bounds_rejects_nonpositive_epoch_length():
+    with pytest.raises(ValueError, match="epoch_seconds"):
+        staging.epoch_bounds(0.0, 0.0, 10.0)
+
+
+# ----- partition operations -------------------------------------------------
+
+
+def test_set_stage_inserts_in_sorted_order_and_leaves_input_untouched():
+    first = staging.StageEpoch(30.0, 30.0, "N2")
+    existing = [first]
+    out = staging.set_stage(existing, staging.StageEpoch(0.0, 30.0, "W"))
+    assert [e.stage for e in out] == ["W", "N2"]
+    assert existing == [first]  # pure: caller's list unchanged
+
+
+def test_set_stage_replaces_the_slot_at_the_same_onset():
+    epochs = [staging.StageEpoch(0.0, 30.0, "N1")]
+    out = staging.set_stage(epochs, staging.StageEpoch(0.0, 30.0, "N2"))
+    assert out == [staging.StageEpoch(0.0, 30.0, "N2")]  # one slot, overwritten
+
+
+def test_clear_stage_removes_only_the_named_slot():
+    epochs = [
+        staging.StageEpoch(0.0, 30.0, "W"),
+        staging.StageEpoch(30.0, 30.0, "N1"),
+    ]
+    out = staging.clear_stage(epochs, 30.0)
+    assert out == [staging.StageEpoch(0.0, 30.0, "W")]
+
+
+def test_stage_at_returns_the_covering_stage_with_exclusive_end():
+    epochs = [
+        staging.StageEpoch(0.0, 30.0, "W"),
+        staging.StageEpoch(30.0, 30.0, "N1"),
+    ]
+    assert staging.stage_at(epochs, 15.0) == "W"
+    assert staging.stage_at(epochs, 30.0) == "N1"  # boundary belongs to next epoch
+    assert staging.stage_at(epochs, 90.0) is None  # past the scored range
+
+
+# ----- sidecar paths --------------------------------------------------------
+
+
+def test_sidecar_paths_sit_beside_the_recording():
+    tsv, js = staging.stages_sidecar_paths("/data/night1.edf")
+    assert tsv == Path("/data/night1.stages.tsv")
+    assert js == Path("/data/night1.stages.json")
+
+
+def test_rater_paths_weave_in_a_sanitized_id():
+    tsv, js = staging.rater_stages_paths("night1.edf", "Alice Smith")
+    assert tsv.name == "night1.stages.Alice_Smith.tsv"
+    assert js.name == "night1.stages.Alice_Smith.json"
+
+
+def test_autosave_paths_are_distinct_from_the_sidecar():
+    assert (
+        staging.stages_autosave_path("night1.edf").name == "night1.stages.autosave.tsv"
+    )
+    assert (
+        staging.rater_stages_autosave_path("night1.edf", "bob").name
+        == "night1.stages.bob.autosave.tsv"
+    )
+
+
+# ----- TSV round-trip -------------------------------------------------------
+
+
+def test_tsv_round_trips_epochs(tmp_path: Path):
+    epochs = [
+        staging.StageEpoch(0.0, 30.0, "W"),
+        staging.StageEpoch(30.0, 30.0, "N1"),
+        staging.StageEpoch(60.0, 30.0, "N2"),
+    ]
+    path = tmp_path / "night1.stages.tsv"
+    staging.write_stages_tsv(epochs, path)
+    assert staging.read_stages_tsv(path) == epochs
+
+
+def test_tsv_is_sparse_only_scored_epochs_get_a_row(tmp_path: Path):
+    path = tmp_path / "night1.stages.tsv"
+    staging.write_stages_tsv([staging.StageEpoch(60.0, 30.0, "N2")], path)
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "onset\tduration\tstage"
+    assert len(lines) == 2  # header + the one scored epoch, no unscored rows
+
+
+def test_read_rejects_a_wrong_header(tmp_path: Path):
+    path = tmp_path / "bad.tsv"
+    path.write_text("onset\tstage\n0.0\tN2\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Not a stages TSV"):
+        staging.read_stages_tsv(path)
+
+
+def test_read_reports_the_line_of_a_bad_row(tmp_path: Path):
+    path = tmp_path / "bad.tsv"
+    path.write_text("onset\tduration\tstage\n0.0\t-5.0\tN2\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="Line 2"):
+        staging.read_stages_tsv(path)
+
+
+def test_read_tolerates_a_notepad_bom(tmp_path: Path):
+    path = tmp_path / "night1.stages.tsv"
+    path.write_text("onset\tduration\tstage\n0.000\t30.000\tN2\n", encoding="utf-8-sig")
+    assert staging.read_stages_tsv(path) == [staging.StageEpoch(0.0, 30.0, "N2")]
+
+
+# ----- JSON sidecar ---------------------------------------------------------
+
+
+def test_json_sidecar_records_manual_grid_and_provenance(tmp_path: Path):
+    path = tmp_path / "night1.stages.json"
+    staging.write_stages_json(
+        path,
+        source_name="night1.edf",
+        meas_date=datetime(2026, 6, 5, 22, 0, tzinfo=UTC),
+        vocabulary=staging.AASM,
+        epoch_seconds=30.0,
+        anchor=0.0,
+        rater_id="alice",
+    )
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["ScoringManual"] == "AASM"
+    assert payload["EpochLength"] == 30.0
+    assert payload["Anchor"] == 0.0
+    assert payload["Rater"] == "alice"
+    assert payload["SourceFile"] == "night1.edf"
+    assert payload["MeasurementDate"] == "2026-06-05T22:00:00+00:00"
+    assert payload["GeneratedBy"] == {"Name": "SMACC", "Version": VERSION}
+    # The stage column documents its allowed levels, so a bare TSV is readable.
+    assert payload["stage"]["Levels"]["N3"].startswith("NREM stage 3")
+
+
+def test_json_sidecar_rater_is_null_for_a_single_rater_review(tmp_path: Path):
+    path = tmp_path / "night1.stages.json"
+    staging.write_stages_json(
+        path,
+        source_name="night1.edf",
+        meas_date=None,
+        vocabulary=staging.RK,
+        epoch_seconds=20.0,
+        anchor=2.5,
+        rater_id=None,
+    )
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["Rater"] is None
+    assert payload["MeasurementDate"] is None
+    assert payload["ScoringManual"] == "R&K-1968"
+    assert "MT" in payload["stage"]["Levels"]


### PR DESCRIPTION
First of three stacked PRs adding a sleep-staging mode to the EEG annotator (#182). Merge in order: this → `feat/eeg-staging-mode` → `feat/eeg-hypnogram-strip`.

The pure core, mirroring `annotations.py` (no GUI, no MNE):

- `StagingVocabulary` — stages, hotkeys, and hypnogram colours as data. **AASM** default (W/N1/N2/N3/R); **Rechtschaffen & Kales** optional (S1–S4 + a Movement-Time epoch).
- `StageEpoch` — one slot of the hypnogram partition (positive duration, one stage), with `set_stage`/`clear_stage`/`stage_at` and `epoch_bounds` on the existing epoch grid (#173).
- Rater-keyed sidecars `night1.stages[.<rater>].tsv` + `.json` (sparse `onset`/`duration`/`stage`, the Sleep-EDF/BIDS hypnogram-as-events shape; the JSON records the scoring manual, epoch grid, and provenance), plus the crash-recovery autosave path.

A hypnogram is a partition, not the overlapping free-text annotation list, so it lives in its own model and its own sidecar. Two raters of one night write two files to compare.

Tested by `tests/test_eeg_staging.py`.