### PR TITLE
ci: bump actions/upload-artifact to v7 (Node 24 runtime)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -175,7 +175,7 @@ jobs:
       # verification run's exes/installer can be downloaded and inspected
       # without publishing anything.
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: smacc-build-${{ env.VERSION }}
           path: |


### PR DESCRIPTION
## Why

The Release workflow logs a deprecation warning:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 ...: `actions/upload-artifact@v4`. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026 ...

## Change

Bump the one Node 20 action in the workflow: `actions/upload-artifact@v4` → `@v7`.

- **`v5` is still Node 20** — `v6` was the first Node 24 major, so this goes to the current `v7` (Node 24) for the longest support runway.
- The `name` / `path` inputs this step uses are unchanged across v4–v7 (verified against `v7`'s `action.yml`).
- Every other action in `release.yaml` is already fine: `actions/checkout@v6` and `softprops/action-gh-release@v3` run on Node 24, and `astral-sh/setup-uv` is a composite action. The other workflows (`ci.yaml`, `docs.yaml`) have no Node 20 actions either (`codecov/codecov-action@v7` is composite).

This PR touches a packaging path, so the Release `build-exe` job runs and exercises the upgraded upload step end to end.