### PR TITLE
feat: redesign the launcher into a flat list of tools

### DIFF
--- a/src/smacc/__main__.py
+++ b/src/smacc/__main__.py
@@ -14,9 +14,9 @@ from PyQt6.QtCore import Qt, QTimer, QUrl
 from PyQt6.QtGui import QDesktopServices, QIcon
 from PyQt6.QtWidgets import QApplication, QMessageBox, QPushButton
 
-from . import crashlog, preferences
+from . import crashlog
 from .config import VERSION
-from .launcher import LauncherWindow, resolve_initial_settings
+from .launcher import LauncherWindow
 from .paths import (
     BUNDLED_CUES_DIR,
     BUNDLED_DEFAULT_SETTINGS,
@@ -24,7 +24,6 @@ from .paths import (
     DEFAULT_DATA_DIR,
     DEFAULT_SETTINGS_PATH,
     LOGO_PATH,
-    preferences_path,
 )
 from .utils import seed_default_settings, seed_demo_cues
 
@@ -257,20 +256,14 @@ def main() -> None:
     seed_demo_cues(DEFAULT_DATA_DIR / "cues", BUNDLED_CUES_DIR)
     file_arg = pick_settings_path(app.arguments())
     if file_arg:
-        # A double-clicked / CLI .smacc opens straight into a session for it;
-        # ending that session quits SMACC (see LauncherWindow._on_tool_closed).
-        # The launcher validates the file on construction (#186): an incompatible
-        # one is reported and rejected there, so show the launcher (with the
-        # built-in defaults selected) instead of starting a session it never
-        # asked for.
+        # A double-clicked / CLI .smacc opens straight into the Session dialog with
+        # that file preselected. The dialog validates it (#186); on Cancel or an
+        # incompatible file it falls back to showing the launcher, so we never leave
+        # no window. Ending the started session quits SMACC (see _on_tool_closed).
         launcher = LauncherWindow(file_arg)
-        if launcher.settings_path:
-            launcher.start_session()
-        else:
-            launcher.show()
+        launcher._open_session()
     else:
-        prefs = preferences.load_preferences(preferences_path)
-        launcher = LauncherWindow(resolve_initial_settings(prefs))
+        launcher = LauncherWindow()
         launcher.show()
     # Hidden QA hook: crash on purpose right after startup (see pick_crash_test).
     _schedule_crash_test(pick_crash_test(sys.argv[1:]))

--- a/src/smacc/dialogs.py
+++ b/src/smacc/dialogs.py
@@ -1,10 +1,12 @@
 """Dialogs shown by SMACC outside the main window."""
 
+from pathlib import Path
 from typing import cast
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from . import config, events, hue, surveys
+from . import config, events, hue, preferences, settings, surveys
+from .paths import DEFAULT_SETTINGS_PATH, preferences_path
 from .utils import normalize_survey_url
 
 
@@ -86,6 +88,254 @@ class SessionInfoDialog(QtWidgets.QDialog):
     def get_inputs(self) -> tuple[str, str, str]:
         """Return the edited subject, session, and notes as strings."""
         return self.subject_id.text(), self.session_id.text(), self.notes.text()
+
+
+# ----- SMACC-file selection (launcher Session… / Editor… dialogs) ------------
+
+# Item-data sentinels for the file combo's non-path entries (vs. a path string).
+_BROWSE_SENTINEL = "\x00browse"
+_NEW_SENTINEL = "\x00new"
+
+
+def load_recent_settings() -> list[str]:
+    """The persisted recent-SMACC-file list (paths, most-recent first)."""
+    prefs = preferences.load_preferences(preferences_path)
+    return [r for r in prefs.get("recent_settings", []) if isinstance(r, str)]
+
+
+def remember_settings(path: str) -> None:
+    """Push ``path`` onto the persisted recent-settings list (most-recent first)."""
+    recents = preferences.push_recent(load_recent_settings(), str(path))
+    preferences.update_preferences(preferences_path, {"recent_settings": recents})
+
+
+def forget_settings(path: str) -> None:
+    """Drop ``path`` from the persisted recent-settings list (it failed to load)."""
+    recents = [r for r in load_recent_settings() if r != str(path)]
+    preferences.update_preferences(preferences_path, {"recent_settings": recents})
+
+
+def validate_settings_file(path: str, parent=None) -> bool:
+    """True if ``path`` loads as a compatible SMACC file; report it otherwise (#186).
+
+    A file that fails is also dropped from recents, so a stale or corrupted entry
+    doesn't keep resurfacing in the picker.
+    """
+    try:
+        settings.load_settings(path)
+    except (OSError, ValueError) as exc:
+        forget_settings(path)
+        QtWidgets.QMessageBox.critical(
+            parent, "Open SMACC file", f"Could not open {Path(path).name}.\n\n{exc}"
+        )
+        return False
+    return True
+
+
+class SmaccFileCombo(QtWidgets.QComboBox):
+    """A dropdown for choosing a SMACC file: default / recents / Browse….
+
+    Encapsulates the validate-then-remember rule (#186): a file picked via
+    Browse… or a recent entry that no longer loads is reported and dropped, and
+    the selection reverts. ``fileChanged`` fires when the chosen file actually
+    changes. With ``allow_new=True`` a leading "New SMACC file" entry is offered
+    (its :meth:`chosen_path` is ``None``, distinguished by :meth:`is_new`).
+    Programmatic population never validates; only a user activation does, matching
+    the launcher's old combo.
+    """
+
+    fileChanged = QtCore.pyqtSignal()
+
+    def __init__(
+        self, preselect: str | None = None, allow_new: bool = False, parent=None
+    ):
+        super().__init__(parent)
+        self._allow_new = allow_new
+        self._path: str | None = None  # chosen .smacc, or None for built-in defaults
+        self._is_new = False
+        self.setStatusTip("Choose the SMACC file (or Browse… for one not listed).")
+        self.activated.connect(self._on_activated)
+        self._populate(preselect)
+
+    def chosen_path(self) -> str | None:
+        """The selected .smacc path, or ``None`` for built-in defaults / a new file."""
+        return self._path
+
+    def is_new(self) -> bool:
+        """True when the "New SMACC file" entry is selected (allow_new only)."""
+        return self._is_new
+
+    def _populate(self, target: str | None) -> None:
+        """Rebuild the list ([New], default, recents, Browse…) and select ``target``."""
+        default = str(DEFAULT_SETTINGS_PATH)
+        recents = load_recent_settings()
+        # A preselect that isn't a recent (e.g. a freshly double-clicked file) is
+        # offered too, so it can actually be selected rather than silently dropping
+        # to "default".
+        if (
+            target
+            and target != default
+            and target not in recents
+            and Path(target).is_file()
+        ):
+            recents = [target, *recents]
+        self.blockSignals(True)  # programmatic fill: don't fire activated
+        self.clear()
+        if self._allow_new:
+            self.addItem("New SMACC file", _NEW_SENTINEL)
+        self.addItem("default", default)
+        self.setItemData(
+            self.count() - 1, default, QtCore.Qt.ItemDataRole.ToolTipRole
+        )  # full path on hover
+        seen = {default}
+        for path in recents:
+            if path in seen:
+                continue
+            seen.add(path)
+            self.addItem(Path(path).stem, path)  # name only — no extension/path
+            self.setItemData(self.count() - 1, path, QtCore.Qt.ItemDataRole.ToolTipRole)
+        self.insertSeparator(self.count())
+        self.addItem("Browse…", _BROWSE_SENTINEL)
+        index = self.findData(target) if target else -1
+        if index < 0:
+            index = 0  # the first real entry (New if allowed, else default)
+        self.setCurrentIndex(index)
+        self._sync(self.currentIndex())
+        self.blockSignals(False)
+
+    def _sync(self, index: int) -> None:
+        """Set ``_path``/``_is_new`` from item ``index`` without validating."""
+        data = self.itemData(index)
+        if data == _NEW_SENTINEL:
+            self._is_new, self._path = True, None
+            return
+        self._is_new = False
+        # The "default" entry maps to the seeded default.smacc, or to built-in
+        # defaults (None) when that file is absent.
+        if data == str(DEFAULT_SETTINGS_PATH) and not Path(data).is_file():
+            self._path = None
+        else:
+            self._path = data
+
+    def _on_activated(self, index: int) -> None:
+        """User picked an entry: Browse… opens a dialog; others validate-then-set."""
+        data = self.itemData(index)
+        if data == _BROWSE_SENTINEL:
+            self._browse()
+            return
+        if data == _NEW_SENTINEL:
+            self._sync(index)
+            self.fileChanged.emit()
+            return
+        # The "default" entry maps to the seeded default.smacc, or to built-in
+        # defaults (None) when it is absent — never an error.
+        if data == str(DEFAULT_SETTINGS_PATH) and not Path(data).is_file():
+            self._sync(index)
+            self.fileChanged.emit()
+            return
+        if not Path(data).is_file():  # a recent that has since disappeared
+            QtWidgets.QMessageBox.warning(
+                self, "SMACC file", "That settings file no longer exists."
+            )
+            forget_settings(data)
+            self._populate(self._path)
+            return
+        if not validate_settings_file(data, self):  # exists but no longer loads
+            self._populate(self._path)  # revert to the last good selection
+            return
+        self._path, self._is_new = data, False
+        self.fileChanged.emit()
+
+    def _browse(self) -> None:
+        """Pick a .smacc not already listed; validate-then-remember, else revert."""
+        start = self._path or str(DEFAULT_SETTINGS_PATH)
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Open SMACC file", start, "SMACC file (*.smacc)"
+        )
+        if not path:
+            self._populate(self._path)  # cancelled: keep the previous selection
+            return
+        if not validate_settings_file(path, self):
+            self._populate(self._path)
+            return
+        remember_settings(path)
+        self._path, self._is_new = path, False
+        self._populate(path)
+        self.fileChanged.emit()
+
+
+class StartSessionDialog(SessionInfoDialog):
+    """Pick a SMACC file and confirm subject/session/notes, then start a session.
+
+    The launcher's "Session…" entry. A SMACC-file row (default / recents /
+    Browse…, preselected from the last-used file) sits above the optional
+    metadata fields inherited from :class:`SessionInfoDialog` (#184). Choosing a
+    file (re)prefills the metadata from that file's stored values — clearing a
+    field afterwards sticks, since the launcher does not re-merge the file's
+    values. :meth:`chosen_path` is the selected file; :meth:`get_inputs` is the
+    metadata, exactly as for a plain session-info prompt.
+    """
+
+    def __init__(self, preselect: str | None = None, parent=None):
+        super().__init__(parent=parent)
+        self.setWindowTitle("Start a session")
+        self.fileCombo = SmaccFileCombo(preselect=preselect, parent=self)
+        form = cast(QtWidgets.QFormLayout, self.layout())
+        form.insertRow(0, "SMACC file", self.fileCombo)
+        self.fileCombo.fileChanged.connect(self._prefill_from_file)
+        self._prefill_from_file()
+
+    def chosen_path(self) -> str | None:
+        """The selected .smacc file (``None`` = built-in defaults)."""
+        return self.fileCombo.chosen_path()
+
+    def _prefill_from_file(self) -> None:
+        """Fill subject/session/notes from the selected file's stored metadata."""
+        stored: dict = {}
+        path = self.fileCombo.chosen_path()
+        if path:
+            try:
+                _, stored = settings.load_settings(path)
+            except (OSError, ValueError):
+                stored = {}  # an unloadable file is reported by the combo's validation
+        self.subject_id.setText(str(stored.get("subject") or ""))
+        self.session_id.setText(str(stored.get("session") or ""))
+        self.notes.setText(str(stored.get("notes") or ""))
+
+
+class EditorFileDialog(QtWidgets.QDialog):
+    """Pick a SMACC file to edit, or start a new one — the launcher's "Editor…" entry.
+
+    Offers "New SMACC file" plus the default / recents / Browse… picker.
+    :meth:`is_new` is True for a fresh file (then :meth:`chosen_path` is ``None``);
+    otherwise :meth:`chosen_path` is the file to open in the Editor.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Open in the Editor")
+        self.setWindowFlags(
+            self.windowFlags() ^ QtCore.Qt.WindowType.WindowContextHelpButtonHint
+        )
+        self.fileCombo = SmaccFileCombo(allow_new=True, parent=self)
+        buttonBox = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel,
+            self,
+        )
+        buttonBox.accepted.connect(self.accept)
+        buttonBox.rejected.connect(self.reject)
+        layout = QtWidgets.QFormLayout(self)
+        layout.addRow("SMACC file", self.fileCombo)
+        layout.addWidget(buttonBox)
+
+    def chosen_path(self) -> str | None:
+        """The file to edit (``None`` for a new file or absent built-in defaults)."""
+        return self.fileCombo.chosen_path()
+
+    def is_new(self) -> bool:
+        """True when "New SMACC file" is selected."""
+        return self.fileCombo.is_new()
 
 
 class SurveyDialog(QtWidgets.QDialog):

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -1,11 +1,11 @@
-"""The SMACC Launcher: pick a SMACC file and choose what to do.
+"""The SMACC Launcher: a flat list of tools to open.
 
-This is the FSL-style opening menu. Instead of dropping straight into a session,
-SMACC opens this small window so the operator first picks (or creates) a **SMACC
-file** (`.smacc`), then chooses to **Start**, **Create**, or **Edit** (or analyze
-a past run). Each SMACC file names the **data directory** its runs are written
-to; with none chosen, SMACC uses built-in defaults and the default data
-directory.
+SMACC opens this small window first rather than dropping straight into a session.
+It is a list of the SMACC tools — **Session**, **Editor**, **Analyzer**, **Audio
+Cue Designer**, and **EEG Annotator**. Choosing a SMACC file (`.smacc`) is not done
+up front: the Session and Editor entries each prompt for one when opened (a file
+names the **data directory** its runs are written to), since the other tools don't
+need a file.
 
 The launcher is the app's persistent root window: opening a tool hides it, and
 closing the tool brings it back (via the tool's ``closed`` signal) — except a live
@@ -19,18 +19,14 @@ from pathlib import Path
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from . import eeg, preferences, settings, updates, winassoc, windowstate
+from . import dialogs, eeg, preferences, settings, updates, winassoc, windowstate
 from .analyze import AnalyzeWindow
 from .config import VERSION
 from .cuedesigner import CueDesignerWindow
-from .dialogs import SessionInfoDialog
 from .gui import SmaccWindow
 from .paths import DEFAULT_DATA_DIR, DEFAULT_SETTINGS_PATH, LOGO_PATH, preferences_path
 from .session import SmaccSession
 from .toolwindow import ToolWindow
-
-# Sentinel item-data for the Settings dropdown's "Browse…" entry (vs. a path str).
-_BROWSE_SENTINEL = "\x00browse"
 
 # Stable id for the launcher's geometry entry in the per-window preferences map.
 _LAUNCHER_WINDOW_ID = "launcher"
@@ -51,36 +47,18 @@ def resolve_initial_settings(prefs: dict) -> str | None:
 
 
 class LauncherWindow(QtWidgets.QMainWindow):
-    """Small hub: pick a SMACC file, then start / create / edit / analyze."""
+    """Small hub: a button per SMACC tool (Session / Editor / Analyzer / …)."""
 
-    def __init__(self, settings_path: str | None) -> None:
+    def __init__(self, settings_path: str | None = None) -> None:
         super().__init__()
-        self._settings_path: str | None = None  # current .smacc, or None for defaults
         self._tool: ToolWindow | None = None
+        # A .smacc given at launch (a double-clicked file) preselects the Session
+        # dialog the first time it opens; it is consumed there, then None.
+        self._launch_file = settings_path
         self.setWindowTitle("SMACC")
         if LOGO_PATH.is_file():
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
         self._build()
-        # A file given at launch (double-clicked .smacc, or the last-used one) must
-        # load before it becomes the selection — an incompatible file is reported
-        # and stays out of recents (#186), leaving the built-in defaults selected.
-        if settings_path:
-            self._set_settings(settings_path)
-        else:
-            self._populate_settings_combo()
-
-    @property
-    def settings_path(self) -> str | None:
-        """The currently selected .smacc file (None = SMACC's built-in defaults)."""
-        return self._settings_path
-
-    # ----- current-settings helpers ----------------------------------------
-
-    def _data_dir(self) -> Path:
-        """The data directory of the current settings file (default when none)."""
-        if self._settings_path:
-            return settings.load_data_directory(self._settings_path, DEFAULT_DATA_DIR)
-        return DEFAULT_DATA_DIR
 
     # ----- UI construction --------------------------------------------------
 
@@ -108,49 +86,54 @@ class LauncherWindow(QtWidgets.QMainWindow):
         title.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(title)
 
-        # One row to choose the settings, then Start / Edit / New acting on it.
-        layout.addLayout(self._build_settings_row())
-        layout.addLayout(self._build_action_row())
+        # One button per tool. Session and Editor prompt for a SMACC file when
+        # opened (the trailing "…" signals that); the rest open straight away.
+        def tool_button(label: str, tip: str, slot) -> QtWidgets.QPushButton:
+            button = QtWidgets.QPushButton(label, self)
+            button.setMinimumHeight(44)
+            button.setStatusTip(tip)
+            button.clicked.connect(slot)
+            layout.addWidget(button)
+            return button
 
-        # Standalone tools that don't act on the selected settings: design a cue
-        # WAV, or analyze a past session. Each opens from here and returns on close.
-        layout.addSpacing(8)
-        designButton = QtWidgets.QPushButton("Audio Cue Designer", self)
-        designButton.setMinimumHeight(40)
-        designButton.setStatusTip("Create a tone cue and export it as a WAV file.")
-        designButton.clicked.connect(self.design_cues)
-        layout.addWidget(designButton)
-
-        analyzeButton = QtWidgets.QPushButton("Analyzer", self)
-        analyzeButton.setMinimumHeight(40)
-        analyzeButton.setStatusTip(
-            "Summarize a past session, export its events, or recover its settings."
+        tool_button(
+            "Session…",
+            "Start a session: choose a SMACC file, confirm the subject/session.",
+            self._open_session,
         )
-        analyzeButton.clicked.connect(self.analyze_session)
-        layout.addWidget(analyzeButton)
-
-        # The optional EEG Annotator component (#136). Shown disabled (not
-        # hidden) when absent, so a lab knows the tool exists and how to get
-        # it — the same surface-don't-hide approach as missing trigger
-        # hardware (#147). Availability is probed once, here: installing the
-        # component mid-run requires closing SMACC anyway (the installer
-        # replaces the locked exe), and a stale True is already handled by
-        # the launch-failure dialog.
-        reviewEegButton = QtWidgets.QPushButton("EEG Annotator", self)
-        reviewEegButton.setMinimumHeight(40)
-        if eeg.available():
-            reviewEegButton.setStatusTip(
-                "Open the EEG Annotator in its own window (annotate a recording)."
-            )
-        else:
-            reviewEegButton.setEnabled(False)
-            reviewEegButton.setStatusTip(
+        tool_button(
+            "Editor…",
+            "Create a new SMACC file or edit an existing one.",
+            self._open_editor,
+        )
+        layout.addSpacing(8)  # group the file-acting tools above the rest
+        tool_button(
+            "Analyzer",
+            "Summarize a past session, export its events, or recover its settings.",
+            self.analyze_session,
+        )
+        tool_button(
+            "Audio Cue Designer",
+            "Create a tone cue and export it as a WAV file.",
+            self.design_cues,
+        )
+        # The optional EEG Annotator component (#136). Shown disabled (not hidden)
+        # when absent, so a lab knows the tool exists and how to get it — the same
+        # surface-don't-hide approach as missing trigger hardware (#147).
+        # Availability is probed once, here: installing the component mid-run
+        # requires closing SMACC anyway (the installer replaces the locked exe),
+        # and a stale True is already handled by the launch-failure dialog.
+        self.reviewEegButton = tool_button(
+            "EEG Annotator",
+            "Open the EEG Annotator in its own window (annotate a recording).",
+            self.review_eeg,
+        )
+        if not eeg.available():
+            self.reviewEegButton.setEnabled(False)
+            self.reviewEegButton.setStatusTip(
                 "The EEG Annotator is not installed — re-run the SMACC "
                 "installer and select the component."
             )
-        reviewEegButton.clicked.connect(self.review_eeg)
-        self.reviewEegButton = reviewEegButton
-        layout.addWidget(reviewEegButton)
 
         layout.addStretch(1)
         # Link to the documentation site (not the repo), hyperlinked. Rich text +
@@ -236,218 +219,64 @@ class LauncherWindow(QtWidgets.QMainWindow):
         quitAction.setStatusTip("Quit SMACC.")
         quitAction.triggered.connect(self.close)
 
-    def _build_settings_row(self) -> QtWidgets.QLayout:
-        """One row: 'SMACC file:' + a dropdown of default / recents / Browse…."""
-        row = QtWidgets.QHBoxLayout()
-        row.addWidget(QtWidgets.QLabel("SMACC file:", self))
-        self.settingsCombo = QtWidgets.QComboBox(self)
-        self.settingsCombo.setStatusTip(
-            "Choose the SMACC file to start, edit, or analyze."
-        )
-        self.settingsCombo.activated.connect(self._on_settings_selected)
-        row.addWidget(self.settingsCombo, 1)
-        return row
-
-    def _build_action_row(self) -> QtWidgets.QLayout:
-        """Three buttons acting on the selected SMACC file: Start / Create / Edit."""
-        row = QtWidgets.QHBoxLayout()
-        for label, slot, tip in (
-            (
-                "Start",
-                self.start_session,
-                "Start a session with the selected SMACC file.",
-            ),
-            ("Create", self.create_settings, "Create a new SMACC file."),
-            ("Edit", self.edit_settings, "Edit the selected SMACC file."),
-        ):
-            button = QtWidgets.QPushButton(label, self)
-            button.setMinimumHeight(44)
-            button.setStatusTip(tip)
-            button.clicked.connect(slot)
-            row.addWidget(button)
-        return row
-
-    # ----- settings selection ----------------------------------------------
-
-    def _populate_settings_combo(self) -> None:
-        """Fill the Settings dropdown: 'default', recents (no .smacc/path), Browse…."""
-        prefs = preferences.load_preferences(preferences_path)
-        recents = [r for r in prefs.get("recent_settings", []) if isinstance(r, str)]
-        default = str(DEFAULT_SETTINGS_PATH)
-        combo = self.settingsCombo
-        combo.blockSignals(True)  # programmatic fill: don't fire activated
-        combo.clear()
-        combo.addItem("default", default)
-        combo.setItemData(
-            0, default, QtCore.Qt.ItemDataRole.ToolTipRole
-        )  # full path on hover
-        seen = {default}
-        for path in recents:
-            if path in seen:
-                continue
-            seen.add(path)
-            combo.addItem(Path(path).stem, path)  # name only — no extension/path
-            combo.setItemData(
-                combo.count() - 1, path, QtCore.Qt.ItemDataRole.ToolTipRole
-            )
-        combo.insertSeparator(combo.count())
-        combo.addItem("Browse…", _BROWSE_SENTINEL)
-        target = self._settings_path or default
-        index = combo.findData(target)
-        combo.setCurrentIndex(index if index >= 0 else 0)
-        combo.blockSignals(False)
-
-    def _on_settings_selected(self, index: int) -> None:
-        data = self.settingsCombo.itemData(index)
-        if data == _BROWSE_SENTINEL:
-            self.open_settings()  # may set a new file; re-sync the dropdown either way
-            self._populate_settings_combo()
-            return
-        if not data:
-            return
-        if not Path(data).is_file():
-            if data == str(DEFAULT_SETTINGS_PATH):
-                self._set_settings(None)  # default absent → SMACC's built-in defaults
-            else:
-                QtWidgets.QMessageBox.warning(
-                    self, "Settings", "That settings file no longer exists."
-                )
-                self._populate_settings_combo()
-            return
-        self._set_settings(data)
-
-    def _set_settings(self, path: str | None) -> None:
-        """Make ``path`` the current SMACC file — only if it actually loads (#186).
-
-        An incompatible file is reported and the previous selection stays; only a
-        successfully loading file is remembered in recents.
-        """
-        if path is not None and not self._check_loadable(path):
-            self._populate_settings_combo()  # re-sync the dropdown to the selection
-            return
-        self._settings_path = path
-        if path:
-            self._remember(path)
-        self._populate_settings_combo()
-
-    def _check_loadable(self, path: str) -> bool:
-        """True if ``path`` loads as a compatible SMACC file; report it otherwise.
-
-        A file that fails is also dropped from recents, so a stale or corrupted
-        entry doesn't keep resurfacing in the dropdown.
-        """
-        try:
-            settings.load_settings(path)
-        except (OSError, ValueError) as exc:
-            self._forget(path)
-            QtWidgets.QMessageBox.critical(
-                self,
-                "Open SMACC file",
-                f"Could not open {Path(path).name}.\n\n{exc}",
-            )
-            return False
-        return True
-
-    def _remember(self, path: str) -> None:
-        """Push ``path`` onto the persisted recent-settings list (most-recent first)."""
-        prefs = preferences.load_preferences(preferences_path)
-        recents = [r for r in prefs.get("recent_settings", []) if isinstance(r, str)]
-        recents = preferences.push_recent(recents, str(path))
-        preferences.update_preferences(preferences_path, {"recent_settings": recents})
-
-    def _forget(self, path: str) -> None:
-        """Drop ``path`` from the persisted recent-settings list (it failed to load)."""
-        prefs = preferences.load_preferences(preferences_path)
-        recents = [
-            r
-            for r in prefs.get("recent_settings", [])
-            if isinstance(r, str) and r != str(path)
-        ]
-        preferences.update_preferences(preferences_path, {"recent_settings": recents})
-
-    def open_settings(self) -> None:
-        """Browse for a .smacc not already in the dropdown and make it current."""
-        path, _ = QtWidgets.QFileDialog.getOpenFileName(
-            self,
-            "Open SMACC file",
-            str(self._data_dir()),
-            "SMACC file (*.smacc)",
-        )
-        if path:
-            self._set_settings(path)
-
     # ----- actions ----------------------------------------------------------
 
-    def start_session(self) -> None:
-        """Run a session using the current settings (writing to its data directory)."""
-        # Re-check right before committing: the file may have changed on disk since
-        # it was selected, and an incompatible file must never get a session window.
-        if self._settings_path and not self._check_loadable(self._settings_path):
-            self._set_settings(None)  # fall back to the built-in defaults
-            self.show()  # the double-click flow starts before the launcher is shown
+    def _open_session(self) -> None:
+        """Choose a SMACC file + metadata, then start a session in its data dir.
+
+        Opened from "Session…" (and from a double-clicked .smacc, which preselects
+        that file the first time). Cancel backs out — and, since the double-click
+        flow runs before the launcher is shown, brings the launcher up rather than
+        leaving no window. The chosen file is re-checked before committing (#186):
+        it may have changed on disk since the dialog selected it.
+        """
+        preselect = self._launch_file or resolve_initial_settings(
+            preferences.load_preferences(preferences_path)
+        )
+        self._launch_file = None  # a launch file preselects only the first time
+        dialog = dialogs.StartSessionDialog(preselect=preselect, parent=self)
+        if not dialog.exec():
+            self.show()
             return
-        # Capture subject/session/notes before the session window opens (#184):
-        # metadata not entered at the start is usually lost. The fields stay
-        # optional — OK with blanks is a conscious skip — but Cancel backs out
-        # of starting the session at all.
-        metadata = self._prompt_session_info()
-        if metadata is None:
-            self.show()  # the double-click flow starts before the launcher is shown
+        path = dialog.chosen_path()
+        if path and not dialogs.validate_settings_file(path, self):
+            self.show()
             return
-        session = SmaccSession(self._data_dir(), metadata=metadata)
-        window = SmaccWindow(session, settings_path=self._settings_path)
-        if self._settings_path:
-            preferences.update_preferences(
-                preferences_path, {"last_settings": self._settings_path}
-            )
+        subject, session_id, notes = dialog.get_inputs()
+        metadata = {"subject": subject, "session": session_id, "notes": notes}
+        data_dir = (
+            settings.load_data_directory(path, DEFAULT_DATA_DIR)
+            if path
+            else DEFAULT_DATA_DIR
+        )
+        session = SmaccSession(data_dir, metadata=metadata)
+        window = SmaccWindow(session, settings_path=path)
+        if path:
+            dialogs.remember_settings(path)  # a started file joins the recents
+            preferences.update_preferences(preferences_path, {"last_settings": path})
         self._open_tool(window)
 
-    def _prompt_session_info(self) -> dict[str, str] | None:
-        """Ask for the optional subject/session/notes; None means Cancel.
-
-        Prefilled from the metadata stored in the selected SMACC file, so a study
-        template's values are offered for confirmation rather than retyped. The
-        prompt's result is the session's metadata — the file's stored values are
-        deliberately not re-merged after this (see SmaccWindow._apply_loaded_settings),
-        so clearing a prefilled field here sticks.
-        """
-        stored: dict = {}
-        if self._settings_path:
-            try:
-                _, stored = settings.load_settings(self._settings_path)
-            except (OSError, ValueError):
-                stored = {}  # already reported by the pre-start check
-        dialog = SessionInfoDialog(
-            str(stored.get("subject") or ""),
-            str(stored.get("session") or ""),
-            str(stored.get("notes") or ""),
-            parent=self,
-        )
+    def _open_editor(self) -> None:
+        """Open the Editor on a new SMACC file or an existing one (from "Editor…")."""
+        dialog = dialogs.EditorFileDialog(parent=self)
         if not dialog.exec():
-            return None
-        subject, session, notes = dialog.get_inputs()
-        return {"subject": subject, "session": session, "notes": notes}
-
-    def create_settings(self) -> None:
-        """Open the editor on a fresh settings file (built-in defaults; Save-As)."""
-        session = SmaccSession(DEFAULT_DATA_DIR, design=True)
-        self._open_tool(SmaccWindow(session, settings_path=None))
-
-    def edit_settings(self) -> None:
-        """Open the editor on the current settings file."""
-        if self._settings_path and not self._check_loadable(self._settings_path):
-            self._set_settings(None)  # fall back to the built-in defaults
             return
-        session = SmaccSession(self._data_dir(), design=True)
-        self._open_tool(SmaccWindow(session, settings_path=self._settings_path))
+        path = None if dialog.is_new() else dialog.chosen_path()
+        data_dir = (
+            settings.load_data_directory(path, DEFAULT_DATA_DIR)
+            if path
+            else DEFAULT_DATA_DIR
+        )
+        session = SmaccSession(data_dir, design=True)
+        self._open_tool(SmaccWindow(session, settings_path=path))
 
     def design_cues(self) -> None:
-        """Open the standalone Audio Cue Designer (exports WAVs to a study's cues folder)."""
-        self._open_tool(CueDesignerWindow(self._data_dir() / "cues"))
+        """Open the standalone Audio Cue Designer (exports WAVs to the cues folder)."""
+        self._open_tool(CueDesignerWindow(DEFAULT_DATA_DIR / "cues"))
 
     def analyze_session(self) -> None:
-        """Open the analyze window over the current settings' data directory."""
-        self._open_tool(AnalyzeWindow(self._data_dir()))
+        """Open the Analyzer over the default data directory."""
+        self._open_tool(AnalyzeWindow(DEFAULT_DATA_DIR))
 
     def review_eeg(self) -> None:
         """Launch the EEG Annotator as its own detached process.
@@ -549,20 +378,23 @@ class LauncherWindow(QtWidgets.QMainWindow):
         self.hide()
 
     def _on_tool_closed(self) -> None:
-        """Bring the launcher back; adopt a settings file the editor may have saved.
+        """Bring the launcher back after a tool closes.
 
         Ending a live session is the exception: a night's run is over, so SMACC
         quits outright rather than reopening the launcher. The editor and the
-        standalone tools still return here.
+        standalone tools still return here. An editor that saved a file is
+        remembered (recents + last_settings) so the next Session… or Editor…
+        dialog offers and preselects it.
         """
         tool = self._tool
         if isinstance(tool, SmaccWindow) and not tool.design:
             self.close()  # persists launcher geometry, then quits the app
             return
         if isinstance(tool, SmaccWindow) and tool.settings_path:
-            self._set_settings(tool.settings_path)
-        else:
-            self._populate_settings_combo()
+            dialogs.remember_settings(tool.settings_path)
+            preferences.update_preferences(
+                preferences_path, {"last_settings": tool.settings_path}
+            )
         # The dark theme is a per-session "lights off" state; a session that ended
         # dark shouldn't leave the launcher dark, so reset to light on return.
         hints = QtGui.QGuiApplication.styleHints()

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import pytest
 from PyQt6 import QtWidgets
 
-from smacc import config, dialogs, surveys
+from smacc import config, dialogs, settings, surveys
 
 # ----- ask_initial_or_final --------------------------------------------------
 
@@ -47,6 +47,109 @@ def test_session_info_dialog_returns_inputs(qtbot):
     assert dialog.get_inputs() == ("001", "2", "a note")
     dialog.subject_id.setText("042")
     assert dialog.get_inputs() == ("042", "2", "a note")
+
+
+# ----- SMACC-file selection (the launcher's Session… / Editor… dialogs) -------
+
+
+def _write_incompatible(path):
+    path.write_text(
+        "kind: smacc/settings\nschema_version: 99\nsettings: {}\n", encoding="utf-8"
+    )
+
+
+def test_validate_settings_file_accepts_a_loadable_file(qtbot, tmp_path, monkeypatch):
+    monkeypatch.setattr(dialogs, "preferences_path", tmp_path / "preferences.yaml")
+    good = tmp_path / "study.smacc"
+    settings.save_settings(good, {}, {})
+    assert dialogs.validate_settings_file(str(good)) is True
+
+
+def test_validate_settings_file_rejects_and_drops_from_recents(
+    qtbot, tmp_path, monkeypatch
+):
+    from smacc import preferences
+
+    prefs_path = tmp_path / "preferences.yaml"
+    monkeypatch.setattr(dialogs, "preferences_path", prefs_path)
+    bad = tmp_path / "old.smacc"
+    _write_incompatible(bad)
+    preferences.update_preferences(prefs_path, {"recent_settings": [str(bad)]})
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox, "critical", lambda *a, **k: calls.append(a)
+    )
+    assert dialogs.validate_settings_file(str(bad)) is False  # #186
+    assert calls  # the user was told why
+    recents = preferences.load_preferences(prefs_path).get("recent_settings", [])
+    assert str(bad) not in recents  # and it won't keep resurfacing in the picker
+
+
+def test_file_combo_browse_validates_and_remembers(qtbot, tmp_path, monkeypatch):
+    from smacc import preferences
+
+    prefs_path = tmp_path / "preferences.yaml"
+    monkeypatch.setattr(dialogs, "preferences_path", prefs_path)
+    good = tmp_path / "study.smacc"
+    settings.save_settings(good, {}, {})
+    monkeypatch.setattr(
+        QtWidgets.QFileDialog, "getOpenFileName", lambda *a, **k: (str(good), "")
+    )
+    combo = dialogs.SmaccFileCombo()
+    qtbot.addWidget(combo)
+    combo._browse()  # the Browse… entry's handler
+    assert combo.chosen_path() == str(good)
+    recents = preferences.load_preferences(prefs_path).get("recent_settings", [])
+    assert str(good) in recents
+
+
+def test_file_combo_surfaces_a_preselect_that_is_not_a_recent(
+    qtbot, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(dialogs, "preferences_path", tmp_path / "preferences.yaml")
+    good = tmp_path / "study.smacc"
+    settings.save_settings(good, {}, {})
+    # A freshly double-clicked file isn't in recents yet; it must still be the
+    # selection rather than silently dropping to "default".
+    combo = dialogs.SmaccFileCombo(preselect=str(good))
+    qtbot.addWidget(combo)
+    assert combo.chosen_path() == str(good)
+
+
+def test_start_session_dialog_prefills_metadata_from_the_file(
+    qtbot, tmp_path, monkeypatch
+):
+    monkeypatch.setattr(dialogs, "preferences_path", tmp_path / "preferences.yaml")
+    good = tmp_path / "study.smacc"
+    settings.save_settings(
+        good, {}, {"subject": "sub-001", "session": "ses-02", "notes": "template"}
+    )
+    dialog = dialogs.StartSessionDialog(preselect=str(good))
+    qtbot.addWidget(dialog)
+    assert dialog.chosen_path() == str(good)
+    assert dialog.get_inputs() == ("sub-001", "ses-02", "template")  # #184
+
+
+def test_start_session_dialog_tolerates_an_unloadable_preselect(
+    qtbot, tmp_path, monkeypatch
+):
+    # A last-used file that has since become corrupt is still selectable, but its
+    # metadata can't be read; the dialog must degrade to blank fields, not crash
+    # (the launcher re-validates and blocks the start before a session opens).
+    monkeypatch.setattr(dialogs, "preferences_path", tmp_path / "preferences.yaml")
+    broken = tmp_path / "broken.smacc"
+    _write_incompatible(broken)
+    dialog = dialogs.StartSessionDialog(preselect=str(broken))
+    qtbot.addWidget(dialog)
+    assert dialog.get_inputs() == ("", "", "")
+
+
+def test_editor_file_dialog_defaults_to_new(qtbot, tmp_path, monkeypatch):
+    monkeypatch.setattr(dialogs, "preferences_path", tmp_path / "preferences.yaml")
+    dialog = dialogs.EditorFileDialog()
+    qtbot.addWidget(dialog)
+    assert dialog.is_new() is True  # "New SMACC file" leads the list
+    assert dialog.chosen_path() is None
 
 
 # ----- SurveyDialog ----------------------------------------------------------

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,10 +1,43 @@
-"""Tests for launcher logic that needs no GUI (initial-settings resolution)."""
+"""Tests for launcher logic: initial-settings resolution and the tool buttons.
+
+File selection + the validate-then-remember rule (#186) and metadata prefill
+(#184) now live in the launcher's dialogs (smacc.dialogs) and are covered in
+tests/test_dialogs.py; here we cover what the launcher itself does with the
+dialogs' results.
+"""
 
 from __future__ import annotations
 
 from smacc import launcher
 from smacc.cuedesigner import CueDesignerWindow
 from smacc.launcher import LauncherWindow, resolve_initial_settings
+from smacc.toolwindow import ToolWindow
+
+
+def _patch_prefs(monkeypatch, tmp_path):
+    """Point both launcher and dialogs at a throwaway preferences file."""
+    from smacc import dialogs
+
+    prefs_path = tmp_path / "preferences.yaml"
+    monkeypatch.setattr(launcher, "preferences_path", prefs_path)
+    monkeypatch.setattr(dialogs, "preferences_path", prefs_path)
+    return prefs_path
+
+
+def _silence_critical(monkeypatch):
+    """Replace the blocking error popup with a recorder; returns the call list."""
+    from PyQt6 import QtWidgets
+
+    calls: list[tuple] = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox,
+        "critical",
+        lambda *a, **k: calls.append(a) or QtWidgets.QMessageBox.StandardButton.Ok,
+    )
+    return calls
+
+
+# ----- initial-settings resolution -------------------------------------------
 
 
 def test_resolve_initial_settings_prefers_last_used(tmp_path):
@@ -29,10 +62,12 @@ def test_resolve_initial_settings_none_when_nothing_available(tmp_path, monkeypa
     )
 
 
+# ----- a tool button opens its tool and hides the launcher --------------------
+
+
 def test_design_cues_button_opens_the_cue_designer(qtbot, tmp_path, monkeypatch):
-    # Point preferences at a temp file so building the launcher can't touch real prefs.
-    monkeypatch.setattr(launcher, "preferences_path", tmp_path / "preferences.yaml")
-    win = LauncherWindow(settings_path=None)
+    _patch_prefs(monkeypatch, tmp_path)
+    win = LauncherWindow()
     qtbot.addWidget(win)
     win.show()
     win.design_cues()
@@ -43,108 +78,17 @@ def test_design_cues_button_opens_the_cue_designer(qtbot, tmp_path, monkeypatch)
     assert win.isVisible()
 
 
-# ----- a .smacc must load before it is opened or remembered (#186) ------------
+# ----- Session…: open the dialog, then run a session with its result ----------
 
 
-def _silence_critical(monkeypatch):
-    """Replace the blocking error popup with a recorder; returns the call list."""
-    from PyQt6 import QtWidgets
-
-    calls: list[tuple] = []
-    monkeypatch.setattr(
-        QtWidgets.QMessageBox,
-        "critical",
-        lambda *a, **k: calls.append(a) or QtWidgets.QMessageBox.StandardButton.Ok,
-    )
-    return calls
-
-
-def _write_incompatible(path):
-    path.write_text(
-        "kind: smacc/settings\nschema_version: 99\nsettings: {}\n", encoding="utf-8"
-    )
-
-
-def test_incompatible_launch_file_is_rejected_and_kept_out_of_recents(
+def test_open_session_starts_with_the_chosen_file_and_metadata(
     qtbot, tmp_path, monkeypatch
 ):
-    from smacc import preferences
+    from smacc import dialogs, settings
 
-    prefs_path = tmp_path / "preferences.yaml"
-    monkeypatch.setattr(launcher, "preferences_path", prefs_path)
-    bad = tmp_path / "old.smacc"
-    _write_incompatible(bad)
-    popups = _silence_critical(monkeypatch)
-    win = LauncherWindow(settings_path=str(bad))
-    qtbot.addWidget(win)
-    assert win.settings_path is None  # rejected → built-in defaults stay selected
-    assert len(popups) == 1  # and the user was told why
-    recents = preferences.load_preferences(prefs_path).get("recent_settings", [])
-    assert str(bad) not in recents
-
-
-def test_valid_launch_file_is_selected_and_remembered(qtbot, tmp_path, monkeypatch):
-    from smacc import preferences, settings
-
-    prefs_path = tmp_path / "preferences.yaml"
-    monkeypatch.setattr(launcher, "preferences_path", prefs_path)
+    _patch_prefs(monkeypatch, tmp_path)
     good = tmp_path / "study.smacc"
     settings.save_settings(good, {}, {})
-    win = LauncherWindow(settings_path=str(good))
-    qtbot.addWidget(win)
-    assert win.settings_path == str(good)
-    recents = preferences.load_preferences(prefs_path).get("recent_settings", [])
-    assert str(good) in recents
-
-
-def test_failed_selection_drops_a_stale_entry_from_recents(
-    qtbot, tmp_path, monkeypatch
-):
-    from smacc import preferences
-
-    # A file that was fine when remembered but is incompatible now must not
-    # keep resurfacing in the dropdown.
-    prefs_path = tmp_path / "preferences.yaml"
-    monkeypatch.setattr(launcher, "preferences_path", prefs_path)
-    bad = tmp_path / "old.smacc"
-    _write_incompatible(bad)
-    preferences.update_preferences(prefs_path, {"recent_settings": [str(bad)]})
-    _silence_critical(monkeypatch)
-    win = LauncherWindow(settings_path=None)
-    qtbot.addWidget(win)
-    win._set_settings(str(bad))  # e.g. picked from the recents dropdown
-    assert win.settings_path is None  # the selection did not change
-    recents = preferences.load_preferences(prefs_path).get("recent_settings", [])
-    assert str(bad) not in recents
-
-
-def test_start_session_aborts_when_the_file_breaks_after_selection(
-    qtbot, tmp_path, monkeypatch
-):
-    from smacc import settings
-
-    monkeypatch.setattr(launcher, "preferences_path", tmp_path / "preferences.yaml")
-    good = tmp_path / "study.smacc"
-    settings.save_settings(good, {}, {})
-    _silence_critical(monkeypatch)
-    win = LauncherWindow(settings_path=str(good))
-    qtbot.addWidget(win)
-    good.write_text("not: [valid", encoding="utf-8")  # corrupted after selection
-    win.start_session()
-    assert win._tool is None  # no session window was constructed
-    assert win.settings_path is None  # selection fell back to the defaults
-    # The double-click flow starts a session before the launcher is ever shown;
-    # on rejection the launcher must come up rather than leave no window at all.
-    assert win.isVisible()
-
-
-# ----- the start-of-session metadata prompt (#184) ----------------------------
-
-
-def test_start_session_prompts_and_passes_metadata(qtbot, tmp_path, monkeypatch):
-    from smacc.toolwindow import ToolWindow
-
-    monkeypatch.setattr(launcher, "preferences_path", tmp_path / "preferences.yaml")
     captured = {}
 
     class FakeSession:
@@ -155,42 +99,111 @@ def test_start_session_prompts_and_passes_metadata(qtbot, tmp_path, monkeypatch)
     monkeypatch.setattr(
         launcher, "SmaccWindow", lambda session, settings_path=None: ToolWindow()
     )
-    entered = {"subject": "sub-001", "session": "ses-02", "notes": "first night"}
+    monkeypatch.setattr(dialogs.StartSessionDialog, "exec", lambda self: True)
     monkeypatch.setattr(
-        LauncherWindow, "_prompt_session_info", lambda self: dict(entered)
+        dialogs.StartSessionDialog, "chosen_path", lambda self: str(good)
     )
-    win = LauncherWindow(settings_path=None)
+    monkeypatch.setattr(
+        dialogs.StartSessionDialog,
+        "get_inputs",
+        lambda self: ("sub-001", "ses-02", "first night"),
+    )
+    win = LauncherWindow()
     qtbot.addWidget(win)
-    win.start_session()
-    assert captured["metadata"] == entered
+    win._open_session()
+    assert captured["metadata"] == {
+        "subject": "sub-001",
+        "session": "ses-02",
+        "notes": "first night",
+    }
     assert win._tool is not None  # the session window was opened
 
 
-def test_start_session_cancelled_prompt_aborts(qtbot, tmp_path, monkeypatch):
-    monkeypatch.setattr(launcher, "preferences_path", tmp_path / "preferences.yaml")
-    monkeypatch.setattr(LauncherWindow, "_prompt_session_info", lambda self: None)
-    win = LauncherWindow(settings_path=None)
+def test_open_session_cancelled_aborts_and_shows_the_launcher(
+    qtbot, tmp_path, monkeypatch
+):
+    from smacc import dialogs
+
+    _patch_prefs(monkeypatch, tmp_path)
+    monkeypatch.setattr(dialogs.StartSessionDialog, "exec", lambda self: False)
+    win = LauncherWindow()
     qtbot.addWidget(win)
-    win.start_session()
-    assert win._tool is None  # no session was started
-    # The double-click flow prompts before the launcher is ever shown; on Cancel
-    # the launcher must come up rather than leave no window at all.
+    win._open_session()
+    assert win._tool is None  # no session started
+    # The double-click flow opens this dialog before the launcher is shown; on
+    # Cancel the launcher must come up rather than leave no window at all.
     assert win.isVisible()
 
 
-def test_prompt_session_info_prefills_from_the_smacc_file(qtbot, tmp_path, monkeypatch):
+def test_open_session_aborts_when_the_chosen_file_breaks_after_the_dialog(
+    qtbot, tmp_path, monkeypatch
+):
     from smacc import dialogs, settings
 
-    monkeypatch.setattr(launcher, "preferences_path", tmp_path / "preferences.yaml")
+    _patch_prefs(monkeypatch, tmp_path)
     good = tmp_path / "study.smacc"
-    settings.save_settings(
-        good, {}, {"subject": "sub-001", "session": "ses-02", "notes": "template"}
+    settings.save_settings(good, {}, {})
+    _silence_critical(monkeypatch)
+    monkeypatch.setattr(dialogs.StartSessionDialog, "exec", lambda self: True)
+    monkeypatch.setattr(
+        dialogs.StartSessionDialog, "chosen_path", lambda self: str(good)
     )
-    monkeypatch.setattr(dialogs.SessionInfoDialog, "exec", lambda self: True)
-    win = LauncherWindow(settings_path=str(good))
+    win = LauncherWindow()
     qtbot.addWidget(win)
-    assert win._prompt_session_info() == {
-        "subject": "sub-001",
-        "session": "ses-02",
-        "notes": "template",
-    }
+    good.write_text("not: [valid", encoding="utf-8")  # corrupted after the dialog
+    win._open_session()
+    assert win._tool is None  # the re-check (#186) blocked the session
+    assert win.isVisible()
+
+
+# ----- Editor…: New file vs an existing one -----------------------------------
+
+
+def test_open_editor_new_opens_a_blank_editor(qtbot, tmp_path, monkeypatch):
+    from smacc import dialogs
+
+    _patch_prefs(monkeypatch, tmp_path)
+    captured = {}
+    monkeypatch.setattr(
+        launcher, "SmaccSession", lambda data_dir, design=False: object()
+    )
+    monkeypatch.setattr(
+        launcher,
+        "SmaccWindow",
+        lambda session, settings_path=None: (
+            captured.update(path=settings_path) or ToolWindow()
+        ),
+    )
+    monkeypatch.setattr(dialogs.EditorFileDialog, "exec", lambda self: True)
+    monkeypatch.setattr(dialogs.EditorFileDialog, "is_new", lambda self: True)
+    win = LauncherWindow()
+    qtbot.addWidget(win)
+    win._open_editor()
+    assert captured["path"] is None  # New → a fresh file (Save-As)
+    assert win._tool is not None
+
+
+def test_open_editor_existing_opens_that_file(qtbot, tmp_path, monkeypatch):
+    from smacc import dialogs, settings
+
+    _patch_prefs(monkeypatch, tmp_path)
+    good = tmp_path / "study.smacc"
+    settings.save_settings(good, {}, {})
+    captured = {}
+    monkeypatch.setattr(
+        launcher, "SmaccSession", lambda data_dir, design=False: object()
+    )
+    monkeypatch.setattr(
+        launcher,
+        "SmaccWindow",
+        lambda session, settings_path=None: (
+            captured.update(path=settings_path) or ToolWindow()
+        ),
+    )
+    monkeypatch.setattr(dialogs.EditorFileDialog, "exec", lambda self: True)
+    monkeypatch.setattr(dialogs.EditorFileDialog, "is_new", lambda self: False)
+    monkeypatch.setattr(dialogs.EditorFileDialog, "chosen_path", lambda self: str(good))
+    win = LauncherWindow()
+    qtbot.addWidget(win)
+    win._open_editor()
+    assert captured["path"] == str(good)


### PR DESCRIPTION
Completes #194 (194b — the launcher redesign; 194a was the naming sweep, merged in #221).

## What changes

The launcher becomes a flat list of five tool buttons — **Session… · Editor… · Analyzer · Audio Cue Designer · EEG Annotator** — replacing the `SMACC file:` dropdown and the Start/Create/Edit action row. The SMACC-file choice is no longer made up front; the two tools that need a file prompt for one when opened.

- **Session…** → `StartSessionDialog`: a SMACC-file row (default / recents / Browse…, preselected from the last-used file) above the subject/session/notes fields. Choosing a file re-prefills the metadata from that file; clearing a field then sticks. On OK the launcher re-validates the file before starting (#186).
- **Editor…** → `EditorFileDialog`: **New SMACC file** / recents / Browse… → maps to the old Create (fresh file) / Edit (existing) flows.
- **Analyzer** / **Audio Cue Designer** open directly over the default data directory.
- **EEG Annotator** unchanged (detached process; disabled with a hint when not installed).
- A double-clicked `.smacc` opens the Session dialog with that file preselected; Cancel falls back to showing the launcher.

## Invariants preserved

The validate-then-remember rule (**#186** — a file that won't load is reported, dropped from recents, never starts a session) and metadata prefill (**#184**) moved intact into the dialogs. `SessionInfoDialog` (subject/session/notes only) is **unchanged** and still used mid-session by the Session window. The tool-window lifecycle (open hides the launcher, close reopens it, ending a live session quits SMACC, dark theme resets on return) is intact.

## Implementation notes

A reusable `SmaccFileCombo` + module-level `validate_settings_file`/`remember_settings`/`forget_settings` implement the file row and #186 once, shared by both dialogs. The launcher no longer holds a "current file" — selection is per-action; persistence is via `recent_settings`/`last_settings` in preferences.

## Verification

`ruff format --check`, `ruff check`, `mypy`, `mdformat --check`, and the full suite (**1121 tests**) pass. The launcher/dialog tests were reworked: #186/#184 coverage now lives at the dialog level (`test_dialogs.py`), and `test_launcher.py` covers the new Session…/Editor… handlers and the double-click flow. Touches no packaging files, so it runs only the standard CI (no installer build).