### PR TITLE
chore: release 0.1.1

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,7 +9,12 @@
 
 <!-- Newest release first. Set the date when a version is tagged. -->
 
-## 0.1.0
+## 0.1.1 — 2026-06-15
+
+- Fixed the Analyzer vanishing on open — clicking **Analyzer** hid the
+    launcher but never showed the Analyzer window.
+
+## 0.1.0 — 2026-06-15
 
 The first published release of SMACC — a Windows control surface for running
 sleep and dream studies. It includes:

--- a/src/smacc/__init__.py
+++ b/src/smacc/__init__.py
@@ -1,4 +1,4 @@
 """SMACC: Sleep Manipulation And Communication Clickything."""
 
 __author__ = "Remington Mallett <mallett.remy@gmail.com>"
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
Cuts the **0.1.1** patch for the Analyzer fix that shipped in #253 (already on main). The squash merge of #253 captured only the fix commit, so the version bump and release notes never landed — this carries them.

- Bumps `__version__` to `0.1.1`.
- Adds the dated `0.1.1` release-notes entry, and dates the `0.1.0` entry (`2026-06-15`).

After squash-merge, push the `v0.1.1` tag → release.yml builds, smoke-tests, and publishes; the tag==`__version__` check will pass.