### PR TITLE
docs: shrink the embedded screenshots and drop the home-page one

### DIFF
--- a/docs/assets/extra.css
+++ b/docs/assets/extra.css
@@ -10,23 +10,29 @@
 
 /* Documentation screenshots (scripts/screenshots.py). The captures are the window
    client area only — no OS title bar — so a subtle frame makes them read as windows.
-   Centered and sized to the window's shape: the default suits a medium tool window,
-   `--wide` is for the two-column Session/Editor/Devices, `--narrow` for the small
-   single-column tools (Launcher, chat, Volume, …) so they aren't upscaled. */
-.shot {
+   Kept modest so they sit within the prose rather than dominating the page; the
+   captures are 2x (retina) so they stay sharp downscaled. The default suits a medium
+   tool window, `--wide` is for the two-column Session/Editor, `--narrow` for the
+   small single-column tools (Launcher, chat, Volume, …). The `.md-typeset img`
+   qualifier is required: Material's own `.md-typeset img { max-width: 100% }` would
+   otherwise out-specify a bare `.shot` and stretch every shot to the full column. */
+.md-typeset img.shot {
   display: block;
   margin: 1.2em auto;
-  max-width: 560px;
+  /* `width` sets the target; `max-width: 100%` keeps it from overflowing a narrow
+     (mobile) content column. The shots are 2x, so a downscaled width stays sharp. */
+  width: 440px;
+  max-width: 100%;
   height: auto;
   border: 1px solid var(--md-default-fg-color--lighter);
   border-radius: 4px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
 }
 
-.shot--wide {
-  max-width: 100%;
+.md-typeset img.shot--wide {
+  width: 540px;
 }
 
-.shot--narrow {
-  max-width: 320px;
+.md-typeset img.shot--narrow {
+  width: 240px;
 }

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -31,7 +31,7 @@ window shows a read-only indicator of where it resolves, for example
 same resolution beside each route — a route pointed at equipment with nothing
 bound reads **→ no device** instead of looking configured.
 
-![The Devices window: the Equipment → devices bindings on top, the Actions → equipment routes below, each showing the device it resolves to.](assets/screenshot-devices.png){ .shot .shot--wide }
+![The Devices window: the Equipment → devices bindings on top, the Actions → equipment routes below, each showing the device it resolves to.](assets/screenshot-devices.png){ .shot }
 
 ```text
 Bedroom speaker       Speakers (USB Audio)

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,8 +11,6 @@ whatever hardware the lab has. SMACC is the clickable control surface for that w
 one window per job, glanceable in the dark, with a volume safety cap and explicit
 device routing so a misclick can't blast or mislead a sleeping participant.
 
-![The SMACC Session window: the Panels column on the left, the live Log preview on the right.](assets/screenshot-session.png){ .shot .shot--wide }
-
 [Download SMACC](https://github.com/remrama/smacc/releases/latest/download/SMACC-Setup.exe){ .md-button .md-button--primary }
 [Installation guide](installation.md){ .md-button }
 


### PR DESCRIPTION
Follow-up to #244, addressing two pieces of feedback.

**Screenshots were rendering at full content width.** The `.shot` rules set a
`max-width`, but Material's own `.md-typeset img { max-width: 100% }` out-specified a
bare `.shot`, so every shot stretched to fill the column (and the Devices shot, mis-
tiered as `--wide`, upscaled past its native size). Fixed by qualifying the selectors
(`.md-typeset img.shot`) so they win, and sizing them down to sit within the prose:
wide Session/Editor 540px, medium tool windows 440px, small ones 240px. Uses
`width` + `max-width: 100%` so they still shrink to fit a narrow (mobile) column.

**Removed the home-page screenshot** per the request; the Session shot still appears
on the Usage page (the file is unchanged).

Verified in a browser at desktop and mobile widths (no horizontal overflow; widths
apply as intended) plus the docs guard test and `mkdocs build --strict`.