### PR TITLE
docs: drop mdformat-mkdocs and reflow to two-space CommonMark nesting

### DIFF
--- a/.claude/skills/dream-engineering/SKILL.md
+++ b/.claude/skills/dream-engineering/SKILL.md
@@ -51,15 +51,15 @@ and observations sit at the right point in that record.
 ## A typical session, in SMACC terms
 
 1. Set up the rig and a `.smacc` settings file (cues, devices, event codes).
-2. Start the EEG recording → `RecordingStarted` marker sets the reference clock.
-3. Watch the participant fall asleep (`SleepOnset`), then monitor stages; mark
+1. Start the EEG recording → `RecordingStarted` marker sets the reference clock.
+1. Watch the participant fall asleep (`SleepOnset`), then monitor stages; mark
    observations (`REMDetected`, `TechInRoom`, notes).
-4. At the target stage, fire a **cue** (audio, sometimes a **BlinkStick** light),
+1. At the target stage, fire a **cue** (audio, sometimes a **BlinkStick** light),
    optionally with masking **noise**; each fires its marker.
-5. Watch for a lucidity signal (`SignalObserved`); use the intercom as needed.
-6. **Wake** the participant and **record a dream report** (`DreamReportStarted`,
+1. Watch for a lucidity signal (`SignalObserved`); use the intercom as needed.
+1. **Wake** the participant and **record a dream report** (`DreamReportStarted`,
    which increments so each report is unique); maybe open a survey.
-7. Repeat across the night, then review the event log.
+1. Repeat across the night, then review the event log.
 
 ## Why this shapes design
 

--- a/.claude/skills/gh/SKILL.md
+++ b/.claude/skills/gh/SKILL.md
@@ -9,18 +9,21 @@ argument-hint: "[issue|pr|repo] [options]"
 When the user requests repository interaction, issue tracking, or PR manipulation, you must execute these operations via the terminal using the official `gh` CLI or the `gh pr-review` extension.
 
 ### Core Execution Rules
+
 1. **No Hedging:** Provide exact command invocations without speculative commentary.
-2. **Prefer Scripting Over Parsing:** Always use the `--json` + `--jq` flags when extracting data from `gh` to handle automation. Do not scrape raw text output.
-3. **Explicit Repo Targeting:** When handling inline review threads with the `gh pr-review` extension, always append the `-R owner/repo` flag explicitly.
-4. **Thread Resolution:** Use `review view` to isolate exact GraphQL node IDs (`PRRT_...`) before attempting thread replies or resolutions.
+1. **Prefer Scripting Over Parsing:** Always use the `--json` + `--jq` flags when extracting data from `gh` to handle automation. Do not scrape raw text output.
+1. **Explicit Repo Targeting:** When handling inline review threads with the `gh pr-review` extension, always append the `-R owner/repo` flag explicitly.
+1. **Thread Resolution:** Use `review view` to isolate exact GraphQL node IDs (`PRRT_...`) before attempting thread replies or resolutions.
 
 ## Parameter Routing
+
 If the user passes manual variables via a slash command (`$ARGUMENTS`), evaluate their intent:
+
 - If `$0` is `issue`, prioritize sections covering **Issues (`gh issue`)**.
 - If `$0` is `pr`, prioritize sections covering **Pull Requests (`gh pr`)**.
 - If no arguments are provided, use the global repo context.
 
----
+______________________________________________________________________
 
 ## Authentication & Environment Variables
 
@@ -30,19 +33,19 @@ gh auth status
 gh auth refresh [--scopes SCOPES]
 ```
 
-| Variable | Purpose |
-|----------|---------|
-| `GH_TOKEN` / `GITHUB_TOKEN` | Auth token (GH_TOKEN wins) |
-| `GH_HOST` | GitHub hostname (Enterprise) |
-| `GH_REPO` | Override repo as `[HOST/]OWNER/REPO` |
-| `GH_EDITOR` | Editor for text input |
-| `GH_BROWSER` | Browser for `--web` |
-| `GH_DEBUG` | Verbose output; `"api"` shows HTTP |
-| `GH_PAGER` | Terminal pager |
-| `GH_FORCE_TTY` | Force terminal output when piped |
-| `NO_COLOR` / `CLICOLOR=0` | Disable colors |
+| Variable                    | Purpose                              |
+| --------------------------- | ------------------------------------ |
+| `GH_TOKEN` / `GITHUB_TOKEN` | Auth token (GH_TOKEN wins)           |
+| `GH_HOST`                   | GitHub hostname (Enterprise)         |
+| `GH_REPO`                   | Override repo as `[HOST/]OWNER/REPO` |
+| `GH_EDITOR`                 | Editor for text input                |
+| `GH_BROWSER`                | Browser for `--web`                  |
+| `GH_DEBUG`                  | Verbose output; `"api"` shows HTTP   |
+| `GH_PAGER`                  | Terminal pager                       |
+| `GH_FORCE_TTY`              | Force terminal output when piped     |
+| `NO_COLOR` / `CLICOLOR=0`   | Disable colors                       |
 
----
+______________________________________________________________________
 
 ## Pull Requests (`gh pr`)
 
@@ -133,7 +136,7 @@ gh pr status
 
 PR selectors: number (`123`), URL, or branch name (`feature` or `OWNER:feature`).
 
----
+______________________________________________________________________
 
 ## Issues (`gh issue`)
 
@@ -164,7 +167,7 @@ gh issue transfer NUMBER|URL DEST_REPO
 gh issue status
 ```
 
----
+______________________________________________________________________
 
 ## Repositories (`gh repo`)
 
@@ -199,7 +202,7 @@ gh repo archive [OWNER/REPO] [--yes]
 gh repo deploy-key list|add|delete
 ```
 
----
+______________________________________________________________________
 
 ## Releases (`gh release`)
 
@@ -224,7 +227,7 @@ gh release delete TAG [--yes] [--cleanup-tag]
 gh release delete-asset TAG ASSET_NAME [--yes]
 ```
 
----
+______________________________________________________________________
 
 ## Workflows & Runs (`gh workflow` / `gh run`)
 
@@ -250,7 +253,7 @@ gh run download [RUN_ID] [-n ARTIFACT_NAME] [-D DIR] [--pattern GLOB]
 
 `WORKFLOW` = filename (`ci.yml`), numeric ID, or display name.
 
----
+______________________________________________________________________
 
 ## Gists, Secrets, Variables, Labels
 
@@ -281,7 +284,7 @@ gh label delete NAME [--yes]
 gh label clone SOURCE_REPO [--force]
 ```
 
----
+______________________________________________________________________
 
 ## Search
 
@@ -298,7 +301,7 @@ gh search prs QUERY [--repo OWNER/REPO] \
   --base BRANCH --head BRANCH --limit NUM --json FIELDS
 ```
 
----
+______________________________________________________________________
 
 ## `gh api` - Direct REST/GraphQL Access
 
@@ -345,7 +348,7 @@ gh api graphql --paginate -f query='
 '
 ```
 
----
+______________________________________________________________________
 
 ## Output Formatting
 
@@ -364,7 +367,7 @@ gh pr list --json number,title,author \
 
 Template functions: `autocolor`, `color`, `join`, `pluck`, `tablerow`, `tablerender`, `timeago`, `timefmt`, `truncate`.
 
----
+______________________________________________________________________
 
 ## Scripting Patterns
 
@@ -389,7 +392,7 @@ gh run watch RUN_ID --exit-status
 GH_TOKEN="$TOKEN" gh pr create --title "..." --body "..."
 ```
 
----
+______________________________________________________________________
 
 ## Other Commands
 
@@ -416,7 +419,7 @@ gh status [--exclude REPOS] [--org ORG]
 -R, --repo OWNER/REPO     # global flag: override target repo
 ```
 
----
+______________________________________________________________________
 
 ## `gh pr-review` Extension - Inline Review Threads
 
@@ -468,6 +471,7 @@ gh pr-review review view [NUMBER|URL] \
 ```
 
 Output schema:
+
 ```json
 {
   "reviews": [{

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -13,24 +13,28 @@ evaluate — **without writing code yet**. The argument is the issue number (e.g
 ## Steps
 
 1. **Read the whole issue.** Use the `gh` skill:
+
    ```sh
    gh issue view <N> --json number,title,body,labels,milestone,comments
    ```
+
    Read the body *and every comment* — in this repo the owner's follow-up comments
    usually carry the real constraints (which hardware is required, pulsed vs held,
    …), not just the original post.
 
-2. **Understand the code.** Find and **read** the modules the change touches; trace
+1. **Understand the code.** Find and **read** the modules the change touches; trace
    the integration points and existing contracts (data shapes, persisted settings,
    tests). Don't plan against a guess — open the files.
 
-3. **Load the domain context.** Pull in the relevant skill so the plan reflects
+1. **Load the domain context.** Pull in the relevant skill so the plan reflects
    reality, not just the ticket:
+
    - **portcodes** — triggers, markers, `events.py`, trigger hardware.
    - **audio-routing** — devices, routing, streams, volume.
    - **dream-engineering** — the research use-case, timing, night-time UX.
 
-4. **Write the plan.** Structure it:
+1. **Write the plan.** Structure it:
+
    - **Problem** — what's actually being asked, in your own words.
    - **Approach** — the recommended design, plus alternatives you considered and
      rejected (and why).
@@ -45,7 +49,7 @@ evaluate — **without writing code yet**. The argument is the issue number (e.g
    - **Verification** — how it'll be tested, including what can only be validated on
      real hardware.
 
-5. **Present for evaluation. Do not start implementing.** Wait for the user to react.
+1. **Present for evaluation. Do not start implementing.** Wait for the user to react.
 
 ## Conventions
 

--- a/.claude/skills/portcodes/SKILL.md
+++ b/.claude/skills/portcodes/SKILL.md
@@ -38,7 +38,7 @@ point** for any additional transport: a parallel/serial write belongs right next
   (`manual`/`control`/`system`), `increment`, plus `key`/`label`/`tooltip`.
 - `increment` events (e.g. `DreamReportStarted`, code 201) advance the code each
   firing (`runtime_code`) so every occurrence is individually findable; clamped to
-  255.
+  255\.
 - `validate_events` **errors** on a code outside 1–255, a duplicate code among
   *triggerable* events (they'd collide on the channel), or a duplicate key; it
   **warns** on a code above a study's `safe_max` (older hardware) and on an
@@ -52,12 +52,12 @@ point** for any additional transport: a parallel/serial write belongs right next
 Rigs ingest markers differently; SMACC should support all *known* ones via
 configuration (issue #28):
 
-| Transport | What it is | How a byte goes out |
-|---|---|---|
-| **LSL marker stream** | Network marker recorded by an LSL-aware recorder (LabRecorder → XDF). Current default. | `StreamOutlet.push_sample`. Same- or cross-computer; no extra hardware. |
-| **Parallel port (LPT)** | Legacy 25-pin port; 8 data pins = the trigger byte, sampled by the amp. Still required by an active lab rig. | Write the byte to the port's data register. On modern Windows needs the **InpOut32 / inpoutx64** kernel driver. |
-| **USB-serial trigger box** | The modern LPT replacement; presents as a COM port and mirrors a received byte onto 8 TTL lines. | `pyserial` write to a configured COM port + baud. |
-| **Serial TTL** | A device that takes the byte directly over serial. | `pyserial`, same as above. |
+| Transport                  | What it is                                                                                                   | How a byte goes out                                                                                             |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| **LSL marker stream**      | Network marker recorded by an LSL-aware recorder (LabRecorder → XDF). Current default.                       | `StreamOutlet.push_sample`. Same- or cross-computer; no extra hardware.                                         |
+| **Parallel port (LPT)**    | Legacy 25-pin port; 8 data pins = the trigger byte, sampled by the amp. Still required by an active lab rig. | Write the byte to the port's data register. On modern Windows needs the **InpOut32 / inpoutx64** kernel driver. |
+| **USB-serial trigger box** | The modern LPT replacement; presents as a COM port and mirrors a received byte onto 8 TTL lines.             | `pyserial` write to a configured COM port + baud.                                                               |
+| **Serial TTL**             | A device that takes the byte directly over serial.                                                           | `pyserial`, same as above.                                                                                      |
 
 ## Parallel port: the driver reality
 
@@ -76,7 +76,7 @@ Trigger boxes and amps differ:
 - **Set-and-hold** — leave the lines at `code` until the next event (old parallel
   semantics).
 - **Pulsed** — raise `code` for a configurable width (e.g. ~5–10 ms), then drop to
-  0. SMACC's labs use **pulsed**; make the width configurable.
+  0\. SMACC's labs use **pulsed**; make the width configurable.
 
 ## SMACC's marker history (so you don't relitigate it)
 

--- a/.claude/skills/quarto/SKILL.md
+++ b/.claude/skills/quarto/SKILL.md
@@ -80,11 +80,15 @@ are gitignored.
 
 ## Formatting
 
-`mdformat` (CI + pre-commit) still runs with **`mdformat-mkdocs`** — kept not for
-Material syntax (gone) but because it preserves the repo's four-space list-nesting
-style across *all* markdown; dropping it would reflow every list (incl. README.md /
-AGENTS.md). It leaves Quarto `:::` callouts and `{…}` attributes intact. `docs/_book`
-and `docs/.quarto` are excluded in `.mdformat.toml`.
+`mdformat` (CI + pre-commit) runs as **`mdformat` + `mdformat-gfm` +
+`mdformat-frontmatter`**. The `mdformat-mkdocs` plugin was dropped after the Quarto
+migration (#265): it only survived to keep the MkDocs-era four-space list nesting,
+which Python-Markdown required but Quarto/Pandoc doesn't, so lists now use standard
+two-space CommonMark nesting. Base `mdformat` still leaves Quarto `:::` callouts and
+`{…}` attributes intact (keep a blank line before a closing `:::` — a list that
+directly abuts the fence pulls it into the list). The in-tree skill docs under
+`.claude/skills/` are formatted too; `.mdformat.toml` excludes only `.venv`,
+`.pytest_cache`, `docs/_book`, `docs/.quarto`, and `.claude/worktrees`.
 
 ## Deferred (separate follow-up PR)
 

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -5,15 +5,17 @@
 # end_of_line = "lf" matches ruff. exclude needs Python 3.13 (glob.translate) —
 # the reason this waited on #168 — and is the single scope source: CI runs
 # `mdformat --check .` and the pre-commit hook crawls the same way, both reading
-# these globs. .claude/ holds the tool-managed AI-assistant configs (out of
-# scope); .venv/ and .pytest_cache/ are not gitignore-aware to mdformat, so the
-# in-tree venv that `uv run` creates must be excluded or the check drowns in
-# site-packages READMEs. docs/_book and docs/.quarto are Quarto's build output and
-# cache (gitignored, but mdformat isn't gitignore-aware), so exclude them too.
+# these globs. The in-tree skill docs under .claude/skills/ are real Markdown and
+# are formatted like the rest; only .claude/worktrees/ is excluded — it holds
+# nested working copies of this repo (mdformat isn't gitignore-aware), which would
+# otherwise be crawled twice. .venv/ and .pytest_cache/ are likewise not
+# gitignore-aware, so the in-tree venv that `uv run` creates must be excluded or
+# the check drowns in site-packages READMEs. docs/_book and docs/.quarto are
+# Quarto's build output and cache (gitignored), so exclude them too.
 wrap = "keep"
 end_of_line = "lf"
 exclude = [
-  ".claude/**",
+  ".claude/worktrees/**",
   ".venv/**",
   ".pytest_cache/**",
   "docs/_book/**",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,11 +10,11 @@ bug reports before starting work.
 ## Conventions
 
 - Always use `uv` when running Python scripts or installing dependencies. Never
-    `pip install` or run naked `python`.
+  `pip install` or run naked `python`.
 - One-line commits with a [Conventional Commits](https://www.conventionalcommits.org)
-    prefix (`feat:`, `fix:`, `docs:`, …); no commit body and no AI attribution. Pull
-    request bodies stay brief. Full guide:
-    [Commit and pull-request style](./docs/contributing.md#commit-and-pull-request-style).
+  prefix (`feat:`, `fix:`, `docs:`, …); no commit body and no AI attribution. Pull
+  request bodies stay brief. Full guide:
+  [Commit and pull-request style](./docs/contributing.md#commit-and-pull-request-style).
 
 ## Architecture at a glance
 

--- a/docs/audio-cues.md
+++ b/docs/audio-cues.md
@@ -54,16 +54,16 @@ bedroom speaker could be muted, unplugged, or turned down at the hardware. The A
 cue window's **Monitoring** section shows two meters so you can tell:
 
 - **Sending** is the level SMACC is emitting to the cue output, the moment it plays.
-    It is exact, but it only confirms SMACC is *playing*; it is blind to everything
-    downstream (Windows volume, the speaker's power switch, the cable). Read it as a
-    diagnostic: if *Sending* is dark, the problem is on SMACC's side (wrong cue, or a
-    per-cue volume or the safety cap at zero); if it is lit but the room is silent,
-    the problem is the speaker.
+  It is exact, but it only confirms SMACC is *playing*; it is blind to everything
+  downstream (Windows volume, the speaker's power switch, the cable). Read it as a
+  diagnostic: if *Sending* is dark, the problem is on SMACC's side (wrong cue, or a
+  per-cue volume or the safety cap at zero); if it is lit but the room is silent,
+  the problem is the speaker.
 - **Bedroom** is the level a microphone actually picks up in the room. This is the
-    objective check: it moves only when sound really happens in the bedroom. Tick the
-    box beside it to start monitoring. Because a faint cue can sit close to a cheap
-    mic's noise floor, the meter also shows the **rise above the room's resting
-    level** (the `+N` next to the reading), so even a small bump stands out.
+  objective check: it moves only when sound really happens in the bedroom. Tick the
+  box beside it to start monitoring. Because a faint cue can sit close to a cheap
+  mic's noise floor, the meter also shows the **rise above the room's resting
+  level** (the `+N` next to the reading), so even a small bump stands out.
 
 ::: {.callout-tip title="A dedicated monitoring mic"}
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -16,13 +16,13 @@ Instead of picking a device separately in every window, SMACC has one **Devices
 window** (in the **Panels** column) where you do two things:
 
 1. **Bind each piece of _equipment_ to a device, once.** Equipment entries are
-    the physical endpoints of a rig, named by place: **Bedroom speaker**, **Control-room speaker**, **Bedroom
-    mic 1** (and an optional **Bedroom mic 2**), the **Control-room mic** (the
-    experimenter's intercom voice), plus the light devices (**BlinkStick light**,
-    **Philips Hue light**).
+   the physical endpoints of a rig, named by place: **Bedroom speaker**, **Control-room speaker**, **Bedroom
+   mic 1** (and an optional **Bedroom mic 2**), the **Control-room mic** (the
+   experimenter's intercom voice), plus the light devices (**BlinkStick light**,
+   **Philips Hue light**).
 1. **Route each _action_ to equipment.** Every action names what SMACC does
-    with a device — *Play audio cue*, *Record dream report* — and each points
-    at a piece of equipment. Hover any row in the window for a full description.
+   with a device — *Play audio cue*, *Record dream report* — and each points
+   at a piece of equipment. Hover any row in the window for a full description.
 
 The cue, the noise, and your intercom voice can all share the **Bedroom
 speaker**, so swapping it is one change rather than several. Every other
@@ -55,17 +55,17 @@ its default device on its own — plugging in an HDMI monitor or a Bluetooth hea
 is enough — and an overnight study must not follow it. Instead:
 
 - When a session starts (or loads a study) with nothing bound to the **Bedroom
-    speaker**, **Bedroom mic 1**, or the **Control-room mic**, SMACC binds the device
-    that is *currently* the Windows default — explicitly, by name — and logs which
-    one it picked. From then on the binding is pinned: changing the Windows default
-    never re-routes a study.
+  speaker**, **Bedroom mic 1**, or the **Control-room mic**, SMACC binds the device
+  that is *currently* the Windows default — explicitly, by name — and logs which
+  one it picked. From then on the binding is pinned: changing the Windows default
+  never re-routes a study.
 - Equipment with nothing bound reads **(none)**, and anything routed to it
-    reports a clear error instead of quietly playing somewhere else.
+  reports a clear error instead of quietly playing somewhere else.
 - If no device is connected at all, the dropdown says so (e.g. **No output device
-    found**) rather than offering an empty choice.
+  found**) rather than offering an empty choice.
 - A bound device that isn't currently connected shows as **(not connected)** and
-    is kept — never silently swapped — until you pick another device or plug it back
-    in (then **Refresh devices (F5)**).
+  is kept — never silently swapped — until you pick another device or plug it back
+  in (then **Refresh devices (F5)**).
 
 The study editor never auto-binds: a study built on an office machine arrives at
 the rig with its equipment unbound, and the rig pins its own defaults on first
@@ -76,19 +76,19 @@ load.
 Three optional routes cover the things you reach for mid-study:
 
 - **Listen to audio cue (fan-out).** Route *Listen to audio cue* to the
-    control-room speaker and each cue plays in the bedroom and the control room at
-    once, so you hear what the participant hears.
+  control-room speaker and each cue plays in the bedroom and the control room at
+  once, so you hear what the participant hears.
 - **Listen to participant.** The intercom is two-way: **Speak to participant**
-    sends your voice — picked up by the **Control-room mic** — to the participant
-    (and is marked in the EEG record), while **Listen to participant** brings the
-    participant's mic to your control-room speaker. The intercom also has a typed
-    [text-chat mode](intercom.md#text-chat) (no audio device involved) for
-    hearing-impaired participants.
+  sends your voice — picked up by the **Control-room mic** — to the participant
+  (and is marked in the EEG record), while **Listen to participant** brings the
+  participant's mic to your control-room speaker. The intercom also has a typed
+  [text-chat mode](intercom.md#text-chat) (no audio device involved) for
+  hearing-impaired participants.
 - **Monitor bedroom noise.** A microphone meter in the Audio cue window that
-    confirms a cue is audible in the bedroom (see
-    [Audio cues](audio-cues.md#is-the-cue-reaching-the-bedroom)). It defaults to
-    **Bedroom mic 1**, or bind a dedicated, more sensitive **Bedroom mic 2** and route
-    *Monitor bedroom noise* to it.
+  confirms a cue is audible in the bedroom (see
+  [Audio cues](audio-cues.md#is-the-cue-reaching-the-bedroom)). It defaults to
+  **Bedroom mic 1**, or bind a dedicated, more sensitive **Bedroom mic 2** and route
+  *Monitor bedroom noise* to it.
 
 ## One audio engine
 

--- a/docs/biocals.md
+++ b/docs/biocals.md
@@ -14,17 +14,17 @@ own row.
 Each row has a toggle button, two checkboxes, and a duration:
 
 - **The biocal's button** runs it. The button stays depressed while it runs and the
-    countdown at the top shows the time remaining in its task window. Press it again
-    to cancel early, so a botched 30-second window need not be waited out.
+  countdown at the top shows the time remaining in its task window. Press it again
+  to cancel early, so a botched 30-second window need not be waited out.
 - **Voice** speaks the pre-recorded instruction (for example, *"Please close your
-    eyes and relax for thirty seconds."*) over the cue output when the biocal starts.
-    Leave it unchecked to give the instruction yourself.
+  eyes and relax for thirty seconds."*) over the cue output when the biocal starts.
+  Leave it unchecked to give the instruction yourself.
 - **Seq** includes the row when **Play sequence** runs the whole stack in order.
-    Standard biocals start checked; the lucid-dreaming ones start unchecked.
+  Standard biocals start checked; the lucid-dreaming ones start unchecked.
 - **Duration** is the task window in seconds. With the voice on, the window (and its
-    countdown) starts when the instruction *ends*, so a 10-second breath hold is a
-    full 10 seconds. This matches the manual practice of speaking first, then marking
-    when the participant complies.
+  countdown) starts when the instruction *ends*, so a 10-second breath hold is a
+  full 10 seconds. This matches the manual practice of speaking first, then marking
+  when the participant complies.
 
 ## Sequences
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -21,20 +21,20 @@ first.
 ## Conventions
 
 - Always use [uv](https://docs.astral.sh/uv/) to run Python scripts and install
-    dependencies. Never `pip install` or run naked `python`.
+  dependencies. Never `pip install` or run naked `python`.
 - Use the marker vocabulary consistently in UI text, docs, and docstrings — *event*,
-    *marker*, *port code*, *trigger*, *transport* each mean exactly one thing; see the
-    [terminology table](triggers.md#terminology).
+  *marker*, *port code*, *trigger*, *transport* each mean exactly one thing; see the
+  [terminology table](triggers.md#terminology).
 - Write the docs as **reference**, not marketing: lead with the fact, keep pages
-    scannable (short paragraphs, tables, steps), and go easy on em-dashes and the
-    "not X, but Y" construction. Page filenames are stable, so cross-link with
-    relative links and matching heading anchors.
+  scannable (short paragraphs, tables, steps), and go easy on em-dashes and the
+  "not X, but Y" construction. Page filenames are stable, so cross-link with
+  relative links and matching heading anchors.
 - Pick log levels by the [session-log convention](reference/session-log.md#log-levels):
-    `DEBUG` for housekeeping/high-frequency detail, `INFO` for markers and meaningful
-    operator actions, `WARNING` for mid-session config changes and recoverable faults,
-    `ERROR` for faults that cost something. The file records every level, so demoting a
-    line to `DEBUG` only moves it out of the default live preview, never out of the
-    record.
+  `DEBUG` for housekeeping/high-frequency detail, `INFO` for markers and meaningful
+  operator actions, `WARNING` for mid-session config changes and recoverable faults,
+  `ERROR` for faults that cost something. The file records every level, so demoting a
+  line to `DEBUG` only moves it out of the default live preview, never out of the
+  record.
 
 ## Commit and pull-request style
 
@@ -44,10 +44,10 @@ Keep the history skimmable and merge commits clean.
 
 - One line only — a subject, with no body or extended description.
 - Start with a [Conventional Commits](https://www.conventionalcommits.org/) prefix:
-    `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `build:`, `ci:`, or
-    `perf:`.
+  `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `build:`, `ci:`, or
+  `perf:`.
 - Imperative mood, lower-case after the prefix, no trailing period, and ideally
-    under ~72 characters.
+  under ~72 characters.
 - No AI attribution or co-author trailers.
 
 ```text
@@ -59,15 +59,15 @@ fix: clamp incrementing port codes to 255
 **Pull requests**
 
 - The title follows the same one-line Conventional-Commits rule — on a squash merge
-    it becomes the commit subject (GitHub appends the `(#NN)` PR number).
+  it becomes the commit subject (GitHub appends the `(#NN)` PR number).
 - The body is a brief summary, not an exhaustive change list: what changed, why, and
-    how it was verified. A few sentences or bullets is plenty.
+  how it was verified. A few sentences or bullets is plenty.
 - No AI attribution footer.
 
 **Merging**
 
 - Squash-merge, and clear the auto-generated commit body so the merged commit is the
-    one-line title alone — no bundled description or commit list.
+  one-line title alone — no bundled description or commit list.
 
 ## Development
 
@@ -213,34 +213,34 @@ renderer silently dropping pages (the bug behind #250).
 SMACC follows [semantic versioning](https://semver.org/).
 
 - **Pre-1.0, the app is not stable.** Settings files, marker codes, the UI, and
-    behavior may change between releases, and there are no compatibility shims. Pin
-    one version for the duration of a study.
+  behavior may change between releases, and there are no compatibility shims. Pin
+  one version for the duration of a study.
 - **Versions are `0.x.y` until 1.0.0.** A new `0.x.0` collects features and `0.x.y`
-    is a smaller follow-up; no pre-1.0 bump is a stability promise.
+  is a smaller follow-up; no pre-1.0 bump is a stability promise.
 - **`0.1.0` is the first published release** — the first with installers attached, a
-    [release-notes](release-notes.md) entry, and a working in-app update check.
-    Earlier `0.0.x` tags predate it and are not in the release notes.
+  [release-notes](release-notes.md) entry, and a working in-app update check.
+  Earlier `0.0.x` tags predate it and are not in the release notes.
 - **1.0.0 is the first stable release.** From then on semantic versioning is binding
-    (backward-compatible changes bump the minor/patch, breaking changes bump the
-    major).
+  (backward-compatible changes bump the minor/patch, breaking changes bump the
+  major).
 
 There are three kinds of build:
 
 - **Stable — `vX.Y.Z`** (no suffix): a full GitHub release, badged *Latest*. The
-    homepage download button, `/releases/latest`, and the in-app update check all
-    resolve to it. `__version__` equals `X.Y.Z`.
+  homepage download button, `/releases/latest`, and the in-app update check all
+  resolve to it. `__version__` equals `X.Y.Z`.
 - **Pre-release — `vX.Y.Z-rc.N`** (also `-alpha.N`/`-beta.N`): a tagged candidate for
-    the upcoming `X.Y.Z`. Any tag with a hyphen is marked *Pre-release* on GitHub, so
-    `/releases/latest` and the update check skip it. Allowed at any point, including
-    the `0.x` line. Set `__version__` to the suffixed string and tag to match.
+  the upcoming `X.Y.Z`. Any tag with a hyphen is marked *Pre-release* on GitHub, so
+  `/releases/latest` and the update check skip it. Allowed at any point, including
+  the `0.x` line. Set `__version__` to the suffixed string and tag to match.
 - **Development build — the `dev` tag**: a single fixed, *moving* tag (not a version
-    number), rebuilt and republished on every code merge to `main` and marked
-    *Pre-release*. It carries the portable `SMACC-dev.zip` (see
-    [Installation](installation.md#development-build-experimental)) and is identified at
-    runtime by the running version plus the commit it was built from, e.g.
-    `v0.1.2 (dev build a1b2c3d)`. The word **dev** is reserved for this channel and the
-    matching **dev** docs site; version pre-releases use `-rc`/`-alpha`/`-beta`, never a
-    literal `-dev` suffix.
+  number), rebuilt and republished on every code merge to `main` and marked
+  *Pre-release*. It carries the portable `SMACC-dev.zip` (see
+  [Installation](installation.md#development-build-experimental)) and is identified at
+  runtime by the running version plus the commit it was built from, e.g.
+  `v0.1.2 (dev build a1b2c3d)`. The word **dev** is reserved for this channel and the
+  matching **dev** docs site; version pre-releases use `-rc`/`-alpha`/`-beta`, never a
+  literal `-dev` suffix.
 
 Cutting a release: bump `__version__` in `src/smacc/__init__.py` and push a matching
 `vX.Y.Z` tag (use `vX.Y.Z-rc.N` for a candidate). CI checks the tag equals
@@ -253,13 +253,13 @@ toward rather than the one just shipped.
 
 - `src/` layout: the package lives in `src/smacc/`.
 - The single source of truth for the version is `__version__` in
-    `src/smacc/__init__.py`; `config.py` and the packaging metadata both read from
-    it.
+  `src/smacc/__init__.py`; `config.py` and the packaging metadata both read from
+  it.
 - The build/runtime Python is pinned to **3.13** in `.python-version`. The
-    minimum OS is **Windows 10**, set by Qt 6 (PyQt6) — Qt 5 was the last line that
-    still ran on Windows 8.1. Keep the pin unless you intend to move the Python floor.
+  minimum OS is **Windows 10**, set by Qt 6 (PyQt6) — Qt 5 was the last line that
+  still ran on Windows 8.1. Keep the pin unless you intend to move the Python floor.
 - SMACC is distributed only as a frozen `SMACC.exe` (no PyPI), so CI tests what
-    ships rather than a version range: the `test` job in `ci.yml` runs on the same
-    `windows-2022` + Python 3.13 + locked dependencies as the release build
-    (`release.yml`), across `windows-2022` and `windows-latest` rather than a
-    Python-version matrix.
+  ships rather than a version range: the `test` job in `ci.yml` runs on the same
+  `windows-2022` + Python 3.13 + locked dependencies as the release build
+  (`release.yml`), across `windows-2022` and `windows-latest` rather than a
+  Python-version matrix.

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -16,26 +16,26 @@ sleep and lucid-dreaming experiments.
 ### What you need
 
 - **A BlinkStick device.** They are sold directly from
-    [blinkstick.com](https://www.blinkstick.com/). SMACC drives them through the
-    [`blinkstick`](https://pypi.org/project/BlinkStick/) Python library, so any
-    model that library supports (BlinkStick Square, Strip, Nano, Flex, …) will work.
+  [blinkstick.com](https://www.blinkstick.com/). SMACC drives them through the
+  [`blinkstick`](https://pypi.org/project/BlinkStick/) Python library, so any
+  model that library supports (BlinkStick Square, Strip, Nano, Flex, …) will work.
 - **Nothing else to install.** The BlinkStick driver is bundled inside
-    `SMACC.exe`, so you only need to plug the device into a USB port before
-    launching SMACC.
+  `SMACC.exe`, so you only need to plug the device into a USB port before
+  launching SMACC.
 
 ### Using it in SMACC
 
 1. Plug the BlinkStick into a USB port, then launch SMACC.
 1. Click **Visual cue** in the **Panels** column.
 1. Bind your BlinkStick to the **BlinkStick light** equipment in the **Devices** window
-    (in the **Panels** column). Plug one in after launch and it's detected
-    automatically, or click **Refresh devices (F5)** in the Devices window to rescan.
+   (in the **Panels** column). Plug one in after launch and it's detected
+   automatically, or click **Refresh devices (F5)** in the Devices window to rescan.
 1. Configure a light cue — color, brightness, pattern (steady, or a pulse/flash at
-    a rate in Hz), and length (or **Loop** until stopped) — and add more cues with
-    **+ Add cue** if the protocol needs several. See [Visual cues](visual.md) for
-    what each pattern is for.
+   a rate in Hz), and length (or **Loop** until stopped) — and add more cues with
+   **+ Add cue** if the protocol needs several. See [Visual cues](visual.md) for
+   what each pattern is for.
 1. Click a cue's **Play** to fire it; **Stop** turns the light off early. The rest
-    of SMACC stays responsive while the light is on.
+   of SMACC stays responsive while the light is on.
 
 Your chosen device and the whole cue board are saved in the
 [SMACC file](smacc-files.md), so the visual-cue
@@ -58,11 +58,11 @@ over the local network. Setup is once per bridge:
 
 1. In the **Devices** window, click **Set up Philips Hue…**.
 1. Click **Find bridge** (or type the bridge's IP — the Hue app shows it under
-    bridge settings).
+   bridge settings).
 1. Press the round **link button** on the bridge itself, then click **Pair**
-    within 30 seconds. **Test** lists the bridge's lights to confirm.
+   within 30 seconds. **Test** lists the bridge's lights to confirm.
 1. Bind a light or group to the **Philips Hue light** equipment, and route
-    **Play visual cue** to **Philips Hue light**.
+   **Play visual cue** to **Philips Hue light**.
 
 The bridge IP and pairing key are stored in the study's `.smacc` (the key is a
 local-network credential — treat the file accordingly). Hue suits ambient,

--- a/docs/eeg-annotator.md
+++ b/docs/eeg-annotator.md
@@ -14,18 +14,18 @@ session runs.
 overnight cueing workflow, not for clinical reading:
 
 - It is **read-only by contract** — the recording is never written; every mark,
-    stage score, and overlay lives in a small sidecar beside it.
+  stage score, and overlay lives in a small sidecar beside it.
 - It is **SMACC-aware** — it imports SMACC's own portcodes off the recording and
-    can overlay a night's [session log](#session-log-overlay) (cues, dream
-    reports, even the recorded report audio), so you see *what SMACC did* on the
-    same timeline.
+  can overlay a night's [session log](#session-log-overlay) (cues, dream
+  reports, even the recorded report audio), so you see *what SMACC did* on the
+  same timeline.
 - It has **blind, multi-rater scoring** built in (see
-    [blind-rater mode](#blind-rater-mode)) — for objective signal and stage
-    scoring, not an afterthought.
+  [blind-rater mode](#blind-rater-mode)) — for objective signal and stage
+  scoring, not an afterthought.
 - Its **[epoch model](#the-epoch-model)** is decoupled from the on-screen window
-    and can be anchored to any feature.
+  and can be anchored to any feature.
 - Recordings are **memory-mapped**, so an 8-hour high-density night opens in
-    seconds and scrolls smoothly regardless of file size.
+  seconds and scrolls smoothly regardless of file size.
 
 ::: {.callout-note title="Built in, runs in its own process"}
 
@@ -55,22 +55,22 @@ stays smooth regardless of file size.
 ## Viewing
 
 - **Window length** — 10/30/60/120 s pages; **30 s** is the default. This is the
-    *on-screen* window, separate from the [scoring epoch](#the-epoch-model).
+  *on-screen* window, separate from the [scoring epoch](#the-epoch-model).
 - **Filters** — high-pass, low-pass, and a 50/60 Hz notch, applied to the
-    *display only* (zero-phase, so nothing shifts in time). Recordings open
-    **unfiltered** — the usual sleep view is two clicks away (HP 0.3 Hz, LP
-    35 Hz).
+  *display only* (zero-phase, so nothing shifts in time). Recordings open
+  **unfiltered** — the usual sleep view is two clicks away (HP 0.3 Hz, LP
+  35 Hz).
 - **Scale** — microvolts per channel lane; smaller numbers mean bigger
-    traces. Trigger/stim channels are auto-fit to their lane.
+  traces. Trigger/stim channels are auto-fit to their lane.
 - **Channels…** picks which channels are shown and reorders them; each channel
-    type (EEG, EOG, EMG, …) scales on its own. **Save profile…** stores the whole
-    montage — channels, filters, scale, and the window/epoch lengths — to a file,
-    and **Load profile…** applies it to any recording, so a lab's house view is
-    one click on every night.
+  type (EEG, EOG, EMG, …) scales on its own. **Save profile…** stores the whole
+  montage — channels, filters, scale, and the window/epoch lengths — to a file,
+  and **Load profile…** applies it to any recording, so a lab's house view is
+  one click on every night.
 - **Export figure…** writes the current window to a publication-ready **PNG, PDF,
-    or SVG**.
+  or SVG**.
 - The status bar shows the cursor's time from recording start **and the
-    wall-clock time**, so events line up with the night's session log.
+  wall-clock time**, so events line up with the night's session log.
 
 ### Keyboard navigation
 
@@ -94,32 +94,32 @@ on-screen window — a 30 s epoch can be inspected inside a 60 s window, and the
 arrow keys step by epoch regardless of how much is on screen.
 
 - **Epoch** length is set in seconds (default **30 s**, the polysomnography
-    standard; 1–300 s).
+  standard; 1–300 s).
 - **Epoch grid** draws faint, **numbered** epoch boundaries over the traces.
 - **Anchor epochs to view** starts an epoch at the left edge of the current view
-    and back/front-fills the whole grid from there (boundaries fall at
-    `anchor + k·epoch`) — so you can line the grid up with lights-out or any
-    feature in the record. **Reset anchor** puts epoch 1 back at the recording
-    start.
+  and back/front-fills the whole grid from there (boundaries fall at
+  `anchor + k·epoch`) — so you can line the grid up with lights-out or any
+  feature in the record. **Reset anchor** puts epoch 1 back at the recording
+  start.
 - **Time axis** labels the x-axis as wall-clock **Clock** time or **Elapsed**
-    seconds from the start. Clock needs a recording start time; an anonymized file
-    that has none falls back to elapsed.
+  seconds from the start. Clock needs a recording start time; an anonymized file
+  that has none falls back to elapsed.
 
 ## Annotating
 
 1. **Drag** across the traces to mark a span (drag never pans — the time
-    axis only moves when you ask it to). To drop a **point** instead,
-    **Ctrl+click** (or press **M**) at the cursor.
+   axis only moves when you ask it to). To drop a **point** instead,
+   **Ctrl+click** (or press **M**) at the cursor.
 1. Name it in the label dialog — recent labels and common marks (LRLR,
-    arousal, artifact, cue response) are one click; free text always works.
-    Tick **instantaneous** to keep just the moment instead of the dragged span.
+   arousal, artifact, cue response) are one click; free text always works.
+   Tick **instantaneous** to keep just the moment instead of the dragged span.
 1. A plain **click** on an annotation selects it; use the side list to rename,
-    delete, or jump to one (double-click).
+   delete, or jump to one (double-click).
 1. **Save annotations** writes the sidecar next to the recording:
-    `night1.edf` → `night1.annotations.tsv` (+ a small `.json` describing it).
-    The recording itself is **never modified**. Unsaved changes star the title
-    and prompt before closing, and saving over a sidecar **this review did not
-    open** asks first — so you never clobber another file by accident.
+   `night1.edf` → `night1.annotations.tsv` (+ a small `.json` describing it).
+   The recording itself is **never modified**. Unsaved changes star the title
+   and prompt before closing, and saving over a sidecar **this review did not
+   open** asks first — so you never clobber another file by accident.
 
 For fast signal scoring, the **Quick marks** row drops a labeled point mark at
 the cursor in one click — or press **1–9** for the first nine. Use **Edit
@@ -216,13 +216,13 @@ Slide the whole log along the EEG to line them up, three ways — all adjusting 
 offset:
 
 - **Drag the log lane.** A left-drag that starts in the top lane slides the log
-    (a drag anywhere else still draws an annotation). On release it snaps onto a
-    nearby mark of yours, so a clapper lands exactly on the artifact it made.
+  (a drag anywhere else still draws an annotation). On release it snaps onto a
+  nearby mark of yours, so a clapper lands exactly on the artifact it made.
 - **Pair an entry to a feature.** Select a log entry, click **Align entry to
-    feature…**, then click the EEG feature it produced — useful when the two are
-    far apart to drag. (Esc cancels.)
+  feature…**, then click the EEG feature it produced — useful when the two are
+  far apart to drag. (Esc cancels.)
 - **Nudge the offset.** The **Offset** box is the exact value, and the fine
-    control.
+  control.
 
 **Auto-align to triggers.** When the amplifier itself recorded SMACC's trigger
 codes — a hardware-TTL rig, where the codes are embedded events in the EEG file —
@@ -273,10 +273,10 @@ are ever shown**, so a rater cannot glimpse what is hidden, with three presets:
 
 - **Fully naive** — every mark is hidden; the rater scrolls a clean recording.
 - **Reports visible** — only dream-report markers are shown; detected signals
-    and cues are hidden.
+  and cues are hidden.
 - **Signal-present (classify only)** — signal *positions* are shown with their
-    labels blanked (a `?`), so the rater sees *where* a signal is and classifies
-    *what* it is.
+  labels blanked (a `?`), so the rater sees *where* a signal is and classifies
+  *what* it is.
 
 Blind mode **requires a rater id** — a blind review seeds from the coordinator's
 truth sidecar (`night1.annotations.tsv`) but saves to the rater's own

--- a/docs/index.md
+++ b/docs/index.md
@@ -42,37 +42,37 @@ the unsigned download and how to get older versions.
 
 - [Overview](usage.md) — the Launcher, the Session window, and the tools.
 - [Audio cues](audio-cues.md) · [Visual cues](visual.md) · [Biocals](biocals.md) ·
-    [Dream reports & surveys](surveys.md) · [Intercom & chat](intercom.md) ·
-    [Markers & port codes](triggers.md)
+  [Dream reports & surveys](surveys.md) · [Intercom & chat](intercom.md) ·
+  [Markers & port codes](triggers.md)
 
 **Devices, volume & timing**
 
 - [Audio routing](audio.md) · [Compatible devices](devices.md) ·
-    [Volume & latency](latency.md)
+  [Volume & latency](latency.md)
 
 **After the night**
 
 - [EEG Annotator](eeg-annotator.md) — review and score recorded EEG.
 - [Troubleshooting](troubleshooting.md) · [Reference](reference/index.md) ·
-    [Contributing](contributing.md)
+  [Contributing](contributing.md)
 
 ## Used by
 
 SMACC is used in dream engineering research, including by:
 
 - [Ken Paller's Cognitive Neuroscience Lab](https://sites.northwestern.edu/pallerlab/)
-    at Northwestern University
-    - Torres-Platas et al. (2026). Intentional lucid dreaming with a transformative learning agenda. *Research Square* doi:[10.21203/rs.3.rs-8745420/v1](https://doi.org/10.21203/rs.3.rs-8745420/v1)
-    - Konkoly et al. (2026). Using real-time reporting to investigate visual experiences in dreams. *J Cogn Neurosci* doi:[10.1162/jocn.a.107](https://doi.org/10.1162/JOCN.a.107)
-    - Morris et al. (2026). Inducing lucid dreaming based on a contemplative practice of compassion. *Brain Sci* doi:[10.3390/brainsci16030315](https://doi.org/10.3390/brainsci16030315)
-    - Konkoly et al. (2026). Creative problem-solving after experimentally provoking dreams of unsolved puzzles during REM sleep. *Neurosci Conscious* doi:[10.1093/nc/niaf067](https://doi.org/10.1093/nc/niaf067)
-    - Konkoly et al. (2025). Investigating dreams by strategically presenting sounds during REM sleep to reactivate waking experiences. *Neuropsychologia* doi:[10.1016/j.neuropsychologia.2025.109229](https://doi.org/10.1016/j.neuropsychologia.2025.109229)
-    - Morris et al. (2025). Lucid dreaming of a prior virtual-reality experience with ego-transcendent qualities: A proof-of-concept study. *Neurosci Conscious* doi:[10.1093/nc/niaf017](https://doi.org/10.1093/nc/niaf017)
-    - Mundt et al. (2024). Treating narcolepsy-related nightmares with cognitive behavioural therapy and targeted lucidity reactivation: A pilot study. *J Sleep Res* doi:[10.1111/jsr.14384](https://doi.org/10.1111/jsr.14384)
-    - Wolk et al. (2024). Lucid dreams from reactivating mindfulness during REM sleep: A pilot study. *Int J Dream Res* doi:[10.11588/ijodr.2024.2.98233](https://doi.org/10.11588/ijodr.2024.2.98233)
+  at Northwestern University
+  - Torres-Platas et al. (2026). Intentional lucid dreaming with a transformative learning agenda. *Research Square* doi:[10.21203/rs.3.rs-8745420/v1](https://doi.org/10.21203/rs.3.rs-8745420/v1)
+  - Konkoly et al. (2026). Using real-time reporting to investigate visual experiences in dreams. *J Cogn Neurosci* doi:[10.1162/jocn.a.107](https://doi.org/10.1162/JOCN.a.107)
+  - Morris et al. (2026). Inducing lucid dreaming based on a contemplative practice of compassion. *Brain Sci* doi:[10.3390/brainsci16030315](https://doi.org/10.3390/brainsci16030315)
+  - Konkoly et al. (2026). Creative problem-solving after experimentally provoking dreams of unsolved puzzles during REM sleep. *Neurosci Conscious* doi:[10.1093/nc/niaf067](https://doi.org/10.1093/nc/niaf067)
+  - Konkoly et al. (2025). Investigating dreams by strategically presenting sounds during REM sleep to reactivate waking experiences. *Neuropsychologia* doi:[10.1016/j.neuropsychologia.2025.109229](https://doi.org/10.1016/j.neuropsychologia.2025.109229)
+  - Morris et al. (2025). Lucid dreaming of a prior virtual-reality experience with ego-transcendent qualities: A proof-of-concept study. *Neurosci Conscious* doi:[10.1093/nc/niaf017](https://doi.org/10.1093/nc/niaf017)
+  - Mundt et al. (2024). Treating narcolepsy-related nightmares with cognitive behavioural therapy and targeted lucidity reactivation: A pilot study. *J Sleep Res* doi:[10.1111/jsr.14384](https://doi.org/10.1111/jsr.14384)
+  - Wolk et al. (2024). Lucid dreams from reactivating mindfulness during REM sleep: A pilot study. *Int J Dream Res* doi:[10.11588/ijodr.2024.2.98233](https://doi.org/10.11588/ijodr.2024.2.98233)
 - [Michelle Carr's Dream Engineering Lab](https://www.dreamengineeringlab.com/)
-    at the University of Montreal and the Center for Advanced Research in Sleep Medicine
-    - Jafarzadeh Esfahani et al. (2024). Highly effective verified lucid dream induction using combined cognitive-sensory training and wearable EEG: A multi-centre study. *bioRxiv* doi:[10.1101/2024.06.21.600133](https://doi.org/10.1101/2024.06.21.600133)
+  at the University of Montreal and the Center for Advanced Research in Sleep Medicine
+  - Jafarzadeh Esfahani et al. (2024). Highly effective verified lucid dream induction using combined cognitive-sensory training and wearable EEG: A multi-centre study. *bioRxiv* doi:[10.1101/2024.06.21.600133](https://doi.org/10.1101/2024.06.21.600133)
 
 SMACC is free software released under the
 [GPL-3.0-or-later](https://github.com/remrama/smacc/blob/main/LICENSE.txt) license.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,15 +8,15 @@ double-click `SMACC-Setup.exe` and click through. The installer:
 - installs SMACC **per-user** — no administrator rights or IT involvement needed;
 - adds a **Start menu** entry (and, if you opt in, a desktop shortcut);
 - associates **`.smacc` files**, so double-clicking one opens the **Start a session**
-    dialog with it preselected;
+  dialog with it preselected;
 - includes the **EEG Annotator** — the post-hoc
-    [EEG viewer/annotator](eeg-annotator.md), opened from the Launcher;
+  [EEG viewer/annotator](eeg-annotator.md), opened from the Launcher;
 - registers an uninstaller — remove SMACC from **Settings › Apps** like any other
-    program. Uninstalling never touches your data: SMACC files, recordings, and
-    logs under `~/SMACC` (or your data directories) all stay put. The
-    uninstaller reminds you of this (and of the folder's location) when it
-    finishes, so finding the folder afterwards is expected — delete it manually
-    if you no longer need the data.
+  program. Uninstalling never touches your data: SMACC files, recordings, and
+  logs under `~/SMACC` (or your data directories) all stay put. The
+  uninstaller reminds you of this (and of the folder's location) when it
+  finishes, so finding the folder afterwards is expected — delete it manually
+  if you no longer need the data.
 
 Installing a newer version over an existing one upgrades it in place.
 
@@ -98,13 +98,13 @@ it and its subfolders on first run.
 The rest of setup is covered on the relevant pages:
 
 - **Your study configuration** lives in a portable [SMACC file](smacc-files.md).
-    SMACC seeds a `default.smacc` and opens it when you don't pick another, so it
-    works out of the box. The installer associates `.smacc` files; enable or repair
-    the association any time from **File › Associate .smacc files (Windows)** in the
-    Launcher.
+  SMACC seeds a `default.smacc` and opens it when you don't pick another, so it
+  works out of the box. The installer associates `.smacc` files; enable or repair
+  the association any time from **File › Associate .smacc files (Windows)** in the
+  Launcher.
 - **Audio cues** go in the data directory's `cues/` folder, alongside the seeded
-    `demo-*` cues — see [Audio cues](audio-cues.md).
+  `demo-*` cues — see [Audio cues](audio-cues.md).
 - **Dream-report surveys** are managed from the Dream recording panel — see
-    [Dream reports & surveys](surveys.md).
+  [Dream reports & surveys](surveys.md).
 - **A recording mic:** to record dreams, bind your mic to **Bedroom mic 1** in the
-    **Devices** window (the **Panels** column) — see [Audio routing](audio.md).
+  **Devices** window (the **Panels** column) — see [Audio routing](audio.md).

--- a/docs/intercom.md
+++ b/docs/intercom.md
@@ -9,10 +9,10 @@ for when audio would intrude.
 ## Voice
 
 - **Talk (to participant)** pipes the control-room mic to the participant's output.
-    Click to latch, or hold the **spacebar** anywhere in SMACC for push-to-talk.
-    Talking is marked in the EEG record.
+  Click to latch, or hold the **spacebar** anywhere in SMACC for push-to-talk.
+  Talking is marked in the EEG record.
 - **Listen (to participant)** brings the bedroom mic to your control-room speakers.
-    It is unmarked.
+  It is unmarked.
 
 Both directions route through equipment set once in the **Devices** window (see
 [Audio routing](audio.md)). A **level meter** beside each button shows the live

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -16,12 +16,12 @@ Three of those live in the OS and are invisible from most apps. SMACC makes its 
 gain explicit and adds a safety limit, in the **Volume** window:
 
 - **Output safety cap.** A single master ceiling, applied as the last gain stage on
-    every cue and noise output. However loud an individual cue is set, the cap is a
-    hard limit, so a full-volume looped cue on a calibrated rig cannot suddenly blast
-    a sleeping participant.
+  every cue and noise output. However loud an individual cue is set, the cap is a
+  hard limit, so a full-volume looped cue on a calibrated rig cannot suddenly blast
+  a sleeping participant.
 - **A read-only view of the Windows stages.** The window shows the current **System
-    volume** (the Windows output endpoint) and **App volume** (SMACC's own level) in
-    the Windows Volume Mixer, so the hidden OS stages are visible.
+  volume** (the Windows output endpoint) and **App volume** (SMACC's own level) in
+  the Windows Volume Mixer, so the hidden OS stages are visible.
 
 ::: {.callout-tip title="Calibrating cue level"}
 
@@ -66,10 +66,10 @@ From the click to the sound, in order:
 The two that matter are separate axes with separate fixes:
 
 - **Marker → sound** (the science): the **output buffer**. SMACC corrects for this
-    (below), and it's what a per-rig measurement pins down.
+  (below), and it's what a per-rig measurement pins down.
 - **Click → sound** (operator feel): dominated by the per-play **stream open**. Not a
-    marker-alignment problem; tracked separately in
-    [#105](https://github.com/remrama/smacc/issues/105).
+  marker-alignment problem; tracked separately in
+  [#105](https://github.com/remrama/smacc/issues/105).
 
 ## The marker marks the software event, not the photons
 
@@ -78,13 +78,13 @@ the sound leaves the speaker (by one output buffer) or, for a light, around when
 device write completes. To keep the marker aligned with the stimulus:
 
 - **Audio cue / noise.** SMACC stamps the marker (its LSL timestamp **and** the
-    canonical log line) at the *estimated onset* — the moment it fires **plus the
-    stream's reported output latency** — so the marker tracks the sound rather than
-    SMACC's buffer, and stays put when you change the latency setting. The raw
-    software-trigger instant is kept on a `DEBUG` line in the log for audit.
+  canonical log line) at the *estimated onset* — the moment it fires **plus the
+  stream's reported output latency** — so the marker tracks the sound rather than
+  SMACC's buffer, and stays put when you change the latency setting. The raw
+  software-trigger instant is kept on a `DEBUG` line in the log for audit.
 - **Visual cue.** The first frame is written to the device **synchronously**, and the
-    marker fires right after, so it trails the photons by microseconds (BlinkStick)
-    rather than leading them.
+  marker fires right after, so it trails the photons by microseconds (BlinkStick)
+  rather than leading them.
 
 ::: {.callout-warning title="This is an estimate, not a measurement"}
 
@@ -117,11 +117,11 @@ Negotiated [high]:  22.0 ms   (SMACC stamps the marker this far ahead of the str
 Two things to take from this:
 
 1. The **negotiated** latency (~22 ms) is what you actually get — *not* the smaller
-    "reported" figure. SMACC corrects the cue marker by this negotiated value.
+   "reported" figure. SMACC corrects the cue marker by this negotiated value.
 1. On **shared-mode WASAPI**, the engine rounds up to its own period, so **Low and
-    High come out the same** here. The Low setting only helps on devices/drivers whose
-    buffer it can actually shrink; true low latency needs WASAPI *exclusive* mode,
-    which SMACC doesn't use today. **Don't assume Low helps — measure it.**
+   High come out the same** here. The Low setting only helps on devices/drivers whose
+   buffer it can actually shrink; true low latency needs WASAPI *exclusive* mode,
+   which SMACC doesn't use today. **Don't assume Low helps — measure it.**
 
 ## The Low / High setting
 
@@ -129,10 +129,10 @@ The Volume window has a **Latency** choice (High / Low), saved in the `.smacc`
 ([`output_latency`](reference/settings-file.md)):
 
 - **High** (default) — PortAudio's robust buffer. Fewer underruns; the safe choice
-    for an overnight looping cue, where a glitch in a sleeper's ear is worse than 20 ms.
+  for an overnight looping cue, where a glitch in a sleeper's ear is worse than 20 ms.
 - **Low** — asks for a smaller buffer. Trims the marker↔sound gap *where the device
-    allows it* (often no change on shared-mode WASAPI). It applies to the next cue or
-    noise played, not the one currently sounding.
+  allows it* (often no change on shared-mode WASAPI). It applies to the next cue or
+  noise played, not the one currently sounding.
 
 Because the marker is corrected by the *negotiated* latency, switching High/Low never
 silently shifts your markers — the correction tracks the setting.
@@ -142,11 +142,11 @@ silently shifts your markers — the correction tracks the setting.
 Light latency depends entirely on the backend:
 
 - **BlinkStick** — a USB-HID write, a few milliseconds. Fast enough that the marker
-    effectively coincides with the light.
+  effectively coincides with the light.
 - **Philips Hue** — each command is an HTTP call to the bridge (~100 ms) plus the
-    bridge→bulb hop, and the bridge rate-limits, so Hue is unsuitable for tight timing
-    or flashing (SMACC refuses `flash` on Hue for this reason). Fine for slow ambient
-    cues; don't time-lock analyses to a Hue marker without measuring it.
+  bridge→bulb hop, and the bridge rate-limits, so Hue is unsuitable for tight timing
+  or flashing (SMACC refuses `flash` on Hue for this reason). Fine for slow ambient
+  cues; don't time-lock analyses to a Hue marker without measuring it.
 
 ## Measure it on your own rig
 
@@ -154,21 +154,21 @@ The numbers above are specific to one machine — **don't quote them for a diffe
 rig**. To characterise yours:
 
 - **Round-trip, on the bench.** Couple the output back to an input (a loopback cable,
-    or a microphone at the speaker) and run:
+  or a microphone at the speaker) and run:
 
-    ```sh
-    uv run tools/measure_latency.py --loopback --repeats 30
-    ```
+  ```sh
+  uv run tools/measure_latency.py --loopback --repeats 30
+  ```
 
-    It plays tone bursts, hears them back, and reports the distribution. Watch the
-    **jitter** (the spread), not just the mean.
+  It plays tone bursts, hears them back, and reports the distribution. Watch the
+  **jitter** (the spread), not just the mean.
 
 - **Against the EEG, per session (authoritative).** Record the real stimulus onset on
-    a spare amplifier channel — a microphone for the cue, a photodiode for the light —
-    alongside the LSL port code. The difference between the port code and the recorded
-    onset, across the night, is the true distribution. SMACC does not plot this itself
-    yet; a per-session view of it needs a spare channel and is tracked in
-    [#104](https://github.com/remrama/smacc/issues/104).
+  a spare amplifier channel — a microphone for the cue, a photodiode for the light —
+  alongside the LSL port code. The difference between the port code and the recorded
+  onset, across the night, is the true distribution. SMACC does not plot this itself
+  yet; a per-session view of it needs a spare channel and is tracked in
+  [#104](https://github.com/remrama/smacc/issues/104).
 
 ::: {.callout-note title="Why the log can't give you this"}
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -17,20 +17,20 @@ from the task-oriented [Overview](../usage.md) guide.
 ## Where each file lives
 
 - The **SMACC directory** (`$SMACC_DIRECTORY`, else `~/SMACC`) holds `preferences.yaml`,
-    the seeded `default.smacc`, and the default data directory.
+  the seeded `default.smacc`, and the default data directory.
 - A **`.smacc`** can live anywhere; it names the **data directory** its runs are
-    written to.
+  written to.
 - Each **run** gets its own timestamped folder (`smacc-YYYYmmdd-HHMMSS/`) under that
-    data directory, holding the session `.log`, any dream-report audio, survey
-    responses, and exports.
+  data directory, holding the session `.log`, any dream-report audio, survey
+  responses, and exports.
 - **Custom survey definitions** live in the SMACC directory's `surveys/` folder
-    (created when you first build or save one); built-in ones ship inside SMACC itself.
+  (created when you first build or save one); built-in ones ship inside SMACC itself.
 - **Bundled assets refresh on upgrade.** `default.smacc` (a read-only template) and
-    the `demo-` cues (seeded into the data directory's `cues/` folder) are re-seeded
-    from the bundle when they change, so a newer
-    SMACC's improvements reach an existing directory; your own files are untouched.
-    Biocal voice recordings are read straight from the bundle, with the SMACC
-    directory's `biocals/` folder as an optional per-recording override.
+  the `demo-` cues (seeded into the data directory's `cues/` folder) are re-seeded
+  from the bundle when they change, so a newer
+  SMACC's improvements reach an existing directory; your own files are untouched.
+  Biocal voice recordings are read straight from the bundle, with the SMACC
+  directory's `biocals/` folder as an optional per-recording override.
 
 ## Stability promise
 

--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -15,16 +15,16 @@ YYYY-MM-DD HH:MM:SS.mmm±HHMM, LEVEL, message
 ```
 
 - **timestamp** — local wall-clock, millisecond precision, with the machine's UTC
-    offset (e.g. `-0500`). The offset lets a reader place the night on an absolute
-    timeline — for example when overlaying the log on an EEG recording whose clock
-    sits in another zone. Logs written before SMACC recorded the offset are
-    timezone-naive (no `±HHMM`); both forms are read back the same way. The *file*
-    is always 24-hour; the live on-screen preview can optionally show 12-hour
-    (AM/PM) time (Session window → **File → 12-hour clock**), which changes only the
-    display, not what is written.
+  offset (e.g. `-0500`). The offset lets a reader place the night on an absolute
+  timeline — for example when overlaying the log on an EEG recording whose clock
+  sits in another zone. Logs written before SMACC recorded the offset are
+  timezone-naive (no `±HHMM`); both forms are read back the same way. The *file*
+  is always 24-hour; the live on-screen preview can optionally show 12-hour
+  (AM/PM) time (Session window → **File → 12-hour clock**), which changes only the
+  display, not what is written.
 - **LEVEL** — a Python logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or
-    `CRITICAL`. The file records every level; the live on-screen preview shows only a
-    configurable subset.
+  `CRITICAL`. The file records every level; the live on-screen preview shows only a
+  configurable subset.
 - **message** — the log text. An **event-marker** line ends in `" - portcode N"`:
 
 ```text

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -14,7 +14,7 @@ compatibility shims. Pin one version for the duration of a study. See the
 ## 0.1.1 — 2026-06-15
 
 - Fixed the Analyzer vanishing on open — clicking **Analyzer** hid the
-    launcher but never showed the Analyzer window.
+  launcher but never showed the Analyzer window.
 
 ## 0.1.0 — 2026-06-15
 
@@ -22,7 +22,7 @@ The first published release of SMACC — a Windows control surface for running
 sleep and dream studies. It includes:
 
 - **Audio cues**, designed in-app with the Audio Cue Designer, plus masking
-    background noise.
+  background noise.
 - **Visual cues** on a BlinkStick or Philips Hue light.
 - **Biocalibrations** as timed, marked tasks.
 - **Dream reports and surveys** for structured night-time data collection.
@@ -30,7 +30,7 @@ sleep and dream studies. It includes:
 - **EEG markers** (port codes) over an LSL marker stream or a hardware TTL trigger.
 - The **EEG Annotator** for reviewing and scoring recordings (optional component).
 - A detailed **session log**, a **volume safety cap**, and explicit **device
-    routing** so a misclick can't blast or mislead a sleeping participant.
+  routing** so a misclick can't blast or mislead a sleeping participant.
 - A per-user **Windows installer** (no admin rights) and a portable `SMACC.exe`.
 
 Earlier `0.0.x` builds predate this release and are not covered here.

--- a/docs/smacc-files.md
+++ b/docs/smacc-files.md
@@ -26,15 +26,15 @@ format, see the [SMACC file reference](reference/settings-file.md).
 There are two ways to make one:
 
 - **From scratch, in the Editor.** In the [Launcher](usage.md#opening-smacc),
-    click **Editor…**. In the dialog, choose **New SMACC file** for a blank
-    configuration (or pick an existing file to edit). Configure each panel on the
-    left, set the data directory, and **Save SMACC file as…** to a new `.smacc`
-    anywhere you like. The Editor never records a run — it only authors configuration.
+  click **Editor…**. In the dialog, choose **New SMACC file** for a blank
+  configuration (or pick an existing file to edit). Configure each panel on the
+  left, set the data directory, and **Save SMACC file as…** to a new `.smacc`
+  anywhere you like. The Editor never records a run — it only authors configuration.
 - **From a live session.** In a running **Session**, use **File › Save
-    SMACC file as…** to snapshot the session's *current* settings — including any
-    mid-session tweaks (volumes, device routing, event-code edits) — to a new
-    SMACC file. Handy when you've tuned things live and want tonight's setup to be
-    tomorrow's starting point.
+  SMACC file as…** to snapshot the session's *current* settings — including any
+  mid-session tweaks (volumes, device routing, event-code edits) — to a new
+  SMACC file. Handy when you've tuned things live and want tonight's setup to be
+  tomorrow's starting point.
 
 SMACC ships a `default.smacc` in your SMACC directory as a working example. It
 is treated as a read-only template — saving over it redirects to Save-As — so
@@ -58,10 +58,10 @@ determines where a night's data ends up.
 Opening a SMACC file starts a new session configured by it:
 
 - **Double-click the file** (Windows build): SMACC opens the **Start a session**
-    dialog with that file preselected, so you confirm the subject/session and click
-    **OK** to start. Enable or repair the file association any time from **File ›
-    Associate .smacc files (Windows)** in the Launcher.
+  dialog with that file preselected, so you confirm the subject/session and click
+  **OK** to start. Enable or repair the file association any time from **File ›
+  Associate .smacc files (Windows)** in the Launcher.
 - **From the Launcher**: click **Session…**, then pick the file in the **Start a
-    session** dialog (recent files are listed; **Browse…** finds any other) and click
-    **OK**.
+  session** dialog (recent files are listed; **Browse…** finds any other) and click
+  **OK**.
 - **From a terminal**: `SMACC path/to/file.smacc`.

--- a/docs/surveys.md
+++ b/docs/surveys.md
@@ -22,10 +22,10 @@ A dream report is often followed by a questionnaire: how lucid was the dream, wh
 did it contain, how confident is the participant. SMACC handles these two ways:
 
 - **In-app surveys** render in a SMACC window and save their responses straight into
-    the run folder, next to the dream-report WAV they accompany. SMACC ships the
-    standard lucid-dreaming instruments, and you can build your own.
+  the run folder, next to the dream-report WAV they accompany. SMACC ships the
+  standard lucid-dreaming instruments, and you can build your own.
 - **Web surveys** (for example a questionnaire hosted on Qualtrics or REDCap) open in
-    the browser; add them by URL.
+  the browser; add them by URL.
 
 In-app surveys exist because the night shift is a bad place for a hosted form: sleep
 labs are often offline, response data belongs with the night's recording rather than
@@ -105,9 +105,9 @@ renders but cannot be submitted — there is no run folder to save into.
 One JSON file per administration, in the run folder:
 
 - `report-02-survey-dlq.json` — auto-opened with dream report 2 (sorts beside
-    `report-02.wav`).
+  `report-02.wav`).
 - `survey-01-lusk.json` — opened standalone; standalone administrations are
-    numbered in their own sequence.
+  numbered in their own sequence.
 
 The payload records the SMACC version, the survey's key, name, title, and content version, the optional
 subject/session metadata, opened/submitted timestamps, the time since the

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -118,15 +118,15 @@ can set:
 - **Code** — the 8-bit port code (1–255) sent when the event triggers.
 - **LSL** — whether a firing sends the code over the LSL marker stream.
 - **TTL** — whether a firing sends the code over the hardware TTL trigger. The
-    column is grayed out until a transport is enabled in the window's **Hardware TTL
-    transport** section (the ticks are kept and re-arm with it). An event with neither
-    LSL nor TTL ticked is log-only.
+  column is grayed out until a transport is enabled in the window's **Hardware TTL
+  transport** section (the ticks are kept and re-arm with it). An event with neither
+  LSL nor TTL ticked is log-only.
 - **Preview** — whether the event shows in the live log preview. The session log
-    *file* always records every event regardless; this only controls the on-screen
-    preview.
+  *file* always records every event regardless; this only controls the on-screen
+  preview.
 - **Increment** — give an event a unique, increasing code on each firing (for
-    example **dream reports**: 201, 202, 203, …) so individual occurrences are
-    findable in the trigger channel. Off uses one fixed code each time.
+  example **dream reports**: 201, 202, 203, …) so individual occurrences are
+  findable in the trigger channel. Off uses one fixed code each time.
 
 **TTL safe max code** raises a soft warning for TTL-routed codes above it, handy when
 your trigger hardware accepts only a limited range (some older systems do; LSL
@@ -220,13 +220,13 @@ is configured (by a switch, firmware, or its manual) to expect a specific rate, 
 SMACC has to match it — a mismatch produces garbled or missed triggers, not an error.
 
 - **Where to find it:** check your trigger box's manual or its configuration utility.
-    Common rates are 9600, 19200, 38400, 57600, **115200**, and 230400.
+  Common rates are 9600, 19200, 38400, 57600, **115200**, and 230400.
 - **SMACC's default is 115200**, which many modern USB trigger boxes (e.g. typical
-    BrainProducts/Neurospec-style adapters) use out of the box. If yours specifies a
-    different rate, pick it from the dropdown (or type any other value).
+  BrainProducts/Neurospec-style adapters) use out of the box. If yours specifies a
+  different rate, pick it from the dropdown (or type any other value).
 - **Higher isn't "better."** A faster rate shaves only microseconds off a one-byte
-    write, which is negligible next to audio/event timing — so choose the rate your box
-    expects rather than the largest one.
+  write, which is negligible next to audio/event timing — so choose the rate your box
+  expects rather than the largest one.
 
 If triggers don't register, a wrong baud rate is one of the first things to check
 (alongside the COM port and the [pulsed vs. set-and-hold](#pulsed-vs-set-and-hold)
@@ -238,13 +238,13 @@ Amplifiers and trigger boxes differ in how they expect the code to appear on the
 lines, so SMACC offers two modes:
 
 - **Pulsed** — SMACC raises the code on the lines, waits a configurable **pulse
-    width** (e.g. 10 ms), then drops them back to 0. Each event is a brief, distinct
-    pulse. Choose this when the amplifier expects a momentary trigger, or when you want
-    SMACC to control the pulse length.
+  width** (e.g. 10 ms), then drops them back to 0. Each event is a brief, distinct
+  pulse. Choose this when the amplifier expects a momentary trigger, or when you want
+  SMACC to control the pulse length.
 - **Set-and-hold** — SMACC writes the code once and leaves it on the lines until the
-    next event. Choose this for amplifiers that sample a held level, **and** for boxes
-    that generate their own fixed-width pulse when they receive a byte (SMACC just sets
-    the value; the box shapes the pulse).
+  next event. Choose this for amplifiers that sample a held level, **and** for boxes
+  that generate their own fixed-width pulse when they receive a byte (SMACC just sets
+  the value; the box shapes the pulse).
 
 If you're not sure which your hardware wants, start with **pulsed at 10 ms** and
 verify with the **Test** button (below); switch to set-and-hold if events don't
@@ -253,19 +253,19 @@ register cleanly.
 ## Configuring trigger output in SMACC
 
 1. Open the **Markers** window from the Panels column (available both in a live
-    Session and in the Editor) and find its **Hardware TTL transport** section.
+   Session and in the Editor) and find its **Hardware TTL transport** section.
 1. Tick **Enable hardware trigger output**.
 1. Choose a **Transport**:
-    - **Serial** — pick your box's **Port** from the dropdown (click **Refresh** if
-        you plugged it in after opening the window) and set the **Baud** rate to match
-        your box (see [What is the baud rate?](#what-is-the-baud-rate); SMACC defaults to
-        115200). If the rig isn't attached right now, you can type the port name (e.g.
-        `COM3`) directly.
-    - **Parallel port** — enter the **Address** as hex (see
-        [Finding your parallel-port address](#finding-your-parallel-port-address)).
+   - **Serial** — pick your box's **Port** from the dropdown (click **Refresh** if
+     you plugged it in after opening the window) and set the **Baud** rate to match
+     your box (see [What is the baud rate?](#what-is-the-baud-rate); SMACC defaults to
+     115200). If the rig isn't attached right now, you can type the port name (e.g.
+     `COM3`) directly.
+   - **Parallel port** — enter the **Address** as hex (see
+     [Finding your parallel-port address](#finding-your-parallel-port-address)).
 1. Choose a **Mode** (pulsed or set-and-hold) and, for pulsed, a **Pulse width**.
 1. Click **Test** to send one pulse and confirm the amplifier sees it. The result
-    appears next to the button; an error explains what went wrong.
+   appears next to the button; an error explains what went wrong.
 1. Click **Apply**.
 
 The whole configuration is saved in your
@@ -298,7 +298,7 @@ Add-in PCIe/PCI parallel cards are frequently mapped somewhere else entirely, so
 1. Open **Device Manager** (press `Win+X`, then choose Device Manager).
 1. Expand **Ports (COM & LPT)** and double-click your parallel port.
 1. Go to the **Resources** tab and read the first **I/O Range** — the start of that
-    range is your address. Enter it in SMACC with a `0x` prefix (e.g. `0x378`).
+   range is your address. Enter it in SMACC with a `0x` prefix (e.g. `0x378`).
 
 ## Installing the InpOut32 driver (parallel port only)
 
@@ -309,9 +309,9 @@ required admin rights every launch). Install it once, manually:
 
 1. Download **InpOutBinaries** from [highrez.co.uk](https://www.highrez.co.uk/downloads/inpout32/).
 1. Run the included **`InstallDriver.exe`** once (as administrator) to install the
-    kernel driver.
+   kernel driver.
 1. Make sure **`inpoutx64.dll`** is where SMACC can load it — on the system path, in
-    `C:\Windows\System32`, or beside `SMACC.exe`.
+   `C:\Windows\System32`, or beside `SMACC.exe`.
 
 If the driver isn't available, SMACC's parallel transport reports a clear error and
 falls back to LSL only — it never crashes a session over a missing driver.
@@ -319,7 +319,7 @@ falls back to LSL only — it never crashes a session over a missing driver.
 ## Verifying
 
 - Use the **Test** button in the Markers window's transport section for a quick
-    "can SMACC drive the line?" check.
+  "can SMACC drive the line?" check.
 - Then confirm end-to-end on the amplifier: record a short block, fire a few events
-    from the **Event logging** window, and check that the codes land on the EEG trigger
-    channel. Only the real recording proves the path works.
+  from the **Event logging** window, and check that the codes land on the EEG trigger
+  channel. Only the real recording proves the path works.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -7,13 +7,13 @@ asks for the **SMACC file** to use, then opens it. To run a night you open a liv
 The Launcher's tools (its title bar reads **SMACC**):
 
 - **Session…** — run a live **Session** for collecting data, the interface for
-    running a night. SMACC prompts for a [SMACC file](smacc-files.md) first.
+  running a night. SMACC prompts for a [SMACC file](smacc-files.md) first.
 - **Editor…** — create or edit a [SMACC file](smacc-files.md) in the **Editor**,
-    without recording anything.
+  without recording anything.
 - **Analyzer** — inspect a past session.
 - **Audio Cue Designer** — build a tone cue and export it as a WAV.
 - **EEG Annotator** — review and annotate a recorded EEG (see
-    [EEG Annotator](eeg-annotator.md)).
+  [EEG Annotator](eeg-annotator.md)).
 
 The **Session** and the **Editor** are the same window in two modes — running a
 night versus authoring a SMACC file.
@@ -27,25 +27,25 @@ exception is double-clicking a `.smacc` file, which opens the **Start a session*
 dialog with that file preselected. From the Launcher:
 
 - **Session…** — opens the **Start a session** dialog. Pick the **SMACC file** (the
-    picker lists recent files, the seeded `default`, and **Browse…** for any other),
-    confirm the optional subject/session/notes, and click **OK** to start. Runs are
-    written to that file's **data directory**; the run folder and log are created only
-    when the session starts. (See [SMACC files](smacc-files.md) for what a SMACC file
-    holds.)
+  picker lists recent files, the seeded `default`, and **Browse…** for any other),
+  confirm the optional subject/session/notes, and click **OK** to start. Runs are
+  written to that file's **data directory**; the run folder and log are created only
+  when the session starts. (See [SMACC files](smacc-files.md) for what a SMACC file
+  holds.)
 - **Editor…** — opens the **Open in the Editor** dialog. Choose **New SMACC file**
-    for a blank configuration, or an existing file (recents / **Browse…**) to edit.
-    The Editor configures the panels (cues, noise, visual, markers, surveys), sets a
-    data directory, and saves with **Save SMACC file as…**; it never records a run.
+  for a blank configuration, or an existing file (recents / **Browse…**) to edit.
+  The Editor configures the panels (cues, noise, visual, markers, surveys), sets a
+  data directory, and saves with **Save SMACC file as…**; it never records a run.
 - **Analyzer** — open a past session (a `.log`, a session folder, or a zipped
-    session) to see a summary (events, duration, subject/session, dream reports),
-    export its events to a BIDS `events.tsv`, or recover its settings to a `.smacc` —
-    all without starting a new session.
+  session) to see a summary (events, duration, subject/session, dream reports),
+  export its events to a BIDS `events.tsv`, or recover its settings to a `.smacc` —
+  all without starting a new session.
 - **Audio Cue Designer** — open the standalone tool to build a simple tone cue and
-    export it as a WAV into a study's `cues/` folder (see
-    [Audio cues](audio-cues.md#designing-a-cue)).
+  export it as a WAV into a study's `cues/` folder (see
+  [Audio cues](audio-cues.md#designing-a-cue)).
 - **EEG Annotator** — open the post-hoc [EEG Annotator](eeg-annotator.md) to review a
-    recorded night and place annotations. It runs as its own window and process, so it
-    stays available while a session runs.
+  recorded night and place annotations. It runs as its own window and process, so it
+  stays available while a session runs.
 
 Closing the Editor or a standalone tool returns you to the Launcher. Ending a
 Session quits SMACC entirely — the night is over. Closing the Launcher also quits
@@ -76,15 +76,15 @@ the same window, dimmed for a dark control room:
 Each tool has its own page:
 
 - [Audio cues](audio-cues.md) — the cue board, the Audio Cue Designer, background
-    noise, and confirming a cue reaches the bedroom.
+  noise, and confirming a cue reaches the bedroom.
 - [Visual cues](visual.md) — light cues on a BlinkStick or Philips Hue.
 - [Biocals](biocals.md) — timed, marked biocalibration tasks.
 - [Dream reports & surveys](surveys.md) — record a report and administer a survey.
 - [Intercom & chat](intercom.md) — talk, listen, and a typed channel.
 - [Markers & port codes](triggers.md) — the Markers window, the Event logging panel,
-    and EEG triggers.
+  and EEG triggers.
 - [Audio routing](audio.md) and [Devices](devices.md) — bind equipment and route
-    actions to it.
+  actions to it.
 - [Volume & latency](latency.md) — the output safety cap and stimulus timing.
 
 ## Event log

--- a/docs/visual.md
+++ b/docs/visual.md
@@ -45,13 +45,13 @@ proof, that's what the bedroom camera (or your own eyes) is for.
 ## Patterns
 
 - **Steady** — constant light for the length. With a long fade-in this is also the
-    ambient/dawn workhorse (see [Recipes](#recipes)).
+  ambient/dawn workhorse (see [Recipes](#recipes)).
 - **Pulse** — a smooth brightness wave at the chosen rate (it starts dark and peaks
-    mid-cycle, so onset is gentle). The usual choice for a salient-but-sleep-friendly
-    cue.
+  mid-cycle, so onset is gentle). The usual choice for a salient-but-sleep-friendly
+  cue.
 - **Flash** — full on/off at the chosen rate (half on, half off). Maximal salience;
-    the classic photic stimulus. BlinkStick only — see
-    [the comparison](#blinkstick-or-philips-hue) and [Safety](#safety).
+  the classic photic stimulus. BlinkStick only — see
+  [the comparison](#blinkstick-or-philips-hue) and [Safety](#safety).
 
 The rate is set in **Hz**, the unit your methods section wants. The fades stay
 separate from the pattern: the pattern is the stimulus, and the fades only shape how
@@ -65,14 +65,14 @@ Every play and stop is marked in the log and on the trigger channel with the
 events, each carrying the cue's name. Two details matter for analysis:
 
 - **`VisualStarted` fires after the first frame is committed to the device.** On a
-    BlinkStick the USB write takes ~1–2 ms, so the marker trails the photons by
-    about that much. On Hue, "committed" means the bridge accepted the command — the
-    bulb itself transitions over the following ~100 ms, so the marker *leads*
-    the photons by that lag (and it varies). Time-locked analyses should use the
-    BlinkStick.
+  BlinkStick the USB write takes ~1–2 ms, so the marker trails the photons by
+  about that much. On Hue, "committed" means the bridge accepted the command — the
+  bulb itself transitions over the following ~100 ms, so the marker *leads*
+  the photons by that lag (and it varies). Time-locked analyses should use the
+  BlinkStick.
 - **`VisualStopped` fires once the light is actually dark** — after the fade-out
-    completes, not when Stop is pressed. The pair brackets the physical stimulus,
-    not the button presses.
+  completes, not when Stop is pressed. The pair brackets the physical stimulus,
+  not the button presses.
 
 Every stop path turns the light off — Stop, the length running out, switching to
 another cue, a device failure, or quitting SMACC — so a cue can't be left burning
@@ -132,33 +132,33 @@ point.
 ## Recipes
 
 - **A TLR-style lucidity cue** — red, brightness ~0.2, **pulse** at 1 Hz, length
-    10 s, fade in/out ~1 s. Salient enough to penetrate REM, gentle enough to keep
-    it.
+  10 s, fade in/out ~1 s. Salient enough to penetrate REM, gentle enough to keep
+  it.
 - **Dawn simulation** — warm white, **steady**, length 300 s, fade in 60 s, on a
-    Hue group: the room brightens like a sunrise for a gentler scheduled awakening.
+  Hue group: the room brightens like a sunrise for a gentler scheduled awakening.
 - **Cue vs. sham** — two identical rows, the sham at brightness 0. The sham fires
-    real `VisualStarted`/`VisualStopped` markers with zero light, so the trigger
-    channel shows both conditions while only one stimulates.
+  real `VisualStarted`/`VisualStopped` markers with zero light, so the trigger
+  channel shows both conditions while only one stimulates.
 
 ## Known limitations
 
 - A BlinkStick's LEDs all show **one color at a time** — per-LED patterns are a
-    documented non-goal
-    ([#11](https://github.com/remrama/smacc/issues/11), closed as documented).
+  documented non-goal
+  ([#11](https://github.com/remrama/smacc/issues/11), closed as documented).
 - **One light at a time**: cues are one-at-a-time on one routed device; SMACC does
-    not fire a BlinkStick and a Hue simultaneously.
+  not fire a BlinkStick and a Hue simultaneously.
 - **No flash on Hue**, and Hue onsets lag their markers — see
-    [the comparison](#blinkstick-or-philips-hue).
+  [the comparison](#blinkstick-or-philips-hue).
 
 ## Troubleshooting
 
 - **The BlinkStick isn't listed** — replug it and press `F5` (or click **Refresh
-    devices** in the Devices window). The driver ships inside SMACC; nothing to install.
+  devices** in the Devices window). The driver ships inside SMACC; nothing to install.
 - **"No light is set."** — bind the device in the **Devices** window *and* check
-    that *Play visual cue* is routed to that light.
+  that *Play visual cue* is routed to that light.
 - **The Hue bridge stopped responding** — its IP probably changed; re-enter it in
-    **Set up Philips Hue…** (and give the bridge a DHCP reservation so it stays
-    put). If pairing fails from lab Wi-Fi, see the network note above.
+  **Set up Philips Hue…** (and give the bridge a DHCP reservation so it stays
+  put). If pairing fails from lab Wi-Fi, see the network note above.
 - **A light stayed on** — SMACC turns lights off on every stop and on quit, so a
-    stuck light means the app was killed mid-cue or the device dropped: replug the
-    stick, or power-cycle the bulb (or toggle it in the Hue app).
+  stuck light means the app was killed mid-cue or the device dropped: replug the
+  stick, or power-cycle the bulb (or toggle it in the Hue app).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,13 +65,13 @@ docs = [
     # now a direct dependency.
     "pypdf",
     # Markdown formatter (the docs counterpart to ruff), run in CI and pre-commit.
-    # gfm covers tables/autolinks; frontmatter leaves YAML front matter alone; mkdocs
-    # keeps the repo's established four-space list-nesting style across all markdown
-    # (and leaves Quarto callouts intact). It no longer parses Material admonitions —
-    # those are gone — but dropping it would reflow every list in the repo.
+    # gfm covers tables/autolinks; frontmatter leaves YAML front matter alone. Lists
+    # nest with standard two-space CommonMark indentation — Quarto/Pandoc renders that
+    # natively, so the MkDocs-era four-space style (and the mdformat-mkdocs plugin that
+    # enforced it) retired with MkDocs (#265). Base mdformat leaves Quarto `:::`
+    # callouts and `{...}` attributes intact.
     "mdformat",
     "mdformat-gfm",
-    "mdformat-mkdocs",
     "mdformat-frontmatter",
 ]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -728,21 +728,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mdformat-mkdocs"
-version = "5.1.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mdformat" },
-    { name = "mdformat-gfm" },
-    { name = "mdit-py-plugins" },
-    { name = "more-itertools" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/25/df38de72a291b96fb7af7549c5285e934267f8f0b269d3ccacda84ef764c/mdformat_mkdocs-5.1.4.tar.gz", hash = "sha256:d3ecf035100328c5ff2b3bd7de87a16ee0484e5c317add9c70022598d15af6a1", size = 28160, upload-time = "2026-01-26T12:12:41.983Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/bf/00ba31df7cd955eb0dbb1b8b0eb388bc6f717f033f807656a12eb8f12a5b/mdformat_mkdocs-5.1.4-py3-none-any.whl", hash = "sha256:6ff339c1023926077c0c598533768433b38981a9eb792ebfe02d2438ba71514d", size = 38377, upload-time = "2026-01-26T12:12:40.326Z" },
-]
-
-[[package]]
 name = "mdit-py-plugins"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -781,15 +766,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/95/72/24cd8137df5a185fe0856ff9b6f8a8f9d387d6783c51961a1c6300a4efe8/mne-1.12.1.tar.gz", hash = "sha256:244f844057f28a4da2509039dba637832ffb65f678ca76fc667312c493b12044", size = 7211821, upload-time = "2026-04-20T17:16:57.295Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/da/a3280dbd8f0024b287b625ef97f8ef79ae853ed852e7732641d0ec3c2160/mne-1.12.1-py3-none-any.whl", hash = "sha256:7823bd276d570e9bed2e63e8d86fdbe74d5ee7817b6d01a8e4dc9510ef9e3a91", size = 7509566, upload-time = "2026-04-20T17:16:54.447Z" },
-]
-
-[[package]]
-name = "more-itertools"
-version = "11.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/de/1d/f4da6f02cdffe04d6362210b807146a26044c88d839208aec273bb0d9184/more_itertools-11.1.0.tar.gz", hash = "sha256:48e8f4d9e7e5878571ecf6f2b4e57634f93cd474cc8cfbd2376f2d11b396e30d", size = 145772, upload-time = "2026-05-22T14:14:29.909Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e8/3d/1087453384dbde46a8c7f9356eead2c58be8a7bf156bca40243377c85715/more_itertools-11.1.0-py3-none-any.whl", hash = "sha256:4b65538ae22f6fed0ce4874efd317463a7489796a0939fa66824dd542125a192", size = 72226, upload-time = "2026-05-22T14:14:28.824Z" },
 ]
 
 [[package]]
@@ -1491,7 +1467,6 @@ docs = [
     { name = "mdformat" },
     { name = "mdformat-frontmatter" },
     { name = "mdformat-gfm" },
-    { name = "mdformat-mkdocs" },
     { name = "pypdf" },
 ]
 
@@ -1502,7 +1477,6 @@ requires-dist = [
     { name = "mdformat", marker = "extra == 'docs'" },
     { name = "mdformat-frontmatter", marker = "extra == 'docs'" },
     { name = "mdformat-gfm", marker = "extra == 'docs'" },
-    { name = "mdformat-mkdocs", marker = "extra == 'docs'" },
     { name = "mne", specifier = ">=1.6" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "numpy" },


### PR DESCRIPTION
Closes #265.

After the Quarto migration (#259, #260), `mdformat-mkdocs` survived only to keep the MkDocs-era four-space list nesting. That style was a requirement of Python-Markdown (MkDocs's parser); Quarto/Pandoc renders standard two-space CommonMark nesting natively, so both the plugin name and the four-space convention are now vestigial.

This drops `mdformat-mkdocs` and reflows all Markdown to two-space nesting.

## Changes

- `pyproject.toml`: remove `mdformat-mkdocs` from the `docs` extra; rewrite the comment.
- `uv.lock`: regenerated (`mdformat-mkdocs` and its `more-itertools` dep removed).
- `.mdformat.toml`: stop ignoring the in-tree skill docs under `.claude/skills/` — they're real Markdown and now formatted like the rest. Only `.claude/worktrees/` (nested repo copies) stays excluded, alongside `.venv`, `.pytest_cache`, `docs/_book`, `docs/.quarto`.
- One mechanical reflow of every Markdown file to two-space list nesting (`uv run --extra docs mdformat .`). Whitespace-only — `git diff -w` is empty for the content files.
- `.claude/skills/quarto/SKILL.md`: update the Formatting section.

## Verification

- `uv run --extra docs mdformat --check .` passes and is idempotent.
- Quarto `:::` callouts and `{...}` image/button attributes are preserved (base mdformat leaves them intact; verified across the callout-heavy pages).
- No CI / pre-commit changes needed — both invoke `uv run --extra docs mdformat …` generically.