### PR TITLE
feat: add a hypnogram overview strip and document staging

### DIFF
--- a/docs/eeg-review.md
+++ b/docs/eeg-review.md
@@ -72,6 +72,50 @@ duplicated).
 The sidecar format is documented in the
 [annotations file reference](reference/annotations-file.md).
 
+## Sleep staging
+
+Score the night a 30 s epoch at a time. Staging is a separate layer from
+annotating — both are always live on the same view, so you can drop an LRLR or
+arousal mark mid-sweep without leaving your place — and it saves to its **own**
+sidecar (`night1.edf` → `night1.stages.tsv`), a partition of one stage per epoch,
+never mixed into the event annotations.
+
+**Stage focus.** Press **Tab** (or the **Stage focus** button) to start a sweep.
+The view locks to one epoch per screen and the epoch grid/length is fixed (so a
+score can't land in the wrong span), a **STAGE FOCUS** chip shows in the status
+bar, and the epoch at the left edge — the one you're about to score — gets a teal
+bracket.
+
+**Scoring.** With stage focus on, the number keys score the epoch at the left
+edge and **auto-advance** to the next one:
+
+| Key               | AASM stage                  |
+| ----------------- | --------------------------- |
+| `W`               | Wake                        |
+| `1` / `2` / `3`   | N1 / N2 / N3                |
+| `R`               | REM                         |
+| `0` / `Backspace` | clear (un-score, stays put) |
+
+The stage **buttons** do the same with the mouse and also work outside stage
+focus (so the number keys stay free for [quick marks](#annotating) until you
+deliberately start a sweep). Re-scoring an epoch overwrites it; `Left`/`Right`
+page back and forth to fix one.
+
+**Reading the night.** Each scored epoch tints the traces a faint stage colour,
+the big readout names the current epoch's stage, and a **hypnogram overview
+strip** under the traces shows the whole night as a colour staircase — click it
+to jump anywhere. The status bar counts scored / total epochs.
+
+**Scoring manual.** AASM (W/N1/N2/N3/R) is the default; switch the **Manual**
+dropdown to **Rechtschaffen & Kales** (S1–S4 + a Movement-Time epoch) before you
+start — it locks once the first epoch is scored, and a resumed hypnogram reopens
+under the manual it was scored with. A sub-epoch **movement or artifact** isn't a
+stage under AASM; mark it as an [annotation](#annotating) over the epoch's stage
+instead (`Artifact` is a default quick mark).
+
+Each [rater](#multiple-raters) scores to their own `night1.stages.<id>.tsv`, so
+two scorers of one night produce two hypnograms to compare.
+
 ## Session log overlay
 
 Load the night's SMACC session [`.log`](reference/session-log.md) onto the

--- a/src/smacc/eeg/view.py
+++ b/src/smacc/eeg/view.py
@@ -30,7 +30,7 @@ from typing import Any, NamedTuple, Protocol
 
 import numpy as np
 import pyqtgraph as pg
-from PyQt6 import QtCore, QtGui
+from PyQt6 import QtCore, QtGui, QtWidgets
 
 from . import dsp
 from .annotations import Annotation
@@ -1174,3 +1174,87 @@ class TraceView(pg.PlotWidget):
             (self._epoch_anchor + k * self._epoch_seconds, str(k + 1))
             for k in range(first, last + 1)
         ]
+
+
+# Hypnogram overview strip (#182c): the height of the whole-night staircase and
+# the accent used for the current-window marker (the teal of the focus bracket).
+_STRIP_HEIGHT = 30
+_STRIP_MARKER_PEN = pg.mkPen((0, 150, 136), width=2)
+
+
+class HypnogramStrip(QtWidgets.QWidget):
+    """A whole-night hypnogram overview the operator scans and clicks to navigate.
+
+    A thin strip under the trace view: the full recording mapped to its width,
+    one stage-coloured cell per scored epoch, unscored gaps left blank, and a
+    bracket marking where the trace window currently sits. Clicking jumps the view
+    there. It is the at-a-glance map of a night's scoring — where the unscored gap
+    starts, where the REM bouts are — that scoring a long recording needs and the
+    per-window bands alone can't give. Pure ``QPainter``, no pyqtgraph: a few
+    hundred filled rects redraw far faster than that many scene items.
+    """
+
+    seekRequested = QtCore.pyqtSignal(float)  # data seconds to centre the view on
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.setFixedHeight(_STRIP_HEIGHT)
+        self.setStatusTip("Hypnogram overview — click to jump the view there.")
+        self._duration = 0.0
+        self._epochs: list[StageEpoch] = []
+        self._colors: dict[str, tuple[int, int, int]] = {}
+        self._window_start = 0.0
+        self._window_seconds = 30.0
+
+    def set_data(
+        self,
+        duration: float,
+        epochs: list[StageEpoch],
+        colors: dict[str, tuple[int, int, int]],
+    ) -> None:
+        """Replace the recording length, scored epochs, and per-stage colours."""
+        self._duration = max(0.0, duration)
+        self._epochs = list(epochs)
+        self._colors = dict(colors)
+        self.update()
+
+    def set_window(self, start: float, seconds: float) -> None:
+        """Move the current-window marker to ``[start, start + seconds)``."""
+        self._window_start = start
+        self._window_seconds = seconds
+        self.update()
+
+    def _x(self, seconds: float) -> float:
+        return seconds / self._duration * self.width()
+
+    def paintEvent(self, event: QtGui.QPaintEvent | None) -> None:
+        painter = QtGui.QPainter(self)
+        base = self.palette().color(QtGui.QPalette.ColorRole.Base)
+        painter.fillRect(self.rect(), base)
+        if self._duration <= 0 or self.width() <= 0:
+            return
+        height = self.height()
+        for epoch in self._epochs:
+            color = self._colors.get(epoch.stage)
+            if color is None:  # a token with no colour (foreign vocab) draws nothing
+                continue
+            red, green, blue = color
+            left = self._x(epoch.onset)
+            width = max(1.0, self._x(epoch.onset + epoch.duration) - left)
+            painter.fillRect(
+                QtCore.QRectF(left, 0.0, width, float(height)),
+                QtGui.QColor(red, green, blue),
+            )
+        # The current trace window, as a bracket the eye tracks while paging.
+        left = self._x(self._window_start)
+        width = max(2.0, self._x(self._window_start + self._window_seconds) - left)
+        painter.setPen(_STRIP_MARKER_PEN)
+        painter.setBrush(QtCore.Qt.BrushStyle.NoBrush)
+        painter.drawRect(QtCore.QRectF(left, 1.0, width, float(height - 2)))
+
+    def mousePressEvent(self, event: QtGui.QMouseEvent | None) -> None:
+        if event is None or self._duration <= 0 or self.width() <= 0:
+            return
+        fraction = event.position().x() / self.width()
+        seconds = max(0.0, min(self._duration, fraction * self._duration))
+        self.seekRequested.emit(seconds)

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -66,6 +66,7 @@ from .staging import (
 from .view import (
     DEFAULT_EPOCH_SECONDS,
     OVERLAY_COLORS,
+    HypnogramStrip,
     LogMark,
     RaterOverlay,
     TraceView,
@@ -894,6 +895,12 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self.scrollBar.setStatusTip("Scroll through the recording.")
         self.scrollBar.valueChanged.connect(self._on_scrollbar)
         viewColumn.addWidget(self.scrollBar)
+        # Hypnogram overview strip (#182c): the whole-night staircase, shown only
+        # once staging is in play (hidden for pure annotation work). Click to jump.
+        self.hypnogramStrip = HypnogramStrip()
+        self.hypnogramStrip.seekRequested.connect(self._on_strip_seek)
+        self.hypnogramStrip.setVisible(False)
+        viewColumn.addWidget(self.hypnogramStrip)
         body.addLayout(viewColumn, 1)
         body.addLayout(self._build_annotation_panel())
         layout.addLayout(body, 1)
@@ -1560,10 +1567,30 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         self._refresh_title()
 
     def _refresh_staging(self) -> None:
-        """Repaint the whole staging overlay (bands, focus, buttons, readout)."""
+        """Repaint the whole staging overlay (bands, focus, buttons, readout, strip)."""
         self.view.set_hypnogram(self._stage_epochs, self._vocab.colors)
         self.view.set_stage_focus(self._staging)
-        self._update_stage_ui()
+        self._update_stage_ui()  # also refreshes the overview strip
+
+    def _refresh_strip(self) -> None:
+        """Feed the hypnogram overview strip cells, shown only when staging is in play.
+
+        The window marker is moved separately by :meth:`_update_epoch_readout` on
+        every scroll; this rebuilds the cells (after a score) and toggles
+        visibility, which only matters when the scored set or recording changes.
+        """
+        duration = self._recording.duration if self._recording is not None else 0.0
+        self.hypnogramStrip.set_data(duration, self._stage_epochs, self._vocab.colors)
+        self.hypnogramStrip.setVisible(
+            self._recording is not None and (self._staging or bool(self._stage_epochs))
+        )
+
+    def _on_strip_seek(self, seconds: float) -> None:
+        """Jump the view so the clicked epoch is framed at the left edge."""
+        onset, _ = staging.epoch_bounds(
+            self.view.epoch_anchor, self.view.epoch_seconds, seconds
+        )
+        self._jump_to(max(0.0, onset))
 
     def _update_stage_ui(self) -> None:
         """Refresh the stage buttons, the progress counter, and the epoch readout."""
@@ -1583,6 +1610,7 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         else:
             self.stageProgressLabel.clear()
         self._update_epoch_readout()
+        self._refresh_strip()
 
     def _refresh_stage_focus_chip(self) -> None:
         """Show/hide the 'STAGE FOCUS' status chip in the active stage colour-neutral tint."""
@@ -2899,6 +2927,9 @@ class EegReviewWindow(QtWidgets.QMainWindow):
         """Show the epoch number (and its scored stage) at the left edge of the view."""
         # Drive off the provider, not the recording, so the readout matches the
         # epoch grid (which a standalone log timeline also draws).
+        # The overview strip's window marker tracks every scroll (wheel/scrollbar/
+        # jump all route through here), cheaply — it only repaints the strip.
+        self.hypnogramStrip.set_window(self.view.window_start, self.view.window_seconds)
         if not self.view.has_provider:
             self.epochLabel.clear()
             self.stageReadout.clear()

--- a/tests/test_eeg_view.py
+++ b/tests/test_eeg_view.py
@@ -17,7 +17,13 @@ from PyQt6 import QtCore, QtGui
 from smacc.eeg import dsp
 from smacc.eeg.annotations import Annotation
 from smacc.eeg.staging import StageEpoch
-from smacc.eeg.view import DEFAULT_TYPE_SCALES, RaterOverlay, TimeAxis, TraceView
+from smacc.eeg.view import (
+    DEFAULT_TYPE_SCALES,
+    HypnogramStrip,
+    RaterOverlay,
+    TimeAxis,
+    TraceView,
+)
 
 SFREQ = 100.0
 DURATION = 60.0
@@ -843,3 +849,46 @@ def test_new_provider_drops_the_previous_hypnogram(loaded):
     view.set_provider(FakeProvider())  # a different recording
     assert view._stage_epochs == []
     assert view._stage_band_items == []
+
+
+# ----- hypnogram overview strip (#182c) --------------------------------------
+
+
+def _press(x, width=600.0):
+    return QtGui.QMouseEvent(
+        QtCore.QEvent.Type.MouseButtonPress,
+        QtCore.QPointF(x, 15.0),
+        QtCore.Qt.MouseButton.LeftButton,
+        QtCore.Qt.MouseButton.LeftButton,
+        QtCore.Qt.KeyboardModifier.NoModifier,
+    )
+
+
+def test_strip_click_emits_a_seek_at_the_clicked_time(qtbot):
+    strip = HypnogramStrip()
+    qtbot.addWidget(strip)
+    strip.resize(600, 30)
+    strip.set_data(600.0, [], {})
+    captured: list[float] = []
+    strip.seekRequested.connect(captured.append)
+    strip.mousePressEvent(_press(300.0))  # half width → half the recording
+    assert captured == [pytest.approx(300.0)]
+
+
+def test_strip_ignores_clicks_with_no_recording(qtbot):
+    strip = HypnogramStrip()
+    qtbot.addWidget(strip)
+    strip.resize(600, 30)
+    captured: list[float] = []
+    strip.seekRequested.connect(captured.append)
+    strip.mousePressEvent(_press(300.0))  # duration is 0 → no seek
+    assert captured == []
+
+
+def test_strip_paints_without_crashing(qtbot):
+    strip = HypnogramStrip()
+    qtbot.addWidget(strip)
+    strip.resize(600, 30)
+    strip.set_data(600.0, [StageEpoch(0.0, 30.0, "N2")], {"N2": (74, 144, 200)})
+    strip.set_window(30.0, 30.0)
+    strip.repaint()  # exercise paintEvent (cells + window marker)

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -2219,3 +2219,29 @@ def test_opening_another_recording_drops_a_discarded_stage_autosave(
 def test_progress_total_counts_only_full_epochs(stage_window):
     # 600 s / 30 s = 20 full epochs; the counter must be able to reach 20/20.
     assert "/20 scored" in stage_window.stageProgressLabel.text()
+
+
+# ----- hypnogram overview strip (#182c) ------------------------------------------
+
+
+def test_strip_is_hidden_until_staging_or_scored(stage_window):
+    assert stage_window.hypnogramStrip.isHidden()  # loaded, nothing scored, not staging
+    stage_window._score_current_epoch("N2")
+    assert not stage_window.hypnogramStrip.isHidden()  # a scored epoch reveals it
+
+
+def test_entering_staging_shows_the_strip(stage_window):
+    assert stage_window.hypnogramStrip.isHidden()
+    stage_window._set_staging(True)
+    assert not stage_window.hypnogramStrip.isHidden()
+
+
+def test_strip_seek_frames_the_clicked_epoch(stage_window):
+    stage_window.hypnogramStrip.seekRequested.emit(95.0)  # epoch [90, 120)
+    assert stage_window.view.window_start == pytest.approx(90.0)
+
+
+def test_strip_tracks_the_window_on_scroll(stage_window):
+    stage_window._score_current_epoch("N2")  # reveal the strip
+    stage_window._jump_to(120.0)
+    assert stage_window.hypnogramStrip._window_start == pytest.approx(120.0)


### PR DESCRIPTION
Third of three stacked PRs (#182). Stacked on #224. Closes #182.

- **Hypnogram overview strip** — a thin whole-night staircase under the traces: one stage-coloured cell per scored epoch, a bracket marking the current window, click to jump anywhere. Pure `QPainter` (a few hundred rects redraw far faster than scene items). Shown only once staging is in play, so it stays out of the way for pure annotation work.
- **Docs** — a "Sleep staging" section in `docs/eeg-review.md` (the keys, stage focus, the manuals, where movement/artifact goes).

Tests in `tests/test_eeg_view.py` and `tests/test_eeg_window.py`.