### PR TITLE
docs: adopt a versioning policy, release notes, and version banners

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,10 +50,18 @@ jobs:
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/')
         run: uv run --extra docs mike deploy --push -F mkdocs-pdf.yml dev
 
-      # Release tags: publish the numbered version and update the latest alias.
+      # Release tags. A final tag (v0.1.0) publishes a numbered version and moves
+      # the `latest` alias + default. A pre-release tag (a `-` suffix, e.g.
+      # v1.0.0-rc.1) is a release candidate: route it to the `dev` site and leave
+      # `latest`/the default untouched, so the version switcher never points users
+      # at an unreleased build.
       - name: Deploy release docs
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
-          uv run --extra docs mike deploy --push -F mkdocs-pdf.yml --update-aliases "$VERSION" latest
-          uv run --extra docs mike set-default --push latest
+          if [[ "$GITHUB_REF_NAME" == *-* ]]; then
+            uv run --extra docs mike deploy --push -F mkdocs-pdf.yml dev
+          else
+            VERSION="${GITHUB_REF_NAME#v}"
+            uv run --extra docs mike deploy --push -F mkdocs-pdf.yml --update-aliases "$VERSION" latest
+            uv run --extra docs mike set-default --push latest
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,6 +207,12 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
+          # A tag with a pre-release suffix (e.g. v1.0.0-rc.1) is published as a
+          # GitHub Pre-release, so /releases/latest skips it and the in-app update
+          # check (updates.py) never nags users toward a release candidate. A final
+          # tag (v0.1.0) is a full release — the homepage download button and the
+          # update check both resolve to it.
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             dist/SMACC.exe
             dist/SMACC-EEG.exe

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -152,7 +152,7 @@ The `blinkstick` driver (BlinkStick visual cues) and its Windows backend
 never uses, so the warning is harmless. If a frozen build ever fails to import
 the driver, add `--hidden-import pywinusb`.
 
-Releases are built automatically: pushing a `v*` tag (e.g. `v0.0.11`) triggers the
+Releases are built automatically: pushing a `v*` tag (e.g. `v0.1.0`) triggers the
 [release workflow](https://github.com/remrama/smacc/blob/main/.github/workflows/release.yml),
 which checks the tag against `smacc.__version__`, builds `SMACC.exe` and
 `SMACC-EEG.exe` (each stamped with version metadata from
@@ -181,9 +181,12 @@ uv run --extra docs mike serve            # preview the versioned site
 ```
 
 The [docs workflow](https://github.com/remrama/smacc/blob/main/.github/workflows/docs.yml)
-runs `mkdocs build --strict` on every pull request, deploys a `dev` version on
-pushes to `main`, and publishes a numbered version (updating the `latest` alias)
-on each `v*` release tag.
+runs `mkdocs build --strict` on every pull request and deploys a `dev` version on
+pushes to `main`. A final release tag (`v0.1.0`) publishes a numbered version and
+moves the `latest` alias; a pre-release tag (`v1.0.0-rc.1`) routes to the `dev` site
+and leaves `latest` untouched. Visitors on an old version see an "outdated" banner
+and the `dev` site shows an "unreleased" banner, both from
+[`overrides/main.html`](https://github.com/remrama/smacc/blob/main/overrides/main.html).
 
 ### PDF manual
 
@@ -200,6 +203,29 @@ To build the manual locally, install WeasyPrint's dependencies, then:
 ```sh
 uv run --extra docs mkdocs build -f mkdocs-pdf.yml
 ```
+
+## Versioning
+
+SMACC follows [semantic versioning](https://semver.org/).
+
+- **Pre-1.0, the app is not stable.** Settings files, marker codes, the UI, and
+    behavior may change between releases, and there are no compatibility shims. Pin
+    one version for the duration of a study.
+- **Versions are `0.x.y` until 1.0.0.** A new `0.x.0` collects features and `0.x.y`
+    is a smaller follow-up; no pre-1.0 bump is a stability promise.
+- **`0.1.0` is the first published release** — the first with installers attached, a
+    [release-notes](release-notes.md) entry, and a working in-app update check.
+    Earlier `0.0.x` tags predate it and are not in the release notes.
+- **`1.0.0-rc.N` tags are reserved for the run-up to a real 1.0.** They are marked
+    *Pre-release* on GitHub (so the update check ignores them) and their docs publish
+    to the **dev** site, not `latest`. There is no `0.x`-era `-dev`/`-alpha` series.
+- **1.0.0 is the first stable release.** From then on semantic versioning is binding
+    (backward-compatible changes bump the minor/patch, breaking changes bump the
+    major), and the pre-1.0 docs are dropped from the version switcher.
+
+Cutting a release: bump `__version__` in `src/smacc/__init__.py` and push a matching
+`vX.Y.Z` tag. CI checks the tag equals `__version__`, builds and smoke-tests the
+installer, attaches it to the GitHub Release, and publishes the docs.
 
 ## Project notes
 

--- a/docs/reference/annotations-file.md
+++ b/docs/reference/annotations-file.md
@@ -52,7 +52,7 @@ Documents each column (BIDS-style) and records provenance:
   "SourceFile": "night1.edf",
   "MeasurementDate": "2026-06-05T22:00:00+00:00",
   "Rater": null,
-  "GeneratedBy": {"Name": "SMACC", "Version": "0.0.10"}
+  "GeneratedBy": {"Name": "SMACC", "Version": "0.1.0"}
 }
 ```
 

--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -28,7 +28,7 @@ YYYY-MM-DD HH:MM:SS.mmm±HHMM, LEVEL, message
 - **message** — the log text. An **event-marker** line ends in `" - portcode N"`:
 
 ```text
-2026-06-09 22:14:01.003-0500, INFO, Opened SMACC v0.0.10
+2026-06-09 22:14:01.003-0500, INFO, Opened SMACC v0.1.0
 2026-06-09 22:14:05.221-0500, INFO, Lights off - portcode 47
 2026-06-09 22:18:30.880-0500, INFO, Dream report started: report-01, t+00:04:29 - portcode 201
 2026-06-09 22:19:02.114-0500, INFO, REM detected - portcode 41
@@ -99,7 +99,7 @@ fenced by sentinels, so log parsers skip it entirely:
 # --8<-- smacc/settings initial
 # kind: smacc/settings
 # schema_version: 1
-# smacc_version: 0.0.10
+# smacc_version: 0.1.0
 # metadata:
 #   subject: '001'
 #   ...

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -15,7 +15,7 @@ guide (creating, editing, sharing). This page is the field reference.
 # SMACC settings — YAML (.smacc). Edit with care.
 kind: smacc/settings
 schema_version: 1
-smacc_version: "0.0.10"
+smacc_version: "0.1.0"
 metadata:
   subject: "001"
   session: "1"
@@ -219,6 +219,6 @@ folder stays valid when moved, copied, or zipped.
 
 ## Version history
 
-| Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                           |
-| ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1       | Introduced as the v0.0.9 baseline (numbering restarted; pre-release schemas were retired without migration); still current as of v0.0.10. Envelope (`kind` / `schema_version` / `smacc_version` / `metadata` / `settings`); panel state; the `biocals`, `devices`, `event_codes` + `event_code_safe_max`, `trigger_output`, `data_directory`, `preview_levels`, `always_on_top`, and `tool_always_on_top` blocks. |
+| Version | Changes                                                                                                                                                                                                                                                                                                                                                                                                          |
+| ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1       | Introduced as the v0.0.9 baseline (numbering restarted; pre-release schemas were retired without migration); still current as of v0.1.0. Envelope (`kind` / `schema_version` / `smacc_version` / `metadata` / `settings`); panel state; the `biocals`, `devices`, `event_codes` + `event_code_safe_max`, `trigger_output`, `data_directory`, `preview_levels`, `always_on_top`, and `tool_always_on_top` blocks. |

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,0 +1,29 @@
+# Release notes
+
+!!! warning "SMACC is pre-1.0"
+
+    SMACC has not reached a stable release. Settings files, marker codes, the
+    interface, and behavior may change between releases, and there are no
+    compatibility shims. Pin one version for the duration of a study. See the
+    [versioning policy](contributing.md#versioning) for what the numbers mean.
+
+<!-- Newest release first. Set the date when a version is tagged. -->
+
+## 0.1.0
+
+The first published release of SMACC — a Windows control surface for running
+sleep and dream studies. It includes:
+
+- **Audio cues**, designed in-app with the Audio Cue Designer, plus masking
+    background noise.
+- **Visual cues** on a BlinkStick or Philips Hue light.
+- **Biocalibrations** as timed, marked tasks.
+- **Dream reports and surveys** for structured night-time data collection.
+- **Intercom** to talk, listen, and type with the participant.
+- **EEG markers** (port codes) over an LSL marker stream or a hardware TTL trigger.
+- The **EEG Annotator** for reviewing and scoring recordings (optional component).
+- A detailed **session log**, a **volume safety cap**, and explicit **device
+    routing** so a misclick can't blast or mislead a sleeping participant.
+- A per-user **Windows installer** (no admin rights) and a portable `SMACC.exe`.
+
+Earlier `0.0.x` builds predate this release and are not covered here.

--- a/docs/surveys.md
+++ b/docs/surveys.md
@@ -122,7 +122,7 @@ dropdown option). Display-only headings collect nothing and are omitted:
 ```json
 {
   "kind": "smacc/survey-response",
-  "smacc_version": "0.0.10",
+  "smacc_version": "0.1.0",
   "survey": {"key": "dlq", "name": "DLQ", "version": "1.0", "builtin": true, "...": "..."},
   "report_number": 2,
   "time_since_recording_start": "02:14:09",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ docs_dir: docs
 
 theme:
   name: material
+  custom_dir: overrides  # version-warning banners; see overrides/main.html (#191)
   logo: assets/icon.png
   favicon: assets/icon.png
   icon:
@@ -62,6 +63,7 @@ nav:
   - Volume & latency: latency.md
   - EEG Annotator: eeg-annotator.md
   - Troubleshooting: troubleshooting.md
+  - Release notes: release-notes.md
   - Reference:
     - File formats: reference/index.md
     - SMACC file (.smacc): reference/settings-file.md

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+<!--
+  Version-warning banners (#191).
+
+  Material for MkDocs renders the `outdated` block only when the visitor is on a
+  version other than the one aliased `latest` (the default), so the current
+  release shows no banner. We split that one block into two messages: the `dev`
+  build (served under /dev/) gets an "unreleased" notice; any older numbered
+  version gets an "outdated" notice. Both link back to the current release.
+
+  The choice is made client-side because the override is shared by every build and
+  cannot know at build time which version it is serving. Running once on load is
+  enough: a version's dev/old status is constant, and crossing to another version
+  is always a full page load (instant navigation only works within one version),
+  which re-runs this script.
+-->
+{% block outdated %}
+  <span data-smacc-banner="outdated">
+    You're reading docs for an old version of SMACC.
+    <a href="{{ '../' ~ base_url }}"><strong>Go to the current release.</strong></a>
+  </span>
+  <span data-smacc-banner="dev" hidden>
+    You're reading the development docs for the next, unreleased SMACC.
+    <a href="{{ '../' ~ base_url }}"><strong>Go to the current release.</strong></a>
+  </span>
+  <script>
+    (function () {
+      if (location.pathname.split("/").includes("dev")) {
+        document
+          .querySelectorAll('[data-smacc-banner="outdated"]')
+          .forEach(function (el) { el.hidden = true; });
+        document
+          .querySelectorAll('[data-smacc-banner="dev"]')
+          .forEach(function (el) { el.hidden = false; });
+      }
+    })();
+  </script>
+{% endblock %}

--- a/src/smacc/__init__.py
+++ b/src/smacc/__init__.py
@@ -1,4 +1,4 @@
 """SMACC: Sleep Manipulation And Communication Clickything."""
 
 __author__ = "Remington Mallett <mallett.remy@gmail.com>"
-__version__ = "0.0.10"
+__version__ = "0.1.0"

--- a/src/smacc/settings.py
+++ b/src/smacc/settings.py
@@ -10,7 +10,7 @@ The on-disk shape (a ``.smacc`` file is YAML text with a leading comment header)
 
     kind: smacc/settings
     schema_version: 1
-    smacc_version: "0.0.9"
+    smacc_version: "0.1.0"
     metadata: {subject: "", session: "", notes: "", created: "..."}
     settings: { ...the panel state from SmaccWindow.gather_settings()... }
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -8,7 +8,9 @@ from smacc import config, events
 
 def test_package_exposes_version():
     assert isinstance(smacc.__version__, str)
-    assert smacc.__version__.count(".") == 2  # e.g. "0.0.7"
+    # X.Y.Z, with an optional pre-release suffix (e.g. "1.0.0-rc.1").
+    core = smacc.__version__.split("-", 1)[0]
+    assert core.count(".") == 2
 
 
 def test_config_version_is_single_sourced():

--- a/tests/test_versionfile.py
+++ b/tests/test_versionfile.py
@@ -1,0 +1,31 @@
+"""Tests for tools/make_versionfile.py (the PyInstaller VSVersionInfo generator).
+
+``tools/`` is not an importable package, so the module is loaded by path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_PATH = Path(__file__).resolve().parents[1] / "tools" / "make_versionfile.py"
+_spec = importlib.util.spec_from_file_location("make_versionfile", _PATH)
+assert _spec is not None and _spec.loader is not None
+make_versionfile = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(make_versionfile)
+
+
+def test_version_tuple_pads_to_four():
+    assert make_versionfile.version_tuple("0.1.0") == (0, 1, 0, 0)
+
+
+def test_version_tuple_drops_prerelease_suffix():
+    # VS_FIXEDFILEINFO is numeric-only: "1.0.0-rc.1" -> (1, 0, 0, 0).
+    assert make_versionfile.version_tuple("1.0.0-rc.1") == (1, 0, 0, 0)
+
+
+def test_render_keeps_the_full_version_string():
+    out = make_versionfile.render("1.0.0-rc.1")
+    # The numeric resource drops the suffix; the string fields keep it.
+    assert "filevers=(1, 0, 0, 0)" in out
+    assert '"1.0.0-rc.1"' in out

--- a/tools/make_versionfile.py
+++ b/tools/make_versionfile.py
@@ -54,8 +54,14 @@ _DEFAULT_DESCRIPTION = "Sleep Manipulation and Communication Clickything"
 
 
 def version_tuple(version: str) -> tuple[int, int, int, int]:
-    """``"0.1.0"`` → ``(0, 1, 0, 0)`` — the four-part numeric form VS_FIXEDFILEINFO needs."""
-    parts = [int(part) for part in version.split(".")]
+    """``"0.1.0"`` → ``(0, 1, 0, 0)`` — the four-part numeric form VS_FIXEDFILEINFO needs.
+
+    A pre-release suffix is dropped first (``"1.0.0-rc.1"`` → ``(1, 0, 0, 0)``):
+    VS_FIXEDFILEINFO is numeric-only. The suffix is preserved in the string
+    ``FileVersion``/``ProductVersion`` fields, which take arbitrary text.
+    """
+    core = version.split("-", 1)[0]
+    parts = [int(part) for part in core.split(".")]
     return tuple(parts + [0] * (4 - len(parts)))[:4]  # type: ignore[return-value]
 
 


### PR DESCRIPTION
Closes #191.

Adopts a written versioning policy plus the docs/release machinery to support it.

- **Policy** (`contributing.md`): `0.x.y` until a stable `1.0.0`; nothing stable before then. `0.1.0` is the first full release; `0.0.x` is pre-history. `1.0.0-rc.N` reserved for the 1.0 run-up — no `-dev`/`-alpha` series.
- **Release notes**: new curated page starting at `0.1.0`, with a pre-1.0 warning.
- **Docs switcher** (`docs.yml`, `overrides/main.html`): final tags publish a numbered version and move `latest`; pre-release (`-`) tags route to the `dev` site and leave `latest` untouched. Old versions get an "outdated" banner, the `dev` site an "unreleased" banner.
- **Pre-release plumbing**: `release.yml` flags `-` tags as GitHub Pre-releases (so `/releases/latest` and the in-app update check skip them); `make_versionfile.py` strips the suffix for the numeric exe resource (new test).
- **Version**: bumped to `0.1.0`; reference-doc `smacc_version` examples refreshed to match (schema-v1 lineage notes kept).

Verified: `ruff`, `mdformat`, `mkdocs build --strict`, and `pytest` (50 version-touching tests) pass. Tagging `v0.1.0` remains a manual step.