### PR TITLE
docs: correct stale UI names, the launcher flow, and reference details

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -12,7 +12,7 @@ This page describes how SMACC handles devices, routing, and volume.
 ## Equipment, not per-window device pickers
 
 Instead of picking a device separately in every window, SMACC has one **Devices
-window** (in the *Tools* column) where you do two things:
+window** (in the **Panels** column) where you do two things:
 
 1. **Bind each piece of _equipment_ to a device, once.** Equipment entries are
     the physical endpoints of a rig, named by place: **Bedroom speaker**, **Control-room speaker**, **Bedroom
@@ -163,8 +163,9 @@ gain explicit and adds a safety limit, in the **Volume** window:
     every cue and noise output. However loud an individual cue is set, the cap is a
     hard limit, so a full-volume looped cue on a calibrated rig can't suddenly blast a
     sleeping participant.
-- **A read-only view of the Windows stages.** The window shows the current **system
-    output volume** and **SMACC's own level** in the Windows Volume Mixer, so the
+- **A read-only view of the Windows stages.** The window shows the current **System
+    volume** (the Windows output endpoint) and **App volume** (SMACC's own level) in
+    the Windows Volume Mixer, so the
     hidden OS stages are visible.
 
 !!! tip "Calibrating cue level"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -88,7 +88,7 @@ device enumeration, the Windows volume read-out) is stubbed in fixtures, so test
 depend on the machine's audio setup.
 
 ```sh
-uv run pytest --cov=smacc --cov-report=term-missing   # the coverage flags CI runs
+uv run --extra dev --extra eeg pytest --cov=smacc --cov-report=term-missing   # CI also adds --cov-report=xml
 ```
 
 To actually watch a test render, override the platform for that run (Windows:
@@ -117,23 +117,25 @@ PyInstaller; if a frozen build ever fails to import `yaml`, add
 `--hidden-import yaml`.
 
 The optional EEG Annotator component (#136) is a second frozen exe with its own
-entry point — it carries the MNE/pyqtgraph stack the base exe deliberately
+entry point — it carries the MNE/pyqtgraph/matplotlib stack the base exe deliberately
 doesn't (requires `uv sync --extra dev --extra eeg`):
 
 ```sh
 uv run pyinstaller entry_eeg.py --name SMACC-EEG --onefile --noconsole \
   --icon src/smacc/assets/icon.ico \
   --add-data "src/smacc/assets/icon.png:smacc/assets" \
-  --collect-submodules mne --collect-data mne
+  --collect-submodules mne --collect-data mne \
+  --collect-submodules matplotlib.backends
 ```
 
 The `--collect-*` flags matter: MNE uses `lazy_loader`, which imports
 submodules by name at runtime and reads the package's `.pyi` stubs — both
 invisible to PyInstaller's static analysis. Without them the exe builds
-cleanly and dies on first MNE use. Don't try `--exclude-module matplotlib`
-to slim the bundle: the viewer never plots with it, but MNE's IO layer
-transitively imports `mne.viz.ui_events` (→ matplotlib) at import time, so
-the exclusion breaks `read_raw_*`.
+cleanly and dies on first MNE use. matplotlib is a real dependency too — the
+figure export (`eeg/export.py`, #180) writes PDF/SVG via `savefig`, and MNE's IO
+layer imports `mne.viz.ui_events` (→ matplotlib) at import time — so
+`--collect-submodules matplotlib.backends` bundles its PDF/SVG backends, and
+`--exclude-module matplotlib` would break both `read_raw_*` and the export.
 
 Verify a built `SMACC-EEG.exe` with `--selftest` (the check is exit code 0):
 it round-trips a synthetic recording through MNE, the display filters, and the
@@ -146,7 +148,7 @@ The `blinkstick` driver (BlinkStick visual cues) and its Windows backend
 never uses, so the warning is harmless. If a frozen build ever fails to import
 the driver, add `--hidden-import pywinusb`.
 
-Releases are built automatically: pushing a `v*` tag (e.g. `v0.0.7`) triggers the
+Releases are built automatically: pushing a `v*` tag (e.g. `v0.0.11`) triggers the
 [release workflow](https://github.com/remrama/smacc/blob/main/.github/workflows/release.yaml),
 which checks the tag against `smacc.__version__`, builds `SMACC.exe` and
 `SMACC-EEG.exe` (each stamped with version metadata from
@@ -191,4 +193,5 @@ on each `v*` release tag.
 - SMACC is distributed only as a frozen `SMACC.exe` (no PyPI), so CI tests what
     ships rather than a version range: the `test` job in `ci.yaml` runs on the same
     `windows-2022` + Python 3.13 + locked dependencies as the release build
-    (`release.yaml`), in a single job rather than a multi-version matrix.
+    (`release.yaml`), across `windows-2022` and `windows-latest` rather than a
+    Python-version matrix.

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -26,9 +26,9 @@ sleep and lucid-dreaming experiments.
 ### Using it in SMACC
 
 1. Plug the BlinkStick into a USB port, then launch SMACC.
-1. Click **Visual cue** in the *Tools* column.
+1. Click **Visual cue** in the **Panels** column.
 1. Bind your BlinkStick to the **BlinkStick light** equipment in the **Devices** window
-    (in the *Tools* column). Plug one in after launch and it's detected
+    (in the **Panels** column). Plug one in after launch and it's detected
     automatically, or click **Refresh devices (F5)** in the Devices window to rescan.
 1. Configure a light cue — color, brightness, pattern (steady, or a pulse/flash at
     a rate in Hz), and length (or **Loop** until stopped) — and add more cues with

--- a/docs/eeg-annotator.md
+++ b/docs/eeg-annotator.md
@@ -200,8 +200,8 @@ annotations.
 
 You can load a log **with or without a recording open**. With one, it overlays
 and aligns to *that* recording's clock. With none, it opens **standalone** on a
-bare time axis — for inspecting a log on its own (the **Analyze** window's *Open
-log in EEG annotator* hands a session off this way). Opening a recording while a
+bare time axis — for inspecting a log on its own (the **Analyzer**'s *Open log in
+EEG Annotator* hands a session off this way). Opening a recording while a
 standalone log is shown switches to the overlaid view.
 
 **Artifacts.** Selecting a dream-report entry lets you **Play** its recorded

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,13 +15,14 @@ a simple, clickable interface and is commonly used in dream engineering research
 <!-- Add a screenshot of the main window here once available, e.g.:
 ![SMACC main window](assets/screenshot-main.png) -->
 
-[Download SMACC](https://github.com/remrama/smacc/releases/latest/download/SMACC.exe){ .md-button .md-button--primary }
+[Download SMACC](https://github.com/remrama/smacc/releases/latest/download/SMACC-Setup.exe){ .md-button .md-button--primary }
 [Installation guide](installation.md){ .md-button }
 
-The button downloads the latest version of SMACC, which runs on 64-bit Windows 10
-or later. The download is a single file — no installer. See
-[Installation](installation.md) if Windows SmartScreen warns about the unsigned
-download, or for downloading older versions.
+The button downloads the installer (`SMACC-Setup.exe`) for the latest version, which
+installs per-user (no admin rights) and runs on 64-bit Windows 10 or later. Prefer a
+single file with no install? A portable `SMACC.exe` ships with every release — see
+[Installation](installation.md), which also covers the Windows SmartScreen warning on
+the unsigned download and how to get older versions.
 
 ## Get started
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,11 +7,12 @@ double-click `SMACC-Setup.exe` and click through. The installer:
 
 - installs SMACC **per-user** — no administrator rights or IT involvement needed;
 - adds a **Start menu** entry (and, if you opt in, a desktop shortcut);
-- associates **`.smacc` files**, so double-clicking a SMACC file opens a session
-    with it;
+- associates **`.smacc` files**, so double-clicking one opens the **Start a session**
+    dialog with it preselected;
 - installs the **EEG Annotator** — the post-hoc
     [EEG viewer/annotator](eeg-annotator.md). Included by default; uncheck it during
-    setup to skip the heavyweight MNE library, or re-run the installer later to
+    setup to skip the heavyweight EEG component (which bundles the MNE library), or
+    re-run the installer later to
     add or remove it;
 - registers an uninstaller — remove SMACC from **Settings › Apps** like any other
     program. Uninstalling never touches your data: SMACC files, recordings, and
@@ -105,7 +106,7 @@ itself remembers window positions and sizes and your recent files in
 
 Your reusable setup is saved to a portable SMACC file (see
 [SMACC files](smacc-files.md)). The installer associates `.smacc` files so you can
-**double-click one to open SMACC and run a session with it**. With the portable
+**double-click one to open the Start-a-session dialog with it preselected**. With the portable
 `SMACC.exe`, enable (or repair) the association any time from
 **File › Associate .smacc files (Windows)** in the Launcher.
 
@@ -114,12 +115,13 @@ Your reusable setup is saved to a portable SMACC file (see
 SMACC seeds a few `demo-*` cue files into the default data directory's `cues/`
 folder (restored if you delete them, and refreshed when you upgrade SMACC), so
 there is always something to test with. You can also place your own sound files
-there — `.wav`, `.mp3`, `.flac`, `.ogg`, and `.aiff` are all supported; only the
+there — common formats such as `.wav`, `.mp3`, `.flac`, `.ogg`, and `.aiff` are
+accepted; only the
 `demo-` files are managed by SMACC, so your own are never touched.
 
 ### Dream report survey
 
-The **Record Dream Report** button can optionally pop open a survey — one of the
+The **Record dream report** button can optionally pop open a survey — one of the
 built-in dream questionnaires (opened in a SMACC window, responses saved into the
 run folder) or a survey URL hosted on e.g. Qualtrics or REDCap (opened in the
 browser). Manage them from the Dream-recording panel's **Manage…** button; saved
@@ -130,4 +132,4 @@ automatically when recording starts, or open any survey on its own from
 ### Recording device
 
 If you plan to record dreams, bind your mic to **Bedroom mic 1** in the
-**Devices** window (in the *Tools* column); the dream-report recorder uses it.
+**Devices** window (in the **Panels** column); the dream-report recorder uses it.

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -86,7 +86,7 @@ Two things to take from this:
 
 ## The Low / High setting
 
-The Volume window has an **Output latency** choice, saved in the `.smacc`
+The Volume window has a **Latency** choice (High / Low), saved in the `.smacc`
 ([`output_latency`](reference/settings-file.md)):
 
 - **High** (default) — PortAudio's robust buffer. Fewer underruns; the safe choice
@@ -127,8 +127,8 @@ rig**. To characterise yours:
 - **Against the EEG, per session (authoritative).** Record the real stimulus onset on
     a spare amplifier channel — a microphone for the cue, a photodiode for the light —
     alongside the LSL port code. The difference between the port code and the recorded
-    onset, across the night, is the true distribution, and it can be visualised in the
-    Analyze tool. This needs a spare channel and is tracked in
+    onset, across the night, is the true distribution. SMACC does not plot this itself
+    yet; a per-session view of it needs a spare channel and is tracked in
     [#104](https://github.com/remrama/smacc/issues/104).
 
 !!! note "Why the log can't give you this"

--- a/docs/reference/annotations-file.md
+++ b/docs/reference/annotations-file.md
@@ -52,7 +52,7 @@ Documents each column (BIDS-style) and records provenance:
   "SourceFile": "night1.edf",
   "MeasurementDate": "2026-06-05T22:00:00+00:00",
   "Rater": null,
-  "GeneratedBy": {"Name": "SMACC", "Version": "1.0.0"}
+  "GeneratedBy": {"Name": "SMACC", "Version": "0.0.10"}
 }
 ```
 
@@ -60,6 +60,8 @@ Documents each column (BIDS-style) and records provenance:
 with the data-relative onsets it reconstructs clock time. It is `null` when
 the format or anonymization dropped it. `Rater` names the reviewer for a
 per-rater sidecar (see below) and is `null` for an ordinary single-rater review.
+`GeneratedBy.Version` is the SMACC app version that wrote the file; the sidecar
+carries no schema version of its own (it tracks the BIDS columns).
 
 ## Multiple raters
 

--- a/docs/reference/bids-export.md
+++ b/docs/reference/bids-export.md
@@ -2,8 +2,9 @@
 
 SMACC can convert a session [log](session-log.md) into a
 [BIDS](https://bids.neuroimaging.io/) events file — a tab-separated `events.tsv` plus
-a JSON sidecar describing its columns. Export one from the **Analyzer**, or from a live
-session's exporters. Only event-marker lines (`" - portcode N"`) become rows.
+a JSON sidecar describing its columns. Export one from the **Analyzer** with its
+**Export events (BIDS)…** button. Only event-marker lines (`" - portcode N"`) become
+rows.
 
 ## `events.tsv`
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -23,10 +23,11 @@ from the task-oriented [Usage](../usage.md) guide.
 - Each **run** gets its own timestamped folder (`smacc-YYYYmmdd-HHMMSS/`) under that
     data directory, holding the session `.log`, any dream-report audio, survey
     responses, and exports.
-- **Custom survey definitions** live in the SMACC directory's `surveys/` folder;
-    built-in ones ship inside SMACC itself.
+- **Custom survey definitions** live in the SMACC directory's `surveys/` folder
+    (created when you first build or save one); built-in ones ship inside SMACC itself.
 - **Bundled assets refresh on upgrade.** `default.smacc` (a read-only template) and
-    the `demo-` cues are re-seeded from the bundle when they change, so a newer
+    the `demo-` cues (seeded into the data directory's `cues/` folder) are re-seeded
+    from the bundle when they change, so a newer
     SMACC's improvements reach an existing directory; your own files are untouched.
     Biocal voice recordings are read straight from the bundle, with the SMACC
     directory's `biocals/` folder as an optional per-recording override.
@@ -34,11 +35,13 @@ from the task-oriented [Usage](../usage.md) guide.
 ## Stability promise
 
 `.smacc` and `preferences.yaml` each carry an integer `schema_version`, currently
-**1** — the first stable release schema. SMACC loads only the current version; it
-does **not** migrate older or unknown versions. Missing *optional* keys are always
-tolerated (each falls back to a default), so a partial or hand-edited file still
-loads.
+**1** — the first stable release schema. A `.smacc` loads only at the matching
+version (any other is rejected); `preferences.yaml` never blocks startup — it ignores
+the version and merges the keys it recognizes over the defaults. Either way, missing
+*optional* keys fall back to a default, so a partial or hand-edited file still loads.
 
-The format will not change incompatibly without **bumping `schema_version`** and
-adding a row to that file's version-history table. The `kind` discriminator
-(`smacc/settings`, `smacc/preferences`) lets SMACC reject files that aren't its own.
+The `.smacc` format will not change incompatibly without **bumping `schema_version`**
+and adding a row to its version-history table. The `kind` discriminator
+(`smacc/settings`, `smacc/preferences`, `smacc/survey`, `smacc/survey-response`) lets
+SMACC reject a file that isn't its own: a `.smacc` with a *different* kind is rejected,
+while a missing kind is tolerated.

--- a/docs/reference/preferences-file.md
+++ b/docs/reference/preferences-file.md
@@ -1,7 +1,9 @@
 # Preferences file (`preferences.yaml`)
 
 `preferences.yaml` holds **per-machine operator preferences** — where each window was
-last placed and the Launcher's recent-files list. It is the machine layer, kept
+last placed, the Launcher's recent-files list, the live log-preview options, and the
+EEG Annotator's per-machine state (recent labels, last-used folders, rater id,
+quick-mark palette). It is the machine layer, kept
 separate from a portable [SMACC file](settings-file.md) (which a researcher shares
 between rigs) and from a per-run [session log](session-log.md).
 
@@ -24,6 +26,7 @@ preferences:
   last_settings: C:\Users\you\SMACC\peter.smacc
   log_preview_max_lines: 1000
   log_preview_clock: 24h
+  eeg_palette_labels: [LRLR, LRLRx2, LRLRx3, IEIE]
 ```
 
 ## Fields
@@ -36,13 +39,13 @@ preferences:
 
 ### `preferences`
 
-| Key                     | Type           | Meaning                                                                                                                                                                                                                                                                                            |
-| ----------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `windows`               | mapping        | Per-window geometry, keyed by a stable window id → `{x, y, w, h}`. Ids include `launcher`, `main` (the Session window), the analyze window, and each tool window. An absent/`null` `x`/`y` means "no saved position — open at a default".                                                          |
-| `recent_settings`       | list of paths  | Recently opened `.smacc` files, most-recent first, de-duplicated and capped at 8.                                                                                                                                                                                                                  |
-| `last_settings`         | path or `null` | The last `.smacc` opened, so the Launcher can preselect it.                                                                                                                                                                                                                                        |
-| `log_preview_max_lines` | integer        | How many lines the Session window's live log preview keeps (default **1000**); the oldest lines are dropped first. The log *file* always records everything, so nothing is lost. Very large values cost GUI memory and repaint time over an overnight session.                                     |
-| `log_preview_clock`     | string         | How the live preview renders the time of day: `24h` (default, e.g. `22:14:01`) or `12h` (`10:14:01 PM`). Presentation only — the log *file* always keeps 24-hour timestamps with a UTC offset. Toggle it from the Session window's **File → 12-hour clock**; an unknown value falls back to `24h`. |
+| Key                     | Type           | Meaning                                                                                                                                                                                                                                                                                                                |
+| ----------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `windows`               | mapping        | Per-window geometry, keyed by a stable window id → `{x, y, w, h}`. Ids include `launcher`, `main` (the Session window), `analyze` (the Analyzer), `eeg-annotator` (the EEG Annotator), and one entry per tool window (keyed by its panel key). An absent/`null` `x`/`y` means "no saved position — open at a default". |
+| `recent_settings`       | list of paths  | Recently opened `.smacc` files, most-recent first, de-duplicated and capped at 8.                                                                                                                                                                                                                                      |
+| `last_settings`         | path or `null` | The last `.smacc` opened, used to preselect it in the Session…/Editor… file picker.                                                                                                                                                                                                                                    |
+| `log_preview_max_lines` | integer        | How many lines the Session window's live log preview keeps (default **1000**); the oldest lines are dropped first. The log *file* always records everything, so nothing is lost. Very large values cost GUI memory and repaint time over an overnight session.                                                         |
+| `log_preview_clock`     | string         | How the live preview renders the time of day: `24h` (default, e.g. `22:14:01`) or `12h` (`10:14:01 PM`). Presentation only — the log *file* always keeps 24-hour timestamps with a UTC offset. Toggle it from the Session window's **File → 12-hour clock**; an unknown value falls back to `24h`.                     |
 
 !!! note "Partial files are fine"
 
@@ -50,8 +53,23 @@ preferences:
     yields every key. There is no cross-version migration; only `schema_version: 1`
     is current.
 
+### EEG Annotator keys
+
+The [EEG Annotator](../eeg-annotator.md) runs as its own process but writes its
+per-machine state into the same `preferences.yaml`:
+
+| Key                    | Type             | Meaning                                                      |
+| ---------------------- | ---------------- | ------------------------------------------------------------ |
+| `eeg_recent_labels`    | list             | Recent annotation labels, seeding the label dialog.          |
+| `eeg_rater_id`         | string or `null` | The active rater id for per-rater sidecars.                  |
+| `eeg_palette_labels`   | list             | Quick-mark palette (default `[LRLR, LRLRx2, LRLRx3, IEIE]`). |
+| `eeg_last_dir`         | path or `null`   | Last folder a recording was opened from.                     |
+| `eeg_last_profile_dir` | path or `null`   | Last view-profile folder.                                    |
+| `eeg_last_export_dir`  | path or `null`   | Last figure-export folder.                                   |
+| `eeg_last_blind_dir`   | path or `null`   | Last blind-config folder.                                    |
+
 ## Version history
 
-| Version | Changes                                                                                                                                                                                                                                                      |
-| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 1       | First stable schema: `windows`, `recent_settings`, `last_settings`. (The pre-release `association_prompted` key was dropped along with the first-run association prompt — the installer owns the association now; a leftover key in an old file is ignored.) |
+| Version | Changes                                                                                                                                                                                                                                                                                                                       |
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1       | First (and current) stable schema, covering window geometry, recents/last-used, the log-preview options, and the EEG Annotator keys. (The pre-release `association_prompted` key was dropped along with the first-run association prompt — the installer owns the association now; a leftover key in an old file is ignored.) |

--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -3,7 +3,7 @@
 Every live run writes one plain-text log to its own timestamped folder
 (`smacc-YYYYmmdd-HHMMSS/`) under the study's data directory. It is the session's
 record: every event marker, the soft interactions (volume / colour / device changes),
-and two embedded snapshots of the full settings the run used. The study *designer*
+and two embedded snapshots of the full settings the run used. The **Editor**
 (which records nothing) writes no log.
 
 ## Line format
@@ -28,17 +28,17 @@ YYYY-MM-DD HH:MM:SS.mmm±HHMM, LEVEL, message
 - **message** — the log text. An **event-marker** line ends in `" - portcode N"`:
 
 ```text
-2026-06-09 22:14:01.003-0500, INFO, Opened SMACC v0.0.7
+2026-06-09 22:14:01.003-0500, INFO, Opened SMACC v0.0.10
 2026-06-09 22:14:05.221-0500, INFO, Lights off - portcode 47
 2026-06-09 22:18:30.880-0500, INFO, Dream report started: report-01, t+00:04:29 - portcode 201
-2026-06-09 22:19:02.114-0500, INFO, Cue volume set to 0.40
+2026-06-09 22:19:02.114-0500, INFO, REM detected - portcode 41
 ```
 
 A marker line is `"{label} - portcode {code}"` when the event drives a trigger, or
 just `"{label}"` when it does not. A dream-report start names its recording
-(`report-NN`, matching `report-NN.wav` in the run folder) and its time since the
-recording-start marker, so the entry can be tied back to both its audio and its
-place in the EEG. The code-to-event map is the study's
+(`report-NN`, matching `report-NN.wav` in the run folder) and, once the
+recording-start marker has been set, its time since that marker, so the entry can be
+tied back to both its audio and its place in the EEG. The code-to-event map is the study's
 [`event_codes`](settings-file.md#event_codes) registry; see the
 [default code catalog](../triggers.md#default-event-codes).
 
@@ -99,7 +99,7 @@ fenced by sentinels, so log parsers skip it entirely:
 # --8<-- smacc/settings initial
 # kind: smacc/settings
 # schema_version: 1
-# smacc_version: 0.0.7
+# smacc_version: 0.0.10
 # metadata:
 #   subject: '001'
 #   ...
@@ -109,8 +109,8 @@ fenced by sentinels, so log parsers skip it entirely:
 ```
 
 Two snapshots are written: **`initial`** (at startup) and **`final`** (appended at
-quit). The `final` block may be absent if a session crashed before quitting. Analyze
-can recover a `.smacc` from either block.
+quit). The `final` block may be absent if a session crashed before quitting. The
+**Analyzer** can recover a `.smacc` from either block.
 
 !!! note "No separate version"
 

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -1,8 +1,8 @@
 # SMACC file (`.smacc`)
 
 A **SMACC file** is a **portable study configuration**: it lets a researcher set
-SMACC up once — cue sounds and volumes, noise, the visual cue, surveys, event codes,
-device routing, optional hardware triggers — and reload it each session so the setup
+SMACC up once — cue sounds and volumes, noise, the visual cue, survey selection, event
+codes, device routing, optional hardware triggers — and reload it each session so the setup
 stays consistent across nights and researchers. It is plain YAML you can read and
 edit. The user-facing extension is `.smacc`, but the `kind` stays `smacc/settings`.
 
@@ -15,7 +15,7 @@ guide (creating, editing, sharing). This page is the field reference.
 # SMACC settings — YAML (.smacc). Edit with care.
 kind: smacc/settings
 schema_version: 1
-smacc_version: "0.0.9"
+smacc_version: "0.0.10"
 metadata:
   subject: "001"
   session: "1"
@@ -43,7 +43,7 @@ settings:
   # --- Participant text chat ---------------------------------------------------
   chat_font_size: 18
   chat_red_text: false
-  chat_experimenter_presets: ["Are you awake?", "Going back to sleep now."]
+  chat_experimenter_presets: ["Please describe everything that was going through your mind before the alarm.", "Are you awake?", "Going back to sleep now."]
   chat_participant_presets: ["Got it", "I'm awake", "Yes", "No"]
   # --- Biocals ---------------------------------------------------------------
   biocals:
@@ -219,6 +219,6 @@ folder stays valid when moved, copied, or zipped.
 
 ## Version history
 
-| Version | Changes                                                                                                                                                                                                                                                                                                                                                                |
-| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1       | The v0.0.9 baseline (numbering restarted; pre-release schemas were retired without migration). Envelope (`kind` / `schema_version` / `smacc_version` / `metadata` / `settings`); panel state; the `biocals`, `devices`, `event_codes` + `event_code_safe_max`, `trigger_output`, `data_directory`, `preview_levels`, `always_on_top`, and `tool_always_on_top` blocks. |
+| Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                           |
+| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1       | Introduced as the v0.0.9 baseline (numbering restarted; pre-release schemas were retired without migration); still current as of v0.0.10. Envelope (`kind` / `schema_version` / `smacc_version` / `metadata` / `settings`); panel state; the `biocals`, `devices`, `event_codes` + `event_code_safe_max`, `trigger_output`, `data_directory`, `preview_levels`, `always_on_top`, and `tool_always_on_top` blocks. |

--- a/docs/smacc-files.md
+++ b/docs/smacc-files.md
@@ -1,7 +1,7 @@
 # SMACC files
 
 A **SMACC file** (`.smacc`) is the study's configuration: cue files, volumes,
-noise, visual cues, biocals, survey presets, event codes, the display choices
+noise, visual cues, biocals, survey presets, event markers, the display choices
 that apply to a session (always-on-top and log-preview levels), and the **data
 directory** where runs are written. It plays the same role for a SMACC study
 that a montage file plays for an EEG setup — configure it once, then reuse it
@@ -27,10 +27,10 @@ format, see the [SMACC file reference](reference/settings-file.md).
 There are two ways to make one:
 
 - **From scratch, in the Editor.** In the [Launcher](usage.md#opening-smacc),
-    click **Create** to open the **Editor** on a fresh configuration (or select an
-    existing SMACC file and click **Edit**). Configure each tool on the left, set
-    the data directory, and **Save as…** to a new `.smacc` anywhere you like. The
-    Editor never records a run — it only authors configuration.
+    click **Editor…**. In the dialog, choose **New SMACC file** for a blank
+    configuration (or pick an existing file to edit). Configure each panel on the
+    left, set the data directory, and **Save SMACC file as…** to a new `.smacc`
+    anywhere you like. The Editor never records a run — it only authors configuration.
 - **From a live session.** In a running **Session**, use **File › Save
     SMACC file as…** to snapshot the session's *current* settings — including any
     mid-session tweaks (volumes, device routing, event-code edits) — to a new
@@ -58,10 +58,11 @@ determines where a night's data ends up.
 
 Opening a SMACC file starts a new session configured by it:
 
-- **Double-click the file** (Windows build): SMACC launches straight into a
-    Session for it. The first launch offers to set up this file association; you
-    can (re)enable it any time from **File › Associate .smacc files
-    (Windows)** in the Launcher.
-- **From the Launcher**: pick the file in the **Settings** dropdown (recent
-    files are listed; **Browse…** finds any other), then click **Start**.
+- **Double-click the file** (Windows build): SMACC opens the **Start a session**
+    dialog with that file preselected, so you confirm the subject/session and click
+    **OK** to start. Enable or repair the file association any time from **File ›
+    Associate .smacc files (Windows)** in the Launcher.
+- **From the Launcher**: click **Session…**, then pick the file in the **Start a
+    session** dialog (recent files are listed; **Browse…** finds any other) and click
+    **OK**.
 - **From a terminal**: `SMACC path/to/file.smacc`.

--- a/docs/surveys.md
+++ b/docs/surveys.md
@@ -81,7 +81,7 @@ since the survey happens after the awakening; tick its **LSL**/**TTL** boxes in
 the [Markers window](usage.md#configuring-codes) if your protocol wants it in
 the trigger channel.
 
-In the study designer (and the read-only previews in the Manage dialog) a survey
+In the Editor (and the read-only previews in the Manage dialog) a survey
 renders but cannot be submitted — there is no run folder to save into.
 
 ## Response files
@@ -93,7 +93,7 @@ One JSON file per administration, in the run folder:
 - `survey-01-lusk.json` — opened standalone; standalone administrations are
     numbered in their own sequence.
 
-The payload records the survey's key, title, and content version, the optional
+The payload records the SMACC version, the survey's key, name, title, and content version, the optional
 subject/session metadata, opened/submitted timestamps, the time since the
 **Start recording** marker (like the dream-report stamp), the linked report
 number (or `null`), the shared scale with its anchors, one
@@ -105,7 +105,8 @@ dropdown option). Display-only headings collect nothing and are omitted:
 ```json
 {
   "kind": "smacc/survey-response",
-  "survey": {"key": "dlq", "version": "1.0", "...": "..."},
+  "smacc_version": "0.0.10",
+  "survey": {"key": "dlq", "name": "DLQ", "version": "1.0", "builtin": true, "...": "..."},
   "report_number": 2,
   "time_since_recording_start": "02:14:09",
   "responses": [

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -46,7 +46,7 @@ study can retune any code in the **Markers** window; the change travels in its
 
 | Code | Event                   | Key                     | Notes                                                                                  |
 | ---- | ----------------------- | ----------------------- | -------------------------------------------------------------------------------------- |
-| 41   | REM detected            | `REMDetected`           |                                                                                        |
+| 41   | REM detected            | `REMDetected`           | sleep-stage observation (keypad 4 in the Event logging window)                         |
 | 42   | Tech in room            | `TechInRoom`            |                                                                                        |
 | 43   | Training start          | `TrainingStart`         | start of a training/learning phase (TMR cue learning, TLR practice)                    |
 | 44   | Training end            | `TrainingEnd`           |                                                                                        |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,55 +1,63 @@
 # Usage
 
-SMACC opens to its **Launcher**, where you pick a **SMACC file** and choose what
-to do; from there you run a live **Session** for collecting data. This page walks
-through the main features.
+SMACC opens to its **Launcher** — a list of the SMACC tools. Click a tool and SMACC
+asks for the **SMACC file** to use, then opens it. To run a night you open a live
+**Session**. This page walks through the main features.
 
-SMACC has three main windows, named consistently throughout these docs:
+The Launcher's tools (its title bar reads **SMACC**):
 
-- the **SMACC Launcher** (*Launcher* for short) — the small hub that opens when
-    you start the app;
-- the **SMACC Session** window (*Session*) — the live interface for running a
-    night and collecting data;
-- the **SMACC Editor** window (*Editor*) — where you create or edit a
-    [SMACC file](smacc-files.md) without recording anything.
+- **Session…** — run a live **Session** for collecting data, the interface for
+    running a night. SMACC prompts for a [SMACC file](smacc-files.md) first.
+- **Editor…** — create or edit a [SMACC file](smacc-files.md) in the **Editor**,
+    without recording anything.
+- **Analyzer** — inspect a past session.
+- **Audio Cue Designer** — build a tone cue and export it as a WAV.
+- **EEG Annotator** — review and annotate a recorded EEG (see
+    [EEG Annotator](eeg-annotator.md)); disabled when its optional component is not
+    installed.
+
+The **Session** and the **Editor** are the same window in two modes — running a
+night versus authoring a SMACC file.
 
 <!-- Add an annotated screenshot of the Launcher + Session window here once
 available, e.g.: ![SMACC Session window](assets/screenshot-session.png) -->
 
 ## Opening SMACC
 
-Open the app itself to get the Launcher — SMACC never drops straight into a
-session (the one exception: double-clicking a `.smacc` file, which starts a
-Session for it directly). In the Launcher you:
+Open the app to get the Launcher. SMACC never drops straight into a session; the one
+exception is double-clicking a `.smacc` file, which opens the **Start a session**
+dialog with that file preselected. From the Launcher:
 
-- **pick a SMACC file** — the dropdown lists the seeded `default.smacc`, your
-    recent files, and **Browse…** to find any other. With none chosen, SMACC uses
-    built-in defaults, so it works out of the box. (See
-    [SMACC files](smacc-files.md) for what one holds.)
-- **Start** — open a live Session using the selected SMACC file, writing runs to
-    that file's **data directory**. The run folder and log are created only now,
-    when the session starts.
-- **Create** — build a new SMACC file in the Editor: configure the tools (cues,
-    noise, visual, event codes, surveys), choose a data directory, and save it
-    anywhere.
-- **Edit** — reopen the selected SMACC file in the Editor.
-- **Audio Cue Designer** — open the standalone tool to build a simple tone cue
-    and export it as a WAV into a study's `cues/` folder, ready to use from the Audio
-    cue board (see [Designing a cue](#designing-a-cue)).
-- **Analyzer** — open a past session (a `.log`, a session folder, or a
-    zipped session) to see a summary (events, duration, subject/session, dream
-    reports), export its events to a BIDS `events.tsv`, or recover its settings to a
-    `.smacc` — all without starting a new session.
+- **Session…** — opens the **Start a session** dialog. Pick the **SMACC file** (the
+    picker lists recent files, the seeded `default`, and **Browse…** for any other),
+    confirm the optional subject/session/notes, and click **OK** to start. Runs are
+    written to that file's **data directory**; the run folder and log are created only
+    when the session starts. (See [SMACC files](smacc-files.md) for what a SMACC file
+    holds.)
+- **Editor…** — opens the **Open in the Editor** dialog. Choose **New SMACC file**
+    for a blank configuration, or an existing file (recents / **Browse…**) to edit.
+    The Editor configures the panels (cues, noise, visual, markers, surveys), sets a
+    data directory, and saves with **Save SMACC file as…**; it never records a run.
+- **Analyzer** — open a past session (a `.log`, a session folder, or a zipped
+    session) to see a summary (events, duration, subject/session, dream reports),
+    export its events to a BIDS `events.tsv`, or recover its settings to a `.smacc` —
+    all without starting a new session.
+- **Audio Cue Designer** — open the standalone tool to build a simple tone cue and
+    export it as a WAV into a study's `cues/` folder, ready to use from the Audio cue
+    board (see [Designing a cue](#designing-a-cue)).
+- **EEG Annotator** — open the post-hoc [EEG Annotator](eeg-annotator.md) to review a
+    recorded night and place annotations. It runs as its own window and process, so it
+    stays available while a session runs.
 
 Closing the Editor or a standalone tool returns you to the Launcher. Ending a
-Session quits SMACC entirely — the night is over. Closing the Launcher also
-quits SMACC.
+Session quits SMACC entirely — the night is over. Closing the Launcher also quits
+SMACC.
 
 ## Audio cues
 
 Place sound files where your settings expect them — by default the data directory's
-`cues/` folder (e.g. `~/SMACC/data/cues/`; `.wav`, `.mp3`, `.flac`, `.ogg`, and
-`.aiff` are supported) — and trigger them from the cue controls. SMACC seeds a few
+`cues/` folder (e.g. `~/SMACC/data/cues/`; common formats such as `.wav`, `.mp3`,
+`.flac`, `.ogg`, and `.aiff` are accepted) — and trigger them from the cue controls. SMACC seeds a few
 `demo-*` cues there so there is always something to test with. You start with one
 cue — prefilled with a random demo — and use **+ Add cue** and each row's **✕** to
 add or remove cues to match a protocol (one minimum, up to 20).
@@ -93,7 +101,7 @@ BlinkStick-vs-Hue comparison, marker timing, and the photosensitivity notes.
 
 ## Dream reports
 
-Use the **Record Dream Report** button to record from the mic bound to the
+Use the **Record dream report** button to record from the mic bound to the
 **Bedroom mic 1** equipment in the **Devices** window.
 Recordings are saved into the current session folder. Each report is also stamped
 with the time elapsed since you pressed **Start recording** (in the Event logging
@@ -311,7 +319,7 @@ launch once it grows large (one older `crash.log.1` generation is kept).
 A **SMACC file** captures your study's whole configuration — cue files, volumes,
 noise, visual cues, survey presets, event codes, display choices, and the **data
 directory** where runs are written — in a single portable `.smacc`. Create one in
-the Editor (the Launcher's **Create**/**Edit** buttons) or snapshot a running
+the Editor (the Launcher's **Editor…** button) or snapshot a running
 Session with **File › Save SMACC file as…**. Opening one starts a new
 session with that configuration. See [SMACC files](smacc-files.md) for the full
 story (creating, the data directory, opening by double-click), and the
@@ -321,7 +329,7 @@ story (creating, the data directory, opening by double-click), and the
 
 Some display choices apply to a session and travel with the study in the SMACC
 file: **always-on-top** (toggled per window — the Session window's **File**
-menu, or each tool window's **View** menu, or **Ctrl+T** in whichever window is
+menu, or each tool window's **File** menu, or **Ctrl+T** in whichever window is
 active) and which **log levels** show in the preview (the checkboxes above the
 log preview). Save them with the rest of the configuration from the Editor or
 with **File › Save SMACC file as…** in a Session.

--- a/docs/visual.md
+++ b/docs/visual.md
@@ -15,7 +15,7 @@ light at sleeping people. For plugging the devices in and binding them, see
 
 ## The visual cue board
 
-The **Visual cue** window (in the *Tools* column) is the light sibling of the
+The **Visual cue** window (in the **Panels** column) is the light sibling of the
 [Audio cue board](usage.md#audio-cues): one row per cue, each kept configured and
 ready so that firing the right light at 3 a.m. is a single click.
 
@@ -67,7 +67,7 @@ events, each carrying the cue's name. Two details matter for analysis:
 - **`VisualStarted` fires after the first frame is committed to the device.** On a
     BlinkStick the USB write takes ~1–2 ms, so the marker trails the photons by
     about that much. On Hue, "committed" means the bridge accepted the command — the
-    bulb itself transitions over the following ~100–200 ms, so the marker *leads*
+    bulb itself transitions over the following ~100 ms, so the marker *leads*
     the photons by that lag (and it varies). Time-locked analyses should use the
     BlinkStick.
 - **`VisualStopped` fires once the light is actually dark** — after the fade-out
@@ -86,8 +86,8 @@ over a sleeping participant.
 | Connection | One USB cable, no network                          | Bridge on the rig's LAN; bulbs via Zigbee                                                             |
 | Buying     | [blinkstick.com](https://www.blinkstick.com/) only | Retail everywhere, but pricier                                                                        |
 | Setup      | Plug in, bind, done                                | Pair once with the bridge's link button ([Devices › Philips Hue](devices.md#philips-hue))             |
-| Cue onset  | ~1–2 ms after the marker                           | ~100–200 ms of lag and jitter                                                                         |
-| Patterns   | Steady, pulse, and flash (up to 20 Hz)             | Steady and slow pulse; **flash is refused** (the bridge rate-limits commands far below a square wave) |
+| Cue onset  | ~1–2 ms after the marker                           | ~100 ms of lag and jitter                                                                             |
+| Patterns   | Steady, plus pulse and flash up to 20 Hz           | Steady and slow pulse; **flash is refused** (the bridge rate-limits commands far below a square wave) |
 | Coverage   | A point source near the bed                        | Whole-room illumination, or a group of rooms                                                          |
 | Fails when | The USB cable/port acts up                         | The bridge IP changes or the network drops                                                            |
 


### PR DESCRIPTION
First step of the #233 docs overhaul: catch the docs up with the redesigned launcher (#235) and renamed tools (#221), and fix reference-page drift. Structure, language, screenshots, and the home rewrite follow separately.

Changes:
- Launcher: replace the stale dropdown / Start / Create / Edit description with the flat tool list (Session… / Editor… open file-picker dialogs); correct the double-click-to-session behavior.
- Naming: Tools column → Panels; Analyze → Analyzer; Output latency → Latency; Record Dream Report → Record dream report; Volume readouts → System volume / App volume.
- Home: point the download button at the installer, matching the installation page.
- Reference: version strings → 0.0.10; add the seven eeg_* preference keys; correct the preferences-vs-.smacc version handling; attribute BIDS export to the Analyzer; add survey response fields and the third chat preset.
- Contributing: add --collect-submodules matplotlib.backends to the EEG build with its rationale (#180, #227); fix the CI matrix and coverage-command notes.

Verified with mkdocs build --strict, pytest tests/test_docs_schema.py, and mdformat --check.