### PR TITLE
docs: restructure into per-feature pages and add troubleshooting

### DIFF
--- a/docs/audio-cues.md
+++ b/docs/audio-cues.md
@@ -1,0 +1,86 @@
+# Audio cues
+
+Audio is SMACC's primary cueing modality. The **Audio cue** window (in the
+**Panels** column) holds the cue board: one row per cue, each ready to fire with a
+single click.
+
+<!-- Add a screenshot of the Audio cue window here once available: the cue rows with
+their volume/loop controls and the Monitoring section. -->
+
+## The cue board
+
+Place sound files where your settings expect them — by default the data directory's
+`cues/` folder (for example `~/SMACC/data/cues/`; common formats such as `.wav`,
+`.mp3`, `.flac`, `.ogg`, and `.aiff` are accepted) — and trigger them from the cue
+controls. SMACC seeds a few `demo-*` cues there so there is always something to test
+with. You start with one cue, prefilled with a random demo, and use **+ Add cue** and
+each row's **✕** to match a protocol (one minimum, up to 20).
+
+Each play and stop is marked in the EEG record. The cue marker is stamped at the
+*estimated sound onset*, not the button press, so it lines up with what the
+participant hears (see [Volume & latency](latency.md)).
+
+## Designing a cue
+
+No sound file ready? Open the **Audio Cue Designer** from the Launcher to build a
+simple cue inside SMACC, with no external audio editor. Lay out a sequence of
+**tone** and **silence** segments (each tone has a frequency, duration, and level,
+with an optional bell-like **decay**), or start from a **preset** (a single chime, a
+pip train). The whole pattern can **repeat** (×N with a gap between repeats, the
+classic pip-train shape), and an optional whole-cue fade in/out and normalize finish
+it. A live **waveform** shows the cue as you edit, **Preview** plays it on your
+default output, and **Export WAV…** writes it into your study's `cues/` folder, where
+it appears in the cue board like any other cue.
+
+The WAV is what the cue board plays; the *design* stays editable through **Save
+design… / Open design…** (a small `.json` file, kept alongside the WAVs by default),
+so you can reopen it tomorrow and nudge a level instead of rebuilding the cue. The
+designer is a standalone tool: it plays on the default device and ignores the
+session's device routing and volume safety cap.
+
+<!-- Add a screenshot of the Audio Cue Designer here once available: the live
+waveform with the Preview and Export WAV… buttons. -->
+
+## Background noise
+
+The **Noise machine** window plays continuous masking noise on the cue route. Pick a
+**color** (white and the other generated colours) or point it at your own WAV
+(the **From file** option), set its **volume**, and start it. **Noise started** (62) and
+**Noise stopped** (63) mark the EEG. Noise shares the bedroom-speaker route and the
+output safety cap with cues, so calibrate it the same way.
+
+## Is the cue reaching the bedroom?
+
+A cue you can hear in the control room is not proof the *participant* heard it: the
+bedroom speaker could be muted, unplugged, or turned down at the hardware. The Audio
+cue window's **Monitoring** section shows two meters so you can tell:
+
+- **Sending** is the level SMACC is emitting to the cue output, the moment it plays.
+    It is exact, but it only confirms SMACC is *playing*; it is blind to everything
+    downstream (Windows volume, the speaker's power switch, the cable). Read it as a
+    diagnostic: if *Sending* is dark, the problem is on SMACC's side (wrong cue, or a
+    per-cue volume or the safety cap at zero); if it is lit but the room is silent,
+    the problem is the speaker.
+- **Bedroom** is the level a microphone actually picks up in the room. This is the
+    objective check: it moves only when sound really happens in the bedroom. Tick the
+    box beside it to start monitoring. Because a faint cue can sit close to a cheap
+    mic's noise floor, the meter also shows the **rise above the room's resting
+    level** (the `+N` next to the reading), so even a small bump stands out.
+
+!!! tip "A dedicated monitoring mic"
+
+    The *Bedroom* meter listens on the **Monitor bedroom noise** route, which
+    defaults to **Bedroom mic 1**. For the most reliable check — especially for the
+    very quiet cues a study often starts at — bind a separate, sensitive **Bedroom
+    mic 2** in the Devices window and route *Monitor bedroom noise* to it. That keeps
+    verification independent of the (often cheaper, voice-activated) dream-report mic.
+
+!!! warning "A quiet mic isn't proof of silence"
+
+    A cheap or voice-activated mic may not register a very faint cue even when it is
+    playing, so a dark *Bedroom* meter is a prompt to check, not proof the cue failed.
+    Read it together with *Sending*.
+
+For how cue levels combine and how to calibrate them, see
+[Volume & latency](latency.md). For binding the speaker and mics, see
+[Audio routing](audio.md).

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -1,4 +1,4 @@
-# Audio & device routing
+# Audio routing
 
 An overnight cueing study can run several audio streams at once: a cue in the
 bedroom, white noise in the bedroom, your voice over an intercom, the participant's
@@ -7,9 +7,10 @@ more than one physical device and two rooms. On Windows, the same speaker can al
 appear under several names, and the level that reaches the participant is the product
 of several controls spread across the OS.
 
-This page describes how SMACC handles devices, routing, and volume.
+This page describes how SMACC handles devices and routing. For the output safety cap
+and stimulus timing, see [Volume & latency](latency.md).
 
-## Equipment, not per-window device pickers
+## Equipment and actions
 
 Instead of picking a device separately in every window, SMACC has one **Devices
 window** (in the **Panels** column) where you do two things:
@@ -78,13 +79,14 @@ Three optional routes cover the things you reach for mid-study:
 - **Listen to participant.** The intercom is two-way: **Speak to participant**
     sends your voice — picked up by the **Control-room mic** — to the participant
     (and is marked in the EEG record), while **Listen to participant** brings the
-    participant's mic to your control-room speaker. The intercom also has a typed [text-chat mode](usage.md#text-chat)
-    (no audio device involved) for hearing-impaired participants.
+    participant's mic to your control-room speaker. The intercom also has a typed
+    [text-chat mode](intercom.md#text-chat) (no audio device involved) for
+    hearing-impaired participants.
 - **Monitor bedroom noise.** A microphone meter in the Audio cue window that
     confirms a cue is audible in the bedroom (see
-    [below](#is-the-cue-reaching-the-bedroom)). It defaults to **Bedroom mic 1**, or
-    bind a dedicated, more sensitive **Bedroom mic 2** and route *Monitor bedroom
-    noise* to it.
+    [Audio cues](audio-cues.md#is-the-cue-reaching-the-bedroom)). It defaults to
+    **Bedroom mic 1**, or bind a dedicated, more sensitive **Bedroom mic 2** and route
+    *Monitor bedroom noise* to it.
 
 ## One audio engine
 
@@ -115,64 +117,13 @@ source.
 automatically, with no restart needed. You can also force a rescan with the
 **Refresh devices (F5)** button in the Devices window.
 
-## Is the cue reaching the bedroom?
+## Monitoring and volume
 
-A cue you can hear in the control room isn't proof the *participant* heard it — the
-bedroom speaker could be muted, unplugged, or turned down at the hardware. The
-**Audio cue** window's **Monitoring** section shows two meters so you can tell:
-
-- **Sending** — the level SMACC is emitting to the cue output, the moment it plays.
-    It's exact, but it only confirms SMACC is *playing*; it's blind to everything
-    downstream (Windows volume, the speaker's power switch, the cable). Treat it as a
-    diagnostic: if *Sending* is dark, the problem is on SMACC's side (wrong cue, the
-    per-cue volume or the safety cap at zero); if it's lit but the room is silent, the
-    problem is the speaker.
-- **Bedroom** — the level a microphone actually picks up in the room. This is the
-    objective check: it only moves when sound really happens in the bedroom. Tick the
-    box beside it to start monitoring. Because a faint cue can sit close to a cheap
-    mic's noise floor, the meter also shows the **rise above the room's resting level**
-    (the `+N` next to the reading), so even a small bump stands out.
-
-!!! tip "A dedicated monitoring mic"
-
-    The *Bedroom* meter listens on the **Monitor bedroom noise** route, which
-    defaults to **Bedroom mic 1**. For the most reliable check — especially for the
-    very quiet cues a study often starts at — bind a separate, sensitive
-    **Bedroom mic 2** in the Devices window and route *Monitor bedroom noise* to
-    it. That keeps verification independent of the (often cheaper,
-    voice-activated) dream-report mic.
-
-!!! warning "A quiet mic isn't proof of silence"
-
-    A cheap or voice-activated mic may not register a very faint cue even when it is
-    playing, so a dark *Bedroom* meter is a prompt to check — not proof the cue
-    failed. Read it together with *Sending*.
-
-## Volume you can see
-
-On Windows, the level reaching the participant is a product of several controls:
-
-```text
-per-cue volume  ×  output safety cap  ×  Windows app volume  ×  Windows device volume  ×  hardware knob
-```
-
-Three of those live in the OS and are invisible from most apps. SMACC makes its own
-gain explicit and adds a safety limit, in the **Volume** window:
-
-- **Output safety cap.** A single master ceiling, applied as the last gain stage on
-    every cue and noise output. However loud an individual cue is set, the cap is a
-    hard limit, so a full-volume looped cue on a calibrated rig can't suddenly blast a
-    sleeping participant.
-- **A read-only view of the Windows stages.** The window shows the current **System
-    volume** (the Windows output endpoint) and **App volume** (SMACC's own level) in
-    the Windows Volume Mixer, so the
-    hidden OS stages are visible.
-
-!!! tip "Calibrating cue level"
-
-    For levels that reproduce across nights and participants, set the Windows device
-    and app volumes to 100%, then calibrate with the per-cue volumes and the safety
-    cap inside SMACC. That way one place, SMACC, determines how loud a cue is.
+To confirm a cue actually reaches the bedroom, use the Audio cue window's
+**Monitoring** meters — see
+[Audio cues](audio-cues.md#is-the-cue-reaching-the-bedroom). For the output safety
+cap, the per-cue gains, and how the Windows volume stages combine, see
+[Volume & latency](latency.md).
 
 ## Windows only
 

--- a/docs/biocals.md
+++ b/docs/biocals.md
@@ -1,0 +1,63 @@
+# Biocals
+
+Sleep studies open with **biocalibrations**: scripted participant actions (eyes
+open, eyes closed, look left/right, and so on) whose known physiological signatures
+verify the recording channels. The **Biocals** window (in the **Panels** column)
+runs them as timed, marked events — every standard biocal plus the common
+lucid-dreaming signal practices (LRLR variants, fist clenches, sniffs), each on its
+own row.
+
+<!-- Add a screenshot of the Biocals window here once available: a row's toggle
+button with its Voice/Seq checkboxes and Duration, and the countdown at the top. -->
+
+## Running a biocal
+
+Each row has a toggle button, two checkboxes, and a duration:
+
+- **The biocal's button** runs it. The button stays depressed while it runs and the
+    countdown at the top shows the time remaining in its task window. Press it again
+    to cancel early, so a botched 30-second window need not be waited out.
+- **Voice** speaks the pre-recorded instruction (for example, *"Please close your
+    eyes and relax for thirty seconds."*) over the cue output when the biocal starts.
+    Leave it unchecked to give the instruction yourself.
+- **Seq** includes the row when **Play sequence** runs the whole stack in order.
+    Standard biocals start checked; the lucid-dreaming ones start unchecked.
+- **Duration** is the task window in seconds. With the voice on, the window (and its
+    countdown) starts when the instruction *ends*, so a 10-second breath hold is a
+    full 10 seconds. This matches the manual practice of speaking first, then marking
+    when the participant complies.
+
+## Sequences
+
+**Play sequence** runs every Seq-checked row top to bottom, depressing each button
+as it goes. Pressing the *active* biocal's button skips that item (a cancel marker,
+then on to the next); pressing the sequence button again aborts the rest. Rows can
+**repeat** a biocal (eyes-closed twice, extra LRLRs — use **+ Add** for another
+instance), be reordered with **▲/▼**, and removed with **✕**. The stack is locked
+while something is running. For a biocal SMACC does not ship, use a custom event
+button in the [Event logging panel](triggers.md#event-logging-panel).
+
+## Markers
+
+Each biocal's *start* code fires when its task window opens. A shared **completed**
+code fires when the window runs out, and a shared **cancelled** code fires on an
+early stop (the preceding start code identifies which biocal). A played sequence is
+bracketed by its own start/stop codes and otherwise fires the same per-biocal
+markers. The defaults are sequence start/stop **105**/**106**, cancelled **107**,
+completed **108**, and one start code per biocal in the **110–126** band. All are
+retunable in the **Markers** window like any built-in event (see
+[Markers & port codes](triggers.md)).
+
+## Voice recordings
+
+Voice recordings ship inside SMACC (generated with
+[ElevenLabs](https://elevenlabs.io) text-to-speech) and are read straight from the
+bundle, so they stay current when you upgrade. To use another voice or language,
+drop your own recording under the same name in your SMACC directory's `biocals/`
+folder (for example `~/SMACC/biocals/`); a file there overrides the bundled one. A
+biocal with no recording in either place still runs, just unvoiced, and session
+start warns when that happens.
+
+The shared **Voice volume** rides the cue route, so the master output cap and the
+control-room monitor fan-out apply to instructions exactly as they do to cues (see
+[Volume & latency](latency.md) and [Audio routing](audio.md)).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -21,6 +21,10 @@
 - Use the marker vocabulary consistently in UI text, docs, and docstrings — *event*,
     *marker*, *port code*, *trigger*, *transport* each mean exactly one thing; see the
     [terminology table](triggers.md#terminology).
+- Write the docs as **reference**, not marketing: lead with the fact, keep pages
+    scannable (short paragraphs, tables, steps), and go easy on em-dashes and the
+    "not X, but Y" construction. Page filenames are stable, so cross-link with
+    relative links and matching heading anchors.
 - Pick log levels by the [session-log convention](reference/session-log.md#log-levels):
     `DEBUG` for housekeeping/high-frequency detail, `INFO` for markers and meaningful
     operator actions, `WARNING` for mid-session config changes and recoverable faults,

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -3,7 +3,7 @@
 SMACC can drive a small number of external devices for cueing. This page lists
 the supported hardware and what each one needs. For how SMACC *assigns and routes*
 devices — equipment, the Devices window, and volume — see
-[Audio & device routing](audio.md); for using the light devices — patterns,
+[Audio routing](audio.md); for using the light devices — patterns,
 timing, choosing between them, and safety — see [Visual cues](visual.md).
 
 ## BlinkStick

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,19 +1,17 @@
 # SMACC
 
-**Sleep Manipulation And Communication Clickything** (SMACC) is a downloadable
-executable file for running sleep and dream manipulation studies — experiments in
-which you control dream content during sleep and collect dream reports. It provides
-a simple, clickable interface and is commonly used in dream engineering research.
+**Sleep Manipulation And Communication Clickything** (SMACC) is a Windows desktop
+app for running sleep and dream studies — presenting cues to a sleeping participant,
+communicating with them, marking events on the EEG, and collecting dream reports.
 
-- Trigger audio cues
-- Trigger visual cues (BlinkStick or Philips Hue)
-- Collect dream reports
-- Trigger EEG port codes
-- Save a detailed event log
-- and more!
+In a dream-engineering session the experimenter has to deliver a precisely-timed cue
+to a sleeping participant, mark each event so it lines up with the EEG, talk with the
+sleeper, and collect a dream report — all from a dark control room, late at night, on
+whatever hardware the lab has. SMACC is the clickable control surface for that work:
+one window per job, glanceable in the dark, with a volume safety cap and explicit
+device routing so a misclick can't blast or mislead a sleeping participant.
 
-<!-- Add a screenshot of the main window here once available, e.g.:
-![SMACC main window](assets/screenshot-main.png) -->
+<!-- Add a screenshot of the SMACC Session window here once available. -->
 
 [Download SMACC](https://github.com/remrama/smacc/releases/latest/download/SMACC-Setup.exe){ .md-button .md-button--primary }
 [Installation guide](installation.md){ .md-button }
@@ -24,15 +22,42 @@ single file with no install? A portable `SMACC.exe` ships with every release —
 [Installation](installation.md), which also covers the Windows SmartScreen warning on
 the unsigned download and how to get older versions.
 
+## What SMACC does
+
+- Trigger **audio cues** (and design them in-app with the Audio Cue Designer)
+- Trigger **visual cues** on a BlinkStick or Philips Hue light
+- Play masking **background noise**
+- Run **biocalibrations** as timed, marked tasks
+- Record **dream reports** and administer **surveys**
+- **Talk, listen, and type** with the participant over an intercom
+- Mark events with **EEG port codes** over LSL or a hardware TTL trigger
+- Review and score recordings in the **EEG Annotator**
+- Save a detailed **event log** for every run
+
 ## Get started
 
+**Getting started**
+
 - [Installation](installation.md) — download and run SMACC.
-- [Usage](usage.md) — trigger cues, record dream reports, send port codes, and more.
 - [SMACC files](smacc-files.md) — create and reuse a study's configuration (`.smacc`).
-- [Audio & routing](audio.md) — bind the rig's equipment to devices, route cues/noise/intercom, and set volume.
-- [Visual cues](visual.md) — light cues on a BlinkStick or Philips Hue: patterns, timing, and safety.
-- [Devices](devices.md) — connect compatible hardware such as a BlinkStick or a Hue bridge.
-- [Contributing](contributing.md) — develop SMACC and build these docs locally.
+
+**Running a session**
+
+- [Overview](usage.md) — the Launcher, the Session window, and the tools.
+- [Audio cues](audio-cues.md) · [Visual cues](visual.md) · [Biocals](biocals.md) ·
+    [Dream reports & surveys](surveys.md) · [Intercom & chat](intercom.md) ·
+    [Markers & port codes](triggers.md)
+
+**Devices, volume & timing**
+
+- [Audio routing](audio.md) · [Compatible devices](devices.md) ·
+    [Volume & latency](latency.md)
+
+**After the night**
+
+- [EEG Annotator](eeg-annotator.md) — review and score recorded EEG.
+- [Troubleshooting](troubleshooting.md) · [Reference](reference/index.md) ·
+    [Contributing](contributing.md)
 
 ## Used by
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -79,57 +79,22 @@ usually pin one version for their whole run, so checking is always an explicit
 click. If you use the portable `SMACC.exe`, download the new one and replace
 your old copy.
 
-## Optional setup
+## After installing
 
-### Data directory
+By default SMACC stores everything under `~/SMACC`. To use a different location, set
+the environment variable `SMACC_DIRECTORY` to the directory you want; SMACC creates
+it and its subfolders on first run.
 
-By default SMACC stores everything under `~/SMACC`. To use a different location,
-set an environment variable called `SMACC_DIRECTORY` to whatever directory you
-want. SMACC will create it and all of the subfolders (if not already present).
+The rest of setup is covered on the relevant pages:
 
-Your reusable setup lives in a **SMACC file** (`.smacc`): cue files, volumes,
-event codes, and the **data directory** where its runs are written. SMACC seeds a
-`default.smacc` in the SMACC directory (with data directory `~/SMACC/data`) and
-opens it when you don't pick another, so it works out of the box. You can keep your
-own SMACC files anywhere. See [SMACC files](smacc-files.md).
-
-Each run gets its own timestamped folder under the SMACC file's data directory
-(e.g. `smacc-20260607-223015/`) holding that run's `.log`, dream-report recordings,
-and any exports. Subject/session are optional metadata (set from **File ›
-Session info…**) recorded inside the log/exports rather than in filenames. Display
-choices that apply to a session — **always-on-top** and which **log-preview** levels
-show — are stored in the SMACC file too, so they travel with the study. The machine
-itself remembers window positions and sizes and your recent files in
-`~/SMACC/preferences.yaml`, restored on the next launch.
-
-### SMACC files (`.smacc`)
-
-Your reusable setup is saved to a portable SMACC file (see
-[SMACC files](smacc-files.md)). The installer associates `.smacc` files so you can
-**double-click one to open the Start-a-session dialog with it preselected**. With the portable
-`SMACC.exe`, enable (or repair) the association any time from
-**File › Associate .smacc files (Windows)** in the Launcher.
-
-### Audio cues
-
-SMACC seeds a few `demo-*` cue files into the default data directory's `cues/`
-folder (restored if you delete them, and refreshed when you upgrade SMACC), so
-there is always something to test with. You can also place your own sound files
-there — common formats such as `.wav`, `.mp3`, `.flac`, `.ogg`, and `.aiff` are
-accepted; only the
-`demo-` files are managed by SMACC, so your own are never touched.
-
-### Dream report survey
-
-The **Record dream report** button can optionally pop open a survey — one of the
-built-in dream questionnaires (opened in a SMACC window, responses saved into the
-run folder) or a survey URL hosted on e.g. Qualtrics or REDCap (opened in the
-browser). Manage them from the Dream-recording panel's **Manage…** button; saved
-URLs persist in your SMACC file. Pick one from the survey dropdown to open it
-automatically when recording starts, or open any survey on its own from
-**File › Surveys**. See [Surveys](surveys.md).
-
-### Recording device
-
-If you plan to record dreams, bind your mic to **Bedroom mic 1** in the
-**Devices** window (in the **Panels** column); the dream-report recorder uses it.
+- **Your study configuration** lives in a portable [SMACC file](smacc-files.md).
+    SMACC seeds a `default.smacc` and opens it when you don't pick another, so it
+    works out of the box. The installer associates `.smacc` files; with the portable
+    build, enable or repair the association from **File › Associate .smacc files
+    (Windows)** in the Launcher.
+- **Audio cues** go in the data directory's `cues/` folder, alongside the seeded
+    `demo-*` cues — see [Audio cues](audio-cues.md).
+- **Dream-report surveys** are managed from the Dream recording panel — see
+    [Dream reports & surveys](surveys.md).
+- **A recording mic:** to record dreams, bind your mic to **Bedroom mic 1** in the
+    **Devices** window (the **Panels** column) — see [Audio routing](audio.md).

--- a/docs/intercom.md
+++ b/docs/intercom.md
@@ -1,0 +1,65 @@
+# Intercom & chat
+
+The **Intercom** window (in the **Panels** column) is the live channel between the
+control room and the bedroom. It carries voice both ways, plus a typed text channel
+for when audio would intrude.
+
+<!-- Add a screenshot of the Intercom window here once available: Talk / Listen with
+their level meters, and the text-chat area below. -->
+
+## Voice
+
+- **Talk (to participant)** pipes the control-room mic to the participant's output.
+    Click to latch, or hold the **spacebar** anywhere in SMACC for push-to-talk.
+    Talking is marked in the EEG record.
+- **Listen (to participant)** brings the bedroom mic to your control-room speakers.
+    It is unmarked.
+
+Both directions route through equipment set once in the **Devices** window (see
+[Audio routing](audio.md)). A **level meter** beside each button shows the live
+input level while that direction is on, so signal on the bar means audio is actually
+flowing (your mic for Talk, the participant's mic for Listen) rather than just a
+latched button.
+
+## Text chat
+
+Below the voice controls is a **typed channel**, for hearing-impaired participants,
+or whenever audio would intrude or you want the exchange in writing. You type in the
+Intercom panel; the participant reads and replies in a separate **Participant chat**
+window built for a dark bedroom: always dark regardless of the lights toggle, large
+text (default 18 pt, resize with `Ctrl+=` / `Ctrl+-`), and an optional **red night
+text** mode (**Display** menu), with no flashing and no sounds.
+
+<!-- Add a screenshot of the Participant chat window here once available: dark, large
+text, showing the "● The keyboard is yours" banner. -->
+
+**Setup.** The first cut assumes one computer: extend the desktop onto a
+bedroom-facing monitor and plug in a second keyboard for the participant. Click
+**Pass keyboard to participant** to open the participant window, drag it onto the
+bedroom display once, and it reopens there next session.
+
+**One keyboard at a time.** Windows gives the machine a single input focus, so the
+two keyboards type into whichever window is active; text chat is half-duplex, like
+push-to-talk. **Pass keyboard to participant** (or `Ctrl+Enter`, which sends your
+message first) activates the participant window so their keystrokes land there.
+Clicking back into SMACC takes focus back. The participant window shows a banner,
+*"● The keyboard is yours"* or *"○ Waiting"*, so a drowsy participant always knows
+whether typing will land.
+
+**Quick replies.** Canned messages save both sides from typing a full sentence at
+3 a.m., and they travel with the study. Click **Manage quick messages…** on the
+Intercom panel to edit two lists: *experimenter prompts* (one click sends a
+standardized prompt, such as the lab's dream-report question or *"Are you awake?"*)
+and *participant replies* mapped to the number keys **1–9** (for example *"Got it"*,
+*"I'm awake"*, *"Yes"*, *"No"*). The participant's replies appear as large numbered
+chips; pressing a number sends that reply, but only while their entry box is empty,
+so a typed reply that contains digits still works. A sent preset is logged and
+marked exactly like a typed message.
+
+**What's recorded.** Every message is written verbatim to the session log as a
+`DEBUG` line (tick *Debug* above the log preview to watch the exchange live). By
+default no port codes fire and nothing reaches the BIDS events export: a typed
+exchange is rapid and conversational, and would flood the marker channel. If a study
+needs marker timestamps, route `Chat to participant` (code 69) and `Chat from participant` (code 70) to LSL/TTL in the **Markers** window (see
+[Markers & port codes](triggers.md)). The markers stay bare, without the message
+text, so the trigger channel stays legible.

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -1,9 +1,43 @@
-# Latency
+# Volume & latency
 
-How long is it from clicking **Play** (or firing a cue) to the participant
-actually hearing the sound or seeing the light — and how well does the event
-marker line up with it? This page answers that, shows how to measure it on your own
-rig, and explains what SMACC does to keep markers honest.
+The **Volume** window holds two things that shape every cue: how loud it can get
+(the output safety cap and the visible OS volume stages) and the output **latency**
+setting. This page covers both.
+
+## Volume
+
+On Windows, the level reaching the participant is a product of several controls:
+
+```text
+per-cue volume  ×  output safety cap  ×  Windows app volume  ×  Windows device volume  ×  hardware knob
+```
+
+Three of those live in the OS and are invisible from most apps. SMACC makes its own
+gain explicit and adds a safety limit, in the **Volume** window:
+
+- **Output safety cap.** A single master ceiling, applied as the last gain stage on
+    every cue and noise output. However loud an individual cue is set, the cap is a
+    hard limit, so a full-volume looped cue on a calibrated rig cannot suddenly blast
+    a sleeping participant.
+- **A read-only view of the Windows stages.** The window shows the current **System
+    volume** (the Windows output endpoint) and **App volume** (SMACC's own level) in
+    the Windows Volume Mixer, so the hidden OS stages are visible.
+
+!!! tip "Calibrating cue level"
+
+    For levels that reproduce across nights and participants, set the Windows device
+    and app volumes to 100%, then calibrate with the per-cue volumes and the safety
+    cap inside SMACC. That way one place, SMACC, determines how loud a cue is.
+
+<!-- Add a screenshot of the Volume window here once available: the safety cap, the
+Latency choice, and the System volume / App volume readouts. -->
+
+## Latency
+
+How long is it from clicking **Play** (or firing a cue) to the participant actually
+hearing the sound or seeing the light, and how well does the event marker line up
+with it? This section answers that, shows how to measure it on your own rig, and
+explains what SMACC does to keep markers honest.
 
 !!! note "The short version"
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,7 +2,7 @@
 
 SMACC reads and writes a handful of files. This section is the **reference** for
 each one — its on-disk shape, every field, and how it is versioned — as distinct
-from the task-oriented [Usage](../usage.md) guide.
+from the task-oriented [Overview](../usage.md) guide.
 
 | File                                            | What it is                                | Format     | Version              |
 | ----------------------------------------------- | ----------------------------------------- | ---------- | -------------------- |

--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -62,7 +62,7 @@ Most markers are stamped when SMACC fires them. **Audio cue and noise** markers 
 the exception: their timestamp — in the log line *and* the LSL stream — is the
 *estimated onset* (the fire time plus the output stream's reported latency), so the
 marker lines up with the sound rather than SMACC's buffer (see
-[Latency](../latency.md)). The raw software-trigger instant rides alongside on a
+[Volume & latency](../latency.md)). The raw software-trigger instant rides alongside on a
 `DEBUG` line:
 
 ```text
@@ -75,7 +75,7 @@ That `DEBUG` line is deliberately **not** a `" - portcode N"` line, so the
 
 ### Text-chat transcript
 
-Each [text-chat](../usage.md#text-chat) message is written verbatim to a `DEBUG`
+Each [text-chat](../intercom.md#text-chat) message is written verbatim to a `DEBUG`
 line, one per message — in the file for the record, out of the live preview and
 the BIDS export by default:
 

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -115,17 +115,17 @@ Any key may be omitted — each falls back to its default.
 | `visual_attack`             | seconds             | Brightness fade-in applied to a starting visual cue.                                                                                                                                                                         |
 | `visual_release`            | seconds             | Brightness fade-out applied to a stopping visual cue.                                                                                                                                                                        |
 | `survey_url`                | string              | The selected survey: a web URL, or `smacc://survey/<key>` for an in-app survey.                                                                                                                                              |
-| `survey_options`            | mapping             | Named *web* survey presets: label → URL. In-app surveys (built-in or custom) are not persisted here — they come from survey definition files (see [Surveys](../surveys.md)).                                                 |
+| `survey_options`            | mapping             | Named *web* survey presets: label → URL. In-app surveys (built-in or custom) are not persisted here — they come from survey definition files (see [Dream reports & surveys](../surveys.md)).                                 |
 | `chat_font_size`            | integer             | Participant chat window text size, in points (8–72).                                                                                                                                                                         |
 | `chat_red_text`             | boolean             | Red-shifted night text in the participant chat window.                                                                                                                                                                       |
 | `chat_experimenter_presets` | list                | Intercom quick-reply prompts the experimenter sends with one click (verbatim, like a typed message). Omitted → seeded defaults; an empty list is respected.                                                                  |
 | `chat_participant_presets`  | list                | Participant quick replies, shown as numbered chips and sent with the number keys 1–9 (max 9). Omitted → seeded defaults; an empty list is respected.                                                                         |
 | `volume_cap`                | 0–1                 | Master output safety cap multiplied into every stimulus (`1.0` = no cap).                                                                                                                                                    |
-| `output_latency`            | `high` \| `low`     | Output buffer for the cue + noise streams: `high` is robust (default), `low` trims marker-to-sound delay where the device allows it (often unchanged on shared-mode WASAPI). See [Latency](../latency.md).                   |
+| `output_latency`            | `high` \| `low`     | Output buffer for the cue + noise streams: `high` is robust (default), `low` trims marker-to-sound delay where the device allows it (often unchanged on shared-mode WASAPI). See [Volume & latency](../latency.md).          |
 
 ### `biocals`
 
-The Biocals window's stack (see [Usage › Biocals](../usage.md#biocals)):
+The Biocals window's stack (see [Biocals](../biocals.md)):
 `voice_volume` (0–1, the shared instruction volume) plus one `rows` entry per
 stack row, in display order. Rows may repeat a biocal (e.g. eyes-closed twice in
 the played sequence). A missing block — or a block without `rows` — loads the
@@ -169,7 +169,7 @@ for TTL-routed codes (LSL carries any code).
 
 ### `devices`
 
-Equipment → device bindings plus action → equipment routing (see [Audio & routing](../audio.md)
+Equipment → device bindings plus action → equipment routing (see [Audio routing](../audio.md)
 and [Devices](../devices.md)).
 
 | Key        | Type    | Meaning                                                                                                                                                                                                                                                                   |
@@ -182,12 +182,12 @@ no devices bound). When a live session starts (or loads a study) with
 `bedroom_speaker`, `bedroom_mic_1`, or `control_mic` unbound, SMACC binds the
 current Windows default device explicitly, by name, and logs the choice — there is
 no "system default" pseudo-selection (see
-[Audio & routing](../audio.md#no-system-default)).
+[Audio routing](../audio.md#no-system-default)).
 
 ### `trigger_output`
 
 Optional hardware TTL trigger output, mirrored alongside the always-on LSL stream
-(see [Triggers & port codes](../triggers.md)).
+(see [Markers & port codes](../triggers.md)).
 
 | Field       | Type                   | Meaning                                                         |
 | ----------- | ---------------------- | --------------------------------------------------------------- |

--- a/docs/surveys.md
+++ b/docs/surveys.md
@@ -1,22 +1,39 @@
-# Surveys
+# Dream reports & surveys
 
-After an awakening, a dream report is often followed by a questionnaire — how
-lucid was the dream, what did it contain, how confident is the participant. SMACC
-handles these two ways:
+After an awakening the participant gives a **dream report**: recorded audio, often
+followed by a questionnaire. SMACC records the audio and can open a survey alongside
+it.
 
-- **In-app surveys** render in a SMACC window and save their responses straight
-    into the run folder, next to the dream-report WAV they accompany. SMACC ships
-    the standard lucid-dreaming instruments, and you can build your own.
-- **Web surveys** (e.g. a questionnaire hosted on Qualtrics or REDCap) open in
-    the browser, exactly as before — add them by URL.
+## Recording a dream report
 
-In-app surveys exist because the night shift is a bad place for a hosted form:
-sleep labs are often offline, response data belongs with the night's recording
-(not in a third-party account), and overnight questionnaires are frequently
-administered *verbally over the intercom* — the participant stays in bed, in the
-dark, while the experimenter reads the items and records the answers. The survey
-window is non-modal for the same reason: the intercom stays reachable while it is
-open.
+Use the **Record dream report** button (in the **Dream recording** panel) to record
+from the mic bound to the **Bedroom mic 1** equipment in the **Devices** window.
+Recordings are saved into the current session folder as `report-NN.wav`. Each report
+is stamped with the time elapsed since you pressed **Start recording** (in the
+[Event logging panel](triggers.md#event-logging-panel)), so it is easy to locate in
+the EEG file. If recording has not been marked yet, the report is still logged and
+SMACC reminds you to mark it.
+
+<!-- Add a screenshot of the Dream recording panel here once available: the Record
+dream report button with the survey dropdown and Manage… button. -->
+
+## Surveys
+
+A dream report is often followed by a questionnaire: how lucid was the dream, what
+did it contain, how confident is the participant. SMACC handles these two ways:
+
+- **In-app surveys** render in a SMACC window and save their responses straight into
+    the run folder, next to the dream-report WAV they accompany. SMACC ships the
+    standard lucid-dreaming instruments, and you can build your own.
+- **Web surveys** (for example a questionnaire hosted on Qualtrics or REDCap) open in
+    the browser; add them by URL.
+
+In-app surveys exist because the night shift is a bad place for a hosted form: sleep
+labs are often offline, response data belongs with the night's recording rather than
+a third-party account, and overnight questionnaires are frequently administered
+*verbally over the intercom*, with the participant in bed in the dark while the
+experimenter reads the items and records the answers. The survey window is non-modal
+for the same reason, so the intercom stays reachable while it is open.
 
 ## Built-in surveys
 
@@ -78,7 +95,7 @@ response file is named after it. Any survey can also be opened standalone from
 Every open logs a `SurveyOpened` event. Submitting an in-app survey writes the
 response file and logs a `SurveySubmitted` event (code 71) — log-only by default,
 since the survey happens after the awakening; tick its **LSL**/**TTL** boxes in
-the [Markers window](usage.md#configuring-codes) if your protocol wants it in
+the [Markers window](triggers.md#configuring-codes) if your protocol wants it in
 the trigger channel.
 
 In the Editor (and the read-only previews in the Manage dialog) a survey

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -1,4 +1,4 @@
-# Triggers & port codes
+# Markers & port codes
 
 This page explains what EEG **triggers** and **port codes** are, the ways SMACC can
 send them, and how to configure each one. If you just want the steps, jump to
@@ -17,7 +17,7 @@ events by their code — e.g. "every 41 is an observed REM onset."
 A port code is an **8-bit value**, so it is always an integer from **1 to 255**. That
 range follows from the hardware: a trigger is physically **eight on/off lines** (eight
 bits), and the amplifier reads them as one byte. SMACC keeps every code inside 1–255
-for this reason. See [Configuring codes](usage.md#configuring-codes) for how to view
+for this reason. See [Configuring codes](#configuring-codes) for how to view
 and edit which event sends which code.
 
 ## Terminology
@@ -105,6 +105,74 @@ study can retune any code in the **Markers** window; the change travels in its
 Codes are integers in **1–255** and must be unique among events routed to a
 transport (LSL or TTL).
 
+## Configuring codes
+
+Open the **Markers** window from the **Panels** column (in a Session or in the
+Editor). It is the home for everything about event signaling: a **routing legend**
+(what the log file, the live preview, LSL, and TTL each receive, and which switch
+governs it), the full event registry grouped by category (including the events with
+no grid button — lights, panel controls, biocals, chat, system), and the
+[hardware TTL transport](#configuring-trigger-output-in-smacc). For each event you
+can set:
+
+- **Code** — the 8-bit port code (1–255) sent when the event triggers.
+- **LSL** — whether a firing sends the code over the LSL marker stream.
+- **TTL** — whether a firing sends the code over the hardware TTL trigger. The
+    column is grayed out until a transport is enabled in the window's **Hardware TTL
+    transport** section (the ticks are kept and re-arm with it). An event with neither
+    LSL nor TTL ticked is log-only.
+- **Preview** — whether the event shows in the live log preview. The session log
+    *file* always records every event regardless; this only controls the on-screen
+    preview.
+- **Increment** — give an event a unique, increasing code on each firing (for
+    example **dream reports**: 201, 202, 203, …) so individual occurrences are
+    findable in the trigger channel. Off uses one fixed code each time.
+
+**TTL safe max code** raises a soft warning for TTL-routed codes above it, handy when
+your trigger hardware accepts only a limited range (some older systems do; LSL
+carries any code). Codes must be unique among routed events and within 1–255; the
+window blocks anything else.
+
+**Custom events.** Use **Add event…** — in the **Event logging** panel itself, or in
+the Markers window — to create your own button events (a label and a code). They
+appear in the Event logging panel alongside the built-ins and can be removed again
+with the Markers window's **Remove**. Built-in events can be retuned but not removed
+or renamed.
+
+Edits are staged until you press **Apply** (which validates them first); **Revert**
+re-reads the session's current setup. The window stays available throughout a
+session. If you change a code mid-session, the change is written to the log with a
+timestamp, so the code-to-event mapping for that session is always recoverable.
+
+Beyond port codes, SMACC logs the important interactions too — volume, colour,
+device, and fade changes — as plain log lines (no port code), so the session record
+is complete.
+
+## Event logging panel
+
+The manual event buttons (the sleep-stage family, Signal observed, Sleep onset,
+Note, your custom events, and so on) live in the **Event logging** panel — open it
+from the Session window's **Panels** column. The sleep-stage buttons take a fixed
+keypad — **0** Wake, **1** N1, **2** N2, **3** N3, **4** REM — and the remaining
+buttons take **5**–**9** in order; the shortcuts are active while the panel is
+focused. The **Lights** toggle stays on the main window (it also flips the dark
+theme).
+
+**Signal observed.** One button covers every lucidity/communication signal a study
+uses (LRLR, sniff, facial, …), so you do not need a separate button per signal. Pick
+the **signal** type (the box is editable — type your own and it is remembered for the
+rest of the session) and a **confidence** (certain / probable / possible) beside the
+button. Pressing it fires the marker immediately and logs your selection as the
+detail, so the marker's timing tracks the observation. Confidence is recorded as a
+comment; it never changes whether the marker reaches the EEG.
+
+## Where codes live
+
+Your codes are saved in the SMACC file (so they travel with it) and written into
+every session `.log` (both the initial and final settings blocks), so any session is
+self-documenting: you can decode its markers later even if the codes changed
+mid-session.
+
 ## How SMACC sends triggers
 
 SMACC emits markers over **LSL** (Lab Streaming Layer), a network marker stream. On
@@ -133,7 +201,7 @@ neither is log-only).
     Most studies leave every event on both transports. Per-event routing earns its
     keep when the TTL hardware is restricted — an older amplifier that only accepts
     a limited code range can keep its key events on TTL (inside the
-    [safe max](usage.md#configuring-codes)) while chattier or higher-coded events
+    [safe max](#configuring-codes)) while chattier or higher-coded events
     still reach the LSL stream.
 
 ### What is the baud rate?

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,37 @@
+# Troubleshooting
+
+When something goes wrong, start here. Most fixes live on the relevant tool's page;
+this page collects the cross-cutting ones and points to the rest.
+
+## Common problems
+
+| Symptom                                                                     | Where to look                                                                                           |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| Windows SmartScreen blocks the download or installer                        | [Installation](installation.md) — expected for the unsigned build; **More info → Run anyway**           |
+| "No output/input device found", or a bound device shows **(not connected)** | [Audio routing](audio.md#no-system-default) — rebind in the Devices window and **Refresh devices (F5)** |
+| A cue plays in the control room but maybe not the bedroom                   | [Audio cues](audio-cues.md#is-the-cue-reaching-the-bedroom) — read the *Sending* and *Bedroom* meters   |
+| The BlinkStick isn't listed, or a light won't fire or stays on              | [Visual cues](visual.md#troubleshooting)                                                                |
+| The Hue bridge stopped responding                                           | [Visual cues](visual.md#troubleshooting) — its IP probably changed                                      |
+| Triggers don't register on the amplifier                                    | [Markers & port codes](triggers.md) — check the COM port, baud rate, and pulsed-vs-set-and-hold mode    |
+| A cue is too loud or too quiet                                              | [Volume & latency](latency.md) — the per-cue volume, the safety cap, and the OS stages                  |
+
+## If SMACC crashes
+
+Separately from the per-run logs, SMACC keeps a permanent crash log at
+`~/SMACC/logs/crash.log`. Uncaught errors, Qt's own fatal messages, and — via
+Python's `faulthandler` — the stack of every thread at a hard crash (such as an
+access violation inside Qt or an audio driver) are appended there, even when no
+session is running. A hard-crash dump shows where the *Python* side was at that
+moment, which is usually enough to identify the failing subsystem. Every launch and
+every session start is also stamped in the file, so a crash can be matched to its
+night and run folder.
+
+The file is rotated at launch once it grows large (one older `crash.log.1`
+generation is kept). When SMACC crashes it shows a dialog with an **Open logs
+folder** button that takes you straight to it.
+
+## Reporting a problem
+
+Open an issue on the [SMACC issue tracker](https://github.com/remrama/smacc/issues)
+with what you did, what happened, and the relevant files: `crash.log` together with
+the affected run's folder, or a session [`.log`](reference/session-log.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,8 +1,8 @@
-# Usage
+# Overview
 
 SMACC opens to its **Launcher** — a list of the SMACC tools. Click a tool and SMACC
 asks for the **SMACC file** to use, then opens it. To run a night you open a live
-**Session**. This page walks through the main features.
+**Session**. This page orients you; each tool then has its own page.
 
 The Launcher's tools (its title bar reads **SMACC**):
 
@@ -19,8 +19,8 @@ The Launcher's tools (its title bar reads **SMACC**):
 The **Session** and the **Editor** are the same window in two modes — running a
 night versus authoring a SMACC file.
 
-<!-- Add an annotated screenshot of the Launcher + Session window here once
-available, e.g.: ![SMACC Session window](assets/screenshot-session.png) -->
+<!-- Add an annotated screenshot of the Launcher (the flat list of tools) here once
+available. -->
 
 ## Opening SMACC
 
@@ -43,8 +43,8 @@ dialog with that file preselected. From the Launcher:
     export its events to a BIDS `events.tsv`, or recover its settings to a `.smacc` —
     all without starting a new session.
 - **Audio Cue Designer** — open the standalone tool to build a simple tone cue and
-    export it as a WAV into a study's `cues/` folder, ready to use from the Audio cue
-    board (see [Designing a cue](#designing-a-cue)).
+    export it as a WAV into a study's `cues/` folder (see
+    [Audio cues](audio-cues.md#designing-a-cue)).
 - **EEG Annotator** — open the post-hoc [EEG Annotator](eeg-annotator.md) to review a
     recorded night and place annotations. It runs as its own window and process, so it
     stays available while a session runs.
@@ -53,290 +53,64 @@ Closing the Editor or a standalone tool returns you to the Launcher. Ending a
 Session quits SMACC entirely — the night is over. Closing the Launcher also quits
 SMACC.
 
-## Audio cues
+## The Session window
 
-Place sound files where your settings expect them — by default the data directory's
-`cues/` folder (e.g. `~/SMACC/data/cues/`; common formats such as `.wav`, `.mp3`,
-`.flac`, `.ogg`, and `.aiff` are accepted) — and trigger them from the cue controls. SMACC seeds a few
-`demo-*` cues there so there is always something to test with. You start with one
-cue — prefilled with a random demo — and use **+ Add cue** and each row's **✕** to
-add or remove cues to match a protocol (one minimum, up to 20).
+A running Session has two columns. The **Panels** column on the left opens each tool
+window (Audio cue, Visual cue, Noise machine, Dream recording, Intercom, Biocals,
+Markers, Event logging, Devices, Volume). The right side is the live **Log preview**,
+with checkboxes to choose which [log levels](reference/session-log.md#log-levels) it
+shows. The **Lights** toggle on the main window dims the room (and flips the app's
+dark theme).
 
-### Designing a cue
+Tool windows close with **Ctrl+W** (or **File › Close window**), which only hides
+the window with its state intact; the session keeps running and the Panels column
+reopens it.
 
-No sound file ready? Open the **Audio Cue Designer** from the Launcher to build a simple cue
-inside SMACC — no external audio editor needed. Lay out a sequence of **tone** and
-**silence** segments (each tone has a frequency, duration, and level, with an
-optional bell-like **decay**), or start from a **preset** (a single chime, a pip
-train). The whole pattern can **repeat** — ×N with a gap between repeats, the
-classic pip-train shape — and an optional whole-cue fade in/out and normalize
-finish it. A live **waveform** shows the cue as you edit, **Preview** plays it on
-your default output, and **Export WAV…** writes it into your study's `cues/`
-folder, where it appears in the Audio cue board like any other cue.
+<!-- Add an annotated screenshot of the Session window here once available: the
+Panels column on the left and the Log preview on the right. -->
 
-The WAV is what the cue board plays; the *design* stays editable through **Save
-design… / Open design…** (a small `.json` file, kept alongside the WAVs by
-default) — reopen it tomorrow and nudge a level instead of rebuilding the cue from
-scratch. The designer is a standalone tool: it plays on the default device and
-ignores the session's device routing and volume safety cap.
+## The tools
 
-### Is the cue reaching the bedroom?
+Each tool has its own page:
 
-The Audio cue window has a **Monitoring** section — a *Sending* meter (what SMACC is
-emitting) beside a *Bedroom* meter (what a mic actually picks up in the room) — so you
-can confirm a cue is audible to the participant, not just leaving SMACC. See
-[Audio & routing](audio.md#is-the-cue-reaching-the-bedroom) for how to read them
-and how to set up a second bedroom mic dedicated to monitoring.
-
-## Visual cues
-
-Light cues live in the **Visual cue** window: one row per cue — color, brightness,
-pattern (steady, a smooth pulse, or a flash at a rate in Hz), length, and loop —
-with a shared fade-in/out, fired on a USB BlinkStick or a Philips Hue light. You
-start with a single red steady cue and use **+ Add cue** / **✕** to match a
-protocol (one minimum, up to 10). Every play and stop is marked in the EEG record,
-every stop path turns the light off, and a *Sending* swatch mirrors exactly what
-SMACC is emitting. See [Visual cues](visual.md) for the patterns, the
-BlinkStick-vs-Hue comparison, marker timing, and the photosensitivity notes.
-
-## Dream reports
-
-Use the **Record dream report** button to record from the mic bound to the
-**Bedroom mic 1** equipment in the **Devices** window.
-Recordings are saved into the current session folder. Each report is also stamped
-with the time elapsed since you pressed **Start recording** (in the Event logging
-panel), so it is easy to locate in the EEG file; if recording has not been marked
-yet, the report is still logged and SMACC reminds you to mark it.
-
-Surveys can follow a report two ways: **in-app surveys** (the bundled LuCiD, DLQ,
-and LUSK instruments, plus any you build) open in a SMACC window and save their
-responses into the run folder next to the report; **web surveys** (e.g. a
-questionnaire on Qualtrics or REDCap, added by URL) open in your browser. Manage
-both with the **Manage…** button next to the survey dropdown. Select a survey in
-the dropdown to open it automatically when recording starts, or open any survey
-on its own from **File › Surveys** (each open is logged as a
-`SurveyOpened` event). See [Surveys](surveys.md) for the bundled instruments,
-the response-file format, and building your own.
-
-## Biocals
-
-Sleep studies open with **biocalibrations** — scripted participant actions (eyes
-open, eyes closed, look left/right, …) whose known physiological signatures verify
-the recording channels. The **Biocals** window runs them as timed, marked events:
-every standard biocal plus the common lucid-dreaming signal practices (LRLR
-variants, fist clenches, sniffs), each on its own row.
-
-Each row has a toggle button plus two checkboxes and a duration:
-
-- **Press the biocal's button** to run it. The button stays depressed while it
-    runs and the countdown at the top shows the time remaining in its task window;
-    press it again to cancel early (no waiting out a botched 30-second window).
-- **Voice** — speak the pre-recorded instruction (e.g. *"Please close your eyes
-    and relax for thirty seconds."*) over the cue output when the biocal starts.
-    Leave it unchecked if you prefer to give instructions yourself.
-- **Seq** — include this row when **Play sequence** runs the whole stack in
-    order. Standard biocals start checked; the lucid-dreaming ones start unchecked.
-- **Duration** — the task window in seconds. With the voice on, the window (and
-    its countdown) starts when the instruction *ends*, so a 10-second breath hold
-    is a full 10 seconds — matching the manual practice of speaking first and
-    marking when the participant complies.
-
-**Markers.** Each biocal's *start* code fires when its task window opens; a shared
-**completed** code fires when the window runs out and a shared **cancelled** code
-fires on an early stop (the preceding start code identifies which biocal). A played
-sequence is bracketed by its own start/stop codes and otherwise fires the identical
-per-biocal markers. Defaults: sequence start/stop **105**/**106**, cancelled
-**107**, completed **108**, and one start code per biocal in the **110–126** band —
-all retunable in the **Markers** window like any built-in event.
-
-**Sequences.** **Play sequence** runs every Seq-checked row top to bottom,
-depressing each button as it goes. Pressing the *active biocal's* button skips just
-that item (cancel marker, then on to the next); pressing the sequence button again
-aborts the rest. Rows can **repeat** a biocal (eyes-closed twice, extra LRLRs —
-use **+ Add** to add another instance), be reordered with **▲/▼**, and removed
-with **✕**; the stack is locked while something is running. Need a biocal SMACC
-doesn't ship? Use a custom event button in the Event logging panel instead.
-
-**Voice recordings** ship inside SMACC (generated with
-[ElevenLabs](https://elevenlabs.io) text-to-speech) and are read straight from
-the bundle, so they stay current when you upgrade. Prefer another voice or
-language? Drop your own recording under the same name in your SMACC directory's
-`biocals/` folder (e.g. `~/SMACC/biocals/`) — a file there overrides the bundled
-one. (A biocal with no recording in either place still runs, just unvoiced;
-session start warns if that happens.) The shared **Voice volume** rides the cue
-route, so the master output cap and the control-room monitor fan-out apply to
-instructions exactly as they do to cues.
-
-## Intercom
-
-The **Intercom** window is the live channel between the control room and the
-bedroom. **Talk** pipes the control-room mic to the participant's output (click to
-latch, or hold the **spacebar** anywhere in SMACC as push-to-talk) and is marked in
-the EEG record; **Listen** brings the bedroom mic to your control-room speakers,
-unmarked.
-The two directions route through equipment set once in the **Devices** window (see
-[Audio & routing](audio.md)). A **level meter** beside each button shows the
-live input level while that direction is on — signal on the bar means audio is
-actually flowing (your mic for Talk, the participant's mic for Listen), not just
-a latched button.
-
-### Text chat
-
-Below the voice controls is a **typed channel** — for hearing-impaired
-participants, or whenever audio would intrude or you want the exchange in writing.
-You type in the Intercom panel; the participant reads and replies in a separate
-**Participant chat** window made for a dark bedroom: always dark regardless of the
-lights toggle, large text (default 18 pt, resize with `Ctrl+=` / `Ctrl+-`), and an
-optional **red night text** mode (**Display** menu), with no flashing and no
-sounds.
-
-**Setup.** The first cut assumes one computer: extend the desktop onto a
-bedroom-facing monitor and plug in a second keyboard for the participant. Click
-**Pass keyboard to participant** to open the participant window, drag it onto the
-bedroom display once, and it reopens there next session.
-
-**One keyboard at a time.** Windows gives the machine a single input focus, so the
-two keyboards type into whichever window is active — text chat is half-duplex,
-like push-to-talk. **Pass keyboard to participant** (or `Ctrl+Enter`, which sends
-your message first) activates the participant window so their keystrokes land
-there; clicking back into SMACC takes the focus back. The participant window shows
-a banner — *"● The keyboard is yours"* / *"○ Waiting"* — so a drowsy participant
-always knows whether typing will land.
-
-**Quick replies.** Canned messages save both sides from typing a full sentence at
-3 a.m.; they travel with the study. Click **Manage quick messages…** on the Intercom
-panel to edit two lists — *experimenter prompts* (one click sends a standardized
-prompt, e.g. the lab's dream-report question or *"Are you awake?"*) and *participant
-replies* mapped to the number keys **1–9** (e.g. *"Got it"*, *"I'm awake"*, *"Yes"*,
-*"No"*). The participant's replies appear as large numbered chips; pressing a number
-sends that reply, but only while their entry box is empty, so a typed reply that
-contains digits still works. A sent preset is logged and marked exactly like a typed
-message.
-
-**What's recorded.** Every message is written verbatim to the session log as a
-DEBUG line (tick *Debug* above the log preview to watch the exchange live). By
-default no port codes fire and nothing reaches the BIDS events export — a typed
-exchange is rapid and conversational, and would flood the marker channel. If a
-study needs marker timestamps, route `Chat to participant` (code 69) and/or
-`Chat from participant` (code 70) to LSL/TTL in the **Markers** window;
-the markers stay bare (no message text) so the trigger channel remains legible.
-
-## EEG port codes
-
-SMACC marks experiment events — a cue played, a dream report, observed REM, the
-lights toggled — by sending a numeric **port code** to its marker stream and writing a
-matching line to the session log, keeping cue delivery and your neural data in sync.
-
-### Configuring codes
-
-Open the **Markers** window from the **Panels** column (in a Session or in the
-Editor). It is the definitive home for everything about event signaling: a
-**routing legend** (what the log file, the live preview, LSL, and TTL each
-receive, and which switch governs it), the full event registry grouped by
-category — including the events with no grid button (lights, panel controls,
-biocals, chat, system) — and the
-[hardware TTL transport](triggers.md#configuring-trigger-output-in-smacc).
-For each event you can set:
-
-- **Code** — the 8-bit port code (1–255) sent when the event triggers.
-- **LSL** — whether a firing sends the code over the LSL marker stream.
-- **TTL** — whether a firing sends the code over the hardware TTL trigger. The
-    column is grayed out until a transport is enabled in the window's **Hardware
-    TTL transport** section (the ticks are kept and re-arm with it). An event with
-    neither LSL nor TTL ticked is log-only.
-- **Preview** — whether the event shows in the live log preview. The session log
-    *file* always records every event regardless; this only controls the on-screen
-    preview.
-- **Increment** — give an event a unique, increasing code on each firing (e.g. **dream
-    reports**: 201, 202, 203, …) so individual occurrences are findable in the trigger
-    channel. Off uses one fixed code each time.
-
-**TTL safe max code** raises a soft warning for TTL-routed codes above it — handy
-when your trigger hardware only accepts a limited range (some older systems do; LSL
-carries any code). Codes must be unique among routed events and within 1–255; the
-window blocks anything else.
-
-**Custom events.** Use **Add event…** — in the **Event logging** panel itself, or in
-the Markers window — to create your own button events (a label and a code); they
-appear in the Event logging panel alongside the built-ins and can be removed again
-with the Markers window's **Remove**. Built-in events can be retuned but not removed
-or renamed.
-
-Edits are staged until you press **Apply** (which validates them first); **Revert**
-re-reads the session's current setup. The window stays available throughout a
-session. If you change a code mid-session, the change is written to the log with a
-timestamp, so the code-to-event mapping for that session is always recoverable.
-
-Beyond port codes, SMACC logs the important interactions too — volume, color, device,
-and fade changes — as plain log lines (no port code), so the session record is complete.
-
-### Event logging panel
-
-The manual event buttons (the sleep-stage family, Signal observed, Sleep onset, Note,
-your custom events, …) live in the **Event logging** panel — open it from the session
-window's **Panels** column. The sleep-stage buttons take a fixed keypad — **0** Wake,
-**1** N1, **2** N2, **3** N3, **4** REM — and the remaining buttons take **5**–**9** in
-order; the shortcuts are active while the panel is focused. The **Lights** toggle stays
-on the main window (it also flips the dark theme).
-
-**Signal observed.** One button covers every lucidity/communication signal a study uses
-(LRLR, sniff, facial, …), so you don't need a separate button per signal. Pick the
-**signal** type (the box is editable — type your own and it's remembered for the rest of
-the session) and a **confidence** (certain / probable / possible) beside the button;
-pressing it fires the marker immediately and logs your selection as the detail, so the
-marker's timing tracks the observation. Confidence is recorded as a comment — it never
-changes whether the marker reaches the EEG.
-
-### Where codes live
-
-Your codes are saved in the SMACC file (so they travel with it) and
-written into every session `.log` (both the initial and final settings blocks), so any
-session is self-documenting: you can decode its markers later even if the codes changed
-mid-session.
+- [Audio cues](audio-cues.md) — the cue board, the Audio Cue Designer, background
+    noise, and confirming a cue reaches the bedroom.
+- [Visual cues](visual.md) — light cues on a BlinkStick or Philips Hue.
+- [Biocals](biocals.md) — timed, marked biocalibration tasks.
+- [Dream reports & surveys](surveys.md) — record a report and administer a survey.
+- [Intercom & chat](intercom.md) — talk, listen, and a typed channel.
+- [Markers & port codes](triggers.md) — the Markers window, the Event logging panel,
+    and EEG triggers.
+- [Audio routing](audio.md) and [Devices](devices.md) — bind equipment and route
+    actions to it.
+- [Volume & latency](latency.md) — the output safety cap and stimulus timing.
 
 ## Event log
 
 Every run writes a detailed `.log` to its own timestamped folder under the SMACC
-file's **data directory** (e.g. `~/SMACC/data/`), capturing the events and settings
-for that session. Open one later from the Launcher's **Analyzer** to see a
-summary, export its events to BIDS, or recover its settings.
-
-### If SMACC crashes
-
-Separately from the per-run logs, SMACC keeps a permanent crash log at
-`~/SMACC/logs/crash.log`. Uncaught errors, Qt's own fatal messages, and — via
-Python's `faulthandler` — the stack of every thread at a hard crash (such as an
-access violation inside Qt or an audio driver) are appended there, even when no
-session is running. Note that a hard-crash dump shows where the *Python* side
-was at that moment, which is usually enough to identify the failing subsystem.
-Every launch and every session start is also stamped in the file, so a crash
-can be matched to its night and run folder. When reporting a crash, send
-`crash.log` together with the affected run's folder. The file is rotated at
-launch once it grows large (one older `crash.log.1` generation is kept).
-
-## SMACC files (`.smacc`)
-
-A **SMACC file** captures your study's whole configuration — cue files, volumes,
-noise, visual cues, survey presets, event codes, display choices, and the **data
-directory** where runs are written — in a single portable `.smacc`. Create one in
-the Editor (the Launcher's **Editor…** button) or snapshot a running
-Session with **File › Save SMACC file as…**. Opening one starts a new
-session with that configuration. See [SMACC files](smacc-files.md) for the full
-story (creating, the data directory, opening by double-click), and the
-[SMACC file reference](reference/settings-file.md) for the exact on-disk format.
+file's **data directory** (for example `~/SMACC/data/`), capturing the events and
+settings for that session. Open one later from the Launcher's **Analyzer** to see a
+summary, export its events to BIDS, or recover its settings. For the line format and
+levels, see the [session log reference](reference/session-log.md). If SMACC crashes,
+see [Troubleshooting](troubleshooting.md#if-smacc-crashes).
 
 ## Display preferences
 
-Some display choices apply to a session and travel with the study in the SMACC
-file: **always-on-top** (toggled per window — the Session window's **File**
-menu, or each tool window's **File** menu, or **Ctrl+T** in whichever window is
-active) and which **log levels** show in the preview (the checkboxes above the
-log preview). Save them with the rest of the configuration from the Editor or
-with **File › Save SMACC file as…** in a Session.
+Some display choices apply to a session and travel with the study in the SMACC file:
+**always-on-top** (toggled per window — the Session window's **File** menu, each tool
+window's **File** menu, or **Ctrl+T** in whichever window is active) and which **log
+levels** show in the preview (the checkboxes above the log preview). Save them with
+the rest of the configuration from the Editor, or with **File › Save SMACC file
+as…** in a Session.
 
-Tool windows close with **Ctrl+W** (or **File › Close window**) — that
-only hides the window, with its state intact; the session keeps running and the
-Session window's Panels column reopens it.
+Separately, the machine remembers window positions and sizes and your recent files
+in `~/SMACC/preferences.yaml`, restored on the next launch (see the
+[preferences reference](reference/preferences-file.md)).
 
-Separately, the machine remembers window positions and sizes and your recent files in
-`~/SMACC/preferences.yaml`, restored on the next launch.
+## SMACC files
+
+A **SMACC file** captures your study's whole configuration — cue files, volumes,
+noise, visual cues, survey presets, event markers, display choices, and the **data
+directory** where runs are written — in a single portable `.smacc`. See
+[SMACC files](smacc-files.md) for the full story, and the
+[SMACC file reference](reference/settings-file.md) for the on-disk format.

--- a/docs/visual.md
+++ b/docs/visual.md
@@ -1,11 +1,10 @@
 # Visual cues
 
-Light is the second cueing modality in SMACC, next to sound. In dream-engineering
-work it earns its place for two reasons: closed eyelids transmit light, so a lamp
-can reach a sleeping (or dreaming) participant directly — flashing lights during
-REM are the classic lucidity-induction signal — and light is silent, so it layers
-cleanly over masking noise or an auditory protocol without touching the
-soundscape. SMACC drives light cues on a USB **BlinkStick** or on **Philips Hue**
+Light is SMACC's second cueing modality, and it earns its place for two reasons.
+Closed eyelids still transmit light, so a lamp can reach a sleeping (or dreaming)
+participant directly; flashing light during REM is the classic lucidity-induction
+signal. And light is silent, so it layers over masking noise or an auditory protocol
+without touching the soundscape. SMACC drives light cues on a USB **BlinkStick** or on **Philips Hue**
 bulbs, from one window, with the same marker discipline as audio.
 
 This page covers the Visual cue board, the patterns, what the markers mean,
@@ -16,7 +15,7 @@ light at sleeping people. For plugging the devices in and binding them, see
 ## The visual cue board
 
 The **Visual cue** window (in the **Panels** column) is the light sibling of the
-[Audio cue board](usage.md#audio-cues): one row per cue, each kept configured and
+[Audio cue board](audio-cues.md#the-cue-board): one row per cue, each kept configured and
 ready so that firing the right light at 3 a.m. is a single click.
 
 Each row holds a **name** (it travels into the event log with every start/stop
@@ -53,10 +52,9 @@ proof, that's what the bedroom camera (or your own eyes) is for.
     [the comparison](#blinkstick-or-philips-hue) and [Safety](#safety).
 
 The rate is set in **Hz**, the unit your methods section wants. The fades stay
-separate from the pattern on purpose: the pattern *is* the stimulus, while the
-fades are how politely it arrives and leaves. Pattern timing is computed from
-elapsed time rather than accumulated per frame, so a busy GUI moment can't drift
-the flicker.
+separate from the pattern: the pattern is the stimulus, and the fades only shape how
+it ramps in and out. Pattern timing is computed from elapsed time rather than
+accumulated per frame, so a busy GUI moment can't drift the flicker.
 
 ## What the markers mean
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -45,16 +45,23 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Installation: installation.md
-  - Usage: usage.md
-  - SMACC files: smacc-files.md
-  - Audio & routing: audio.md
-  - Visual cues: visual.md
-  - Latency: latency.md
-  - Devices: devices.md
-  - Surveys: surveys.md
-  - Triggers & port codes: triggers.md
+  - Getting started:
+    - Installation: installation.md
+    - SMACC files: smacc-files.md
+  - Running a session:
+    - Overview: usage.md
+    - Audio cues: audio-cues.md
+    - Visual cues: visual.md
+    - Biocals: biocals.md
+    - Dream reports & surveys: surveys.md
+    - Intercom & chat: intercom.md
+    - Markers & port codes: triggers.md
+  - Devices & routing:
+    - Audio routing: audio.md
+    - Compatible devices: devices.md
+  - Volume & latency: latency.md
   - EEG Annotator: eeg-annotator.md
+  - Troubleshooting: troubleshooting.md
   - Reference:
     - File formats: reference/index.md
     - SMACC file (.smacc): reference/settings-file.md


### PR DESCRIPTION
Second step of the #233 docs overhaul (follows #239). Restructures the site so each tool is its own page, and applies the language goals (reference voice, fewer em-dashes and clichés).

- **Nav**: Getting started · Running a session · Devices & routing · Volume & latency · EEG Annotator · Troubleshooting · Reference · Contributing.
- **Split the Usage mega-page** into a slim Overview plus new Audio cues, Biocals, and Intercom & chat pages.
- **Merge / retitle** (filenames kept, so no broken URLs): Markers & port codes (was Triggers; now also holds the Markers-window and Event-logging sections), Dream reports & surveys (was Surveys; now also the dream-report recording section), Volume & latency (was Latency; now holds the Volume section moved out of Audio routing), Audio routing (was Audio & device routing).
- **New Troubleshooting page** with a symptom index and the crash-log section.
- **Home**: add a 'what problems SMACC solves' paragraph, expand the feature list, and group the links.
- Trim duplicated setup from the Installation page; add a docs-voice convention to Contributing.
- Seed screenshot placeholders across the new pages (helps #129).

Filenames are unchanged, so existing links and the docs-schema test paths still resolve. The auto event-codes table on the Markers page is preserved verbatim. Verified with mkdocs build --strict, mdformat --check, and pytest tests/test_docs_schema.py.