### PR TITLE
ci: gate docs site to stable releases; attach manual to every release

### DIFF
--- a/.claude/skills/quarto/SKILL.md
+++ b/.claude/skills/quarto/SKILL.md
@@ -16,10 +16,10 @@ system libraries. Quarto is a standalone binary (bundles Typst + Pandoc); it is
 ```sh
 quarto preview docs    # live-reload HTML while writing
 quarto render docs     # build HTML site + PDF into docs/_book/
-quarto render docs --to typst   # PDF only (the release manual-pdf job)
+quarto render docs --to typst   # PDF only (the release build-pdf job)
 
 uv run python scripts/check_links.py docs/_book                                 # internal links + anchors
-uv run --extra docs python scripts/check_manual.py docs/_book/smacc-manual.pdf  # PDF completeness
+uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf  # PDF completeness
 ```
 
 The project root is `docs/` (so Quarto only scans the docs tree, never README.md /
@@ -41,8 +41,10 @@ are gitignored.
   heavy/brand theming is deferred (see below).
 - **`number-sections: false`** — books number chapters by default; SMACC's docs are
   unnumbered.
-- **`output-file: smacc-manual`** — the PDF lands at `docs/_book/smacc-manual.pdf`
-  and, published, at `…/smacc/smacc-manual.pdf`.
+- **`output-file: SMACC-manual`** — the PDF lands at `docs/_book/SMACC-manual.pdf`,
+  is served on the (stable) site, and is attached to every release as `SMACC-manual.pdf`.
+- **`downloads: [pdf]`** — surfaces Quarto's built-in sidebar "Download PDF" button,
+  which points at the site-hosted (stable) PDF copy.
 
 ## Markdown conventions
 
@@ -60,13 +62,17 @@ are gitignored.
 
 ## CI
 
-- **`.github/workflows/docs.yml`** — two jobs: `build` (quarto-actions/setup, render,
-  run both checks, upload-pages-artifact) and `deploy` (actions/deploy-pages, push to
-  `main` only). Uses the official GitHub Actions Pages deployment — **no `gh-pages`
-  branch**; the repo's Pages source must be set to "GitHub Actions" (Settings → Pages).
-- **`.github/workflows/release.yml`** `manual-pdf` job — on a tag, render `--to typst`,
-  check, and attach `docs/_book/smacc-manual.pdf` (unversioned name; the release is the
-  version) to the release.
+- **`.github/workflows/docs.yml`** — two jobs: `build` (render + both checks, every
+  PR/push) and `deploy` (actions/deploy-pages). The site publishes to GitHub Pages
+  **only on a stable `vX.Y.Z` tag** (no pre-release suffix), so the live site always
+  reflects the current stable version — never dev/pre-release. Official Actions Pages
+  deployment — **no `gh-pages` branch**; the repo's Pages source must be "GitHub
+  Actions" (Settings → Pages).
+- **`.github/workflows/release.yml`** `build-pdf` job — renders `--to typst` and
+  attaches `SMACC-manual.pdf` to whatever release the run publishes: a tagged release
+  (stable/pre-release) or the rolling `dev` pre-release on a main push. Uses
+  `gh release upload --clobber` (asset-only — build-exe owns each release's metadata),
+  so **every** release carries its manual.
 - **`scripts/check_links.py`** replaces `mkdocs build --strict`'s link validation:
   it parses the rendered `_book` HTML and fails on any dead internal link or `#anchor`
   (the main migration footgun). **`scripts/check_manual.py`** (renderer-agnostic,

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,8 @@ name: Docs
 on:
   push:
     branches: [main]
+    # Stable release tags publish the live site; see the deploy gate below.
+    tags: ["v*"]
   pull_request:
     branches: [main]
 
@@ -26,20 +28,23 @@ jobs:
       # system libraries, unlike the old mkdocs-exporter + headless-Chromium path.
       - uses: quarto-dev/quarto-actions/setup@v2
 
-      # Render the HTML site and the single-file PDF manual from docs/. Two guards
-      # replace `mkdocs build --strict`: check_manual catches a renderer silently
-      # truncating the PDF (#250); check_links validates every internal cross-link
-      # and heading anchor (the main migration footgun, #259). Both run on PRs too,
-      # so a broken link or a dropped page fails the build before merge.
+      # Render the HTML site and the single-file PDF manual from docs/, on every PR
+      # and push, so docs breakage is caught early. Two guards replace
+      # `mkdocs build --strict`: check_manual catches a renderer silently truncating
+      # the PDF (#250); check_links validates every internal cross-link and heading
+      # anchor (the main migration footgun, #259).
       - name: Render and check docs
         run: |
           quarto render docs
-          uv run --extra docs python scripts/check_manual.py docs/_book/smacc-manual.pdf
+          uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf
           uv run python scripts/check_links.py docs/_book
 
-      # Hand the built site to the Pages pipeline (push to main only).
+      # Only a stable release (a `vX.Y.Z` tag with no pre-release suffix) publishes the
+      # live site, so it always reflects the current stable version — never a dev or
+      # pre-release build. The PDF manual for every release (incl. dev/pre-release) is
+      # attached to that release by release.yml instead.
       - name: Upload Pages artifact
-        if: github.event_name == 'push'
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/_book
@@ -47,7 +52,7 @@ jobs:
   # Publish to GitHub Pages via the official Actions deployment (no gh-pages branch).
   # Requires the repo's Pages source to be set to "GitHub Actions" (Settings -> Pages).
   deploy:
-    if: github.event_name == 'push'
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-')
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -232,14 +232,14 @@ jobs:
             copy. For studies, use the stable release.
           files: dist/SMACC-dev.zip
 
-  manual-pdf:
-    # Attach the PDF manual to each tagged release, so the docs for an older
-    # version stay retrievable alongside that version's installer (the docs site
-    # itself is unversioned). Tag-gated, and runs after build-exe so it adds to the
-    # release that step already created. Builds on Linux — Quarto's Typst engine
-    # needs no system libraries, and apt is faster than the Windows job.
-    name: Attach the PDF manual
-    if: startsWith(github.ref, 'refs/tags/')
+  build-pdf:
+    # Build the single-file PDF manual and attach it to whatever release this run
+    # publishes — a tagged release (stable or pre-release) or the rolling `dev`
+    # pre-release on a main push — so every release carries its own manual and old
+    # versions stay retrievable. Runs after build-exe so the release already exists.
+    # Builds on Linux — Quarto's Typst engine needs no system libraries, and apt is
+    # faster than the Windows job.
+    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
     needs: build-exe
     runs-on: ubuntu-latest
     permissions:
@@ -253,13 +253,15 @@ jobs:
       - name: Build the PDF manual
         run: |
           quarto render docs --to typst
-          uv run --extra docs python scripts/check_manual.py docs/_book/smacc-manual.pdf
-      - name: Attach to the release
-        uses: softprops/action-gh-release@v3
-        with:
-          # Match the installer step: a hyphenated tag (v0.2.0-rc.1) is a GitHub
-          # Pre-release; a final tag is a full release.
-          prerelease: ${{ contains(github.ref_name, '-') }}
-          # smacc-manual.pdf (unversioned name) — the release it's attached to is the
-          # version.
-          files: docs/_book/smacc-manual.pdf
+          uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf
+      # Attach the manual to the release this run publishes: the tag's release on a
+      # tag, or the rolling `dev` pre-release on a main push. `gh release upload` only
+      # adds/replaces the asset and never touches release metadata — build-exe owns
+      # each release's prerelease flag, name, and body.
+      - name: Attach the manual to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          [ "${GITHUB_REF}" = "refs/heads/main" ] && tag="dev"
+          gh release upload "$tag" docs/_book/SMACC-manual.pdf --clobber

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -23,9 +23,12 @@ book:
   site-url: https://remrama.github.io/smacc/
   repo-url: https://github.com/remrama/smacc
   search: true
-  # Base name for the downloadable single-file formats; the PDF lands at
-  # docs/_book/smacc-manual.pdf and, once published, …/smacc/smacc-manual.pdf.
-  output-file: smacc-manual
+  # Base name for the single-file PDF; it lands at docs/_book/SMACC-manual.pdf, is
+  # served on the (stable) site, and is attached to every release as SMACC-manual.pdf.
+  output-file: SMACC-manual
+  # Surface Quarto's built-in "Download PDF" control in the sidebar, pointing at the
+  # site-hosted (stable) copy.
+  downloads: [pdf]
   chapters:
     - index.md
     - part: Getting started

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -187,16 +187,20 @@ Heading slugs use `gfm_auto_identifiers` so the cross-page `#anchor` links resol
 the same way GitHub renders them.
 
 The [docs workflow](https://github.com/remrama/smacc/blob/main/.github/workflows/docs.yml)
-renders the docs on every pull request and, on pushes to `main`, publishes the site
-(with the PDF manual) to GitHub Pages. The site is unversioned — one current copy;
-the manual for an older release is the PDF attached to that release.
+renders and checks the docs on every pull request and push, and publishes the live
+site to GitHub Pages only on a **stable release tag** (`vX.Y.Z`) — so the site always
+reflects the current stable version, never a dev or pre-release build. The PDF manual
+is attached to *every* release (stable, pre-release, and the rolling `dev` build) by
+the [release workflow](https://github.com/remrama/smacc/blob/main/.github/workflows/release.yml),
+and the live site serves the current stable manual via the sidebar **Download PDF**
+button.
 
 Two checks run in CI after the render — run them locally before a docs PR. Together
 they replace what `mkdocs build --strict` used to cover:
 
 ```sh
 uv run python scripts/check_links.py docs/_book                                 # internal links + heading anchors
-uv run --extra docs python scripts/check_manual.py docs/_book/smacc-manual.pdf  # PDF completeness
+uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf  # PDF completeness
 ```
 
 `check_links.py` fails on any dead cross-page link or `#anchor` (heading slugs

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,8 +19,6 @@ installs per-user (no admin rights) and runs on 64-bit Windows 10 or later. See
 [Installation](installation.md), which also covers the Windows SmartScreen warning on
 the unsigned download and how to get older versions.
 
-Working offline? [Download these docs as a single PDF](https://remrama.github.io/smacc/smacc-manual.pdf).
-
 ## What SMACC does
 
 - Trigger **audio cues** (and design them in-app with the Audio Cue Designer)

--- a/scripts/check_manual.py
+++ b/scripts/check_manual.py
@@ -6,7 +6,7 @@ leaving a truncated manual that still "builds" green. Renderer-agnostic — it r
 the finished PDF — so it carried over unchanged from the MkDocs/Chromium manual to
 the Quarto/Typst one (#259). Run in CI after the PDF build:
 
-    uv run --extra docs python scripts/check_manual.py docs/_book/smacc-manual.pdf
+    uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf
 
 Exits non-zero (with a clear message) if the manual is short or is missing content
 from its later sections. The tripwire strings are distinctive tokens that live in
@@ -56,4 +56,4 @@ def main(path: str) -> int:
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "docs/_book/smacc-manual.pdf"))
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "docs/_book/SMACC-manual.pdf"))


### PR DESCRIPTION
Refines the docs deploy model from #260: the live site now tracks **stable releases only**, and the PDF manual is attached to **every** release in one consistent way.

## Behavior
- **Live site (HTML) → Pages: stable only.** `docs.yml` renders + checks on every PR/push (breakage still caught early), but publishes to GitHub Pages only on a stable `vX.Y.Z` tag (no pre-release suffix). The site never reflects a dev or pre-release build.
- **PDF → every release.** One `build-pdf` job (renamed from `manual-pdf`) renders the Typst PDF and attaches `SMACC-manual.pdf` to whatever release the run publishes — a tagged release (stable/pre-release) or the rolling `dev` pre-release on a main push — via `gh release upload --clobber` (asset-only; never touches the release's metadata, which `build-exe` owns). Old and dev manuals stay retrievable from their release assets.
- **Built-in Download PDF button kept.** `book: downloads: [pdf]` surfaces Quarto's sidebar "Download PDF" control (serving the site-hosted stable copy); the manual in-page PDF link on the home page is removed since the button covers it.
- Asset renamed to `SMACC-manual.pdf` (matches `SMACC-Setup.exe` / `SMACC-dev.zip`).

## Notes
- Docs-only merges to `main` (paths-ignored from `release.yml`) don't republish the dev manual — it refreshes with the next dev build (a code change) — and the live site only changes on a stable release. By design.
- Pages source must stay "GitHub Actions" (set during #260).

Verified locally: `quarto render docs` produces `SMACC-manual.pdf` and the Download PDF button; `check_links` + `check_manual` pass; `mdformat` / `ruff` / docs-schema tests pass.
