### PR TITLE
refactor: ship one onedir SMACC binary with the EEG Annotator built in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
       # #168. --extra docs is where mdformat + its mkdocs/gfm/frontmatter plugins live.
       - name: Markdown format check
         run: uv run --extra docs mdformat --check .
-      # mypy doesn't need the eeg extra: neither mne nor pyqtgraph ships
-      # py.typed, so installing them adds no type information (and
-      # ignore_missing_imports already covers their absence).
+      # mne, matplotlib and pyqtgraph ship no py.typed, so they add no type
+      # information even though --extra dev now installs them (they are core
+      # dependencies); ignore_missing_imports covers them either way.
       - name: Type check
         run: uv run --extra dev mypy
 
@@ -55,10 +55,10 @@ jobs:
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
-      # --extra eeg pulls mne/pyqtgraph so the optional EEG Annotator tests run
-      # too (#136); they importorskip, so a base env still passes without it.
+      # The EEG stack (mne/pyqtgraph) is a core dependency now, so the EEG
+      # Annotator tests (#136) always run — no extra needed.
       - name: Run tests
-        run: uv run --extra dev --extra eeg pytest --cov=smacc --cov-report=xml --cov-report=term-missing
+        run: uv run --extra dev pytest --cov=smacc --cov-report=xml --cov-report=term-missing
       # Smoke-test the docs screenshot harness so a renamed widget or removed window
       # fails CI instead of silently rotting the committed images. Offscreen
       # (QT_QPA_PLATFORM above) into a temp dir, in the base env that mirrors the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,10 @@ on:
       - "tools/smacc.iss"
       - "tools/make_versionfile.py"
       - "entry.py"
-      - "entry_eeg.py"
+      # The freeze bundles the core dependencies (incl. MNE), so a direct
+      # dependency change can break the frozen build — verify it here too.
+      # (Not uv.lock: routine transitive relocks would run this heavy job too often.)
+      - "pyproject.toml"
 
 permissions:
   contents: write
@@ -33,23 +36,21 @@ jobs:
     # Windows runner, maximizing compatibility for labs on older Windows. CI's
     # test job (ci.yml) uses the same runner so it validates this exact env.
     runs-on: windows-2022
-    # Backstop the whole job: a healthy run is ~6 min (two onefile builds plus
-    # the smoke tests), but a crashed --noconsole exe pops a "Failed to execute
-    # script" MessageBox that Start-Process sits behind forever, and Defender
-    # scanning the big onefiles can occasionally thrash the runner into a stall.
-    # 18 min is ~3x a healthy run — clear of a slow-but-fine build, but it nearly
-    # halves a stalled run's wasted time versus the old 30 (and GitHub's 6h default).
+    # Backstop the whole job: a healthy run is a single onedir build plus the
+    # smoke tests, but a crashed --noconsole exe pops a "Failed to execute
+    # script" MessageBox that Start-Process sits behind forever. 18 min is well
+    # clear of a slow-but-fine build while nearly halving a stalled run's wasted
+    # time versus the old 30 (and GitHub's 6h default).
     timeout-minutes: 18
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
-      # --extra eeg supplies mne/pyqtgraph for the SMACC-EEG.exe build (#136).
-      # It cannot leak into SMACC.exe: PyInstaller traces entry.py's imports,
-      # and nothing reachable from the base app imports the MNE-touching eeg
-      # modules (smacc.eeg's __init__ is import-light by design).
-      - run: uv sync --extra dev --extra eeg
+      # The EEG stack (mne/matplotlib/pyqtgraph) is a core dependency now — the
+      # Annotator ships inside the one SMACC binary — so --extra dev is all the
+      # build needs.
+      - run: uv sync --extra dev
       # The installer is stamped with smacc.__version__ on every run; a
       # dispatch/PR verification run builds whatever version is checked out.
       - name: Read smacc.__version__
@@ -68,54 +69,50 @@ jobs:
           }
       # Embeds product name/version/publisher in the exe's Properties dialog —
       # metadata IT departments look at when vetting or whitelisting a binary.
-      # Each call is checked: the step's result otherwise reflects only the
-      # last command, and a failed first write would surface one step late
-      # (at the SMACC.exe build) misattributed to PyInstaller.
-      - name: Generate the exe version-info resources
+      # Checked explicitly: a failed write would otherwise surface one step late
+      # (at the build) misattributed to PyInstaller.
+      - name: Generate the exe version-info resource
         run: |
           uv run python tools/make_versionfile.py version_info.txt
-          if ($LASTEXITCODE -ne 0) { throw "make_versionfile (SMACC) exited with code $LASTEXITCODE" }
-          uv run python tools/make_versionfile.py version_info_eeg.txt --product SMACC-EEG --description "SMACC EEG Annotator"
-          if ($LASTEXITCODE -ne 0) { throw "make_versionfile (SMACC-EEG) exited with code $LASTEXITCODE" }
-      - name: Build SMACC.exe
-        run: uv run pyinstaller entry.py --name SMACC --onefile --noconsole --icon src/smacc/assets/icon.ico --version-file version_info.txt --add-data "src/smacc/assets/icon.png;smacc/assets" --add-data "src/smacc/assets/default.smacc;smacc/assets" --add-data "src/smacc/assets/cues;smacc/assets/cues" --add-data "src/smacc/assets/biocals;smacc/assets/biocals" --add-data "src/smacc/assets/surveys;smacc/assets/surveys"
-      # The optional EEG Annotator component (#136): a second frozen exe carrying
-      # the MNE/pyqtgraph stack the base exe deliberately doesn't. MNE uses
+          if ($LASTEXITCODE -ne 0) { throw "make_versionfile exited with code $LASTEXITCODE" }
+      # One onedir build is the whole app, EEG Annotator included. --onedir (not
+      # --onefile) means nothing extracts to a temp dir at launch: Python imports
+      # off the install folder lazily, so a session never loads MNE and there is
+      # no 120 MB temp blob for Defender to thrash on. The EEG modules reach the
+      # bundle through smacc.__main__'s `--eeg` dispatch import. MNE itself uses
       # lazy_loader, which imports submodules by name at runtime and reads the
       # package's .pyi stubs — both invisible to PyInstaller's static analysis —
-      # so MNE's submodules and data must be collected explicitly (without them
-      # the exe builds fine and dies on first MNE use). matplotlib must ship
-      # even though the viewer renders with pyqtgraph: MNE's IO layer
-      # transitively imports mne.viz.ui_events (-> matplotlib) at import time,
-      # so excluding it kills read_raw_*. Figure export (#180) additionally
-      # writes PDF/SVG, whose matplotlib backends are imported by name at
-      # savefig time — invisible to static analysis, exactly like MNE's lazy
-      # submodules — so collect matplotlib.backends too (without it PDF/SVG
-      # export raises ModuleNotFoundError; PNG/Agg is already pulled in via the
-      # explicit canvas import). The --selftest smoke below proves all of this
-      # end to end.
-      - name: Build SMACC-EEG.exe
-        run: uv run pyinstaller entry_eeg.py --name SMACC-EEG --onefile --noconsole --icon src/smacc/assets/icon.ico --version-file version_info_eeg.txt --add-data "src/smacc/assets/icon.png;smacc/assets" --collect-submodules mne --collect-data mne --collect-submodules matplotlib.backends
+      # so collect MNE's submodules and data explicitly (without them the build
+      # succeeds and dies on first MNE use). matplotlib must ship even though
+      # traces render with pyqtgraph: MNE's IO layer imports mne.viz.ui_events
+      # (-> matplotlib) at import time, so excluding it kills read_raw_*. Figure
+      # export (#180) writes PDF/SVG, whose matplotlib backends are imported by
+      # name at savefig time — collect matplotlib.backends too (without it PDF/SVG
+      # export raises ModuleNotFoundError; PNG/Agg is pulled in via the explicit
+      # canvas import). The `--eeg --selftest` smoke below proves all of this end
+      # to end.
+      - name: Build SMACC (onedir)
+        run: uv run pyinstaller entry.py --name SMACC --onedir --noconsole --icon src/smacc/assets/icon.ico --version-file version_info.txt --add-data "src/smacc/assets/icon.png;smacc/assets" --add-data "src/smacc/assets/default.smacc;smacc/assets" --add-data "src/smacc/assets/cues;smacc/assets/cues" --add-data "src/smacc/assets/biocals;smacc/assets/biocals" --add-data "src/smacc/assets/surveys;smacc/assets/surveys" --collect-submodules mne --collect-data mne --collect-submodules matplotlib.backends
       # A broken bundle (missing data file, import error) otherwise ships silently:
-      # the exes are windowed (--noconsole), so PowerShell won't wait for them on
-      # their own and there is no stdout — Start-Process -Wait + the exit code is
-      # the test. For the EEG exe we run only --selftest: it resolves the full
-      # import tree AND round-trips a synthetic recording through MNE, the
-      # filters, and the annotation sidecar — a superset of --version, so a
-      # separate --version run (another 120 MB onefile extraction) is redundant.
-      # Every Start-Process below is bounded like the crash-log test's: -Wait
-      # would sit behind any stray window/prompt until the job timeout, reporting
-      # nothing about which command hung. A kill + throw names the culprit within
-      # minutes instead. 300s covers the slowest legitimate case (the MNE onefile
-      # extracting + importing on a runner under Defender's real-time scan).
-      - name: Smoke-test the exes
+      # the exe is windowed (--noconsole), so PowerShell won't wait for it on its
+      # own and there is no stdout — Start-Process + the exit code is the test.
+      # --version proves the bundle unpacks and the base import tree resolves;
+      # `--eeg --selftest` resolves the full MNE/pyqtgraph tree AND round-trips a
+      # synthetic recording through MNE, the filters, and the annotation sidecar
+      # (a superset of an EEG --version). Every Start-Process is bounded: -Wait
+      # would sit behind a stray window/prompt until the job timeout, reporting
+      # nothing about which command hung; a kill + throw names the culprit within
+      # minutes. 300s covers the slowest legitimate selftest (MNE importing on a
+      # runner under Defender's real-time scan).
+      - name: Smoke-test the exe
         run: |
-          $p = Start-Process -FilePath dist/SMACC.exe -ArgumentList '--version' -PassThru
+          $exe = "dist/SMACC/SMACC.exe"
+          $p = Start-Process -FilePath $exe -ArgumentList '--version' -PassThru
           if (-not $p.WaitForExit(120000)) { $p.Kill(); throw "SMACC.exe --version did not exit within 120s" }
           if ($p.ExitCode -ne 0) { throw "SMACC.exe --version exited with code $($p.ExitCode)" }
-          $p = Start-Process -FilePath dist/SMACC-EEG.exe -ArgumentList '--selftest' -PassThru
-          if (-not $p.WaitForExit(300000)) { $p.Kill(); throw "SMACC-EEG.exe --selftest did not exit within 300s" }
-          if ($p.ExitCode -ne 0) { throw "SMACC-EEG.exe --selftest exited with code $($p.ExitCode)" }
+          $p = Start-Process -FilePath $exe -ArgumentList '--eeg','--selftest' -PassThru
+          if (-not $p.WaitForExit(300000)) { $p.Kill(); throw "SMACC.exe --eeg --selftest did not exit within 300s" }
+          if ($p.ExitCode -ne 0) { throw "SMACC.exe --eeg --selftest exited with code $($p.ExitCode)" }
       # The crash-log pipeline (#149) matters most in exactly this windowed build,
       # where nothing else can capture a crash — and it's the one build the test
       # suite can't cover. Crash the exe on purpose (the hidden --crash-test flag,
@@ -125,7 +122,7 @@ jobs:
       - name: Smoke-test the crash-log pipeline
         run: |
           $env:SMACC_DIRECTORY = "$env:RUNNER_TEMP\smacc-crash-test"
-          $p = Start-Process -FilePath dist/SMACC.exe -ArgumentList '--crash-test=native' -PassThru
+          $p = Start-Process -FilePath dist/SMACC/SMACC.exe -ArgumentList '--crash-test=native' -PassThru
           if (-not $p.WaitForExit(60000)) {
             $p.Kill()
             throw "SMACC.exe --crash-test=native did not exit within 60s"
@@ -143,14 +140,10 @@ jobs:
           & "C:\Program Files (x86)\Inno Setup 6\ISCC.exe" /DAppVersion=$env:VERSION tools\smacc.iss
           if ($LASTEXITCODE -ne 0) { throw "ISCC exited with code $LASTEXITCODE" }
       # Same idea as the exe smoke test, one level up: a broken installer (bad
-      # source path, registry section typo) would otherwise ship silently. The
-      # default install now INCLUDES the EEG Annotator (checked by default); this
-      # verifies SMACC.exe and SMACC-EEG.exe land, the EEG Start-menu shortcut is
-      # created, and the .smacc association registers. It only *verifies* the EEG
-      # exe was placed (a size floor), it does not run it — the dist copy is
-      # byte-identical and already ran --selftest above, and a third 120 MB
-      # extract/scan here intermittently thrashed the runner into a timeout.
-      - name: Smoke-test the installer (default - includes the EEG Annotator)
+      # source path, registry section typo) would otherwise ship silently. One
+      # install, one app: verify the onedir tree lands, the installed SMACC.exe
+      # runs, and the .smacc association registers.
+      - name: Smoke-test the installer
         run: |
           $p = Start-Process -FilePath dist/SMACC-Setup.exe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/CURRENTUSER' -PassThru
           if (-not $p.WaitForExit(180000)) { $p.Kill(); throw "SMACC-Setup.exe did not exit within 180s" }
@@ -162,48 +155,18 @@ jobs:
           if ($p.ExitCode -ne 0) { throw "Installed SMACC.exe --version exited with code $($p.ExitCode)" }
           $progid = (Get-ItemProperty -Path 'HKCU:\Software\Classes\.smacc').'(default)'
           if ($progid -ne 'SMACC.Study') { throw ".smacc association not registered (got '$progid')" }
-          $eeg = "$env:LOCALAPPDATA\Programs\SMACC\SMACC-EEG.exe"
-          if (-not (Test-Path $eeg)) { throw "Default install must include SMACC-EEG.exe (the EEG Annotator is checked by default)" }
-          # Verify the whole onefile was copied, but do not run it (see comment
-          # above); a size floor catches a truncated/partial install.
-          $size = (Get-Item $eeg).Length
-          if ($size -lt 50MB) { throw "Installed SMACC-EEG.exe is implausibly small ($size bytes) - partial copy?" }
-          # The EEG component also creates a Start-menu shortcut; assert it exists
-          # so the opt-out step below can prove [InstallDelete] removes it.
-          $lnk = "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\SMACC EEG Annotator.lnk"
-          if (-not (Test-Path $lnk)) { throw "Default install must create the EEG Annotator shortcut at $lnk" }
-      # Opt-out path (#234): a second, in-place install with the EEG component
-      # deselected must drop the previously-installed SMACC-EEG.exe and its
-      # Start-menu shortcut via [InstallDelete]. CloseApplications=no (smacc.iss)
-      # stops Inno's Restart Manager from hanging this in-place upgrade; the
-      # WaitForExit cap fails a regression in ~3 min instead of stalling to the
-      # job timeout. /COMPONENTS=core needs no quoting (single component, no comma).
-      - name: Smoke-test the installer (opt-out - EEG Annotator deselected)
-        run: |
-          $p = Start-Process -FilePath dist/SMACC-Setup.exe -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART','/CURRENTUSER','/COMPONENTS=core' -PassThru
-          if (-not $p.WaitForExit(180000)) { $p.Kill(); throw "Core-only SMACC-Setup.exe did not exit within 180s" }
-          if ($p.ExitCode -ne 0) { throw "Core-only SMACC-Setup.exe exited with code $($p.ExitCode)" }
-          $base = "$env:LOCALAPPDATA\Programs\SMACC"
-          if (-not (Test-Path "$base\SMACC.exe")) { throw "Core-only install missing SMACC.exe" }
-          if (Test-Path "$base\SMACC-EEG.exe") { throw "[InstallDelete] did not remove SMACC-EEG.exe on EEG deselect" }
-          $lnk = "$env:APPDATA\Microsoft\Windows\Start Menu\Programs\SMACC EEG Annotator.lnk"
-          if (Test-Path $lnk) { throw "[InstallDelete] did not remove the EEG Annotator shortcut on EEG deselect" }
-          $progid = (Get-ItemProperty -Path 'HKCU:\Software\Classes\.smacc').'(default)'
-          if ($progid -ne 'SMACC.Study') { throw ".smacc association lost after in-place upgrade (got '$progid')" }
-      # Every run leaves the build products behind as workflow artifacts, so a
-      # verification run's exes/installer can be downloaded and inspected
-      # without publishing anything.
-      - name: Upload build artifacts
+      # Every run leaves the installer behind as a workflow artifact, so a
+      # verification run's build can be downloaded and inspected without
+      # publishing anything. (The onedir SMACC.exe is not independently
+      # distributable, so only the installer is uploaded.)
+      - name: Upload build artifact
         uses: actions/upload-artifact@v7
         with:
           name: smacc-build-${{ env.VERSION }}
-          path: |
-            dist/SMACC.exe
-            dist/SMACC-EEG.exe
-            dist/SMACC-Setup.exe
+          path: dist/SMACC-Setup.exe
       # Publishing is tag-gated: dispatch/PR verification runs stop at the
       # artifact upload above.
-      - name: Attach exes and installer to release
+      - name: Attach the installer to release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
@@ -213,7 +176,4 @@ jobs:
           # tag (v0.1.0) is a full release — the homepage download button and the
           # update check both resolve to it.
           prerelease: ${{ contains(github.ref_name, '-') }}
-          files: |
-            dist/SMACC.exe
-            dist/SMACC-EEG.exe
-            dist/SMACC-Setup.exe
+          files: dist/SMACC-Setup.exe

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Used for dream engineering by the [Paller Lab](https://sites.northwestern.edu/pa
 
 ## Installation
 
-To install SMACC, go to the [releases page](https://github.com/remrama/smacc/releases), click the _Assets_ dropdown for the latest release, and download SMACC (a single portable file — no installer). Once downloaded, double-clicking it will run SMACC.
+To install SMACC, go to the [releases page](https://github.com/remrama/smacc/releases), download `SMACC-Setup.exe` from the latest release's _Assets_, and run it. It installs per-user (no administrator rights needed), adds a Start menu entry, and associates `.smacc` files so double-clicking one opens it. Full details — older versions, machine-wide/IT installs, and the Windows SmartScreen prompt — are in the [installation guide](https://remrama.github.io/smacc/installation/).
 
 SMACC requires 64-bit Windows 10 or later.
 
-Note that for some features, you will need to open SMACC with Administrator privileges (Right-click to open and select `Run as administrator`).
+Note that for some features, you will need to open SMACC with Administrator privileges (right-click the Start menu entry and select `Run as administrator`).
 
 ## Optional setup
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -92,7 +92,7 @@ device enumeration, the Windows volume read-out) is stubbed in fixtures, so test
 depend on the machine's audio setup.
 
 ```sh
-uv run --extra dev --extra eeg pytest --cov=smacc --cov-report=term-missing   # CI also adds --cov-report=xml
+uv run --extra dev pytest --cov=smacc --cov-report=term-missing   # CI also adds --cov-report=xml
 ```
 
 To actually watch a test render, override the platform for that run (Windows:
@@ -100,51 +100,48 @@ To actually watch a test render, override the platform for that run (Windows:
 
 ## Building the executable
 
-Build the standalone Windows executable:
+Build the Windows app — one `--onedir` bundle that includes the EEG Annotator:
 
 ```sh
-uv run pyinstaller entry.py --name SMACC --onefile --noconsole \
+uv run pyinstaller entry.py --name SMACC --onedir --noconsole \
   --icon src/smacc/assets/icon.ico \
   --add-data "src/smacc/assets/icon.png:smacc/assets" \
   --add-data "src/smacc/assets/default.smacc:smacc/assets" \
   --add-data "src/smacc/assets/cues:smacc/assets/cues" \
   --add-data "src/smacc/assets/biocals:smacc/assets/biocals" \
-  --add-data "src/smacc/assets/surveys:smacc/assets/surveys"
-```
-
-`--icon` sets the executable's file icon; `--add-data` bundles the runtime
-window/taskbar icon, which SMACC resolves via `sys._MEIPASS`. On Windows the
-`--add-data` separator is `;` rather than `:` (i.e. `...png;smacc/assets`).
-
-PyYAML (settings export/import) is pure Python and is picked up automatically by
-PyInstaller; if a frozen build ever fails to import `yaml`, add
-`--hidden-import yaml`.
-
-The optional EEG Annotator component (#136) is a second frozen exe with its own
-entry point — it carries the MNE/pyqtgraph/matplotlib stack the base exe deliberately
-doesn't (requires `uv sync --extra dev --extra eeg`):
-
-```sh
-uv run pyinstaller entry_eeg.py --name SMACC-EEG --onefile --noconsole \
-  --icon src/smacc/assets/icon.ico \
-  --add-data "src/smacc/assets/icon.png:smacc/assets" \
+  --add-data "src/smacc/assets/surveys:smacc/assets/surveys" \
   --collect-submodules mne --collect-data mne \
   --collect-submodules matplotlib.backends
 ```
 
-The `--collect-*` flags matter: MNE uses `lazy_loader`, which imports
-submodules by name at runtime and reads the package's `.pyi` stubs — both
-invisible to PyInstaller's static analysis. Without them the exe builds
-cleanly and dies on first MNE use. matplotlib is a real dependency too — the
-figure export (`eeg/export.py`, #180) writes PDF/SVG via `savefig`, and MNE's IO
-layer imports `mne.viz.ui_events` (→ matplotlib) at import time — so
-`--collect-submodules matplotlib.backends` bundles its PDF/SVG backends, and
-`--exclude-module matplotlib` would break both `read_raw_*` and the export.
+This produces `dist/SMACC/SMACC.exe` (a folder, not a single file). `--onedir`
+rather than `--onefile` is deliberate: a session launch imports lazily off the
+install folder and never loads the heavy MNE stack, with no per-launch temp
+extraction (and so no ~120 MB blob for antivirus to rescan each run). On Windows
+the `--add-data` separator is `;` rather than `:` (i.e. `...png;smacc/assets`).
+`--icon` sets the executable's file icon; `--add-data` bundles the runtime
+window/taskbar icon, which SMACC resolves via `sys._MEIPASS`.
 
-Verify a built `SMACC-EEG.exe` with `--selftest` (the check is exit code 0):
-it round-trips a synthetic recording through MNE, the display filters, and the
-annotation sidecar. `--version` alone would not catch a broken MNE bundling —
-MNE is imported lazily, so it only loads when a recording is actually touched.
+The EEG Annotator (#136) is a mode of this same binary — `SMACC.exe --eeg`,
+re-exec'd as its own process (see `smacc.eeg.launch`) — so it is built in, not a
+second exe. The `--collect-*` flags are what make its MNE stack survive freezing:
+MNE uses `lazy_loader`, which imports submodules by name at runtime and reads the
+package's `.pyi` stubs — both invisible to PyInstaller's static analysis — so
+without them the build succeeds and dies on first MNE use. matplotlib is a real
+dependency too: figure export (`eeg/export.py`, #180) writes PDF/SVG via
+`savefig`, and MNE's IO layer imports `mne.viz.ui_events` (→ matplotlib) at import
+time — so `--collect-submodules matplotlib.backends` bundles its PDF/SVG
+backends, and `--exclude-module matplotlib` would break both `read_raw_*` and the
+export.
+
+Verify the built app with `SMACC.exe --eeg --selftest` (the check is exit
+code 0): it round-trips a synthetic recording through MNE, the display filters,
+and the annotation sidecar. A plain `--version` would not catch broken MNE
+bundling — MNE is imported lazily, so it only loads when a recording is touched.
+
+PyYAML (settings export/import) is pure Python and is picked up automatically by
+PyInstaller; if a frozen build ever fails to import `yaml`, add
+`--hidden-import yaml`.
 
 The `blinkstick` driver (BlinkStick visual cues) and its Windows backend
 `pywinusb` are pure Python and bundle the same way. PyInstaller may warn that
@@ -154,14 +151,12 @@ the driver, add `--hidden-import pywinusb`.
 
 Releases are built automatically: pushing a `v*` tag (e.g. `v0.1.0`) triggers the
 [release workflow](https://github.com/remrama/smacc/blob/main/.github/workflows/release.yml),
-which checks the tag against `smacc.__version__`, builds `SMACC.exe` and
-`SMACC-EEG.exe` (each stamped with version metadata from
-`tools/make_versionfile.py`), wraps them in an Inno Setup installer
-(`tools/smacc.iss` → `SMACC-Setup.exe`, with the EEG exe as the optional
-component), smoke-tests the exes (`--version`, and `--selftest` for the EEG
-one) and both installer component configurations, and attaches the three
-artifacts to the GitHub Release. The installer's asset name is a stable
-contract — the docs' download button links
+which checks the tag against `smacc.__version__`, builds the onedir
+`SMACC.exe` (stamped with version metadata from `tools/make_versionfile.py`),
+wraps it in an Inno Setup installer (`tools/smacc.iss` → `SMACC-Setup.exe`),
+smoke-tests the app (`--version` and `--eeg --selftest`) and the installer, and
+attaches `SMACC-Setup.exe` to the GitHub Release. The installer's asset name is a
+stable contract — the docs' download button links
 `releases/latest/download/SMACC-Setup.exe` — so don't rename it. The installer's
 `[Registry]` section must mirror `winassoc.association_entries()` exactly (so an
 installed build sees the association as already registered);

--- a/docs/eeg-annotator.md
+++ b/docs/eeg-annotator.md
@@ -6,9 +6,9 @@ annotations — saved as a small sidecar file next to the recording, which is
 **never modified**. It is a review tool, not a real-time display; nothing
 about it runs during a live session.
 
-It opens from the Launcher's **EEG Annotator** button, from its own Start-menu
-entry (**SMACC EEG Annotator**), and always runs as its own window and process —
-you can keep reviewing last night's file while tonight's session runs.
+It opens from the Launcher's **EEG Annotator** button and always runs as its own
+window and process — so you can keep reviewing last night's file while tonight's
+session runs.
 
 **How it differs from a generic EEG viewer.** The Annotator is built for the
 overnight cueing workflow, not for clinical reading:
@@ -27,14 +27,12 @@ overnight cueing workflow, not for clinical reading:
 - Recordings are **memory-mapped**, so an 8-hour high-density night opens in
     seconds and scrolls smoothly regardless of file size.
 
-!!! note "An optional component"
+!!! note "Built in, runs in its own process"
 
-    The Annotator ships as the installer's **EEG Annotator** component, **checked
-    by default**. It carries the MNE library (a heavyweight dependency), so labs
-    that only run sessions can **uncheck it during setup** to skip it; re-run the
-    [installer](installation.md) later to add or remove it on an existing install.
-    When the component is missing, the Launcher's button is shown disabled with a
-    hint, so you always know the tool exists.
+    The Annotator is part of SMACC — there is nothing extra to install. It opens
+    in its own process, so it can outlive the Launcher and a heavy recording can
+    never disturb a running session; that is why it appears as a separate window
+    rather than a panel inside the session app.
 
 ## Supported recordings
 
@@ -289,7 +287,7 @@ quick-mark palette) as a shareable `study.smacc-blind.json` and hand out a
 one-click command:
 
 ```sh
-SMACC-EEG.exe --rater alice --blind study.smacc-blind.json night1.edf
+SMACC.exe --eeg --rater alice --blind study.smacc-blind.json night1.edf
 ```
 
 Blinding is a workflow aid, not a security boundary: the guarantee is that the
@@ -298,9 +296,9 @@ recording or the truth sidecar directly.
 
 ## For developers
 
-Run it from a source checkout with the `eeg` extra:
+Run it from a source checkout:
 
 ```sh
-uv sync --extra dev --extra eeg
+uv sync --extra dev
 uv run python -m smacc.eeg [recording.edf]
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,8 +15,7 @@ device routing so a misclick can't blast or mislead a sleeping participant.
 [Installation guide](installation.md){ .md-button }
 
 The button downloads the installer (`SMACC-Setup.exe`) for the latest version, which
-installs per-user (no admin rights) and runs on 64-bit Windows 10 or later. Prefer a
-single file with no install? A portable `SMACC.exe` ships with every release — see
+installs per-user (no admin rights) and runs on 64-bit Windows 10 or later. See
 [Installation](installation.md), which also covers the Windows SmartScreen warning on
 the unsigned download and how to get older versions.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -9,11 +9,8 @@ double-click `SMACC-Setup.exe` and click through. The installer:
 - adds a **Start menu** entry (and, if you opt in, a desktop shortcut);
 - associates **`.smacc` files**, so double-clicking one opens the **Start a session**
     dialog with it preselected;
-- installs the **EEG Annotator** — the post-hoc
-    [EEG viewer/annotator](eeg-annotator.md). Included by default; uncheck it during
-    setup to skip the heavyweight EEG component (which bundles the MNE library), or
-    re-run the installer later to
-    add or remove it;
+- includes the **EEG Annotator** — the post-hoc
+    [EEG viewer/annotator](eeg-annotator.md), opened from the Launcher;
 - registers an uninstaller — remove SMACC from **Settings › Apps** like any other
     program. Uninstalling never touches your data: SMACC files, recordings, and
     logs under `~/SMACC` (or your data directories) all stay put. The
@@ -21,8 +18,7 @@ double-click `SMACC-Setup.exe` and click through. The installer:
     finishes, so finding the folder afterwards is expected — delete it manually
     if you no longer need the data.
 
-Installing a newer version over an existing one upgrades it in place, keeping
-whichever components you had chosen.
+Installing a newer version over an existing one upgrades it in place.
 
 To get an older or specific version, browse the
 [releases page](https://github.com/remrama/smacc/releases): pick the release you
@@ -50,18 +46,6 @@ itself come from the releases page.)
     dream reports, LSL markers) you can run SMACC normally, without administrator
     rights.
 
-## Portable SMACC.exe (no install)
-
-Every release also ships the same app as a single portable `SMACC.exe` — download
-it, double-click it, no installation. This suits USB-stick deployment, machines
-where nothing may be installed, and quick tests. The portable build skips the
-installer's conveniences (Start menu entry, uninstaller, the `.smacc`
-file association) — you can associate `.smacc` files from the Launcher's File
-menu instead (see below). The
-[EEG Annotator](eeg-annotator.md) is likewise available portable as
-`SMACC-EEG.exe` — put it **next to** `SMACC.exe` and the Launcher's *EEG
-Annotator* button lights up (it also runs standalone).
-
 !!! note "For IT departments"
 
     The default install is per-user (under `%LOCALAPPDATA%\Programs\SMACC`, no
@@ -76,8 +60,7 @@ newer release exists and, if one does, offers to open the download page in your
 browser — run the new installer and it upgrades the existing install in place.
 SMACC never checks on its own: lab machines are often offline, and studies
 usually pin one version for their whole run, so checking is always an explicit
-click. If you use the portable `SMACC.exe`, download the new one and replace
-your old copy.
+click.
 
 ## After installing
 
@@ -89,9 +72,9 @@ The rest of setup is covered on the relevant pages:
 
 - **Your study configuration** lives in a portable [SMACC file](smacc-files.md).
     SMACC seeds a `default.smacc` and opens it when you don't pick another, so it
-    works out of the box. The installer associates `.smacc` files; with the portable
-    build, enable or repair the association from **File › Associate .smacc files
-    (Windows)** in the Launcher.
+    works out of the box. The installer associates `.smacc` files; enable or repair
+    the association any time from **File › Associate .smacc files (Windows)** in the
+    Launcher.
 - **Audio cues** go in the data directory's `cues/` folder, alongside the seeded
     `demo-*` cues — see [Audio cues](audio-cues.md).
 - **Dream-report surveys** are managed from the Dream recording panel — see

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -13,8 +13,7 @@ The Launcher's tools (its title bar reads **SMACC**):
 - **Analyzer** — inspect a past session.
 - **Audio Cue Designer** — build a tone cue and export it as a WAV.
 - **EEG Annotator** — review and annotate a recorded EEG (see
-    [EEG Annotator](eeg-annotator.md)); disabled when its optional component is not
-    installed.
+    [EEG Annotator](eeg-annotator.md)).
 
 The **Session** and the **Editor** are the same window in two modes — running a
 night versus authoring a SMACC file.

--- a/entry_eeg.py
+++ b/entry_eeg.py
@@ -1,9 +1,0 @@
-# PyInstaller bootstrap for the optional EEG review component (#136):
-#   > pyinstaller entry_eeg.py --name SMACC-EEG --onefile --noconsole
-# Same absolute-import requirement as entry.py: PyInstaller runs its target as
-# the top-level __main__, where smacc/eeg/__main__.py's relative imports would
-# fail. For normal runs use `python -m smacc.eeg`.
-from smacc.eeg.__main__ import main
-
-if __name__ == "__main__":
-    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,15 @@ dependencies = [
     "scipy",
     "sounddevice",
     "soundfile>=0.12",
+    # The EEG Annotator (#136) ships inside the one SMACC binary — it is no longer
+    # a separate optional exe — so its stack is a core dependency. MNE reads and
+    # writes recordings (imported lazily, in smacc.eeg.io only); pyqtgraph renders
+    # the traces; matplotlib backs figure export (#180). MNE is heavy, but the
+    # onedir build imports it lazily off disk, so a session that never opens the
+    # Annotator never loads it.
+    "matplotlib>=3.7",
+    "mne>=1.6",
+    "pyqtgraph>=0.13",
 ]
 
 [project.optional-dependencies]
@@ -62,17 +71,6 @@ docs = [
     "mdformat-gfm",
     "mdformat-mkdocs",
     "mdformat-frontmatter",
-]
-# The optional EEG review tool (#136). MNE is far too heavy for the base install,
-# so the viewer ships as a separate frozen exe / installer component; this extra
-# is its dev/CI environment. MNE is I/O and annotation conversion only — on-screen
-# rendering is pyqtgraph and display filtering is scipy (a core dependency).
-# matplotlib is pinned explicitly because the figure export (#180) imports it
-# directly; it already ships in the bundle as an MNE dependency, so this is free.
-eeg = [
-    "matplotlib>=3.7",
-    "mne>=1.6",
-    "pyqtgraph>=0.13",
 ]
 dev = [
     "pytest",

--- a/scripts/screenshots.py
+++ b/scripts/screenshots.py
@@ -40,7 +40,7 @@ from pathlib import Path
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from smacc import devices, eeg, winvolume
+from smacc import devices, winvolume
 from smacc.cuedesigner import CueDesignerWindow
 from smacc.gui import SmaccWindow
 from smacc.launcher import LauncherWindow
@@ -81,8 +81,6 @@ def _patch_hardware() -> None:
     winvolume.app_volume = lambda: 1.0
     # The marker outlet would open a network stream in a live session.
     SmaccSession.init_lsl_stream = lambda self, *a, **k: setattr(self, "outlet", None)
-    # Show the EEG Annotator as installed so the Launcher button isn't greyed out.
-    eeg.available = lambda: True
 
 
 # A clean, representative data directory for the Editor shot (the real one is a

--- a/src/smacc/__main__.py
+++ b/src/smacc/__main__.py
@@ -15,7 +15,7 @@ from PyQt6.QtGui import QDesktopServices, QIcon
 from PyQt6.QtWidgets import QApplication, QMessageBox, QPushButton
 
 from . import crashlog
-from .config import VERSION
+from .config import VERSION, set_taskbar_app_id
 from .launcher import LauncherWindow
 from .paths import (
     BUNDLED_CUES_DIR,
@@ -219,7 +219,21 @@ def main() -> None:
     release workflow smoke-tests the frozen exe with it — reaching this point
     proves the bundle unpacks and every import resolves. The exe is built
     ``--noconsole`` (no stdout), so the check is the exit code, not the output.
+
+    ``--eeg`` routes to the EEG Annotator: it is a mode of this single binary,
+    run in its own process (see ``smacc.eeg.launch``), not a separate program.
     """
+    if "--eeg" in sys.argv[1:]:
+        # Hand off to the Annotator's entry point, which parses the rest
+        # (--selftest, --version, --log, --rater, --blind, the recording path).
+        # Imported here, not at module top, so the launcher path never pulls in
+        # the MNE/pyqtgraph tree. Strip the routing flag so the Annotator sees
+        # only its own arguments.
+        from smacc.eeg.__main__ import main as eeg_main
+
+        sys.argv = [sys.argv[0], *(a for a in sys.argv[1:] if a != "--eeg")]
+        eeg_main()  # always sys.exit()s; the return guards a future change
+        return
     if "--version" in sys.argv[1:]:
         if sys.stdout is not None:  # absent in a --noconsole build
             print(f"SMACC {VERSION}")
@@ -231,6 +245,7 @@ def main() -> None:
     crashlog.install_qt_message_handler()
     _install_excepthook()
     _quiet_qt_multimedia_logging()  # before QApplication: Qt reads the rule at startup
+    set_taskbar_app_id()  # group with the EEG Annotator under one taskbar app
     app = QApplication(sys.argv)
     # Fusion honors the full QPalette consistently across platforms, which the
     # native Windows style does not — required for the lights-off dark theme.

--- a/src/smacc/analyze.py
+++ b/src/smacc/analyze.py
@@ -139,7 +139,7 @@ class AnalyzeWindow(ToolWindow):
         self.revealButton.setStatusTip("Open the session's folder in the file browser.")
         self.revealButton.clicked.connect(self.reveal_folder)
         # Hand the session to the EEG Annotator, which overlays this log on the
-        # timeline (#125). Shown only where the annotator component is available.
+        # timeline (#125).
         self.annotateButton = QtWidgets.QPushButton("Open log in EEG Annotator", self)
         self.annotateButton.setStatusTip(
             "Open this session log in the EEG Annotator (overlaid on a recording, "
@@ -163,10 +163,13 @@ class AnalyzeWindow(ToolWindow):
 
     def _set_loaded(self, loaded: bool) -> None:
         """Enable the action buttons only once a session has been loaded."""
-        for button in (self.exportButton, self.recoverButton, self.revealButton):
+        for button in (
+            self.exportButton,
+            self.recoverButton,
+            self.revealButton,
+            self.annotateButton,
+        ):
             button.setEnabled(loaded)
-        # The annotator handoff also needs the optional EEG component installed.
-        self.annotateButton.setEnabled(loaded and eeg.available())
 
     # ----- opening a session ------------------------------------------------
 

--- a/src/smacc/config.py
+++ b/src/smacc/config.py
@@ -1,11 +1,36 @@
 """Configuration constants for SMACC."""
 
+import ctypes
+import sys
+
 from smacc import __version__
 
 VERSION = __version__
 
 DEVELOPMENT_ID = "999"
 DEFAULT_VOLUME = 0.5
+
+# Windows taskbar identity. SMACC is one app, but the EEG Annotator runs in its
+# own re-exec'd process (it keeps reviewing last night's file while a session
+# runs). Giving both processes the same explicit AppUserModelID makes Windows
+# group them under a single taskbar button and one pinnable icon, rather than
+# treating the Annotator window as a separate app.
+APP_USER_MODEL_ID = "Mallett.SMACC"
+
+
+def set_taskbar_app_id() -> None:
+    """Pin SMACC's Windows taskbar identity; a no-op off Windows.
+
+    Call once per process, before creating the QApplication. Best-effort: a
+    failure here only affects taskbar grouping, never startup.
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(APP_USER_MODEL_ID)
+    except (AttributeError, OSError):
+        pass
+
 
 # Named survey presets shown in the dream-recording panel's survey dropdown.
 # Maps a display label to its URL. Extend per study (persisted in settings YAML).

--- a/src/smacc/eeg/__init__.py
+++ b/src/smacc/eeg/__init__.py
@@ -1,23 +1,23 @@
 """The EEG Annotator: post-hoc trace viewing and annotation (#136).
 
-This subpackage is SMACC's *optional* EEG component. It opens a recorded EEG
-file (EDF, BrainVision, FIF), scrolls its traces, applies display-only filters,
-and saves named annotations to a TSV sidecar — the source file is never
-modified. It is an annotation tool, not a real-time display: nothing here runs
-during a live session, and nothing in the live-session path imports from here.
+This subpackage is SMACC's EEG Annotator. It opens a recorded EEG file (EDF,
+BrainVision, FIF), scrolls its traces, applies display-only filters, and saves
+named annotations to a TSV sidecar — the source file is never modified. It is
+an annotation tool, not a real-time display: nothing here runs during a live
+session, and nothing in the live-session path imports from here.
 
-The component always runs as its own process with its own ``QApplication``.
-The base ``SMACC.exe`` does not bundle MNE, so an in-process viewer is
-impossible in the packaged app; keeping development behavior identical gives
-one code path and isolates the heavy MNE/pyqtgraph process from the
-lab-critical session app.
+The Annotator always runs as its own process with its own ``QApplication`` —
+so it can outlive the launcher and keep showing last night's recording while
+tonight's session runs, and so its heavy MNE/pyqtgraph work can never crash the
+lab-critical session app. It is *not* a separate program: it is a mode of the
+single SMACC binary, re-exec'd with ``--eeg`` (see :func:`launch`).
 
 Layout keeps the heavy dependency at the edges: :mod:`~smacc.eeg.annotations`
 (the model and sidecar I/O) and :mod:`~smacc.eeg.dsp` (display filtering) are
 pure Python over numpy/scipy and import no MNE; :mod:`~smacc.eeg.io` is the
 only module that touches MNE, and imports it lazily. This module itself stays
-import-light so the base app can probe for the component without paying for it:
-:func:`available` and :func:`launch` below are everything the launcher uses.
+import-light so the launcher can pull it in without paying for MNE until the
+Annotator is actually opened.
 """
 
 # NO `from __future__ import annotations` here, on purpose: in a package
@@ -25,49 +25,25 @@ import-light so the base app can probe for the component without paying for it:
 # shadow the smacc.eeg.annotations submodule for `from smacc.eeg import
 # annotations` (the runtime annotations below don't need the future import).
 import sys
-from importlib.util import find_spec
-from pathlib import Path
-
-# The frozen EEG component, installed beside SMACC.exe by the installer's
-# optional "EEG Annotator" component (see tools/smacc.iss).
-EXE_NAME = "SMACC-EEG.exe"
-
-
-def component_exe() -> Path:
-    """Where the packaged build expects the frozen EEG exe (beside SMACC.exe)."""
-    return Path(sys.executable).resolve().parent / EXE_NAME
-
-
-def available() -> bool:
-    """True when the EEG Annotator can be launched from this install.
-
-    Packaged build: the installer component dropped ``SMACC-EEG.exe`` next to
-    ``SMACC.exe``. Development: the ``eeg`` extra (mne + pyqtgraph) is in the
-    environment. Checked via ``find_spec`` so probing costs no imports —
-    the launcher calls this at startup.
-    """
-    if getattr(sys, "frozen", False):
-        return component_exe().is_file()
-    return find_spec("mne") is not None and find_spec("pyqtgraph") is not None
 
 
 def launch(args: list[str] | None = None) -> bool:
-    """Start the EEG Annotator as its own detached process; True if started.
+    """Re-exec SMACC into the EEG Annotator as its own detached process.
 
-    Detached on purpose: the viewer outlives the launcher (or a session) and
-    never shares a process with them — see the isolation rationale above. The
-    development path runs ``python -m smacc.eeg`` with the current
-    interpreter, the packaged path runs the installed exe. ``args`` are extra
-    command-line arguments (e.g. ``["--log", path]`` for the Analyzer handoff),
-    appended after the module/exe so both paths receive them identically.
+    Detached on purpose: the Annotator outlives the launcher (or a session) and
+    never shares a process with them — see the isolation rationale above. Both
+    the packaged exe and a dev checkout re-exec *this same binary* with
+    ``--eeg`` (the frozen build bundles MNE, so there is no separate exe);
+    ``smacc.__main__`` routes ``--eeg`` to the Annotator's entry point. ``args``
+    are extra command-line arguments (e.g. ``["--log", path]`` for the Analyzer
+    handoff), forwarded after ``--eeg`` so both paths receive them identically.
     """
     from PyQt6 import QtCore  # deferred: keep this module import-light
 
     extra = list(args) if args else []
     if getattr(sys, "frozen", False):
-        started, _pid = QtCore.QProcess.startDetached(str(component_exe()), extra)
+        argv = ["--eeg", *extra]
     else:
-        started, _pid = QtCore.QProcess.startDetached(
-            sys.executable, ["-m", "smacc.eeg", *extra]
-        )
+        argv = ["-m", "smacc", "--eeg", *extra]
+    started, _pid = QtCore.QProcess.startDetached(sys.executable, argv)
     return started

--- a/src/smacc/eeg/__main__.py
+++ b/src/smacc/eeg/__main__.py
@@ -1,8 +1,9 @@
 """Run the EEG Annotator: ``python -m smacc.eeg [recording]``.
 
-The component's own entry point — its own process and ``QApplication``, never
-sharing one with a live session (see the package docstring). The frozen
-``SMACC-EEG.exe`` targets the same :func:`main` via ``entry_eeg.py``.
+The Annotator's entry point — its own process and ``QApplication``, never
+sharing one with a live session (see the package docstring). In the packaged
+build this same :func:`main` is reached by re-exec'ing the one SMACC binary
+with ``--eeg`` (``smacc.__main__`` routes it here); there is no separate exe.
 
 ``--version`` exits immediately (code 0) without opening any window, mirroring
 the base app: reaching that point proves the bundle unpacks and every import —
@@ -10,9 +11,9 @@ including the pyqtgraph tree — resolves. It does *not* prove MNE works: MNE is
 imported lazily inside :mod:`smacc.eeg.io`, so a bundle missing half of it
 would still print a version. That is what ``--selftest`` is for — it
 round-trips a synthetic recording through MNE, the slice filters, and the
-annotation sidecar, headless, and is what the release workflow runs against
-the frozen ``SMACC-EEG.exe``. The exe is built ``--noconsole`` (no stdout), so
-the check is the exit code, not the output.
+annotation sidecar, headless, and is what the release workflow runs (via
+``SMACC.exe --eeg --selftest``). The exe is built ``--noconsole`` (no stdout),
+so the check is the exit code, not the output.
 """
 
 from __future__ import annotations
@@ -22,7 +23,7 @@ import traceback
 
 from PyQt6.QtWidgets import QApplication
 
-from ..config import VERSION
+from ..config import VERSION, set_taskbar_app_id
 
 # Imported eagerly, on purpose: --version must prove the whole MNE/pyqtgraph
 # import tree resolves in the frozen bundle (that is the point of the smoke
@@ -72,7 +73,7 @@ def pick_rater_id(args: list[str]) -> str | None:
     """Return the ``--rater`` value from CLI args, or ``None``.
 
     Accepts both ``--rater alice`` and ``--rater=alice`` so a coordinator can
-    hand out a one-click command (``SMACC-EEG.exe --rater alice night1.edf``).
+    hand out a one-click command (``SMACC.exe --eeg --rater alice night1.edf``).
     Sanitizing/validation is the window's job — an empty or unusable id falls
     back to single-rater there rather than failing the launch.
     """
@@ -92,7 +93,7 @@ def pick_log_path(args: list[str]) -> str | None:
     """Return the ``--log`` value (a SMACC session log to overlay/show), or ``None``.
 
     Lets the Analyzer hand a session off to the annotator
-    (``SMACC-EEG.exe --log night1.log``): with no recording the log opens
+    (``SMACC.exe --eeg --log night1.log``): with no recording the log opens
     standalone, with one it overlays. Read/parse errors surface as a dialog after
     the window opens, not as a vanishing process.
     """
@@ -241,6 +242,7 @@ def main() -> None:
         except Exception:
             traceback.print_exc()
             sys.exit(1)
+    set_taskbar_app_id()  # share SMACC's taskbar identity (one app, not two)
     app = QApplication(sys.argv)
     app.setApplicationName("SMACC EEG Annotator")
     window = EegAnnotatorWindow(

--- a/src/smacc/eeg/export.py
+++ b/src/smacc/eeg/export.py
@@ -4,7 +4,7 @@ Renders a :class:`~smacc.eeg.snapshot.Snapshot` to PNG / PDF / SVG with
 matplotlib's headless backends — the engine MNE itself uses for static figures,
 and the only one of the available libraries that does PDF and reliable vector
 text (pyqtgraph has no PDF exporter and its SVG exporter mishandles the view's
-stacked transforms). matplotlib already ships inside ``SMACC-EEG.exe`` as an MNE
+stacked transforms). matplotlib already ships in the frozen build as an MNE
 dependency, so this adds no packaging weight.
 
 The figure is built straight on a :class:`matplotlib.figure.Figure` with an

--- a/src/smacc/eeg/sessionlog.py
+++ b/src/smacc/eeg/sessionlog.py
@@ -4,7 +4,7 @@ The EEG annotator can overlay a past session's ``.log`` on its timeline as a
 read-only reference track: every marker, cue, dream report, and survey shown
 where it happened, so a reviewer sees what SMACC *did* alongside the EEG. This
 module is the pure model behind that overlay — no GUI, no MNE — so it is
-directly unit-testable and safe to import in the frozen ``SMACC-EEG.exe``. It
+directly unit-testable and safe to import in the Annotator process. It
 builds on the log parsers in :mod:`smacc.bids` (shared with the Analyzer),
 adding the per-entry classification, dream-report numbering, and the wall-clock
 placement math the overlay needs.

--- a/src/smacc/eeg/window.py
+++ b/src/smacc/eeg/window.py
@@ -17,8 +17,8 @@ the title and prompt on close.
 
 This is a *daytime* analysis tool: unlike the session windows there is no dark
 theme, no always-on-top, and nothing here may import from the live-session
-modules (the frozen ``SMACC-EEG.exe`` doesn't ship them all — and review work
-must never share a process with a running night).
+modules — review work must never share a process with a running night (the
+Annotator runs as ``SMACC.exe --eeg``, its own process).
 """
 
 from __future__ import annotations
@@ -164,8 +164,8 @@ def _section_title(text: str) -> QtWidgets.QLabel:
 
     Deliberately duplicated from ``panels.base.make_section_title``: importing
     ``panels.base`` executes ``import sounddevice`` and pulls in the whole
-    live-session stack, which this process must never load (see the module
-    docstring) and the frozen ``SMACC-EEG.exe`` will not ship.
+    live-session stack, which the Annotator process must never load (see the
+    module docstring).
     """
     label = QtWidgets.QLabel(text)
     label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
@@ -680,8 +680,8 @@ class EegAnnotatorWindow(QtWidgets.QMainWindow):
         self._alignment: align.Alignment | None = None
         # Dream-report audio playback (#125e, folds in #179). Created lazily on
         # first play and kept alive on the window so it isn't GC'd mid-clip.
-        # QtMultimedia, never sounddevice/PortAudio — the frozen SMACC-EEG.exe
-        # ships no live-session audio stack.
+        # QtMultimedia, never sounddevice/PortAudio — the Annotator process
+        # never loads the live-session audio stack.
         self._player: Any = None
         self._audio_output: Any = None
         self._playing_wav: Path | None = None
@@ -2310,8 +2310,8 @@ class EegAnnotatorWindow(QtWidgets.QMainWindow):
     def _play_or_stop_report(self) -> None:
         """Play the selected dream report's audio, or stop it if it's playing.
 
-        QtMultimedia, never the live-session audio stack: the annotator runs as
-        the frozen ``SMACC-EEG.exe``, which ships no sounddevice/PortAudio.
+        QtMultimedia, never the live-session audio stack: the Annotator runs in
+        its own process and never loads sounddevice/PortAudio.
         """
         from PyQt6.QtMultimedia import QMediaPlayer
 

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -117,23 +117,14 @@ class LauncherWindow(QtWidgets.QMainWindow):
             "Create a tone cue and export it as a WAV file.",
             self.design_cues,
         )
-        # The optional EEG Annotator component (#136). Shown disabled (not hidden)
-        # when absent, so a lab knows the tool exists and how to get it — the same
-        # surface-don't-hide approach as missing trigger hardware (#147).
-        # Availability is probed once, here: installing the component mid-run
-        # requires closing SMACC anyway (the installer replaces the locked exe),
-        # and a stale True is already handled by the launch-failure dialog.
+        # The EEG Annotator (#136) opens in its own process so it can outlive a
+        # session (see review_eeg). MNE ships inside the one SMACC binary, so the
+        # tool is always present — the button is never gated.
         self.reviewEegButton = tool_button(
             "EEG Annotator",
             "Open the EEG Annotator in its own window (annotate a recording).",
             self.review_eeg,
         )
-        if not eeg.available():
-            self.reviewEegButton.setEnabled(False)
-            self.reviewEegButton.setStatusTip(
-                "The EEG Annotator is not installed — re-run the SMACC "
-                "installer and select the component."
-            )
 
         layout.addStretch(1)
         # Link to the documentation site (not the repo), hyperlinked. Rich text +
@@ -279,12 +270,11 @@ class LauncherWindow(QtWidgets.QMainWindow):
         self._open_tool(AnalyzeWindow(DEFAULT_DATA_DIR))
 
     def review_eeg(self) -> None:
-        """Launch the EEG Annotator as its own detached process.
+        """Open the EEG Annotator in its own process (this binary, re-exec'd).
 
         Unlike the launcher-managed tools this never hides the launcher: the
-        viewer is a sibling app in a separate process (the frozen build can't
-        run it in-process — MNE isn't bundled in SMACC.exe), so there is no
-        ``closed`` signal to bring the launcher back.
+        Annotator runs in a separate process so it can outlive the launcher (or
+        a session), so there is no ``closed`` signal to bring the launcher back.
         """
         if eeg.launch():
             bar = self.statusBar()
@@ -294,9 +284,7 @@ class LauncherWindow(QtWidgets.QMainWindow):
         QtWidgets.QMessageBox.warning(
             self,
             "EEG Annotator",
-            "Could not start the EEG Annotator.\n\n"
-            "Re-running the SMACC installer and selecting the EEG Annotator "
-            "component may repair it.",
+            "Could not start the EEG Annotator.",
         )
 
     def associate_files(self) -> None:

--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -52,8 +52,8 @@ DEFAULTS: dict[str, Any] = {
     # EEG Annotator (#136): recently used annotation labels (most-recent
     # first, seeding the label dialog's dropdown) and the last folder a
     # recording was opened from. Note loading only round-trips keys present
-    # here, so the EEG window's keys must stay in DEFAULTS even though the
-    # tool is an optional component.
+    # here, so the EEG window's keys must stay in DEFAULTS even though only
+    # the Annotator reads them.
     "eeg_recent_labels": [],
     "eeg_last_dir": None,
     # The folder the EEG Annotator last saved/loaded a view profile from (#177).

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -89,7 +89,6 @@ def test_window_shows_itself_on_construction(analyze_window):
 
 
 def test_open_in_annotator_launches_with_the_log(analyze_window, tmp_path, monkeypatch):
-    monkeypatch.setattr(eeg, "available", lambda: True)
     calls: list[list[str] | None] = []
     monkeypatch.setattr(eeg, "launch", lambda args=None: calls.append(args) or True)
     log = tmp_path / "smacc-x.log"
@@ -100,14 +99,14 @@ def test_open_in_annotator_launches_with_the_log(analyze_window, tmp_path, monke
     assert calls == [["--log", str(log)]]
 
 
-def test_annotate_button_disabled_without_the_eeg_component(
-    analyze_window, tmp_path, monkeypatch
-):
-    monkeypatch.setattr(eeg, "available", lambda: False)
+def test_annotate_button_disabled_until_a_session_loads(analyze_window, tmp_path):
+    # The handoff has nothing to hand off until a session is loaded; the EEG
+    # Annotator itself is always present (it ships inside the one SMACC binary).
+    assert not analyze_window.annotateButton.isEnabled()
     log = tmp_path / "smacc-y.log"
     log.write_text(A_LOG, encoding="utf-8")
     analyze_window._load_log(log, log.parent)
-    assert not analyze_window.annotateButton.isEnabled()  # component absent
+    assert analyze_window.annotateButton.isEnabled()
 
 
 def test_handoff_copies_a_zip_extracted_log_out_of_temp(
@@ -116,7 +115,6 @@ def test_handoff_copies_a_zip_extracted_log_out_of_temp(
     # A zip-extracted log lives under a temp dir Analyze deletes on close; the
     # detached annotator reads it later, so the handoff must pass a copy that
     # survives that cleanup, not the temp path.
-    monkeypatch.setattr(eeg, "available", lambda: True)
     launched: list[list[str] | None] = []
     monkeypatch.setattr(eeg, "launch", lambda args=None: launched.append(args) or True)
     temp = tmp_path / "smacc-analyze-xyz"
@@ -137,7 +135,6 @@ def test_handoff_copies_a_zip_extracted_log_out_of_temp(
 def test_handoff_passes_a_real_log_path_through_unchanged(
     analyze_window, tmp_path, monkeypatch
 ):
-    monkeypatch.setattr(eeg, "available", lambda: True)
     launched: list[list[str] | None] = []
     monkeypatch.setattr(eeg, "launch", lambda args=None: launched.append(args) or True)
     log = tmp_path / "smacc-z.log"

--- a/tests/test_argv.py
+++ b/tests/test_argv.py
@@ -43,6 +43,19 @@ def test_version_flag_exits_before_any_window(monkeypatch, capsys):
     assert f"SMACC {VERSION}" in capsys.readouterr().out
 
 
+def test_eeg_flag_routes_to_the_annotator(monkeypatch):
+    # `SMACC --eeg …` is the single binary run in Annotator mode: main() hands
+    # off to the EEG entry point with the routing flag stripped, so the
+    # Annotator sees only its own arguments.
+    import smacc.eeg.__main__ as eeg_main_mod
+
+    seen: dict[str, list[str]] = {}
+    monkeypatch.setattr(eeg_main_mod, "main", lambda: seen.update(argv=list(sys.argv)))
+    monkeypatch.setattr(sys, "argv", ["SMACC.exe", "--eeg", "--log", "night1.log"])
+    main()
+    assert seen["argv"] == ["SMACC.exe", "--log", "night1.log"]
+
+
 # ----- Qt-multimedia logging rule (quiet the FFmpeg startup banner) ----------
 
 

--- a/tests/test_eeg_launch.py
+++ b/tests/test_eeg_launch.py
@@ -1,9 +1,9 @@
-"""Tests for launching the optional EEG component from the launcher (#136).
+"""Tests for launching the EEG Annotator from the launcher (#136).
 
-Covers the availability probe (dev extra vs. frozen exe-beside-exe), the
-detached-process launch, and the launcher's EEG Annotator button — which is shown
-disabled (never hidden) when the component is absent, the same
-surface-don't-hide approach as missing trigger hardware (#147).
+The Annotator is a mode of the single SMACC binary: :func:`smacc.eeg.launch`
+re-execs this binary with ``--eeg`` as a detached process (so it can outlive the
+launcher), and ``smacc.__main__`` routes ``--eeg`` to its entry point. MNE ships
+inside the one binary, so the launcher button is always enabled.
 """
 
 from __future__ import annotations
@@ -16,32 +16,6 @@ from PyQt6 import QtCore, QtWidgets
 import smacc.eeg as eeg
 from smacc import launcher
 from smacc.launcher import LauncherWindow
-
-# ----- availability ----------------------------------------------------------
-
-
-def test_available_in_development_needs_the_eeg_extra():
-    # This test env has the extra installed, so the probe must say yes.
-    assert eeg.available()
-
-
-def test_available_in_development_without_the_extra(monkeypatch):
-    monkeypatch.setattr(eeg, "find_spec", lambda name: None)
-    assert not eeg.available()
-
-
-def test_available_frozen_checks_for_the_exe(tmp_path, monkeypatch):
-    monkeypatch.setattr(sys, "frozen", True, raising=False)
-    monkeypatch.setattr(sys, "executable", str(tmp_path / "SMACC.exe"))
-    assert not eeg.available()  # component not installed
-    (tmp_path / eeg.EXE_NAME).write_bytes(b"")
-    assert eeg.available()
-
-
-def test_component_exe_sits_beside_the_main_exe(tmp_path, monkeypatch):
-    monkeypatch.setattr(sys, "executable", str(tmp_path / "SMACC.exe"))
-    assert eeg.component_exe() == tmp_path / eeg.EXE_NAME
-
 
 # ----- launching ----------------------------------------------------------------
 
@@ -59,30 +33,32 @@ def spawned(monkeypatch):
     return calls
 
 
-def test_launch_in_development_runs_the_module(spawned):
+def test_launch_in_development_reexecs_the_module(spawned):
     assert eeg.launch()
-    assert spawned == [(sys.executable, ["-m", "smacc.eeg"])]
+    assert spawned == [(sys.executable, ["-m", "smacc", "--eeg"])]
 
 
-def test_launch_frozen_runs_the_component_exe(spawned, tmp_path, monkeypatch):
+def test_launch_frozen_reexecs_itself(spawned, monkeypatch):
+    # The frozen build re-execs SMACC.exe itself with --eeg — there is no
+    # separate exe, and sys.executable is the SMACC.exe being run.
     monkeypatch.setattr(sys, "frozen", True, raising=False)
-    monkeypatch.setattr(sys, "executable", str(tmp_path / "SMACC.exe"))
     assert eeg.launch()
-    assert spawned == [(str(tmp_path / eeg.EXE_NAME), [])]
+    assert spawned == [(sys.executable, ["--eeg"])]
 
 
 def test_launch_forwards_extra_args_in_development(spawned):
-    # The Analyze "open in annotator" handoff passes --log; it must reach the
-    # module after the -m smacc.eeg invocation.
+    # The Analyzer "open in annotator" handoff passes --log; it must reach the
+    # binary after the --eeg flag.
     assert eeg.launch(["--log", "night1.log"])
-    assert spawned == [(sys.executable, ["-m", "smacc.eeg", "--log", "night1.log"])]
+    assert spawned == [
+        (sys.executable, ["-m", "smacc", "--eeg", "--log", "night1.log"])
+    ]
 
 
-def test_launch_forwards_extra_args_when_frozen(spawned, tmp_path, monkeypatch):
+def test_launch_forwards_extra_args_when_frozen(spawned, monkeypatch):
     monkeypatch.setattr(sys, "frozen", True, raising=False)
-    monkeypatch.setattr(sys, "executable", str(tmp_path / "SMACC.exe"))
     assert eeg.launch(["--log", "night1.log"])
-    assert spawned == [(str(tmp_path / eeg.EXE_NAME), ["--log", "night1.log"])]
+    assert spawned == [(sys.executable, ["--eeg", "--log", "night1.log"])]
 
 
 # ----- the launcher button ----------------------------------------------------------
@@ -102,31 +78,18 @@ def make_launcher(qtbot, tmp_path, monkeypatch):
     return build
 
 
-def test_button_launches_and_keeps_the_launcher_visible(
-    make_launcher, monkeypatch, spawned
-):
-    monkeypatch.setattr(eeg, "available", lambda: True)
+def test_button_launches_and_keeps_the_launcher_visible(make_launcher, spawned):
     win = make_launcher()
     assert win.reviewEegButton.isEnabled()
     win.reviewEegButton.click()
     assert len(spawned) == 1
-    # Unlike launcher-managed tools, the viewer is a sibling process: the
+    # Unlike launcher-managed tools, the Annotator is a sibling process: the
     # launcher must stay up (there is no closed signal to bring it back).
     assert win.isVisible()
 
 
-def test_button_is_disabled_with_an_install_hint_when_absent(
-    make_launcher, monkeypatch
-):
-    monkeypatch.setattr(eeg, "available", lambda: False)
-    win = make_launcher()
-    assert not win.reviewEegButton.isEnabled()
-    assert "installer" in win.reviewEegButton.statusTip()
-
-
 def test_failed_launch_shows_a_warning(make_launcher, monkeypatch):
-    monkeypatch.setattr(eeg, "available", lambda: True)
-    monkeypatch.setattr(eeg, "launch", lambda: False)
+    monkeypatch.setattr(eeg, "launch", lambda args=None: False)
     warnings: list[str] = []
     monkeypatch.setattr(
         QtWidgets.QMessageBox,

--- a/tests/test_eeg_window.py
+++ b/tests/test_eeg_window.py
@@ -1008,10 +1008,10 @@ def test_wall_time_without_meas_date_is_none(tmp_path):
 
 
 def test_eeg_window_never_imports_the_live_session_stack():
-    # The EEG tool runs as its own process and the frozen SMACC-EEG.exe will
-    # not ship the live-session stack — importing it here (e.g. panels.base,
-    # which imports sounddevice and SmaccSession at module scope) would break
-    # the packaged build and the documented process isolation.
+    # The Annotator runs as its own process (SMACC.exe --eeg). It must not pull
+    # in the live-session stack — importing it here (e.g. panels.base, which
+    # imports sounddevice and SmaccSession at module scope) would break the
+    # documented process isolation and bloat the Annotator process.
     code = (
         "import sys; import smacc.eeg.window; "
         "leaks = [m for m in ('sounddevice', 'smacc.session', 'smacc.devices', "
@@ -1025,8 +1025,9 @@ def test_eeg_window_never_imports_the_live_session_stack():
 
 
 def test_version_flag_exits_zero_without_a_window():
-    # The release workflow smoke-tests the frozen SMACC-EEG.exe with exactly
-    # this invocation; the import tree resolving and exit code 0 are the test.
+    # The Annotator's --version (dev entry); the import tree resolving and exit
+    # code 0 are the test. The release workflow smoke-tests the frozen build
+    # with SMACC.exe --eeg --selftest (a superset that also exercises MNE).
     proc = subprocess.run(
         [sys.executable, "-m", "smacc.eeg", "--version"],
         capture_output=True,

--- a/tools/bench_eeg_view.py
+++ b/tools/bench_eeg_view.py
@@ -1,7 +1,7 @@
 # Benchmark the EEG TraceView against the #136 performance target:
 # an 8 h x 32 ch x 512 Hz overnight recording must scroll smoothly.
 #
-#   > uv run --extra eeg python tools/bench_eeg_view.py
+#   > uv run python tools/bench_eeg_view.py
 #
 # A synthetic provider generates EEG-shaped data on demand (so the bench needs
 # no gigabyte fixture file); each "refresh" is what one scroll step costs:

--- a/tools/make_versionfile.py
+++ b/tools/make_versionfile.py
@@ -5,12 +5,9 @@ so the exe's Properties dialog (and tools IT departments use to vet binaries)
 show the product name, version, and publisher instead of nothing. The version is
 read from ``smacc.__version__`` — the single source of truth — so the resource
 can never drift from the release tag (the release workflow checks the tag against
-the same attribute). Run by the release workflow before PyInstaller, once per
-exe (the optional EEG component, #136, is a second frozen exe)::
+the same attribute). Run by the release workflow before PyInstaller::
 
     uv run python tools/make_versionfile.py version_info.txt
-    uv run python tools/make_versionfile.py version_info_eeg.txt \\
-        --product SMACC-EEG --description "SMACC EEG Annotator"
 """
 
 from __future__ import annotations
@@ -84,21 +81,9 @@ def main() -> None:
     parser.add_argument(
         "output", type=Path, help="path to write (e.g. version_info.txt)"
     )
-    parser.add_argument(
-        "--product",
-        default="SMACC",
-        help="ProductName / OriginalFilename stem (e.g. SMACC-EEG)",
-    )
-    parser.add_argument(
-        "--description",
-        default=_DEFAULT_DESCRIPTION,
-        help="FileDescription shown in the exe's Properties dialog",
-    )
     args = parser.parse_args()
-    args.output.write_text(
-        render(__version__, args.product, args.description), encoding="utf-8"
-    )
-    print(f"Wrote VSVersionInfo for {args.product} {__version__} to {args.output}")
+    args.output.write_text(render(__version__), encoding="utf-8")
+    print(f"Wrote VSVersionInfo for SMACC {__version__} to {args.output}")
 
 
 if __name__ == "__main__":

--- a/tools/smacc.iss
+++ b/tools/smacc.iss
@@ -45,54 +45,29 @@ ChangesAssociations=yes
 WizardStyle=modern
 Compression=lzma2
 SolidCompression=yes
-; Disable Inno's Restart Manager (#234). On a second, in-place install it
-; enumerates processes holding handles to the exes it's about to replace or
-; [InstallDelete], and can block on a lingering OS/Defender scan handle to the
-; just-written binary even under /VERYSILENT /SUPPRESSMSGBOXES - which hung the
-; release workflow's opt-out smoke test to the job timeout. SMACC is a small
-; per-user tool with no need to gracefully close running apps mid-upgrade;
-; users close it before updating (the manual update-check flow prompts them).
-; This also turns RM off in the uninstaller: uninstalling while SMACC is running
-; falls back to the legacy file-in-use path instead of RM's close-and-restart page.
+; Disable Inno's Restart Manager (#234). On a second, in-place install (an
+; upgrade over an existing install) it enumerates processes holding handles to
+; the exes it's about to replace and can block on a lingering OS/Defender scan
+; handle to a just-written binary even under /VERYSILENT /SUPPRESSMSGBOXES.
+; SMACC is a small per-user tool with no need to gracefully close running apps
+; mid-upgrade; users close it before updating (the manual update-check flow
+; prompts them). This also turns RM off in the uninstaller: uninstalling while
+; SMACC is running falls back to the legacy file-in-use path instead of RM's
+; close-and-restart page.
 CloseApplications=no
 
 [Tasks]
 ; Desktop shortcut is opt-in (unchecked by default); the Start menu entry is always created.
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
 
-; The EEG Annotator (#136) is an optional component: the SMACC-EEG.exe bundle
-; carries the full MNE/pyqtgraph stack, so labs that only run sessions can skip
-; it. It installs by default by being part of the default "full" type (the first
-; [Types] entry, so a silent install with no /COMPONENTS uses it); unchecking it
-; switches the setup type to "custom". A [Types] section is required: without it
-; a silent install selects no components at all (not even fixed "core"). A silent
-; install can pin the set with /COMPONENTS="core" or "core,eeg", and re-running
-; the installer later can add or drop the component on an existing install.
-[Types]
-Name: "full"; Description: "Full installation"
-Name: "custom"; Description: "Custom installation"; Flags: iscustom
-
-[Components]
-Name: "core"; Description: "SMACC"; Types: full custom; Flags: fixed
-Name: "eeg"; Description: "EEG Annotator (view and annotate recordings)"; Types: full
-
 [Files]
-Source: "..\dist\SMACC.exe"; DestDir: "{app}"; Components: core; Flags: ignoreversion
-Source: "..\dist\SMACC-EEG.exe"; DestDir: "{app}"; Components: eeg; Flags: ignoreversion
-
-[InstallDelete]
-; Inno never removes a *deselected* component's files on an upgrade — without
-; this, dropping the EEG component would leave a stale, never-again-updated
-; SMACC-EEG.exe behind, which the launcher's availability probe would still
-; detect and happily run.
-Type: files; Name: "{app}\SMACC-EEG.exe"; Components: not eeg
-Type: files; Name: "{autoprograms}\SMACC EEG Annotator.lnk"; Components: not eeg
+; The whole onedir build: SMACC.exe plus its bundled Python/Qt/MNE runtime. The
+; EEG Annotator is a mode of SMACC.exe (re-exec'd with --eeg), not a separate
+; exe, so there are no installer components — every install is the full app.
+Source: "..\dist\SMACC\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
 Name: "{autoprograms}\SMACC"; Filename: "{app}\SMACC.exe"
-; The EEG Annotator is also launchable from inside SMACC, but a reviewer doing
-; daytime analysis shouldn't have to open the session app to get there.
-Name: "{autoprograms}\SMACC EEG Annotator"; Filename: "{app}\SMACC-EEG.exe"; Components: eeg
 Name: "{autodesktop}\SMACC"; Filename: "{app}\SMACC.exe"; Tasks: desktopicon
 
 [Registry]

--- a/uv.lock
+++ b/uv.lock
@@ -1765,10 +1765,13 @@ name = "smacc"
 source = { editable = "." }
 dependencies = [
     { name = "blinkstick", marker = "sys_platform == 'win32'" },
+    { name = "matplotlib" },
+    { name = "mne" },
     { name = "numpy" },
     { name = "pycaw", marker = "sys_platform == 'win32'" },
     { name = "pylsl" },
     { name = "pyqt6" },
+    { name = "pyqtgraph" },
     { name = "pyserial" },
     { name = "pyyaml" },
     { name = "scipy" },
@@ -1797,16 +1800,11 @@ docs = [
     { name = "mkdocs-with-pdf" },
     { name = "weasyprint" },
 ]
-eeg = [
-    { name = "matplotlib" },
-    { name = "mne" },
-    { name = "pyqtgraph" },
-]
 
 [package.metadata]
 requires-dist = [
     { name = "blinkstick", marker = "sys_platform == 'win32'" },
-    { name = "matplotlib", marker = "extra == 'eeg'", specifier = ">=3.7" },
+    { name = "matplotlib", specifier = ">=3.7" },
     { name = "mdformat", marker = "extra == 'docs'" },
     { name = "mdformat-frontmatter", marker = "extra == 'docs'" },
     { name = "mdformat-gfm", marker = "extra == 'docs'" },
@@ -1814,7 +1812,7 @@ requires-dist = [
     { name = "mike", marker = "extra == 'docs'" },
     { name = "mkdocs-material", marker = "extra == 'docs'" },
     { name = "mkdocs-with-pdf", marker = "extra == 'docs'" },
-    { name = "mne", marker = "extra == 'eeg'", specifier = ">=1.6" },
+    { name = "mne", specifier = ">=1.6" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "numpy" },
     { name = "pre-commit", marker = "extra == 'dev'" },
@@ -1822,7 +1820,7 @@ requires-dist = [
     { name = "pyinstaller", marker = "extra == 'dev'" },
     { name = "pylsl" },
     { name = "pyqt6" },
-    { name = "pyqtgraph", marker = "extra == 'eeg'", specifier = ">=0.13" },
+    { name = "pyqtgraph", specifier = ">=0.13" },
     { name = "pyserial" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
@@ -1835,7 +1833,7 @@ requires-dist = [
     { name = "types-pyyaml", marker = "extra == 'dev'" },
     { name = "weasyprint", marker = "extra == 'docs'" },
 ]
-provides-extras = ["docs", "eeg", "dev"]
+provides-extras = ["docs", "dev"]
 
 [[package]]
 name = "sounddevice"


### PR DESCRIPTION
Collapses SMACC's three release artifacts (`SMACC-Setup.exe`, portable `SMACC.exe`, `SMACC-EEG.exe`) and two Windows apps into **one onedir binary** distributed by a single installer.

## Rationale

The EEG split existed to keep the heavy MNE stack out of the lab-critical session app. That cost is a property of `--onefile` (which extracts the whole archive to a temp dir on every launch), not of having one binary. `--onedir` extracts nothing — a session imports MNE lazily off disk and never pays for it. Process isolation is preserved without a second exe: the Annotator is re-exec'd as its own detached process (`SMACC.exe --eeg`).

Trade-off: every install now carries MNE (~3x on-disk size); there is no single-file portable build. Confirmed acceptable — the installer already serves locked-down / no-admin machines.

## Changes

- **One binary.** `smacc.__main__` routes `--eeg` to the Annotator entry point; `eeg.launch()` re-execs this binary. Removed `entry_eeg.py`, `eeg.available()`, `eeg.component_exe()`, `eeg.EXE_NAME`; the launcher's EEG button is always enabled.
- **Dependencies.** `mne` / `matplotlib` / `pyqtgraph` moved into core `dependencies`; the `eeg` extra removed.
- **Build / CI.** One `--onedir` PyInstaller build with the MNE/matplotlib collect flags; smoke tests are `--version` and `--eeg --selftest`; only `SMACC-Setup.exe` is uploaded/released. `pyproject.toml` added to the `build-exe` triggers, since the freeze now depends on the core deps.
- **Installer.** Dropped `[Types]` / `[Components]` / `[InstallDelete]` and the second Start-menu entry; installs the onedir tree. A shared AppUserModelID groups the Annotator window under one taskbar app.
- **Docs.** README / installation / eeg-annotator / index / usage / contributing updated to installer-only, EEG always-included. The 0.1.0-0.1.1 release notes are left as historical.

This removes the opt-out / `[InstallDelete]` machinery that #234 covered (its CI smoke test is gone); the in-place-upgrade hang is mitigated by `CloseApplications=no`.

## Verification

- ruff, ruff format, mypy, mdformat: clean. 1122 tests pass.
- Local onedir build: `SMACC.exe --version` exit 0; `SMACC.exe --eeg --selftest` exit 0 (the merged build freezes MNE + matplotlib backends correctly).
- The `build-exe` job runs on this PR (it touches packaging paths) and is the installer gate.