### PR TITLE
fix: bundle matplotlib's PDF/SVG backends in the EEG annotator exe

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -85,10 +85,15 @@ jobs:
       # the exe builds fine and dies on first MNE use). matplotlib must ship
       # even though the viewer renders with pyqtgraph: MNE's IO layer
       # transitively imports mne.viz.ui_events (-> matplotlib) at import time,
-      # so excluding it kills read_raw_*. The --selftest smoke below proves
-      # all of this end to end.
+      # so excluding it kills read_raw_*. Figure export (#180) additionally
+      # writes PDF/SVG, whose matplotlib backends are imported by name at
+      # savefig time — invisible to static analysis, exactly like MNE's lazy
+      # submodules — so collect matplotlib.backends too (without it PDF/SVG
+      # export raises ModuleNotFoundError; PNG/Agg is already pulled in via the
+      # explicit canvas import). The --selftest smoke below proves all of this
+      # end to end.
       - name: Build SMACC-EEG.exe
-        run: uv run pyinstaller entry_eeg.py --name SMACC-EEG --onefile --noconsole --icon src/smacc/assets/icon.ico --version-file version_info_eeg.txt --add-data "src/smacc/assets/icon.png;smacc/assets" --collect-submodules mne --collect-data mne
+        run: uv run pyinstaller entry_eeg.py --name SMACC-EEG --onefile --noconsole --icon src/smacc/assets/icon.ico --version-file version_info_eeg.txt --add-data "src/smacc/assets/icon.png;smacc/assets" --collect-submodules mne --collect-data mne --collect-submodules matplotlib.backends
       # A broken bundle (missing data file, import error) otherwise ships silently:
       # the exes are windowed (--noconsole), so PowerShell won't wait for them on
       # their own and there is no stdout — Start-Process -Wait + the exit code is

--- a/src/smacc/eeg/__main__.py
+++ b/src/smacc/eeg/__main__.py
@@ -18,6 +18,7 @@ the check is the exit code, not the output.
 from __future__ import annotations
 
 import sys
+import traceback
 
 from PyQt6.QtWidgets import QApplication
 
@@ -230,7 +231,16 @@ def main() -> None:
         print(f"SMACC EEG review v{VERSION}")
         sys.exit(0)
     if "--selftest" in sys.argv:
-        sys.exit(selftest())
+        # A windowed (--noconsole) build pops a *blocking* "Failed to execute
+        # script" dialog on an unhandled exception, which hangs a headless CI
+        # runner until the smoke-test timeout instead of failing fast. Catch
+        # everything and exit non-zero so a broken bundle (a missing lazy
+        # submodule, a dropped data file) surfaces as an error, not a 300s hang.
+        try:
+            sys.exit(selftest())
+        except Exception:
+            traceback.print_exc()
+            sys.exit(1)
     app = QApplication(sys.argv)
     app.setApplicationName("SMACC EEG review")
     window = EegReviewWindow(


### PR DESCRIPTION
## The bug

The frozen `SMACC-EEG.exe` **cannot export figures to PDF or SVG** — it raises `ModuleNotFoundError: No module named 'matplotlib.backends.backend_pdf'`. matplotlib loads a format's backend dynamically at `savefig` time (`import_module("matplotlib.backends.backend_pdf")`), which PyInstaller's static analysis never sees, so those backends were never bundled. PNG works only because the export path imports its Agg canvas explicitly.

This is a real user-facing bug: *Export figure → PDF/SVG* in the shipped EEG annotator crashes. It exists on `main` today.

## Why it went unnoticed

The release smoke-test build (`build-exe`) only runs on PRs that touch packaging files, so it hadn't run since figure export (#180) added PDF/SVG rendering to the EEG exe's `--selftest` round-trip. It surfaced on the first packaging PR since then.

## The fix

- Collect `matplotlib.backends` in the `SMACC-EEG.exe` PyInstaller build — the same explicit-collection treatment MNE's lazy submodules already get. Verified on a local onefile build: the frozen `--selftest` now passes end-to-end (it exercises PNG/PDF/SVG).
- Make `--selftest` fail loudly. A `--noconsole` build pops a *blocking* "Failed to execute script" dialog on an unhandled exception, which hangs a headless runner until the 300s smoke-test timeout — presenting a crash as a mysterious timeout. The selftest now catches and exits non-zero, so a broken bundle is a fast, clear failure.

## Verification

`build-exe` in this PR rebuilds the EEG exe with the flag and runs `--selftest`, validating the fix in CI. Local checks (ruff, mypy, from-source selftest, entry-point tests) are green.