### PR TITLE
docs: numbered figure captions for screenshots (#264)

### DIFF
--- a/.claude/skills/quarto/SKILL.md
+++ b/.claude/skills/quarto/SKILL.md
@@ -51,12 +51,16 @@ are gitignored.
 - **Admonitions are callouts:** `::: {.callout-note title="…"}` … `:::`
   (Material `!!! note "…"` is gone). Types in use: note, tip, warning. There is no
   `info` callout — Material `info` blocks became `note`.
-- **Screenshots:** `![](path){width=N% fig-alt="description"}` — empty caption +
-  `fig-alt` is what keeps Quarto from rendering the alt text as a *visible numbered
-  caption* (matching the old Material site, which showed none). Widths: narrow `45%`,
-  medium `75%`, wide `100%` (the old `.shot` / `--narrow` / `--wide` intent). Avoid a
-  literal `"` inside `fig-alt` — use single quotes there (a `\"` escape gets stripped
-  by mdformat, which silently breaks the attribute).
+- **Screenshots:** `![Caption.](path){#fig-name width=N% fig-alt="description"}` —
+  each shot is a **numbered figure** (#264): a short visible caption, a `#fig-…` id
+  (so it can be cross-referenced with `@fig-…`), and the full description in `fig-alt`
+  for screen readers. In a book, Quarto numbers these per chapter (e.g. "Figure 11.1").
+  The earlier caption-less convention (empty caption + `fig-alt` only) was dropped on
+  purpose — captions are wanted for the manual. Widths: narrow `45%`, medium `75%`,
+  wide `100%` (the old `.shot` / `--narrow` / `--wide` intent). Avoid a literal `"`
+  inside `fig-alt` (and the caption) — use single quotes there (a `\"` escape gets
+  stripped by mdformat, which silently breaks the attribute). Screenshot framing
+  (border/shadow) and brand color are still deferred — see #268.
 - **Download buttons:** `[text](url){.btn .btn-primary role="button"}` (or
   `.btn-secondary`) — Bootstrap, styled by the theme; degrade to plain links in PDF.
 
@@ -90,11 +94,14 @@ directly abuts the fence pulls it into the list). The in-tree skill docs under
 `.claude/skills/` are formatted too; `.mdformat.toml` excludes only `.venv`,
 `.pytest_cache`, `docs/_book`, `docs/.quarto`, and `.claude/worktrees`.
 
-## Deferred (separate follow-up PR)
+## Deferred (separate follow-up PR — #268)
 
 Heavy visual customization is **out of scope** for the migration: a brand SCSS theme,
-a custom **Typst** cover and running header (the old `pdf/cover.html` +
-`pdf/print.css` + `pdf/hooks.py`, which injected the cover/footer version), and table
-styling. The brand color is **`#3c48aa`** (matches the icon background); the logo is
-`docs/assets/icon.png`. Because the PDF engine is Typst, that custom cover/template
-work will be authored in **Typst**, not CSS/Paged.js or LaTeX.
+screenshot framing (the old `extra.css` border/radius/shadow — captures are
+title-bar-less, so a frame makes them read as windows), a custom **Typst** cover and
+running header (the old `pdf/cover.html` + `pdf/print.css` + `pdf/hooks.py`, which
+injected the cover/footer version), and table styling. The brand color is
+**`#3c48aa`** (matches the icon background); the logo is `docs/assets/icon.png`.
+Because the PDF engine is Typst, that custom cover/template work — and the screenshot
+framing, which must match in both outputs — will be authored in **Typst**, not
+CSS/Paged.js or LaTeX.

--- a/docs/audio-cues.md
+++ b/docs/audio-cues.md
@@ -4,7 +4,7 @@ Audio is SMACC's primary cueing modality. The **Audio cue** window (in the
 **Panels** column) holds the cue board: one row per cue, each ready to fire with a
 single click.
 
-![](assets/screenshot-audio-cue.png){width=75% fig-alt="The Audio cue window: a cue row with its volume and loop controls, and the Monitoring section below."}
+![The Audio cue window.](assets/screenshot-audio-cue.png){#fig-audio-cue width=75% fig-alt="The Audio cue window: a cue row with its volume and loop controls, and the Monitoring section below."}
 
 ## The cue board
 
@@ -37,7 +37,7 @@ so you can reopen it tomorrow and nudge a level instead of rebuilding the cue. T
 designer is a standalone tool: it plays on the default device and ignores the
 session's device routing and volume safety cap.
 
-![](assets/screenshot-cue-designer.png){width=75% fig-alt="The Audio Cue Designer: tone and silence segments above a live waveform, with the Preview and Export WAV… buttons."}
+![The Audio Cue Designer.](assets/screenshot-cue-designer.png){#fig-cue-designer width=75% fig-alt="The Audio Cue Designer: tone and silence segments above a live waveform, with the Preview and Export WAV… buttons."}
 
 ## Background noise
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -31,7 +31,7 @@ window shows a read-only indicator of where it resolves, for example
 same resolution beside each route — a route pointed at equipment with nothing
 bound reads **→ no device** instead of looking configured.
 
-![](assets/screenshot-devices.png){width=75% fig-alt="The Devices window: the Equipment → devices bindings on top, the Actions → equipment routes below, each showing the device it resolves to."}
+![The Devices window.](assets/screenshot-devices.png){#fig-devices width=75% fig-alt="The Devices window: the Equipment → devices bindings on top, the Actions → equipment routes below, each showing the device it resolves to."}
 
 ```text
 Bedroom speaker       Speakers (USB Audio)

--- a/docs/biocals.md
+++ b/docs/biocals.md
@@ -7,7 +7,7 @@ runs them as timed, marked events — every standard biocal plus the common
 lucid-dreaming signal practices (LRLR variants, fist clenches, sniffs), each on its
 own row.
 
-![](assets/screenshot-biocals.png){width=75% fig-alt="The Biocals window: the countdown and Play sequence button above the scrolling stack of biocal rows, each with Seq/Voice checkboxes and a duration."}
+![The Biocals window.](assets/screenshot-biocals.png){#fig-biocals width=75% fig-alt="The Biocals window: the countdown and Play sequence button above the scrolling stack of biocal rows, each with Seq/Voice checkboxes and a duration."}
 
 ## Running a biocal
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -182,7 +182,9 @@ quarto render docs    # build the HTML site and the PDF into docs/_book/
 The project config is `docs/_quarto.yml` — a Quarto *book*, the project type that
 yields one combined PDF. Pages are plain Markdown; admonitions are
 [callouts](https://quarto.org/docs/authoring/callouts.html) (`::: {.callout-note}`),
-and each screenshot carries a `width=` attribute with its description in `fig-alt`.
+and each screenshot is a numbered figure — a short visible caption, a `#fig-…` id
+(so it can be cross-referenced with `@fig-…`), a `width=` attribute, and its full
+description in `fig-alt` for screen readers.
 Heading slugs use `gfm_auto_identifiers` so the cross-page `#anchor` links resolve
 the same way GitHub renders them.
 

--- a/docs/intercom.md
+++ b/docs/intercom.md
@@ -4,7 +4,7 @@ The **Intercom** window (in the **Panels** column) is the live channel between t
 control room and the bedroom. It carries voice both ways, plus a typed text channel
 for when audio would intrude.
 
-![](assets/screenshot-intercom.png){width=75% fig-alt="The Intercom window: Talk and Listen with their level meters, and the text-chat area with quick-reply buttons below."}
+![The Intercom window.](assets/screenshot-intercom.png){#fig-intercom width=75% fig-alt="The Intercom window: Talk and Listen with their level meters, and the text-chat area with quick-reply buttons below."}
 
 ## Voice
 
@@ -29,7 +29,7 @@ window built for a dark bedroom: always dark regardless of the lights toggle, la
 text (default 18 pt, resize with `Ctrl+=` / `Ctrl+-`), and an optional **red night
 text** mode (**Display** menu), with no flashing and no sounds.
 
-![](assets/screenshot-chat.png){width=45% fig-alt="The Participant chat window: dark with large text, the 'The keyboard is yours' banner, and number-key quick replies."}
+![The Participant chat window.](assets/screenshot-chat.png){#fig-chat width=45% fig-alt="The Participant chat window: dark with large text, the 'The keyboard is yours' banner, and number-key quick replies."}
 
 **Setup.** The first cut assumes one computer: extend the desktop onto a
 bedroom-facing monitor and plug in a second keyboard for the participant. Click

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -31,7 +31,7 @@ cap inside SMACC. That way one place, SMACC, determines how loud a cue is.
 
 :::
 
-![](assets/screenshot-volume.png){width=45% fig-alt="The Volume window: the safety cap, the latency choice, and the read-only System volume and App volume levels."}
+![The Volume window.](assets/screenshot-volume.png){#fig-volume width=45% fig-alt="The Volume window: the safety cap, the latency choice, and the read-only System volume and App volume levels."}
 
 ## Latency
 

--- a/docs/smacc-files.md
+++ b/docs/smacc-files.md
@@ -19,7 +19,7 @@ sit beside it — so a self-contained study folder stays valid if you move, copy
 or zip it — and **absolute** when they point elsewhere. For the exact on-disk
 format, see the [SMACC file reference](reference/settings-file.md).
 
-![](assets/screenshot-editor.png){width=100% fig-alt="The SMACC Editor: the editing banner, the Panels column, the data directory, and the save panel."}
+![The SMACC Editor.](assets/screenshot-editor.png){#fig-editor width=100% fig-alt="The SMACC Editor: the editing banner, the Panels column, the data directory, and the save panel."}
 
 ## Creating a SMACC file
 

--- a/docs/surveys.md
+++ b/docs/surveys.md
@@ -14,7 +14,7 @@ is stamped with the time elapsed since you pressed **Start recording** (in the
 the EEG file. If recording has not been marked yet, the report is still logged and
 SMACC reminds you to mark it.
 
-![](assets/screenshot-recording.png){width=45% fig-alt="The Dream recording panel: the Record dream report button with the survey dropdown and Manage… button."}
+![The Dream recording panel.](assets/screenshot-recording.png){#fig-recording width=45% fig-alt="The Dream recording panel: the Record dream report button with the survey dropdown and Manage… button."}
 
 ## Surveys
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,7 +18,7 @@ The Launcher's tools (its title bar reads **SMACC**):
 The **Session** and the **Editor** are the same window in two modes — running a
 night versus authoring a SMACC file.
 
-![](assets/screenshot-launcher.png){width=45% fig-alt="The SMACC Launcher: a button per tool, with the version and a documentation link."}
+![The SMACC Launcher.](assets/screenshot-launcher.png){#fig-launcher width=45% fig-alt="The SMACC Launcher: a button per tool, with the version and a documentation link."}
 
 ## Opening SMACC
 
@@ -64,12 +64,12 @@ Tool windows close with **Ctrl+W** (or **File › Close window**), which only hi
 the window with its state intact; the session keeps running and the Panels column
 reopens it.
 
-![](assets/screenshot-session.png){width=100% fig-alt="The Session window: the Panels column opens each tool, the Log preview streams events on the right, and the Lights toggle sits at the bottom-left."}
+![The Session window.](assets/screenshot-session.png){#fig-session width=100% fig-alt="The Session window: the Panels column opens each tool, the Log preview streams events on the right, and the Lights toggle sits at the bottom-left."}
 
 Flip **Lights** off and the whole app switches to a dark theme for the night —
 the same window, dimmed for a dark control room:
 
-![](assets/screenshot-session-dark.png){width=100% fig-alt="The Session window with the lights off: the same layout in SMACC's dark night theme."}
+![The Session window with the lights off.](assets/screenshot-session-dark.png){#fig-session-dark width=100% fig-alt="The Session window with the lights off: the same layout in SMACC's dark night theme."}
 
 ## The tools
 

--- a/docs/visual.md
+++ b/docs/visual.md
@@ -18,7 +18,7 @@ The **Visual cue** window (in the **Panels** column) is the light sibling of the
 [Audio cue board](audio-cues.md#the-cue-board): one row per cue, each kept configured and
 ready so that firing the right light at 3 a.m. is a single click.
 
-![](assets/screenshot-visual.png){width=75% fig-alt="The Visual cue window: a cue row with its color, brightness, pattern, length, and loop controls, and the Sending swatch below."}
+![The Visual cue window.](assets/screenshot-visual.png){#fig-visual width=75% fig-alt="The Visual cue window: a cue row with its color, brightness, pattern, length, and loop controls, and the Sending swatch below."}
 
 Each row holds a **name** (it travels into the event log with every start/stop
 marker), a **color**, a **brightness** (0–1 — the visual volume), a **pattern**


### PR DESCRIPTION
Closes #264.

Each of the 13 documentation screenshots is now a **numbered figure** — a short visible caption, a `#fig-…` id (so it can be cross-referenced with `@fig-…`), and the full description kept in `fig-alt` for screen readers. The Quarto Book numbers them per chapter (e.g. "Figure 11.1: The Devices window."), in both the HTML site and the Typst PDF manual.

This resolves the caption half of #264. The styling half — restoring the screenshot framing (the removed `extra.css` border/shadow) and the brand color, consistent across HTML and PDF — is split out to #268.

## Verification
- `quarto render docs` — HTML + PDF compile clean; all 13 captions render as numbered figures.
- `mdformat --check` passes (the `{#fig-… …}` attribute blocks survive formatting).
- `scripts/check_links.py` — 23 pages, all internal links resolve.
- `scripts/check_manual.py` — 94-page PDF, all tripwire content present.