### PR TITLE
feat: add a sleep-staging mode to the EEG annotator

### DIFF
--- a/src/smacc/eeg/__main__.py
+++ b/src/smacc/eeg/__main__.py
@@ -151,6 +151,25 @@ def selftest() -> int:
         config = blind.read_blind_config(blind_path)
         hidden = blind.apply_blind([Annotation(1.0, 0.0, "SignalObserved")], config)
         assert hidden == [Annotation(1.0, 0.0, "?")], hidden
+        # Sleep staging (#182): round-trip a hypnogram sidecar and exercise the
+        # partition ops, so the frozen bundle proves the staging stack.
+        from . import staging
+
+        onset, dur = staging.epoch_bounds(0.0, 30.0, 45.0)
+        assert (onset, dur) == (30.0, 30.0), (onset, dur)
+        epochs = staging.set_stage([], staging.StageEpoch(onset, dur, "N2"))
+        stages_tsv, stages_json = staging.rater_stages_paths(fif, "selftest")
+        staging.write_stages_tsv(epochs, stages_tsv)
+        staging.write_stages_json(
+            stages_json,
+            source_name=fif.name,
+            meas_date=recording.meas_date,
+            vocabulary=staging.AASM,
+            epoch_seconds=30.0,
+            anchor=0.0,
+            rater_id="selftest",
+        )
+        assert staging.read_stages_tsv(stages_tsv) == epochs
         # Figure export (#180): prove matplotlib's PNG/PDF/SVG backends are bundled
         # — a missed backend only surfaces when one actually writes a file.
         from .export import ExportOptions, render

--- a/src/smacc/eeg/staging.py
+++ b/src/smacc/eeg/staging.py
@@ -327,6 +327,28 @@ def read_stages_tsv(path: str | Path) -> list[StageEpoch]:
     return sorted(epochs)
 
 
+def read_stages_json(path: str | Path) -> dict[str, object]:
+    """Read a hypnogram JSON sidecar back into its payload dict.
+
+    Lets a resume reconcile the live session with the manual and epoch grid the
+    file was scored on (``ScoringManual``/``EpochLength``/``Anchor``) instead of
+    the operator's defaults — so an R&K file does not open under AASM. ``utf-8-sig``
+    tolerates a Notepad BOM.
+
+    Raises:
+        OSError: if the file can't be read.
+        ValueError: on invalid JSON or a non-object payload.
+    """
+    text = Path(path).read_text(encoding="utf-8-sig")
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("A stages JSON sidecar must be a JSON object")
+    return payload
+
+
 def stages_sidecar(
     source_name: str,
     meas_date: datetime | None,

--- a/src/smacc/eeg/view.py
+++ b/src/smacc/eeg/view.py
@@ -35,6 +35,7 @@ from PyQt6 import QtCore, QtGui
 from . import dsp
 from .annotations import Annotation
 from .snapshot import Snapshot, SnapshotEpoch, SnapshotMark, SnapshotTrace
+from .staging import StageEpoch
 
 # Bioelectric channels are recorded in volts and displayed in microvolts.
 # Other kinds (stim/misc/…) carry arbitrary units — a trigger channel holds
@@ -86,6 +87,20 @@ _EPOCH_PEN = pg.mkPen((128, 128, 128, 110), width=1, style=QtCore.Qt.PenStyle.Da
 _EPOCH_LABEL_COLOR = (128, 128, 128, 200)
 # The standard polysomnography scoring epoch; the sleep default everywhere.
 DEFAULT_EPOCH_SECONDS = 30.0
+
+# Sleep-staging overlay (#182). A scored epoch paints a translucent stage-coloured
+# band *behind* the traces (z below the curves, a pure backdrop tint) so the
+# hypnogram reads at a glance without ever obscuring a deflection. The colour is
+# the vocabulary's per-stage RGB; the alpha is low enough to keep traces crisp.
+_STAGE_BAND_ALPHA = 45
+_STAGE_BAND_Z = -5
+# While staging, the epoch about to be scored (the one at the left edge) gets a
+# bright accent bracket — a teal that is none of the stage colours, so the
+# focused epoch is unmistakable over the amber/blue/rose bands. Above the grid,
+# below the editable marks.
+_FOCUS_PEN = pg.mkPen((0, 150, 136), width=2)
+_FOCUS_BRUSH = (0, 150, 136, 22)
+_FOCUS_Z = 3
 
 # Session-log overlay (#125): the parsed log is drawn as a read-only reference
 # track in a thin lane across the top of the plot, kept clear of the traces and
@@ -377,6 +392,14 @@ class TraceView(pg.PlotWidget):
         self._epoch_anchor = 0.0
         self._show_epochs = True
         self._epoch_items: list[pg.InfiniteLine] = []
+        # Sleep-staging overlay (#182): the scored epochs and their per-stage
+        # colours paint as backdrop bands; ``_stage_focus_active`` brackets the
+        # left-edge epoch (the scoring target) while a staging sweep is on.
+        self._stage_epochs: list[StageEpoch] = []
+        self._stage_colors: dict[str, tuple[int, int, int]] = {}
+        self._stage_band_items: list[pg.LinearRegionItem] = []
+        self._stage_focus_active = False
+        self._focused_epoch_item: pg.LinearRegionItem | None = None
         self._annotations: list[Annotation] = []
         self._selected = -1
         self._annotation_items: list[pg.LinearRegionItem | pg.InfiniteLine] = []
@@ -463,13 +486,14 @@ class TraceView(pg.PlotWidget):
         self._epoch_anchor = 0.0  # a new recording starts epoch 1 at its start
         self._overlays = []  # peers belong to the previous recording; window reloads
         self._log_marks = []  # the log belongs to the previous recording too
+        self._stage_epochs = []  # the hypnogram belongs to the previous recording
         self._viewbox.set_log_lane_active(False)
         # Show every channel in file order by default; a profile may narrow this.
         self._visible = list(range(len(provider.ch_names))) if provider else []
         self._build_curves()
         self._refresh_data()
         self._refresh_annotations()
-        self._refresh_epochs()
+        self._refresh_epoch_layer()
         self._refresh_log_marks()
 
     def set_spec(self, spec: dsp.FilterSpec) -> None:
@@ -570,7 +594,7 @@ class TraceView(pg.PlotWidget):
         self._build_curves()
         self._refresh_data()
         self._refresh_annotations()
-        self._refresh_epochs()
+        self._refresh_epoch_layer()
         self._refresh_log_marks()
 
     def build_snapshot(
@@ -642,7 +666,7 @@ class TraceView(pg.PlotWidget):
         self._clamp_window_start()
         self._refresh_data()
         self._refresh_annotations()
-        self._refresh_epochs()
+        self._refresh_epoch_layer()
         self._refresh_log_marks()
 
     def set_window_start(self, seconds: float) -> None:
@@ -650,13 +674,13 @@ class TraceView(pg.PlotWidget):
         self._clamp_window_start()
         self._refresh_data()
         self._refresh_annotations()
-        self._refresh_epochs()
+        self._refresh_epoch_layer()
         self._refresh_log_marks()
 
     def set_epoch_seconds(self, seconds: float) -> None:
         """Set the scoring-epoch length (≥ 1 s); redraws the epoch grid."""
         self._epoch_seconds = max(1.0, float(seconds))
-        self._refresh_epochs()
+        self._refresh_epoch_layer()
 
     def set_epoch_anchor(self, seconds: float) -> None:
         """Set the time at which an epoch boundary falls (epoch 1 starts here).
@@ -665,11 +689,11 @@ class TraceView(pg.PlotWidget):
         (e.g. the start of an LRLR) lets the signal sit cleanly inside one epoch.
         """
         self._epoch_anchor = max(0.0, float(seconds))
-        self._refresh_epochs()
+        self._refresh_epoch_layer()
 
     def set_epochs_visible(self, visible: bool) -> None:
         self._show_epochs = bool(visible)
-        self._refresh_epochs()
+        self._refresh_epoch_layer()
 
     def set_time_axis_mode(self, mode: str) -> None:
         """Label the time axis with ``"clock"`` wall time or ``"elapsed"`` seconds."""
@@ -710,6 +734,24 @@ class TraceView(pg.PlotWidget):
         """
         self._overlays = list(overlays)
         self._refresh_overlays()
+
+    def set_hypnogram(
+        self, epochs: list[StageEpoch], colors: dict[str, tuple[int, int, int]]
+    ) -> None:
+        """Show the scored epochs as backdrop stage-coloured bands (#182).
+
+        ``colors`` maps a stage token to its RGB (the active vocabulary's
+        palette). Read-only context — the bands are never selectable; staging
+        edits go through the window's hotkeys, not the view.
+        """
+        self._stage_epochs = list(epochs)
+        self._stage_colors = dict(colors)
+        self._refresh_stage_bands()
+
+    def set_stage_focus(self, active: bool) -> None:
+        """Bracket the left-edge epoch (the scoring target) while staging (#182)."""
+        self._stage_focus_active = bool(active)
+        self._refresh_focused_epoch()
 
     def set_log_marks(self, marks: list[LogMark]) -> None:
         """Replace the read-only session-log overlay in the top lane (#125).
@@ -1015,6 +1057,81 @@ class TraceView(pg.PlotWidget):
             line.setZValue(_LOG_Z)
             plot_item.addItem(line)
             self._log_items.append(line)
+
+    def _refresh_epoch_layer(self) -> None:
+        """Redraw everything keyed to the epoch grid: gridlines, stage bands, focus.
+
+        Called from every window/epoch lifecycle change (and the wheel scroll),
+        so the staging overlay tracks the grid without the window reaching in on
+        each scroll. The three are independent — the stage bands show even when
+        the gridlines are toggled off — so they are separate draws, not nested.
+        """
+        self._refresh_epochs()
+        self._refresh_stage_bands()
+        self._refresh_focused_epoch()
+
+    def _refresh_stage_bands(self) -> None:
+        """Redraw the stage-coloured backdrop bands for the visible window (#182).
+
+        One translucent band per scored epoch in view, behind the curves, so the
+        hypnogram tints the trace without obscuring it. Only the handful of epochs
+        inside the window are drawn, so this stays cheap on scroll.
+        """
+        plot_item = self.getPlotItem()
+        assert plot_item is not None
+        for old in self._stage_band_items:
+            plot_item.removeItem(old)
+        self._stage_band_items = []
+        if self._provider is None or not self._stage_epochs:
+            return
+        lo = self._window_start
+        hi = self._window_start + self._window_seconds
+        for epoch in self._stage_epochs:
+            # Half-open overlap with [lo, hi): an epoch tiling exactly to the right
+            # edge belongs to the *next* screen, not this one — so each page shows
+            # exactly its own epochs rather than a sliver of the following band.
+            if epoch.onset >= hi or epoch.onset + epoch.duration <= lo:
+                continue
+            color = self._stage_colors.get(epoch.stage)
+            if (
+                color is None
+            ):  # a token with no colour (foreign vocab) just tints nothing
+                continue
+            red, green, blue = color
+            band = pg.LinearRegionItem(
+                values=(epoch.onset, epoch.onset + epoch.duration),
+                movable=False,
+                brush=(red, green, blue, _STAGE_BAND_ALPHA),
+                pen=pg.mkPen((red, green, blue, 0)),  # no border, just the wash
+            )
+            band.setZValue(_STAGE_BAND_Z)
+            plot_item.addItem(band)
+            self._stage_band_items.append(band)
+
+    def _refresh_focused_epoch(self) -> None:
+        """Bracket the left-edge epoch while a staging sweep is active (#182).
+
+        The focused epoch is the one a stage key will score — always the epoch at
+        the left edge of the window, the same one the status-bar readout names.
+        """
+        plot_item = self.getPlotItem()
+        assert plot_item is not None
+        if self._focused_epoch_item is not None:
+            plot_item.removeItem(self._focused_epoch_item)
+            self._focused_epoch_item = None
+        if self._provider is None or not self._stage_focus_active:
+            return
+        k = math.floor((self._window_start - self._epoch_anchor) / self._epoch_seconds)
+        onset = self._epoch_anchor + k * self._epoch_seconds
+        item = pg.LinearRegionItem(
+            values=(onset, onset + self._epoch_seconds),
+            movable=False,
+            brush=_FOCUS_BRUSH,
+            pen=_FOCUS_PEN,
+        )
+        item.setZValue(_FOCUS_Z)
+        plot_item.addItem(item)
+        self._focused_epoch_item = item
 
     def _refresh_epochs(self) -> None:
         """Redraw the epoch boundary gridlines for the visible window.

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -32,7 +32,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import preferences, windowstate
 from ..paths import LOGO_PATH, preferences_path
-from . import align, blind, dsp, io, sessionlog
+from . import align, blind, dsp, io, sessionlog, staging
 from .annotations import (
     Annotation,
     autosave_path,
@@ -51,6 +51,18 @@ from .annotations import (
 from .profiles import FILE_FILTER as PROFILE_FILE_FILTER
 from .profiles import PROFILE_SUFFIX, ViewProfile, read_view_profile, write_view_profile
 from .sessionlog import LogEntry
+from .staging import (
+    StageEpoch,
+    rater_stages_autosave_path,
+    rater_stages_paths,
+    read_stages_json,
+    read_stages_tsv,
+    stages_autosave_path,
+    stages_sidecar_paths,
+    vocabulary_by_name,
+    write_stages_json,
+    write_stages_tsv,
+)
 from .view import (
     DEFAULT_EPOCH_SECONDS,
     OVERLAY_COLORS,
@@ -120,6 +132,29 @@ _VERTICAL_NAV_KEYS = frozenset(
         QtCore.Qt.Key.Key_End,
     }
 )
+
+# Keys that un-score the current epoch in stage focus (clear, never advance).
+_STAGE_CLEAR_KEYS = frozenset(
+    {
+        QtCore.Qt.Key.Key_0,
+        QtCore.Qt.Key.Key_Backspace,
+        QtCore.Qt.Key.Key_Delete,
+    }
+)
+
+
+def _stage_char(key: int) -> str | None:
+    """The character a Qt key denotes for staging (``A``-``Z`` / ``0``-``9``), or None.
+
+    Qt's letter/digit key codes equal their ASCII, so ``chr`` recovers the upper-
+    case character the vocabulary's hotkey map is keyed on (#182).
+    """
+    if (
+        QtCore.Qt.Key.Key_0 <= key <= QtCore.Qt.Key.Key_9
+        or QtCore.Qt.Key.Key_A <= key <= QtCore.Qt.Key.Key_Z
+    ):
+        return chr(key)
+    return None
 
 
 def _section_title(text: str) -> QtWidgets.QLabel:
@@ -657,6 +692,19 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._autosave_timer.setSingleShot(True)
         self._autosave_timer.setInterval(_AUTOSAVE_DEBOUNCE_MS)
         self._autosave_timer.timeout.connect(self._write_autosave)
+        # Sleep staging (#182): the hypnogram is a separate partition with its own
+        # rater-keyed sidecar, dirty/owns/recovery state paralleling the
+        # annotations above. ``_staging`` is the sticky stage-focus that governs
+        # the bare-digit hotkeys and auto-advance; the data (bands, scored epochs)
+        # is always live regardless, so a rater scores and annotates the same
+        # recording without a mode that loses their place. The vocabulary (AASM by
+        # default, R&K optional) is data, resolved from a saved preference.
+        self._staging = False
+        self._stage_epochs: list[StageEpoch] = []
+        self._vocab = self._resolve_vocabulary()
+        self._stage_dirty = False
+        self._owns_stage_sidecar = False
+        self._recovery_stages: list[StageEpoch] | None = None
         self.setWindowTitle("SMACC — EEG review")
         if LOGO_PATH.is_file():
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
@@ -719,6 +767,23 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             return autosave_path(source)
         return rater_autosave_path(source, self._rater_id)
 
+    def _stage_sidecar_for(self, source: str | Path) -> tuple[Path, Path]:
+        """The (TSV, JSON) hypnogram sidecar paths for the active rater (#182)."""
+        if self._rater_id is None:
+            return stages_sidecar_paths(source)
+        return rater_stages_paths(source, self._rater_id)
+
+    def _stage_autosave_for(self, source: str | Path) -> Path:
+        """The crash-recovery autosave path for the active rater's hypnogram (#182)."""
+        if self._rater_id is None:
+            return stages_autosave_path(source)
+        return rater_stages_autosave_path(source, self._rater_id)
+
+    def _resolve_vocabulary(self) -> staging.StagingVocabulary:
+        """The staging vocabulary from the saved preference (AASM default, #182)."""
+        prefs = preferences.load_preferences(preferences_path)
+        return vocabulary_by_name(prefs.get("eeg_staging_vocabulary"))
+
     def _refresh_rater_button(self) -> None:
         """Keep the rater button (and so the toolbar) showing the active id."""
         self.raterButton.setText(
@@ -761,14 +826,18 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             return
         self._autosave_timer.stop()
         self._clear_autosave()  # uses the *old* id (still current here)
+        self._clear_stage_autosave()  # likewise re-point the hypnogram autosave
         self._rater_id = new_id
         self._owns_sidecar = False
+        self._owns_stage_sidecar = False  # the new id hasn't loaded its hypnogram
         # Re-confirm the new id on its next save (discard is a no-op for None).
         self._confirmed_raters.discard(new_id)
         preferences.update_preferences(preferences_path, {"eeg_rater_id": new_id})
         self._refresh_rater_button()
         if self._recording is not None and self._annotations:
             self._mark_dirty()  # unsaved work now belongs to the new id
+        if self._recording is not None and self._stage_epochs:
+            self._mark_stage_dirty()  # the scored epochs now belong to the new id
         self._refresh_title()
 
     def _confirm_rater_identity(self) -> bool:
@@ -806,6 +875,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         layout.addLayout(self._build_controls_row())
         layout.addLayout(self._build_epoch_row())
         layout.addLayout(self._build_palette_row())
+        layout.addLayout(self._build_stage_row())
 
         body = QtWidgets.QHBoxLayout()
         viewColumn = QtWidgets.QVBoxLayout()
@@ -832,6 +902,10 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         # Permanent (right-aligned) state: the epoch at the left edge of the view
         # and the recording summary. Transient messages and the cursor clock use
         # the normal message area.
+        self.stageFocusLabel = QtWidgets.QLabel("", self)
+        self.stageFocusLabel.setStatusTip(
+            "Stage focus is on: number keys score the epoch and auto-advance."
+        )
         self.epochLabel = QtWidgets.QLabel("", self)
         self.epochLabel.setStatusTip("The epoch at the left edge of the view.")
         self.logInfoLabel = QtWidgets.QLabel("", self)
@@ -839,6 +913,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.fileInfoLabel = QtWidgets.QLabel("", self)
         status_bar = self.statusBar()
         assert status_bar is not None
+        status_bar.addPermanentWidget(self.stageFocusLabel)
         status_bar.addPermanentWidget(self.epochLabel)
         status_bar.addPermanentWidget(self.logInfoLabel)
         status_bar.addPermanentWidget(self.fileInfoLabel)
@@ -1065,6 +1140,71 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._rebuild_palette_buttons()
         return row
 
+    def _build_stage_row(self) -> QtWidgets.QLayout:
+        """The sleep-staging controls (#182): focus toggle, vocabulary, stage keys.
+
+        Staging and annotating share one surface — the stage bands and the event
+        marks are always drawn — so this row never hides the annotation tools. The
+        "Stage focus" toggle (or Tab) only decides whether the bare number keys
+        score stages and the view auto-advances; the stage buttons and the W/R
+        keys score regardless, so a rater drops the odd Wake epoch without flipping
+        anything. The big readout names the epoch under the left edge and its
+        stage; the counter tracks how many epochs remain unscored.
+        """
+        row = QtWidgets.QHBoxLayout()
+        self.stagingButton = QtWidgets.QPushButton("Stage focus", self)
+        self.stagingButton.setCheckable(True)
+        self.stagingButton.setStatusTip(
+            "Stage focus (Tab): number keys score the epoch and auto-advance; "
+            "one epoch fills the screen. The stage buttons and W/R work either way."
+        )
+        self.stagingButton.toggled.connect(self._on_staging_toggled)
+        row.addWidget(self.stagingButton)
+
+        row.addWidget(QtWidgets.QLabel("Manual:", self))
+        self.vocabCombo = QtWidgets.QComboBox(self)
+        for vocab in staging.VOCABULARIES.values():
+            self.vocabCombo.addItem(vocab.name, vocab.name)
+        self.vocabCombo.setCurrentText(self._vocab.name)
+        self.vocabCombo.setStatusTip(
+            "Scoring manual: AASM (W/N1/N2/N3/R) or Rechtschaffen & Kales "
+            "(S1-S4 + Movement). Locked once an epoch is scored."
+        )
+        self.vocabCombo.currentIndexChanged.connect(self._on_vocabulary_changed)
+        row.addWidget(self.vocabCombo)
+
+        self.stageButtonsLayout = QtWidgets.QHBoxLayout()
+        self.stageButtonsLayout.setSpacing(4)
+        self._stage_buttons: dict[str, QtWidgets.QPushButton] = {}
+        row.addLayout(self.stageButtonsLayout)
+
+        self.stageReadout = QtWidgets.QLabel("", self)
+        self.stageReadout.setStatusTip(
+            "The stage scored for the epoch at the left edge."
+        )
+        font = self.stageReadout.font()
+        font.setPointSize(font.pointSize() + 4)
+        font.setBold(True)
+        self.stageReadout.setFont(font)
+        self.stageReadout.setMinimumWidth(150)
+        self.stageReadout.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        row.addWidget(self.stageReadout)
+
+        row.addStretch(1)
+        self.stageProgressLabel = QtWidgets.QLabel("", self)
+        self.stageProgressLabel.setStatusTip("Scored / total epochs in the recording.")
+        self.stageProgressLabel.setEnabled(False)  # quiet, dimmed
+        row.addWidget(self.stageProgressLabel)
+        self.saveStageButton = QtWidgets.QPushButton("Save staging", self)
+        self.saveStageButton.setStatusTip(
+            "Write the hypnogram sidecar (night1.stages[.<rater>].tsv) next to the "
+            "recording; the recording itself is never modified."
+        )
+        self.saveStageButton.clicked.connect(self.save_staging)
+        row.addWidget(self.saveStageButton)
+        self._rebuild_stage_buttons()
+        return row
+
     def _build_contract_caption(self) -> QtWidgets.QLabel:
         """A quiet, always-visible reminder of the tool's safety contract (#175)."""
         caption = QtWidgets.QLabel(
@@ -1247,10 +1387,15 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             self.saveProfileButton,
             self.loadProfileButton,
             self.exportButton,
+            self.stagingButton,
+            self.saveStageButton,
         ):
             widget.setEnabled(loaded)
         for button in self._palette_buttons:  # no recording → nothing to mark
             button.setEnabled(loaded)
+        if not loaded and self._staging:
+            self._set_staging(False)  # can't stay in stage focus with nothing loaded
+        self._update_stage_ui()  # stage buttons + readout follow the load state
         self._update_log_controls()  # log loading is gated on a recording too
 
     # ----- quick-mark palette (#181) ---------------------------------------------
@@ -1298,6 +1443,249 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             return
         preferences.update_preferences(preferences_path, {"eeg_palette_labels": result})
         self._rebuild_palette_buttons()
+
+    # ----- sleep staging (#182) --------------------------------------------------
+
+    def _rebuild_stage_buttons(self) -> None:
+        """Recreate the stage buttons from the active vocabulary (W/N1/N2/N3/R …)."""
+        while self.stageButtonsLayout.count():
+            item = self.stageButtonsLayout.takeAt(0)
+            widget = item.widget() if item is not None else None
+            if widget is not None:
+                widget.deleteLater()
+        self._stage_buttons = {}
+        # The button caption shows the hotkey so the mapping is discoverable; key
+        # lookup is the vocabulary's, so R&K's digits and AASM's line up with it.
+        key_for_stage = {stage: key for key, stage in self._vocab.hotkeys.items()}
+        for stage in self._vocab.stages:
+            key = key_for_stage.get(stage, "")
+            button = QtWidgets.QPushButton(f"{stage} ({key})" if key else stage, self)
+            red, green, blue = self._vocab.colors[stage]
+            button.setStatusTip(
+                f"Score the current epoch as {staging.STAGE_LABELS.get(stage, stage)}"
+                + (f" (key {key})." if key else ".")
+            )
+            button.clicked.connect(
+                lambda _checked=False, s=stage: self._score_current_epoch(s)
+            )
+            button.setEnabled(self._recording is not None)
+            self.stageButtonsLayout.addWidget(button)
+            self._stage_buttons[stage] = button
+        # Tint the band swatch onto each button so the colour key is visible.
+        for stage, button in self._stage_buttons.items():
+            red, green, blue = self._vocab.colors[stage]
+            button.setStyleSheet(
+                f"QPushButton {{ border-left: 4px solid rgb({red},{green},{blue}); }}"
+            )
+
+    def _on_vocabulary_changed(self) -> None:
+        """Switch the scoring vocabulary (only allowed before any epoch is scored)."""
+        name = self.vocabCombo.currentData()
+        self._vocab = vocabulary_by_name(name)
+        preferences.update_preferences(
+            preferences_path, {"eeg_staging_vocabulary": name}
+        )
+        self._rebuild_stage_buttons()
+        self._refresh_staging()
+
+    def _on_staging_toggled(self, checked: bool) -> None:
+        """Enter/leave stage focus from the toggle button."""
+        self._set_staging(checked)
+
+    def _toggle_staging(self) -> None:
+        """Flip stage focus (the Tab key path); drives the toggle button."""
+        self.stagingButton.toggle()  # emits toggled → _on_staging_toggled
+
+    def _set_staging(self, on: bool) -> None:
+        """Turn stage focus on/off: epoch-lock the view and route the number keys.
+
+        Entering snaps the window to one epoch per screen (the standard scoring
+        view) and locks the epoch length/anchor so the grid can't shift mid-sweep
+        and silently re-slot the scores. The data is unchanged either way — only
+        the bare-digit hotkeys and auto-advance follow this flag.
+        """
+        on = on and self._recording is not None
+        self._staging = on
+        if self.stagingButton.isChecked() != on:
+            self.stagingButton.blockSignals(True)
+            self.stagingButton.setChecked(on)
+            self.stagingButton.blockSignals(False)
+        # Lock the epoch grid controls while staging: re-anchoring or re-length-ing
+        # mid-sweep would remap which span each score lands in.
+        self.epochSpin.setEnabled(not on)
+        self.anchorButton.setEnabled(not on)
+        self.resetAnchorButton.setEnabled(not on)
+        if on:
+            onset, _ = self._current_epoch_bounds()
+            self._select_window_seconds(self.view.epoch_seconds)  # one epoch/screen
+            self._jump_to(max(0.0, onset))  # frame that epoch at the left edge
+        self._refresh_staging()
+        self._refresh_stage_focus_chip()
+
+    def _current_epoch_bounds(self) -> tuple[float, float]:
+        """``(onset, duration)`` of the epoch at the left edge — the scoring target."""
+        return staging.epoch_bounds(
+            self.view.epoch_anchor, self.view.epoch_seconds, self.view.window_start
+        )
+
+    def _score_current_epoch(self, stage: str) -> None:
+        """Score the left-edge epoch as ``stage`` and, while staging, auto-advance."""
+        if self._recording is None:
+            return
+        onset, duration = self._current_epoch_bounds()
+        if onset < 0:  # the left edge sits before the recording start / anchor
+            return
+        self._stage_epochs = staging.set_stage(
+            self._stage_epochs, StageEpoch(onset, duration, stage)
+        )
+        self.view.set_hypnogram(self._stage_epochs, self._vocab.colors)
+        self._mark_stage_dirty()
+        if self._staging:
+            self._jump_to(onset + duration)  # next epoch, snapped to the boundary
+        self._update_stage_ui()
+
+    def _clear_current_epoch(self) -> None:
+        """Un-score the left-edge epoch (back to unscored); never auto-advances."""
+        if self._recording is None:
+            return
+        onset, _ = self._current_epoch_bounds()
+        self._stage_epochs = staging.clear_stage(self._stage_epochs, onset)
+        self.view.set_hypnogram(self._stage_epochs, self._vocab.colors)
+        self._mark_stage_dirty()
+        self._update_stage_ui()
+
+    def _mark_stage_dirty(self) -> None:
+        self._stage_dirty = True
+        self._autosave_timer.start()  # (re)arm the shared debounced recovery write
+        self._refresh_title()
+
+    def _refresh_staging(self) -> None:
+        """Repaint the whole staging overlay (bands, focus, buttons, readout)."""
+        self.view.set_hypnogram(self._stage_epochs, self._vocab.colors)
+        self.view.set_stage_focus(self._staging)
+        self._update_stage_ui()
+
+    def _update_stage_ui(self) -> None:
+        """Refresh the stage buttons, the progress counter, and the epoch readout."""
+        loaded = self._recording is not None
+        for button in self._stage_buttons.values():
+            button.setEnabled(loaded)
+        # The vocabulary is locked once scoring starts (mixed manuals corrupt a
+        # hypnogram), so the combo is enabled only on an empty, loaded recording.
+        self.vocabCombo.setEnabled(loaded and not self._stage_epochs)
+        if self._recording is not None:
+            # Count only *full* epochs (floor): a trailing fragment shorter than the
+            # epoch length isn't a scorable epoch and can't be framed at the left
+            # edge (the window can't scroll past the data), so counting it would
+            # leave the sweep stuck below 100%.
+            total = max(1, int(self._recording.duration // self.view.epoch_seconds))
+            self.stageProgressLabel.setText(f"{len(self._stage_epochs)}/{total} scored")
+        else:
+            self.stageProgressLabel.clear()
+        self._update_epoch_readout()
+
+    def _refresh_stage_focus_chip(self) -> None:
+        """Show/hide the 'STAGE FOCUS' status chip in the active stage colour-neutral tint."""
+        if self._staging:
+            self.stageFocusLabel.setText("  STAGE FOCUS  ")
+            self.stageFocusLabel.setStyleSheet(
+                "QLabel { background: rgb(0,150,136); color: white; "
+                "border-radius: 3px; }"
+            )
+        else:
+            self.stageFocusLabel.clear()
+            self.stageFocusLabel.setStyleSheet("")
+
+    def save_staging(self) -> None:
+        """Write the hypnogram sidecar for the active rater (mirrors save_annotations)."""
+        if self._recording is None:
+            return
+        if not self._confirm_rater_identity():
+            return
+        tsv_path, json_path = self._stage_sidecar_for(self._recording.path)
+        if not self._owns_stage_sidecar and tsv_path.is_file():
+            if not self._confirm_overwrite(tsv_path, kind="staging"):
+                return
+        try:
+            write_stages_tsv(self._stage_epochs, tsv_path)
+            write_stages_json(
+                json_path,
+                source_name=self._recording.path.name,
+                meas_date=self._recording.meas_date,
+                vocabulary=self._vocab,
+                epoch_seconds=self.view.epoch_seconds,
+                anchor=self.view.epoch_anchor,
+                rater_id=self._rater_id,
+            )
+        except OSError as exc:
+            self._error("Could not save the staging.", str(exc))
+            return
+        self._stage_dirty = False
+        self._owns_stage_sidecar = True
+        self._clear_stage_autosave()
+        self._maybe_stop_autosave()
+        self._refresh_title()
+        status_bar = self.statusBar()
+        assert status_bar is not None
+        status_bar.showMessage(
+            f"Saved {len(self._stage_epochs)} scored epochs to {tsv_path.name}", 5000
+        )
+
+    def _clear_stage_autosave(self) -> None:
+        """Delete the active rater's hypnogram recovery file for this recording."""
+        if self._recording is not None:
+            self._stage_autosave_for(self._recording.path).unlink(missing_ok=True)
+
+    def _load_stages(self, tsv_path: Path) -> tuple[list[StageEpoch], bool]:
+        """Load a hypnogram sidecar; return ``(epochs, owns)``.
+
+        Absent → ``([], False)``. A corrupt sidecar is not fatal to the open (the
+        annotations may be fine) but it is *not* claimed as ours, so the overwrite
+        guard catches the next save instead of silently clobbering it.
+        """
+        if not tsv_path.is_file():
+            return [], False
+        try:
+            return read_stages_tsv(tsv_path), True
+        except (OSError, ValueError) as exc:
+            self._error(
+                "Could not read the existing staging sidecar.",
+                f"{tsv_path.name}: {exc}\n\nFix or rename it; staging starts empty "
+                "and will not overwrite it without confirmation.",
+            )
+            return [], False
+
+    def _apply_stage_provenance(self, json_path: Path) -> None:
+        """Adopt the manual + epoch grid a resumed hypnogram was scored on (#182).
+
+        The TSV is self-describing for the data, but the *vocabulary* (so the
+        keyboard map, band colours, and the locked combo match) and the *epoch
+        grid* (so new scores tile on the same boundaries as the loaded bands) live
+        in the JSON. Applied after ``set_provider`` (which resets the anchor). A
+        missing/unreadable JSON leaves the preference defaults — never fatal.
+        """
+        try:
+            payload = read_stages_json(json_path)
+        except (OSError, ValueError):
+            return
+        manual = payload.get("ScoringManual")
+        if isinstance(manual, str):
+            self._vocab = vocabulary_by_name(manual)
+            self._rebuild_stage_buttons()
+            index = self.vocabCombo.findData(self._vocab.name)
+            if index >= 0:
+                self.vocabCombo.blockSignals(True)
+                self.vocabCombo.setCurrentIndex(index)
+                self.vocabCombo.blockSignals(False)
+        epoch_length = payload.get("EpochLength")
+        if isinstance(epoch_length, int | float) and epoch_length > 0:
+            self.epochSpin.blockSignals(True)
+            self.epochSpin.setValue(int(epoch_length))
+            self.epochSpin.blockSignals(False)
+            self.view.set_epoch_seconds(float(epoch_length))
+        anchor = payload.get("Anchor")
+        if isinstance(anchor, int | float) and anchor >= 0:
+            self.view.set_epoch_anchor(float(anchor))
 
     # ----- blind-rater mode (#181) -----------------------------------------------
 
@@ -2021,9 +2409,11 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             self._error("Could not open the recording.", str(exc))
             return
         # Opened cleanly: stop autosaving the recording we're leaving and drop its
-        # recovery file (the user already saved or discarded it via open_file).
+        # recovery files — both layers (the user already saved or discarded it via
+        # open_file), so a discarded staging sweep isn't re-offered on the next open.
         self._autosave_timer.stop()
         self._clear_autosave()
+        self._clear_stage_autosave()
         tsv_path, _ = self._sidecar_for(path)
         if tsv_path.is_file():
             # Resume a previous review. A sidecar that exists but won't parse
@@ -2051,8 +2441,22 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         # We own the sidecar when we loaded from it; a fresh review does not yet,
         # so its first save guards against overwriting one that appeared meanwhile.
         self._owns_sidecar = tsv_path.is_file()
+        # Stages (#182) are an independent partition with their own sidecar — loaded
+        # unconditionally (no blind filter applies to a hypnogram).
+        stage_tsv, stage_json = self._stage_sidecar_for(path)
+        self._stage_epochs, self._owns_stage_sidecar = self._load_stages(stage_tsv)
+        self._stage_dirty = False
+        # A fresh recording uses the preference vocabulary; a resumed hypnogram
+        # adopts the manual + epoch grid it was scored on (applied after
+        # set_provider, which resets the anchor), so the keyboard map, the band
+        # colours, and the grid all match the file rather than the operator default.
+        if not self._stage_epochs:
+            self._vocab = self._resolve_vocabulary()
         self.view.set_provider(recording)
         self.view.set_annotations(annotations)
+        if self._stage_epochs and stage_json.is_file():
+            self._apply_stage_provenance(stage_json)
+        self.view.set_hypnogram(self._stage_epochs, self._vocab.colors)
         # Hand the view the localized recording start so the time axis can label
         # clock time; default to clock when the file carries one, else elapsed.
         started = wall_time(recording, 0.0)
@@ -2084,6 +2488,9 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         # re-loads it for the new file if wanted.
         self._clear_log_overlay()
         self._check_for_recovery(tsv_path)
+        # Re-establish staging for this recording: re-frame/lock if a sweep was on,
+        # and paint the bands/readout/buttons either way.
+        self._set_staging(self._staging)
 
     def _fresh_annotations(
         self, path: Path, recording: io.Recording
@@ -2241,8 +2648,8 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             return
         self._dirty = False
         self._owns_sidecar = True  # ours now; later saves don't re-prompt
-        self._autosave_timer.stop()
         self._clear_autosave()  # the work is persisted; no recovery needed
+        self._maybe_stop_autosave()  # but keep autosaving an unsaved hypnogram
         self._refresh_title()
         status_bar = self.statusBar()
         assert status_bar is not None
@@ -2250,13 +2657,17 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             f"Saved {len(self._annotations)} annotations to {tsv_path.name}", 5000
         )
 
-    def _confirm_overwrite(self, tsv_path: Path) -> bool:
-        """Ask before overwriting a sidecar this review did not open."""
+    def _confirm_overwrite(self, tsv_path: Path, kind: str = "annotations") -> bool:
+        """Ask before overwriting a sidecar this review did not open.
+
+        ``kind`` names the artifact (``"annotations"`` or ``"staging"``) so the
+        destructive confirmation matches the file actually being saved.
+        """
         button = QtWidgets.QMessageBox.question(
             self,
-            "Overwrite annotations?",
+            "Overwrite?",
             f"{tsv_path.name} already exists and was not opened in this review.\n\n"
-            "Overwrite it with the current annotations?",
+            f"Overwrite it with the current {kind}?",
             QtWidgets.QMessageBox.StandardButton.Yes
             | QtWidgets.QMessageBox.StandardButton.No,
         )
@@ -2296,7 +2707,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         name = f" — {self._recording.path.name}" if self._recording else ""
         rater = f" · rater {self._rater_id}" if self._rater_id else ""
         blinded = f" · blind:{self._blind.preset}" if self._blind is not None else ""
-        star = " *" if self._dirty else ""
+        star = " *" if self._dirty or self._stage_dirty else ""
         self.setWindowTitle(f"SMACC — EEG review{name}{rater}{blinded}{star}")
 
     def _recent_labels(self) -> list[str]:
@@ -2313,16 +2724,37 @@ class EegReviewWindow(QtWidgets.QMainWindow):
     # ----- autosave / crash recovery (#176) ----------------------------------------
 
     def _write_autosave(self) -> None:
-        """Write the recovery file (best-effort, atomic); fired by the debounce timer."""
-        if self._recording is None or not self._dirty:
+        """Write the recovery files (best-effort, atomic); fired by the debounce timer.
+
+        One debounce serves both layers: the dirty annotation list and the dirty
+        hypnogram each write their own recovery file, so a crash mid-staging
+        recovers the scored epochs just as it recovers unsaved marks.
+        """
+        if self._recording is None:
             return
-        path = self._autosave_for(self._recording.path)
-        tmp = path.with_suffix(".tmp")  # write-then-rename so a crash never half-writes
-        try:
-            write_annotations_tsv(self._annotations, tmp)
-            tmp.replace(path)
-        except OSError:
-            pass  # autosave must never interrupt the review
+        if self._dirty:
+            path = self._autosave_for(self._recording.path)
+            tmp = path.with_suffix(
+                ".tmp"
+            )  # write-then-rename so a crash never half-writes
+            try:
+                write_annotations_tsv(self._annotations, tmp)
+                tmp.replace(path)
+            except OSError:
+                pass  # autosave must never interrupt the review
+        if self._stage_dirty:
+            path = self._stage_autosave_for(self._recording.path)
+            tmp = path.with_suffix(".tmp")
+            try:
+                write_stages_tsv(self._stage_epochs, tmp)
+                tmp.replace(path)
+            except OSError:
+                pass
+
+    def _maybe_stop_autosave(self) -> None:
+        """Stop the shared debounce once neither layer has unsaved work."""
+        if not self._dirty and not self._stage_dirty:
+            self._autosave_timer.stop()
 
     def _clear_autosave(self) -> None:
         """Delete the active rater's recovery file for this recording, if any."""
@@ -2330,47 +2762,81 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             self._autosave_for(self._recording.path).unlink(missing_ok=True)
 
     def _check_for_recovery(self, tsv_path: Path) -> None:
-        """On open, offer to restore a recovery file newer than the saved sidecar."""
+        """On open, offer to restore recovery files newer than the saved sidecars.
+
+        Covers both layers in one banner: the annotation autosave and the
+        hypnogram autosave (#182). A recovery file is offered unless a clean save
+        is strictly newer than it (then it is stale and dropped); a same-second
+        tie errs toward offering it, never losing work.
+        """
         self.recoveryBanner.setVisible(False)
         self._recovery_annotations = None
+        self._recovery_stages = None
         if self._recording is None:
             return
+        parts: list[str] = []
         recovery = self._autosave_for(self._recording.path)
-        if not recovery.is_file():
-            return
-        # A recovery file with a clean save strictly newer than it is stale — the
-        # save happened after the autosave, so there is nothing left to recover.
-        # Strict so a same-second tie errs toward offering recovery, never losing it.
-        stale = (
-            tsv_path.is_file() and tsv_path.stat().st_mtime > recovery.stat().st_mtime
-        )
-        if stale:
-            recovery.unlink(missing_ok=True)
-            return
-        try:
-            recovered = read_annotations_tsv(recovery)
-        except (OSError, ValueError):
-            return  # an unreadable recovery file must not block the open
-        self._recovery_annotations = recovered
-        self.recoveryLabel.setText(
-            f"Recovered {len(recovered)} unsaved annotation(s) from a previous session."
-        )
-        self.recoveryBanner.setVisible(True)
+        if recovery.is_file():
+            stale = (
+                tsv_path.is_file()
+                and tsv_path.stat().st_mtime > recovery.stat().st_mtime
+            )
+            if stale:
+                recovery.unlink(missing_ok=True)
+            else:
+                try:
+                    self._recovery_annotations = read_annotations_tsv(recovery)
+                except (OSError, ValueError):
+                    self._recovery_annotations = None  # don't block the open
+                if self._recovery_annotations is not None:
+                    parts.append(
+                        f"{len(self._recovery_annotations)} unsaved annotation(s)"
+                    )
+        stage_tsv, _ = self._stage_sidecar_for(self._recording.path)
+        stage_recovery = self._stage_autosave_for(self._recording.path)
+        if stage_recovery.is_file():
+            stale = (
+                stage_tsv.is_file()
+                and stage_tsv.stat().st_mtime > stage_recovery.stat().st_mtime
+            )
+            if stale:
+                stage_recovery.unlink(missing_ok=True)
+            else:
+                try:
+                    self._recovery_stages = read_stages_tsv(stage_recovery)
+                except (OSError, ValueError):
+                    self._recovery_stages = None
+                if self._recovery_stages is not None:
+                    parts.append(f"{len(self._recovery_stages)} scored epoch(s)")
+        if parts:
+            self.recoveryLabel.setText(
+                "Recovered " + " and ".join(parts) + " from a previous session."
+            )
+            self.recoveryBanner.setVisible(True)
 
     def _restore_autosave(self) -> None:
-        if self._recovery_annotations is None:
+        if self._recovery_annotations is None and self._recovery_stages is None:
             return
-        self._annotations = self._recovery_annotations
+        if self._recovery_annotations is not None:
+            self._annotations = self._recovery_annotations
+            self.view.set_annotations(self._annotations)
+            self._refresh_list()
+            self._mark_dirty()  # restored but not yet saved — keep the recovery alive
+        if self._recovery_stages is not None:
+            self._stage_epochs = self._recovery_stages
+            self.view.set_hypnogram(self._stage_epochs, self._vocab.colors)
+            self._mark_stage_dirty()
+            self._update_stage_ui()
         self._recovery_annotations = None
+        self._recovery_stages = None
         self.recoveryBanner.setVisible(False)
-        self.view.set_annotations(self._annotations)
-        self._refresh_list()
-        self._mark_dirty()  # restored but not yet saved — keep the recovery alive
 
     def _dismiss_autosave(self) -> None:
         self._recovery_annotations = None
+        self._recovery_stages = None
         self.recoveryBanner.setVisible(False)
-        self._clear_autosave()  # the user declined the recovery; drop it
+        self._clear_autosave()  # the user declined the recovery; drop both
+        self._clear_stage_autosave()
 
     # ----- selection sync ---------------------------------------------------------
 
@@ -2430,11 +2896,12 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._update_epoch_readout()
 
     def _update_epoch_readout(self) -> None:
-        """Show the epoch number at the left edge of the view in the status bar."""
+        """Show the epoch number (and its scored stage) at the left edge of the view."""
         # Drive off the provider, not the recording, so the readout matches the
         # epoch grid (which a standalone log timeline also draws).
         if not self.view.has_provider:
             self.epochLabel.clear()
+            self.stageReadout.clear()
             return
         number = (
             math.floor(
@@ -2444,6 +2911,24 @@ class EegReviewWindow(QtWidgets.QMainWindow):
             + 1
         )
         self.epochLabel.setText(f"Epoch {number}")
+        # The big readout names the current epoch's stage in its own colour, or a
+        # dash when unscored — the at-a-glance answer to "what is this epoch?".
+        stage = staging.stage_at(self._stage_epochs, self.view.window_start)
+        if self._recording is None:
+            self.stageReadout.clear()
+        elif stage is None:
+            self.stageReadout.setText("—")
+            self.stageReadout.setStyleSheet("")
+        else:
+            self.stageReadout.setText(stage)
+            color = self._vocab.colors.get(stage)
+            if color is not None:
+                red, green, blue = color
+                self.stageReadout.setStyleSheet(
+                    f"QLabel {{ color: rgb({red},{green},{blue}); }}"
+                )
+            else:
+                self.stageReadout.setStyleSheet("")
 
     def eventFilter(
         self, obj: QtCore.QObject | None, event: QtCore.QEvent | None
@@ -2470,10 +2955,24 @@ class EegReviewWindow(QtWidgets.QMainWindow):
                 if status_bar is not None:
                     status_bar.showMessage("Alignment cancelled.", 3000)
                 return True
+            # Tab toggles stage focus (#182), but only with a recording open and
+            # the focus off any text/number entry — so Tab still moves between the
+            # filter fields when you are editing them.
+            if (
+                event.key() == QtCore.Qt.Key.Key_Tab
+                and not event.modifiers()
+                and self._recording is not None
+                and not self._focus_is_text_entry()
+            ):
+                self._toggle_staging()
+                return True
             # Navigation works whenever something is loaded (a recording, or the
-            # standalone log timeline); the quick-mark palette needs a recording
-            # to annotate.
+            # standalone log timeline). Stage keys (in focus) and the quick-mark
+            # palette both need a recording; stage keys go first so a staging sweep
+            # owns the bare digits, then they fall through to quick-marks otherwise.
             if self.view.has_provider and self._handle_nav_key(event):
+                return True
+            if self._recording is not None and self._handle_stage_key(event):
                 return True
             if self._recording is not None and self._handle_palette_key(event):
                 return True
@@ -2516,6 +3015,46 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         if isinstance(focus, QtWidgets.QComboBox | QtWidgets.QAbstractItemView):
             return key in _VERTICAL_NAV_KEYS
         return False
+
+    def _focus_is_text_entry(self) -> bool:
+        """True if a spin box / line edit / combo box has focus (don't hijack typing)."""
+        focus = QtWidgets.QApplication.focusWidget()
+        return isinstance(
+            focus,
+            QtWidgets.QAbstractSpinBox | QtWidgets.QLineEdit | QtWidgets.QComboBox,
+        )
+
+    def _handle_stage_key(self, event: QtGui.QKeyEvent) -> bool:
+        """Score (or clear) the current epoch from a stage hotkey; return if consumed.
+
+        Keyboard scoring is confined to stage focus: outside it a bare ``W``/``R``
+        or digit is *not* consumed here, so a stray letter can never silently start
+        a hypnogram during plain annotation review, and digits stay quick-mark
+        hotkeys (#181b). The mouse stage buttons remain the way to score the odd
+        epoch without entering focus. In focus an unmapped digit (6-9 under AASM) is
+        swallowed so a mis-key never scatters a quick-mark mid-sweep; an unmapped
+        letter falls through (it may be another shortcut). Yields to any focused
+        text/number entry so typing is never hijacked.
+        """
+        if not self._staging:
+            return False
+        if event.modifiers() & ~QtCore.Qt.KeyboardModifier.KeypadModifier:
+            return False  # only a bare key (keypad ok), not Ctrl/Alt/Shift+key
+        if self._focus_is_text_entry():
+            return False
+        key = event.key()
+        if key in _STAGE_CLEAR_KEYS:
+            self._clear_current_epoch()
+            return True
+        char = _stage_char(key)
+        if char is None:
+            return False
+        stage = self._vocab.stage_for_key(char)
+        if stage is not None:
+            self._score_current_epoch(stage)
+            return True
+        # An unmapped digit is inert but swallowed; an unmapped letter falls through.
+        return char.isdigit()
 
     def _handle_nav_key(self, event: QtGui.QKeyEvent) -> bool:
         """Apply one navigation/amplitude key; return whether it was consumed."""
@@ -2810,20 +3349,24 @@ class EegReviewWindow(QtWidgets.QMainWindow):
     # ----- helpers / lifecycle -------------------------------------------------------
 
     def _confirm_discard(self) -> bool:
-        """True when it's safe to drop the current annotations (saved or confirmed)."""
-        if not self._dirty:
+        """True when it's safe to drop the current work (saved or confirmed)."""
+        if not self._dirty and not self._stage_dirty:
             return True
         button = QtWidgets.QMessageBox.question(
             self,
-            "Unsaved annotations",
-            "Save the annotations before closing this recording?",
+            "Unsaved work",
+            "Save the annotations and staging before closing this recording?",
             QtWidgets.QMessageBox.StandardButton.Save
             | QtWidgets.QMessageBox.StandardButton.Discard
             | QtWidgets.QMessageBox.StandardButton.Cancel,
         )
         if button == QtWidgets.QMessageBox.StandardButton.Save:
-            self.save_annotations()
-            return not self._dirty  # a failed save keeps the recording open
+            if self._dirty:
+                self.save_annotations()
+            if self._stage_dirty:
+                self.save_staging()
+            # A failed save (or a declined rater confirm) keeps the recording open.
+            return not self._dirty and not self._stage_dirty
         return button == QtWidgets.QMessageBox.StandardButton.Discard
 
     def _error(self, short: str, detail: str | None = None) -> None:
@@ -2841,9 +3384,10 @@ class EegReviewWindow(QtWidgets.QMainWindow):
                 event.ignore()
             return
         # Closing cleanly (saved or discarded): there is no unsaved work to
-        # recover, so drop the recovery file and stop the autosave timer.
+        # recover, so drop the recovery files and stop the autosave timer.
         self._autosave_timer.stop()
         self._clear_autosave()
+        self._clear_stage_autosave()
         self._stop_player()  # don't leave a report playing after the window closes
         # Drop the app-level key filter before this window goes away, so a stray
         # late event can never reach a half-deleted window.

--- a/tests/test_eeg_staging.py
+++ b/tests/test_eeg_staging.py
@@ -240,6 +240,30 @@ def test_json_sidecar_records_manual_grid_and_provenance(tmp_path: Path):
     assert payload["stage"]["Levels"]["N3"].startswith("NREM stage 3")
 
 
+def test_read_json_sidecar_round_trips_the_provenance(tmp_path: Path):
+    path = tmp_path / "night1.stages.json"
+    staging.write_stages_json(
+        path,
+        source_name="night1.edf",
+        meas_date=None,
+        vocabulary=staging.RK,
+        epoch_seconds=20.0,
+        anchor=2.5,
+        rater_id="bob",
+    )
+    payload = staging.read_stages_json(path)
+    assert payload["ScoringManual"] == "R&K-1968"
+    assert payload["EpochLength"] == 20.0
+    assert payload["Anchor"] == 2.5
+
+
+def test_read_json_sidecar_rejects_non_json(tmp_path: Path):
+    path = tmp_path / "bad.json"
+    path.write_text("not json", encoding="utf-8")
+    with pytest.raises(ValueError, match="Not valid JSON"):
+        staging.read_stages_json(path)
+
+
 def test_json_sidecar_rater_is_null_for_a_single_rater_review(tmp_path: Path):
     path = tmp_path / "night1.stages.json"
     staging.write_stages_json(

--- a/tests/test_eeg_view.py
+++ b/tests/test_eeg_view.py
@@ -16,6 +16,7 @@ from PyQt6 import QtCore, QtGui
 
 from smacc.eeg import dsp
 from smacc.eeg.annotations import Annotation
+from smacc.eeg.staging import StageEpoch
 from smacc.eeg.view import DEFAULT_TYPE_SCALES, RaterOverlay, TimeAxis, TraceView
 
 SFREQ = 100.0
@@ -796,3 +797,49 @@ def test_build_snapshot_time_axis_label_follows_mode(loaded):
     assert (
         view.build_snapshot(marks=[], show_epochs=False).time_axis_label == "clock time"
     )
+
+
+# ----- sleep-staging overlay (#182) ------------------------------------------
+
+
+def test_set_hypnogram_draws_a_band_per_visible_scored_epoch(loaded):
+    view, _ = loaded
+    view.set_window_seconds(60.0)  # whole 60 s file in view
+    view.set_hypnogram(
+        [StageEpoch(0.0, 30.0, "W"), StageEpoch(30.0, 30.0, "N2")],
+        {"W": (242, 201, 76), "N2": (74, 144, 200)},
+    )
+    assert len(view._stage_band_items) == 2
+
+
+def test_stage_bands_only_draw_the_epochs_in_view(loaded):
+    view, _ = loaded
+    view.set_window_seconds(30.0)
+    view.set_window_start(0.0)  # only [0, 30) is visible
+    view.set_hypnogram(
+        [StageEpoch(0.0, 30.0, "W"), StageEpoch(30.0, 30.0, "N2")],
+        {"W": (242, 201, 76), "N2": (74, 144, 200)},
+    )
+    assert len(view._stage_band_items) == 1
+
+
+def test_a_stage_with_no_colour_tints_nothing(loaded):
+    view, _ = loaded
+    view.set_hypnogram([StageEpoch(0.0, 30.0, "N2")], {})  # no colour for N2
+    assert view._stage_band_items == []
+
+
+def test_stage_focus_brackets_the_left_edge_epoch(loaded):
+    view, _ = loaded
+    view.set_stage_focus(True)
+    assert view._focused_epoch_item is not None
+    view.set_stage_focus(False)
+    assert view._focused_epoch_item is None
+
+
+def test_new_provider_drops_the_previous_hypnogram(loaded):
+    view, _ = loaded
+    view.set_hypnogram([StageEpoch(0.0, 30.0, "N2")], {"N2": (74, 144, 200)})
+    view.set_provider(FakeProvider())  # a different recording
+    assert view._stage_epochs == []
+    assert view._stage_band_items == []

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -40,6 +40,16 @@ from smacc.eeg.annotations import (
     sidecar_paths,
     write_annotations_tsv,
 )
+from smacc.eeg.staging import (
+    RK,
+    StageEpoch,
+    rater_stages_paths,
+    read_stages_tsv,
+    stages_autosave_path,
+    stages_sidecar_paths,
+    write_stages_json,
+    write_stages_tsv,
+)
 from smacc.eeg.window import SEED_LABELS, EegReviewWindow, LabelDialog
 
 SFREQ = 100.0
@@ -2002,3 +2012,210 @@ def test_clearing_the_log_stops_playback(window, recording_path, monkeypatch, tm
     other.write_bytes(b"")
     window._load(other)  # opening a new recording clears the log
     assert window._player.stopped
+
+
+# ----- sleep staging (#182) ------------------------------------------------------
+
+
+@pytest.fixture
+def stage_window(window, recording_path, monkeypatch):
+    """A loaded window with focus pinned to nothing, ready for stage hotkeys."""
+    window._load(recording_path)
+    monkeypatch.setattr(
+        QtWidgets.QApplication, "focusWidget", staticmethod(lambda: None)
+    )
+    return window
+
+
+def test_scoring_an_epoch_adds_it_to_the_hypnogram(stage_window):
+    stage_window._score_current_epoch("N2")  # left-edge epoch is [0, 30)
+    assert stage_window._stage_epochs == [StageEpoch(0.0, 30.0, "N2")]
+    assert stage_window._stage_dirty
+    assert stage_window.windowTitle().endswith("*")
+    assert stage_window.stageReadout.text() == "N2"
+
+
+def test_stage_digit_scores_and_autoadvances_in_focus(stage_window):
+    stage_window._set_staging(True)
+    assert stage_window._handle_stage_key(_key(QtCore.Qt.Key.Key_2)) is True
+    assert stage_window._stage_epochs == [StageEpoch(0.0, 30.0, "N2")]
+    assert stage_window.view.window_start == pytest.approx(30.0)  # advanced one epoch
+
+
+def test_letter_keys_do_not_score_outside_focus(stage_window):
+    # A stray W/R during plain annotation review must NOT silently start a
+    # hypnogram — keyboard scoring is confined to stage focus.
+    assert not stage_window._staging
+    assert stage_window._handle_stage_key(_key(QtCore.Qt.Key.Key_W)) is False
+    assert stage_window._stage_epochs == []
+
+
+def test_letter_key_scores_in_focus(stage_window):
+    stage_window._set_staging(True)
+    assert stage_window._handle_stage_key(_key(QtCore.Qt.Key.Key_W)) is True
+    assert stage_window._stage_epochs == [StageEpoch(0.0, 30.0, "W")]
+
+
+def test_stage_button_scores_without_focus(stage_window):
+    # The mouse buttons remain the no-focus way to score the odd epoch.
+    assert not stage_window._staging
+    stage_window._stage_buttons["W"].click()
+    assert stage_window._stage_epochs == [StageEpoch(0.0, 30.0, "W")]
+    assert stage_window.view.window_start == pytest.approx(0.0)  # no auto-advance
+
+
+def test_digits_fall_through_to_palette_outside_focus(stage_window):
+    # Outside stage focus a bare digit stays a quick-mark hotkey, so the stage
+    # handler must decline it (lets _handle_palette_key run next).
+    assert stage_window._handle_stage_key(_key(QtCore.Qt.Key.Key_2)) is False
+    assert stage_window._stage_epochs == []
+
+
+def test_unmapped_digit_is_inert_but_swallowed_in_focus(stage_window):
+    # 4-9 score nothing under AASM, but in focus they must not scatter a quick-mark.
+    stage_window._set_staging(True)
+    assert stage_window._handle_stage_key(_key(QtCore.Qt.Key.Key_7)) is True
+    assert stage_window._stage_epochs == []
+
+
+def test_clear_key_unscores_the_current_epoch(stage_window):
+    stage_window._set_staging(True)
+    stage_window._handle_stage_key(_key(QtCore.Qt.Key.Key_2))  # score [0,30), advance
+    stage_window._jump_to(0.0)  # back to the first epoch
+    assert stage_window._handle_stage_key(_key(QtCore.Qt.Key.Key_0)) is True
+    assert stage_window._stage_epochs == []
+
+
+def test_rescoring_replaces_the_stage(stage_window):
+    stage_window._score_current_epoch("N1")  # not staging → no advance, same epoch
+    stage_window._score_current_epoch("N2")
+    assert stage_window._stage_epochs == [StageEpoch(0.0, 30.0, "N2")]
+
+
+def test_entering_staging_locks_the_grid_and_snaps_to_one_epoch(stage_window):
+    stage_window._select_window_seconds(60.0)
+    stage_window._set_staging(True)
+    assert stage_window.view.window_seconds == pytest.approx(30.0)  # one epoch/screen
+    assert not stage_window.epochSpin.isEnabled()  # grid locked while staging
+    assert not stage_window.anchorButton.isEnabled()
+    assert "STAGE FOCUS" in stage_window.stageFocusLabel.text()
+
+
+def test_tab_toggles_stage_focus(stage_window):
+    assert not stage_window._staging
+    stage_window._toggle_staging()
+    assert stage_window._staging
+    stage_window._toggle_staging()
+    assert not stage_window._staging
+
+
+def test_vocabulary_combo_locks_after_the_first_score(stage_window):
+    assert stage_window.vocabCombo.isEnabled()
+    stage_window._score_current_epoch("N2")
+    assert not stage_window.vocabCombo.isEnabled()  # no mixing manuals mid-hypnogram
+
+
+def test_save_staging_writes_the_sidecar(stage_window, recording_path):
+    stage_window._score_current_epoch("N2")
+    stage_window.save_staging()
+    tsv, json_path = stages_sidecar_paths(recording_path)
+    assert read_stages_tsv(tsv) == [StageEpoch(0.0, 30.0, "N2")]
+    assert not stage_window._stage_dirty
+    assert stage_window._owns_stage_sidecar
+    payload = json.loads(json_path.read_text(encoding="utf-8"))
+    assert payload["ScoringManual"] == "AASM"
+    assert payload["EpochLength"] == 30.0
+
+
+def test_staging_save_is_independent_of_annotation_save(stage_window, recording_path):
+    # The two artifacts have separate sidecars and separate dirty state.
+    stage_window._score_current_epoch("N2")
+    stage_window.save_staging()
+    assert not stage_window._stage_dirty
+    assert not sidecar_paths(recording_path)[0].is_file()  # no annotations written
+
+
+def test_load_resumes_an_existing_hypnogram(window, recording_path):
+    tsv, _ = stages_sidecar_paths(recording_path)
+    write_stages_tsv([StageEpoch(0.0, 30.0, "N3")], tsv)
+    window._load(recording_path)
+    assert window._stage_epochs == [StageEpoch(0.0, 30.0, "N3")]
+    assert window._owns_stage_sidecar
+
+
+def test_rater_staging_uses_a_rater_keyed_sidecar(window, recording_path):
+    window._apply_rater_id("alice")
+    window._confirmed_raters.add("alice")  # skip the once-per-id save confirm
+    window._load(recording_path)
+    window._score_current_epoch("N2")
+    window.save_staging()
+    rater_tsv, _ = rater_stages_paths(recording_path, "alice")
+    assert rater_tsv.is_file()
+    assert not stages_sidecar_paths(recording_path)[0].is_file()  # not the plain one
+
+
+def test_crashed_staging_is_offered_and_restored(window, recording_path):
+    # A stage autosave newer than any saved sidecar is offered on open.
+    write_stages_tsv([StageEpoch(0.0, 30.0, "R")], stages_autosave_path(recording_path))
+    window._load(recording_path)
+    assert window.recoveryBanner.isVisible()
+    window._restore_autosave()
+    assert window._stage_epochs == [StageEpoch(0.0, 30.0, "R")]
+    assert window._stage_dirty  # restored but unsaved
+
+
+def test_resume_adopts_the_files_scoring_manual(window, recording_path):
+    # An R&K hypnogram must open under R&K (not the AASM default), so its bands
+    # tint and its keys/combo match — and a save can't relabel it to AASM.
+    tsv, json_path = stages_sidecar_paths(recording_path)
+    write_stages_tsv([StageEpoch(0.0, 30.0, "S2")], tsv)
+    write_stages_json(
+        json_path,
+        source_name=recording_path.name,
+        meas_date=None,
+        vocabulary=RK,
+        epoch_seconds=30.0,
+        anchor=0.0,
+    )
+    window._load(recording_path)
+    assert window._vocab is RK
+    assert window.vocabCombo.currentData() == "R&K-1968"
+    assert "S2" in window._vocab.colors  # the loaded band can tint
+
+
+def test_resume_restores_a_nondefault_epoch_grid(window, recording_path):
+    tsv, json_path = stages_sidecar_paths(recording_path)
+    write_stages_tsv([StageEpoch(0.0, 20.0, "N2")], tsv)
+    write_stages_json(
+        json_path,
+        source_name=recording_path.name,
+        meas_date=None,
+        vocabulary=window._vocab,
+        epoch_seconds=20.0,
+        anchor=2.5,
+    )
+    window._load(recording_path)
+    assert window.view.epoch_seconds == pytest.approx(20.0)
+    assert window.view.epoch_anchor == pytest.approx(2.5)
+    assert window.epochSpin.value() == 20
+
+
+def test_opening_another_recording_drops_a_discarded_stage_autosave(
+    window, recording_path, tmp_path
+):
+    # Score, then open a different recording (the fixture answers the discard
+    # prompt with Discard): the first file's stage autosave must not survive to be
+    # re-offered on its next open.
+    window._load(recording_path)
+    window._score_current_epoch("N2")
+    window._write_autosave()  # the debounce would do this; force it now
+    assert stages_autosave_path(recording_path).is_file()
+    other = tmp_path / "night2.edf"
+    other.write_bytes(b"")
+    window._load(other)
+    assert not stages_autosave_path(recording_path).is_file()  # discarded, not leaked
+
+
+def test_progress_total_counts_only_full_epochs(stage_window):
+    # 600 s / 30 s = 20 full epochs; the counter must be able to reach 20/20.
+    assert "/20 scored" in stage_window.stageProgressLabel.text()


### PR DESCRIPTION
Second of three stacked PRs (#182). Stacked on #223 — review/merge that first.

The staging mode itself. Staging and annotating share one surface — the stage bands and event marks are always drawn and always editable — so a rater scores stages and drops the odd LRLR/arousal mark on the same recording without a mode that loses their place.

- **Stage focus** (Tab, or the button): epoch-locks the view to one epoch per screen, locks the epoch grid so a score can't land in the wrong span, shows a status chip, and brackets the epoch at the left edge.
- **Hotkeys** score the current epoch and auto-advance: `W`/`R` and `1`/`2`/`3` (digits are stage keys only in focus, so they stay quick-mark hotkeys otherwise); `0`/`Backspace` clears. The stage buttons score with the mouse, in or out of focus.
- **Feedback:** per-epoch stage bands behind the traces, a large current-stage readout, a scored/total counter.
- **Vocabulary** combo (AASM / R&K), locked once an epoch is scored; a resumed hypnogram reopens under the manual and epoch grid it was scored with.
- Save / autosave / crash-recovery / discard-on-close all wired through the existing rater plumbing, independent of the annotation sidecar.

A sub-epoch movement or artifact stays an annotation over the epoch's stage (neither manual has an Artifact stage; AASM has no Movement stage). YASA automated staging is tracked separately.

Offscreen tests in `tests/test_eeg_window.py` and `tests/test_eeg_view.py`; the staging round-trip is added to `--selftest`.