### PR TITLE
fix: drop invalid codecov 'name' field that voided the whole config

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -11,13 +11,11 @@ coverage:
   status:
     project:
       default:
-        name: codecov/project
         # SMACC is a GUI-heavy desktop app where some glue is hard to cover
         # headlessly, so 60% is a floor to ratchet up over time, not a ceiling.
         target: 60%
         threshold: 1% # tolerate a 1% dip before the check fails (anti-flap)
     patch:
       default:
-        name: codecov/patch
         target: 60% # ~60% of the lines a PR changes should be covered
         informational: true # patch result is visible but never blocks a merge


### PR DESCRIPTION
## Symptom

`codecov/patch` blocks PRs despite `informational: true`, and Codecov still posts PR comments despite `comment: false` (added in #214).

## Cause

`name` is **not a valid field** under `coverage.status.*.default`. Codecov's validator rejects it:

```
Error at ['coverage', 'status', 'patch', 'default', 'name']: unknown field
```

A single unknown field makes Codecov reject the **entire** `codecov.yaml` and fall back to its **defaults** — which post comments and treat `codecov/patch` as a blocking status. So both `comment: false` *and* `informational: true` were being ignored. The `name` lines were introduced by #214 (alongside `comment: false`), which is why disabling comments never took effect.

## Fix

Remove the two `name:` lines. They were redundant anyway — the `default` key already produces exactly the `codecov/project` and `codecov/patch` contexts. The file now validates clean:

```
$ curl --data-binary @codecov.yaml https://codecov.io/validate
Valid!
```

and the parsed result keeps `comment: false` and `patch.default.informational: true`. After this merges, PRs based on it should stop getting comments and `codecov/patch` becomes non-blocking.