### PR TITLE
docs: simplify the version-warning banner (#247)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,7 +7,7 @@ docs_dir: docs
 
 theme:
   name: material
-  custom_dir: overrides  # version-warning banners; see overrides/main.html (#191)
+  custom_dir: overrides  # version-warning banner; see overrides/main.html (#191, #247)
   logo: assets/icon.png
   favicon: assets/icon.png
   icon:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,39 +1,16 @@
 {% extends "base.html" %}
 
 <!--
-  Version-warning banners (#191).
+  Version-warning banner (#191, #247).
 
-  Material for MkDocs renders the `outdated` block only when the visitor is on a
-  version other than the one aliased `latest` (the default), so the current
-  release shows no banner. We split that one block into two messages: the `dev`
-  build (served under /dev/) gets an "unreleased" notice; any older numbered
-  version gets an "outdated" notice. Both link back to the current release.
-
-  The choice is made client-side because the override is shared by every build and
-  cannot know at build time which version it is serving. Running once on load is
-  enough: a version's dev/old status is constant, and crossing to another version
-  is always a full page load (instant navigation only works within one version),
-  which re-runs this script.
+  Material for MkDocs ships no default banner text — the `outdated` block is empty
+  unless overridden, and Material renders it only when the visitor is on a version
+  other than the one aliased `latest` (the default), so the current release shows
+  no banner. Every non-latest version (the `dev` build and any older release) gets
+  this single message; Material draws no distinction between them, and neither do
+  we.
 -->
 {% block outdated %}
-  <span data-smacc-banner="outdated">
-    You're reading docs for an old version of SMACC.
-    <a href="{{ '../' ~ base_url }}"><strong>Go to the current release.</strong></a>
-  </span>
-  <span data-smacc-banner="dev" hidden>
-    You're reading the development docs for the next, unreleased SMACC.
-    <a href="{{ '../' ~ base_url }}"><strong>Go to the current release.</strong></a>
-  </span>
-  <script>
-    (function () {
-      if (location.pathname.split("/").includes("dev")) {
-        document
-          .querySelectorAll('[data-smacc-banner="outdated"]')
-          .forEach(function (el) { el.hidden = true; });
-        document
-          .querySelectorAll('[data-smacc-banner="dev"]')
-          .forEach(function (el) { el.hidden = false; });
-      }
-    })();
-  </script>
+  You're not viewing the latest version of SMACC.
+  <a href="{{ '../' ~ base_url }}"><strong>Go to the current release.</strong></a>
 {% endblock %}


### PR DESCRIPTION
Closes #247.

The switcher banners were inconsistent because each version's banner HTML is frozen at build time: `0.0.8` carried an old "development version" override, `0.0.9`/`0.0.10` had an empty `outdated` block (no banner), and `dev` carried the dual-message override. Changing the template can't retroactively fix already-deployed versions.

- **Simplify the override.** Collapse `overrides/main.html` to Material's single documented `outdated` block — one generic "you're not viewing the latest version" message for every non-`latest` version. Drops the dual-span markup and the client-side `/dev/` path sniffing.
- **Prune pre-0.1.0 docs.** Ran `mike delete --push 0.0.7 0.0.8 0.0.9 0.0.10`; `gh-pages` now serves only `dev` and `0.1.0` (latest). This removes the stale banner variants and shrinks the switcher dropdown, which also reduces the accidental-`dev`-click problem noted in the issue.

The `dev` site picks up the new banner on the next push to `main` (the docs workflow redeploys it). `0.1.0` correctly shows no banner and is unchanged.