### PR TITLE
feat: downloadable rolling dev build and pre-release versioning policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,25 @@ name: Release
 
 on:
   push:
+    # A code merge to main publishes the rolling `dev` pre-release (#251); a
+    # `v*` tag cuts a real release (full, or a Pre-release for a hyphenated tag).
+    # paths-ignore keeps docs-only merges off this heavy Windows job — they never
+    # change the frozen binary. It also applies to the tag side, but a release
+    # tag always bumps src/smacc/__init__.py, so a tag is never docs-only.
+    branches: [main]
     tags:
       - "v*"
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - "mkdocs*.yml"
+      - ".mdformat.toml"
+      - "overrides/**"
+      - "LICENSE.txt"
   # Non-publishing verification runs (#190): trigger manually, or automatically
   # on PRs that touch the packaging files. These build and smoke-test the exes
   # and installer and upload them as workflow artifacts, but never create a
-  # GitHub release — publishing is gated on a tag ref below.
+  # GitHub release — publishing is gated on a tag/branch ref below.
   workflow_dispatch:
   pull_request:
     paths:
@@ -23,9 +36,10 @@ on:
 permissions:
   contents: write
 
-# A packaging PR can push several times in a row; each run holds a Windows
-# runner for up to 30 minutes, so supersede in-flight verification runs. Tag
-# runs are never cancelled.
+# A packaging PR (or a burst of merges to main) can push several times in a row,
+# so supersede in-flight verification and dev-build runs. Tag runs are never
+# cancelled. For the rolling dev channel this means last-merge-wins: the
+# published `dev` asset reflects the latest completed merge, not every merge.
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/') }}
@@ -37,11 +51,12 @@ jobs:
     # test job (ci.yml) uses the same runner so it validates this exact env.
     runs-on: windows-2022
     # Backstop the whole job: a healthy run is a single onedir build plus the
-    # smoke tests, but a crashed --noconsole exe pops a "Failed to execute
-    # script" MessageBox that Start-Process sits behind forever. 18 min is well
-    # clear of a slow-but-fine build while nearly halving a stalled run's wasted
-    # time versus the old 30 (and GitHub's 6h default).
-    timeout-minutes: 18
+    # smoke tests (~3.5-4 min), but a crashed --noconsole exe pops a "Failed to
+    # execute script" MessageBox that Start-Process sits behind forever. 12 min
+    # is ~3x a healthy run — clear of a slow-but-fine build, and above the
+    # worst-case sum of the per-step WaitForExit caps below (120 + 300 + 60 +
+    # 180s), so a real hang is what trips it, not a slow build.
+    timeout-minutes: 12
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v8.2.0
@@ -75,6 +90,18 @@ jobs:
         run: |
           uv run python tools/make_versionfile.py version_info.txt
           if ($LASTEXITCODE -ne 0) { throw "make_versionfile exited with code $LASTEXITCODE" }
+      # Rolling dev builds (#251) self-identify by the commit they were built
+      # from: write smacc._build so the About dialog, --version, and the crash
+      # log read "v0.1.2 (dev build <sha>)". Only on a main push — tag and PR
+      # builds leave it absent, so config.BUILD is None and the version string
+      # stays clean. config.py imports it under try/except (the SHA is kept out
+      # of __version__, which must stay a plain PEP 440 string), so PyInstaller
+      # bundles the module when present and the app runs fine without it.
+      - name: Stamp the dev build with its commit
+        if: github.ref == 'refs/heads/main'
+        run: |
+          $sha = "${{ github.sha }}".Substring(0, 7)
+          "BUILD = `"$sha`"" | Out-File -Encoding utf8 src/smacc/_build.py
       # One onedir build is the whole app, EEG Annotator included. --onedir (not
       # --onefile) means nothing extracts to a temp dir at launch: Python imports
       # off the install folder lazily, so a session never loads MNE and there is
@@ -170,10 +197,39 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v3
         with:
-          # A tag with a pre-release suffix (e.g. v1.0.0-rc.1) is published as a
+          # A tag with a pre-release suffix (e.g. v0.2.0-rc.1) is published as a
           # GitHub Pre-release, so /releases/latest skips it and the in-app update
           # check (updates.py) never nags users toward a release candidate. A final
-          # tag (v0.1.0) is a full release — the homepage download button and the
+          # tag (v0.1.2) is a full release — the homepage download button and the
           # update check both resolve to it.
           prerelease: ${{ contains(github.ref_name, '-') }}
           files: dist/SMACC-Setup.exe
+      # The rolling dev channel (#251): on a code merge to main, zip the onedir
+      # tree (download-and-run — no installer, so it never touches a tester's
+      # installed stable copy) and publish it to the single moving `dev`
+      # pre-release, replacing the asset in place. Zip the folder (not its
+      # contents) so it extracts to a named SMACC/ folder. Tag/PR runs never
+      # reach these steps.
+      - name: Package the portable dev build
+        if: github.ref == 'refs/heads/main'
+        run: Compress-Archive -Path dist/SMACC -DestinationPath dist/SMACC-dev.zip -Force
+      - name: Publish rolling dev pre-release
+        if: github.ref == 'refs/heads/main'
+        uses: softprops/action-gh-release@v3
+        with:
+          # One fixed, moving tag — re-pointed to this commit, its one asset
+          # replaced, on every code merge. prerelease is hardcoded true (NOT the
+          # contains(ref_name,'-') heuristic the tag step uses: on main, ref_name
+          # is "main", which has no hyphen and would publish a FULL release that
+          # hijacks /releases/latest). make_latest:false keeps the newest stable
+          # release badged "Latest".
+          tag_name: dev
+          prerelease: true
+          make_latest: false
+          name: Development build (latest main)
+          body: >-
+            Automated build of the latest `main` (${{ github.sha }}). Unreleased,
+            unsigned, and untested — overwritten on every merge. Download,
+            extract, and run `SMACC.exe`; it won't disturb an installed stable
+            copy. For studies, use the stable release.
+          files: dist/SMACC-dev.zip

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 build/
 *.spec
 version_info.txt
+src/smacc/_build.py
 .venv/
 .*_cache/
 .coverage

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -211,16 +211,35 @@ SMACC follows [semantic versioning](https://semver.org/).
 - **`0.1.0` is the first published release** — the first with installers attached, a
     [release-notes](release-notes.md) entry, and a working in-app update check.
     Earlier `0.0.x` tags predate it and are not in the release notes.
-- **`1.0.0-rc.N` tags are reserved for the run-up to a real 1.0.** They are marked
-    *Pre-release* on GitHub (so the update check ignores them) and their docs publish
-    to the **dev** site, not `latest`. There is no `0.x`-era `-dev`/`-alpha` series.
 - **1.0.0 is the first stable release.** From then on semantic versioning is binding
     (backward-compatible changes bump the minor/patch, breaking changes bump the
     major), and the pre-1.0 docs are dropped from the version switcher.
 
+There are three kinds of build:
+
+- **Stable — `vX.Y.Z`** (no suffix): a full GitHub release, badged *Latest*. The
+    homepage download button, `/releases/latest`, and the in-app update check all
+    resolve to it, and its docs publish to `latest`. `__version__` equals `X.Y.Z`.
+- **Pre-release — `vX.Y.Z-rc.N`** (also `-alpha.N`/`-beta.N`): a tagged candidate for
+    the upcoming `X.Y.Z`. Any tag with a hyphen is marked *Pre-release* on GitHub, so
+    `/releases/latest` and the update check skip it and its docs publish to the **dev**
+    site, not `latest`. Allowed at any point, including the `0.x` line. Set
+    `__version__` to the suffixed string and tag to match.
+- **Development build — the `dev` tag**: a single fixed, *moving* tag (not a version
+    number), rebuilt and republished on every code merge to `main` and marked
+    *Pre-release*. It carries the portable `SMACC-dev.zip` (see
+    [Installation](installation.md#development-build-experimental)) and is identified at
+    runtime by the running version plus the commit it was built from, e.g.
+    `v0.1.2 (dev build a1b2c3d)`. The word **dev** is reserved for this channel and the
+    matching **dev** docs site; version pre-releases use `-rc`/`-alpha`/`-beta`, never a
+    literal `-dev` suffix.
+
 Cutting a release: bump `__version__` in `src/smacc/__init__.py` and push a matching
-`vX.Y.Z` tag. CI checks the tag equals `__version__`, builds and smoke-tests the
-installer, attaches it to the GitHub Release, and publishes the docs.
+`vX.Y.Z` tag (use `vX.Y.Z-rc.N` for a candidate). CI checks the tag equals
+`__version__`, builds and smoke-tests the installer, attaches it to the GitHub Release,
+and publishes the docs. Right after a stable release, bump `__version__` on `main` to
+the next target `X.Y.(Z+1)`, so development builds report the version they're heading
+toward rather than the one just shipped.
 
 ## Project notes
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -62,6 +62,25 @@ SMACC never checks on its own: lab machines are often offline, and studies
 usually pin one version for their whole run, so checking is always an explicit
 click.
 
+## Development build (experimental)
+
+Every code change merged to `main` is rebuilt and published as a single rolling
+**development build**, so you can try an unreleased fix or feature before the next
+stable release.
+
+[Download the development build](https://github.com/remrama/smacc/releases/download/dev/SMACC-dev.zip){ .md-button }
+
+Unzip it and run `SMACC.exe` from the extracted `SMACC` folder. It's portable, so it
+runs without installing and leaves any installed copy of SMACC untouched.
+
+!!! warning "For testing only"
+
+    The development build is unsigned, unreleased, and **not tested**, and it is
+    overwritten every time `main` changes — so it's a moving target, not a fixed
+    version. Don't use it to run a study; pin a stable release for that. The
+    **Download SMACC** button at the top of this page and the in-app **File › Check
+    for updates…** always point at the latest *stable* release, never this build.
+
 ## After installing
 
 By default SMACC stores everything under `~/SMACC`. To use a different location, set

--- a/src/smacc/__init__.py
+++ b/src/smacc/__init__.py
@@ -1,4 +1,4 @@
 """SMACC: Sleep Manipulation And Communication Clickything."""
 
 __author__ = "Remington Mallett <mallett.remy@gmail.com>"
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/src/smacc/__main__.py
+++ b/src/smacc/__main__.py
@@ -15,7 +15,7 @@ from PyQt6.QtGui import QDesktopServices, QIcon
 from PyQt6.QtWidgets import QApplication, QMessageBox, QPushButton
 
 from . import crashlog
-from .config import VERSION, set_taskbar_app_id
+from .config import display_version, set_taskbar_app_id
 from .launcher import LauncherWindow
 from .paths import (
     BUNDLED_CUES_DIR,
@@ -236,12 +236,12 @@ def main() -> None:
         return
     if "--version" in sys.argv[1:]:
         if sys.stdout is not None:  # absent in a --noconsole build
-            print(f"SMACC {VERSION}")
+            print(f"SMACC {display_version()}")
         return
     # Crash capture first, before any Qt: a native crash during Qt startup is
     # exactly what the persistent crash log exists to record (#149). The
     # excepthook's dialog arms itself once the QApplication below exists.
-    crashlog.install(VERSION)
+    crashlog.install(display_version())
     crashlog.install_qt_message_handler()
     _install_excepthook()
     _quiet_qt_multimedia_logging()  # before QApplication: Qt reads the rule at startup

--- a/src/smacc/config.py
+++ b/src/smacc/config.py
@@ -7,6 +7,29 @@ from smacc import __version__
 
 VERSION = __version__
 
+# A rolling `dev` build (#251) is stamped with the git commit it was built from:
+# the release workflow writes smacc._build on main-push builds only. It is absent
+# in a tagged release, a PR build, or a source checkout — then BUILD is None and
+# the displayed version is just VERSION. The SHA is deliberately kept out of
+# __version__, which must stay a plain PEP 440 string (the exe version-info
+# resource and the package metadata both derive from it).
+try:
+    from smacc._build import BUILD  # type: ignore[import-not-found]
+except ImportError:
+    BUILD = None
+
+
+def display_version() -> str:
+    """Human-facing version; appends the commit stamp on a rolling dev build.
+
+    ``"0.1.2"`` for a release, ``"0.1.2 (dev build a1b2c3d)"`` for a dev build.
+    Use this anywhere a person reads the version (About dialog, ``--version``,
+    the crash-log banner); keep the bare :data:`VERSION` for the provenance
+    written into data files, so a SMACC file never records a build stamp.
+    """
+    return f"{VERSION} (dev build {BUILD})" if BUILD else VERSION
+
+
 DEVELOPMENT_ID = "999"
 DEFAULT_VOLUME = 0.5
 

--- a/src/smacc/eeg/__main__.py
+++ b/src/smacc/eeg/__main__.py
@@ -23,7 +23,7 @@ import traceback
 
 from PyQt6.QtWidgets import QApplication
 
-from ..config import VERSION, set_taskbar_app_id
+from ..config import display_version, set_taskbar_app_id
 
 # Imported eagerly, on purpose: --version must prove the whole MNE/pyqtgraph
 # import tree resolves in the frozen bundle (that is the point of the smoke
@@ -229,7 +229,7 @@ def selftest() -> int:
 
 def main() -> None:
     if "--version" in sys.argv:
-        print(f"SMACC EEG Annotator v{VERSION}")
+        print(f"SMACC EEG Annotator v{display_version()}")
         sys.exit(0)
     if "--selftest" in sys.argv:
         # A windowed (--noconsole) build pops a *blocking* "Failed to execute

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -21,7 +21,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from . import dialogs, eeg, preferences, settings, updates, winassoc, windowstate
 from .analyze import AnalyzeWindow
-from .config import VERSION
+from .config import display_version
 from .cuedesigner import CueDesignerWindow
 from .gui import SmaccWindow
 from .paths import DEFAULT_DATA_DIR, DEFAULT_SETTINGS_PATH, LOGO_PATH, preferences_path
@@ -133,7 +133,7 @@ class LauncherWindow(QtWidgets.QMainWindow):
         # text is the short word "documentation" rather than the full URL so the
         # footer doesn't force the whole launcher wider than it needs to be.
         footer = QtWidgets.QLabel(
-            f'v{VERSION} — <a href="https://remrama.github.io/smacc">documentation</a>'
+            f'v{display_version()} — <a href="https://remrama.github.io/smacc">documentation</a>'
         )
         footer.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         footer.setTextFormat(QtCore.Qt.TextFormat.RichText)
@@ -336,13 +336,13 @@ class LauncherWindow(QtWidgets.QMainWindow):
             QtWidgets.QMessageBox.information(
                 self,
                 "Check for updates",
-                f"You are running the latest version of SMACC (v{VERSION}).",
+                f"You are running the latest version of SMACC (v{display_version()}).",
             )
             return
         reply = QtWidgets.QMessageBox.question(
             self,
             "Update available",
-            f"SMACC {result.latest} is available (you are running v{VERSION}).\n\n"
+            f"SMACC {result.latest} is available (you are running v{display_version()}).\n\n"
             "Open the download page in your browser?",
         )
         if reply == QtWidgets.QMessageBox.StandardButton.Yes:
@@ -354,7 +354,9 @@ class LauncherWindow(QtWidgets.QMainWindow):
         box.setStandardButtons(QtWidgets.QMessageBox.StandardButton.Ok)
         box.setWindowTitle("About SMACC")
         box.setText("Sleep Manipulation and Communication Clickything")
-        box.setInformativeText(f"version: v{VERSION}\nhttps://github.com/remrama/smacc")
+        box.setInformativeText(
+            f"version: v{display_version()}\nhttps://github.com/remrama/smacc"
+        )
         box.exec()
 
     # ----- tool-window lifecycle -------------------------------------------

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,17 @@
+"""Tests for the human-facing version string (the rolling dev build stamp, #251)."""
+
+from smacc import config
+
+
+def test_display_version_is_plain_without_a_stamp(monkeypatch):
+    # A tagged release, a PR build, or a source checkout has no smacc._build, so
+    # BUILD is None and the displayed version is exactly __version__.
+    monkeypatch.setattr(config, "BUILD", None)
+    assert config.display_version() == config.VERSION
+
+
+def test_display_version_appends_the_dev_stamp(monkeypatch):
+    # A rolling dev build is stamped with the commit it was built from, so a bug
+    # report can be traced back to a specific main commit.
+    monkeypatch.setattr(config, "BUILD", "a1b2c3d")
+    assert config.display_version() == f"{config.VERSION} (dev build a1b2c3d)"


### PR DESCRIPTION
Closes #251.

Publishes a development build of `main` to a stable, public link on the installation page, kept separate from stable releases.

## What this does

- **Rolling `dev` pre-release.** Every code-bearing merge to `main` rebuilds the onedir app and republishes it to a single, fixed, *moving* tag `dev`, marked Pre-release, carrying the portable `SMACC-dev.zip`. One tag and one release entry — re-pointed and overwritten each time, so nothing accumulates on the releases page. Docs/markdown-only merges are skipped via `paths-ignore`.
- **Download link** added to `docs/installation.md` → `releases/download/dev/SMACC-dev.zip`, behind a "for testing only" warning. It's a zipped onedir (extract and run `SMACC.exe`), so it never disturbs an installed stable copy — `#255` removed the single-file portable build, and using a zip avoids the installer's shared `AppId` clobbering a tester's stable install.
- **Build self-identification.** `config.display_version()` appends `(dev build <sha>)` when a CI-generated `smacc._build` is present; `__version__` stays a clean PEP 440 string. Shown in About, `--version`, and the crash-log banner.
- **Versioning policy** (`docs/contributing.md`) rewritten around three build kinds — stable `vX.Y.Z`, pre-release `vX.Y.Z-rc.N`/`-beta`/`-alpha` (now allowed in the 0.x line), and the rolling `dev` channel. `__version__` bumped to the next target (`0.1.2`) per the new cadence.

## Design notes

- The dev publish step **hardcodes** `prerelease: true` + `make_latest: false` (not the tag step's `contains(ref_name, '-')` heuristic — on `main` there is no hyphen, which would publish a full release and hijack `/releases/latest`).
- `updates.py` and `tools/smacc.iss` are unchanged: `/releases/latest` already skips pre-releases, so the stable download button and the in-app update check are unaffected.
- Job timeout trimmed `18 → 12` min (post-#255 healthy run is ~3.5-4 min).

## Verification

ruff, ruff format, mypy, mdformat, and the full test suite (1124, incl. new `test_config.py`) pass. `python -m smacc --version` prints a clean `SMACC 0.1.2` locally (no stamp without `_build.py`).

Note: the zip/publish steps are `main`-gated, so this PR's verification build will not exercise them — their first real run is post-merge. Confirm then that `gh release view dev` shows `isPrerelease: true` / `isLatest: false` and that `releases/download/dev/SMACC-dev.zip` resolves.