### PR TITLE
fix: show the Analyzer window on open

### DIFF
--- a/src/smacc/analyze.py
+++ b/src/smacc/analyze.py
@@ -86,6 +86,7 @@ class AnalyzeWindow(ToolWindow):
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
         self._build()
         self._set_loaded(False)
+        self.show()  # the launcher hides itself and relies on the tool showing itself
 
     # ----- UI construction --------------------------------------------------
 

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -81,6 +81,13 @@ def analyze_window(qtbot, tmp_path, monkeypatch):
     return win
 
 
+def test_window_shows_itself_on_construction(analyze_window):
+    # The launcher hides itself in _open_tool and relies on the tool showing
+    # itself (#249); a window that builds but never shows reads to a user as
+    # "the Analyzer crashed on opening."
+    assert analyze_window.isVisible()
+
+
 def test_open_in_annotator_launches_with_the_log(analyze_window, tmp_path, monkeypatch):
     monkeypatch.setattr(eeg, "available", lambda: True)
     calls: list[list[str] | None] = []


### PR DESCRIPTION
Clicking **Analyzer** in the launcher hid the launcher but never showed the Analyzer window. Because the app sets `quitOnLastWindowClosed(False)`, SMACC was left running with no visible window — to a user, a crash on open.

`_open_tool` hides the launcher and relies on each tool window to show itself; `AnalyzeWindow` was the only `ToolWindow` that never called `self.show()`. Added it (matching `SmaccWindow` and `CueDesignerWindow`), plus a regression test asserting the window is visible after construction.

The 0.1.1 release that ships this fix — the `__version__` bump and release notes — is in #254; this PR squash-merged with only the fix commit.

Verified: `pytest tests/test_analyze.py` (11 passed); `ruff format --check` / `ruff check` clean.

Fixes #249.