### PR TITLE
docs: fix anchorless cross-chapter links dead in the PDF manual

### DIFF
--- a/.claude/skills/quarto/SKILL.md
+++ b/.claude/skills/quarto/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quarto
-description: Reference for SMACC's documentation toolchain — the Quarto Book that renders both the HTML site and the single-file PDF manual from docs/, the Markdown conventions (callouts, screenshot sizing, download buttons), the Typst PDF engine, the GitHub Pages deploy, and the link/completeness checks. Use when touching docs/, docs/_quarto.yml, the docs or release CI workflows, scripts/check_links.py / scripts/check_manual.py, or anything about building/publishing the docs or the PDF manual.
+description: Reference for SMACC's documentation toolchain — the Quarto Book that renders both the HTML site and the single-file PDF manual from docs/, the Markdown conventions (callouts, screenshot sizing, download buttons), the Typst PDF engine, the GitHub Pages deploy, and the link/completeness checks. Use when touching docs/, docs/_quarto.yml, the docs or release CI workflows, scripts/check_links.py / scripts/check_manual.py / scripts/check_pdf_links.py, or anything about building/publishing the docs or the PDF manual.
 ---
 
 # SMACC docs: the Quarto toolchain
@@ -18,8 +18,9 @@ quarto preview docs    # live-reload HTML while writing
 quarto render docs     # build HTML site + PDF into docs/_book/
 quarto render docs --to typst   # PDF only (the release build-pdf job)
 
-uv run python scripts/check_links.py docs/_book                                 # internal links + anchors
-uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf  # PDF completeness
+uv run python scripts/check_links.py docs/_book                                   # HTML links + anchors
+uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf    # PDF completeness
+uv run --extra docs python scripts/check_pdf_links.py docs/_book/SMACC-manual.pdf # PDF cross-chapter links
 ```
 
 The project root is `docs/` (so Quarto only scans the docs tree, never README.md /
@@ -81,6 +82,13 @@ are gitignored.
   it parses the rendered `_book` HTML and fails on any dead internal link or `#anchor`
   (the main migration footgun). **`scripts/check_manual.py`** (renderer-agnostic,
   carried over unchanged) fails if the PDF is short or missing late-section content.
+  **`scripts/check_pdf_links.py`** (#262) reads the PDF's link annotations and fails
+  on any cross-chapter link emitted as a dead `/URI` ending in `.md` — the HTML check
+  can't see this. **Cross-chapter links must carry an explicit `#anchor`:** Quarto +
+  Typst turn an anchorless `[…](other.md)` into a dead external `/URI` in the combined
+  PDF. Each chapter title has a `{#chap-…}` id (globally unique — a plain title slug
+  like `troubleshooting` collides with same-named sections in the single-file PDF), so
+  a whole-chapter link is `[…](other.md#chap-other)`.
 
 ## Formatting
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,15 +29,17 @@ jobs:
       - uses: quarto-dev/quarto-actions/setup@v2
 
       # Render the HTML site and the single-file PDF manual from docs/, on every PR
-      # and push, so docs breakage is caught early. Two guards replace
+      # and push, so docs breakage is caught early. Three guards replace
       # `mkdocs build --strict`: check_manual catches a renderer silently truncating
       # the PDF (#250); check_links validates every internal cross-link and heading
-      # anchor (the main migration footgun, #259).
+      # anchor in the HTML site (the main migration footgun, #259); check_pdf_links
+      # catches cross-chapter links that go dead in the PDF (#262).
       - name: Render and check docs
         run: |
           quarto render docs
           uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf
           uv run python scripts/check_links.py docs/_book
+          uv run --extra docs python scripts/check_pdf_links.py docs/_book/SMACC-manual.pdf
 
       # Only a stable release (a `vX.Y.Z` tag with no pre-release suffix) publishes the
       # live site, so it always reflects the current stable version — never a dev or

--- a/docs/audio-cues.md
+++ b/docs/audio-cues.md
@@ -1,4 +1,4 @@
-# Audio cues
+# Audio cues {#chap-audio-cues}
 
 Audio is SMACC's primary cueing modality. The **Audio cue** window (in the
 **Panels** column) holds the cue board: one row per cue, each ready to fire with a
@@ -17,7 +17,7 @@ each row's **✕** to match a protocol (one minimum, up to 20).
 
 Each play and stop is marked in the EEG record. The cue marker is stamped at the
 *estimated sound onset*, not the button press, so it lines up with what the
-participant hears (see [Volume & latency](latency.md)).
+participant hears (see [Volume & latency](latency.md#chap-latency)).
 
 ## Designing a cue
 
@@ -84,5 +84,5 @@ Read it together with *Sending*.
 :::
 
 For how cue levels combine and how to calibrate them, see
-[Volume & latency](latency.md). For binding the speaker and mics, see
-[Audio routing](audio.md).
+[Volume & latency](latency.md#chap-latency). For binding the speaker and mics, see
+[Audio routing](audio.md#chap-audio).

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -1,14 +1,14 @@
-# Audio routing
+# Audio routing {#chap-audio}
 
 An overnight cueing study can run several audio streams at once: a cue in the
 bedroom, white noise in the bedroom, your voice over an intercom, the participant's
-voice coming back, a dream-report mic, and sometimes a [light cue](visual.md). These often span
+voice coming back, a dream-report mic, and sometimes a [light cue](visual.md#chap-visual). These often span
 more than one physical device and two rooms. On Windows, the same speaker can also
 appear under several names, and the level that reaches the participant is the product
 of several controls spread across the OS.
 
 This page describes how SMACC handles devices and routing. For the output safety cap
-and stimulus timing, see [Volume & latency](latency.md).
+and stimulus timing, see [Volume & latency](latency.md#chap-latency).
 
 ## Equipment and actions
 
@@ -129,7 +129,7 @@ To confirm a cue actually reaches the bedroom, use the Audio cue window's
 **Monitoring** meters — see
 [Audio cues](audio-cues.md#is-the-cue-reaching-the-bedroom). For the output safety
 cap, the per-cue gains, and how the Windows volume stages combine, see
-[Volume & latency](latency.md).
+[Volume & latency](latency.md#chap-latency).
 
 ## Windows only
 

--- a/docs/biocals.md
+++ b/docs/biocals.md
@@ -1,4 +1,4 @@
-# Biocals
+# Biocals {#chap-biocals}
 
 Sleep studies open with **biocalibrations**: scripted participant actions (eyes
 open, eyes closed, look left/right, and so on) whose known physiological signatures
@@ -45,7 +45,7 @@ bracketed by its own start/stop codes and otherwise fires the same per-biocal
 markers. The defaults are sequence start/stop **105**/**106**, cancelled **107**,
 completed **108**, and one start code per biocal in the **110–126** band. All are
 retunable in the **Markers** window like any built-in event (see
-[Markers & port codes](triggers.md)).
+[Markers & port codes](triggers.md#chap-triggers)).
 
 ## Voice recordings
 
@@ -59,4 +59,4 @@ start warns when that happens.
 
 The shared **Voice volume** rides the cue route, so the master output cap and the
 control-room monitor fan-out apply to instructions exactly as they do to cues (see
-[Volume & latency](latency.md) and [Audio routing](audio.md)).
+[Volume & latency](latency.md#chap-latency) and [Audio routing](audio.md#chap-audio)).

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,4 +1,4 @@
-# Contributing
+# Contributing {#chap-contributing}
 
 ::: {.callout-note title="For both human and AI contributors"}
 
@@ -186,7 +186,10 @@ and each screenshot is a numbered figure — a short visible caption, a `#fig-�
 (so it can be cross-referenced with `@fig-…`), a `width=` attribute, and its full
 description in `fig-alt` for screen readers.
 Heading slugs use `gfm_auto_identifiers` so the cross-page `#anchor` links resolve
-the same way GitHub renders them.
+the same way GitHub renders them. Always give a cross-chapter link an explicit
+`#anchor` — an anchorless `[…](other.md)` link goes dead in the combined PDF (#262).
+Each chapter's title carries a `{#chap-…}` id for exactly this, so a link to a whole
+chapter is `[…](other.md#chap-other)`.
 
 The [docs workflow](https://github.com/remrama/smacc/blob/main/.github/workflows/docs.yml)
 renders and checks the docs on every pull request and push, and publishes the live
@@ -197,18 +200,21 @@ the [release workflow](https://github.com/remrama/smacc/blob/main/.github/workfl
 and the live site serves the current stable manual via the sidebar **Download PDF**
 button.
 
-Two checks run in CI after the render — run them locally before a docs PR. Together
+Three checks run in CI after the render — run them locally before a docs PR. Together
 they replace what `mkdocs build --strict` used to cover:
 
 ```sh
-uv run python scripts/check_links.py docs/_book                                 # internal links + heading anchors
-uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf  # PDF completeness
+uv run python scripts/check_links.py docs/_book                                   # HTML links + heading anchors
+uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf    # PDF completeness
+uv run --extra docs python scripts/check_pdf_links.py docs/_book/SMACC-manual.pdf # PDF cross-chapter links
 ```
 
-`check_links.py` fails on any dead cross-page link or `#anchor` (heading slugs
-differ between renderers — the main migration footgun). `check_manual.py` fails if
-the manual is short or missing content from its later sections, guarding against a
-renderer silently dropping pages (the bug behind #250).
+`check_links.py` fails on any dead cross-page link or `#anchor` in the HTML site
+(heading slugs differ between renderers — the main migration footgun).
+`check_manual.py` fails if the manual is short or missing content from its later
+sections, guarding against a renderer silently dropping pages (the bug behind #250).
+`check_pdf_links.py` fails on any cross-chapter link left dead in the PDF — the
+anchorless-link bug behind #262.
 
 ## Versioning
 
@@ -220,7 +226,7 @@ SMACC follows [semantic versioning](https://semver.org/).
 - **Versions are `0.x.y` until 1.0.0.** A new `0.x.0` collects features and `0.x.y`
   is a smaller follow-up; no pre-1.0 bump is a stability promise.
 - **`0.1.0` is the first published release** — the first with installers attached, a
-  [release-notes](release-notes.md) entry, and a working in-app update check.
+  [release-notes](release-notes.md#chap-release-notes) entry, and a working in-app update check.
   Earlier `0.0.x` tags predate it and are not in the release notes.
 - **1.0.0 is the first stable release.** From then on semantic versioning is binding
   (backward-compatible changes bump the minor/patch, breaking changes bump the

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -1,10 +1,10 @@
-# Compatible devices
+# Compatible devices {#chap-devices}
 
 SMACC can drive a small number of external devices for cueing. This page lists
 the supported hardware and what each one needs. For how SMACC *assigns and routes*
 devices — equipment, the Devices window, and volume — see
-[Audio routing](audio.md); for using the light devices — patterns,
-timing, choosing between them, and safety — see [Visual cues](visual.md).
+[Audio routing](audio.md#chap-audio); for using the light devices — patterns,
+timing, choosing between them, and safety — see [Visual cues](visual.md#chap-visual).
 
 ## BlinkStick
 
@@ -32,13 +32,13 @@ sleep and lucid-dreaming experiments.
    automatically, or click **Refresh devices (F5)** in the Devices window to rescan.
 1. Configure a light cue — color, brightness, pattern (steady, or a pulse/flash at
    a rate in Hz), and length (or **Loop** until stopped) — and add more cues with
-   **+ Add cue** if the protocol needs several. See [Visual cues](visual.md) for
+   **+ Add cue** if the protocol needs several. See [Visual cues](visual.md#chap-visual) for
    what each pattern is for.
 1. Click a cue's **Play** to fire it; **Stop** turns the light off early. The rest
    of SMACC stays responsive while the light is on.
 
 Your chosen device and the whole cue board are saved in the
-[SMACC file](smacc-files.md), so the visual-cue
+[SMACC file](smacc-files.md#chap-smacc-files), so the visual-cue
 setup travels with the rest of your configuration; the device is reconnected by
 serial on the next launch (and flagged if it isn't plugged in).
 

--- a/docs/eeg-annotator.md
+++ b/docs/eeg-annotator.md
@@ -1,4 +1,4 @@
-# EEG Annotator
+# EEG Annotator {#chap-eeg-annotator}
 
 The **EEG Annotator** is SMACC's post-hoc viewer for recorded EEG: open a
 file, scroll through the night, apply display filters, and place named
@@ -140,7 +140,7 @@ sidecar exists it is the single source of truth (nothing is re-imported or
 duplicated).
 
 The sidecar format is documented in the
-[annotations file reference](reference/annotations-file.md).
+[annotations file reference](reference/annotations-file.md#chap-reference-annotations-file).
 
 ## Sleep staging
 
@@ -188,7 +188,7 @@ two scorers of one night produce two hypnograms to compare.
 
 ## Session log overlay
 
-Load the night's SMACC session [`.log`](reference/session-log.md) onto the
+Load the night's SMACC session [`.log`](reference/session-log.md#chap-reference-session-log) onto the
 timeline as a **read-only reference track** — every marker, cue, dream report,
 and survey shown where it happened, so you see what SMACC *did* alongside the
 EEG. Click **Load session log…** in the **Session log** panel. Ticks appear in a

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# SMACC
+# SMACC {#chap-index}
 
 **Sleep Manipulation And Communication Clickything** (SMACC) is a Windows desktop
 app for running sleep and dream studies — presenting cues to a sleeping participant,
@@ -12,11 +12,11 @@ one window per job, glanceable in the dark, with a volume safety cap and explici
 device routing so a misclick can't blast or mislead a sleeping participant.
 
 [Download SMACC](https://github.com/remrama/smacc/releases/latest/download/SMACC-Setup.exe){.btn .btn-primary role="button"}
-[Installation guide](installation.md){.btn .btn-secondary role="button"}
+[Installation guide](installation.md#chap-installation){.btn .btn-secondary role="button"}
 
 The button downloads the installer (`SMACC-Setup.exe`) for the latest version, which
 installs per-user (no admin rights) and runs on 64-bit Windows 10 or later. See
-[Installation](installation.md), which also covers the Windows SmartScreen warning on
+[Installation](installation.md#chap-installation), which also covers the Windows SmartScreen warning on
 the unsigned download and how to get older versions.
 
 ## What SMACC does
@@ -35,26 +35,26 @@ the unsigned download and how to get older versions.
 
 **Getting started**
 
-- [Installation](installation.md) — download and run SMACC.
-- [SMACC files](smacc-files.md) — create and reuse a study's configuration (`.smacc`).
+- [Installation](installation.md#chap-installation) — download and run SMACC.
+- [SMACC files](smacc-files.md#chap-smacc-files) — create and reuse a study's configuration (`.smacc`).
 
 **Running a session**
 
-- [Overview](usage.md) — the Launcher, the Session window, and the tools.
-- [Audio cues](audio-cues.md) · [Visual cues](visual.md) · [Biocals](biocals.md) ·
-  [Dream reports & surveys](surveys.md) · [Intercom & chat](intercom.md) ·
-  [Markers & port codes](triggers.md)
+- [Overview](usage.md#chap-usage) — the Launcher, the Session window, and the tools.
+- [Audio cues](audio-cues.md#chap-audio-cues) · [Visual cues](visual.md#chap-visual) · [Biocals](biocals.md#chap-biocals) ·
+  [Dream reports & surveys](surveys.md#chap-surveys) · [Intercom & chat](intercom.md#chap-intercom) ·
+  [Markers & port codes](triggers.md#chap-triggers)
 
 **Devices, volume & timing**
 
-- [Audio routing](audio.md) · [Compatible devices](devices.md) ·
-  [Volume & latency](latency.md)
+- [Audio routing](audio.md#chap-audio) · [Compatible devices](devices.md#chap-devices) ·
+  [Volume & latency](latency.md#chap-latency)
 
 **After the night**
 
-- [EEG Annotator](eeg-annotator.md) — review and score recorded EEG.
-- [Troubleshooting](troubleshooting.md) · [Reference](reference/index.md) ·
-  [Contributing](contributing.md)
+- [EEG Annotator](eeg-annotator.md#chap-eeg-annotator) — review and score recorded EEG.
+- [Troubleshooting](troubleshooting.md#chap-troubleshooting) · [Reference](reference/index.md#chap-reference-index) ·
+  [Contributing](contributing.md#chap-contributing)
 
 ## Used by
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,4 +1,4 @@
-# Installation
+# Installation {#chap-installation}
 
 [Download SMACC](https://github.com/remrama/smacc/releases/latest/download/SMACC-Setup.exe){.btn .btn-primary role="button"}
 
@@ -10,7 +10,7 @@ double-click `SMACC-Setup.exe` and click through. The installer:
 - associates **`.smacc` files**, so double-clicking one opens the **Start a session**
   dialog with it preselected;
 - includes the **EEG Annotator** — the post-hoc
-  [EEG viewer/annotator](eeg-annotator.md), opened from the Launcher;
+  [EEG viewer/annotator](eeg-annotator.md#chap-eeg-annotator), opened from the Launcher;
 - registers an uninstaller — remove SMACC from **Settings › Apps** like any other
   program. Uninstalling never touches your data: SMACC files, recordings, and
   logs under `~/SMACC` (or your data directories) all stay put. The
@@ -97,14 +97,14 @@ it and its subfolders on first run.
 
 The rest of setup is covered on the relevant pages:
 
-- **Your study configuration** lives in a portable [SMACC file](smacc-files.md).
+- **Your study configuration** lives in a portable [SMACC file](smacc-files.md#chap-smacc-files).
   SMACC seeds a `default.smacc` and opens it when you don't pick another, so it
   works out of the box. The installer associates `.smacc` files; enable or repair
   the association any time from **File › Associate .smacc files (Windows)** in the
   Launcher.
 - **Audio cues** go in the data directory's `cues/` folder, alongside the seeded
-  `demo-*` cues — see [Audio cues](audio-cues.md).
+  `demo-*` cues — see [Audio cues](audio-cues.md#chap-audio-cues).
 - **Dream-report surveys** are managed from the Dream recording panel — see
-  [Dream reports & surveys](surveys.md).
+  [Dream reports & surveys](surveys.md#chap-surveys).
 - **A recording mic:** to record dreams, bind your mic to **Bedroom mic 1** in the
-  **Devices** window (the **Panels** column) — see [Audio routing](audio.md).
+  **Devices** window (the **Panels** column) — see [Audio routing](audio.md#chap-audio).

--- a/docs/intercom.md
+++ b/docs/intercom.md
@@ -1,4 +1,4 @@
-# Intercom & chat
+# Intercom & chat {#chap-intercom}
 
 The **Intercom** window (in the **Panels** column) is the live channel between the
 control room and the bedroom. It carries voice both ways, plus a typed text channel
@@ -15,7 +15,7 @@ for when audio would intrude.
   It is unmarked.
 
 Both directions route through equipment set once in the **Devices** window (see
-[Audio routing](audio.md)). A **level meter** beside each button shows the live
+[Audio routing](audio.md#chap-audio)). A **level meter** beside each button shows the live
 input level while that direction is on, so signal on the bar means audio is actually
 flowing (your mic for Talk, the participant's mic for Listen) rather than just a
 latched button.
@@ -59,5 +59,5 @@ marked exactly like a typed message.
 default no port codes fire and nothing reaches the BIDS events export: a typed
 exchange is rapid and conversational, and would flood the marker channel. If a study
 needs marker timestamps, route `Chat to participant` (code 69) and `Chat from participant` (code 70) to LSL/TTL in the **Markers** window (see
-[Markers & port codes](triggers.md)). The markers stay bare, without the message
+[Markers & port codes](triggers.md#chap-triggers)). The markers stay bare, without the message
 text, so the trigger channel stays legible.

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -1,4 +1,4 @@
-# Volume & latency
+# Volume & latency {#chap-latency}
 
 The **Volume** window holds two things that shape every cue: how loud it can get
 (the output safety cap and the visible OS volume stages) and the output **latency**
@@ -126,7 +126,7 @@ Two things to take from this:
 ## The Low / High setting
 
 The Volume window has a **Latency** choice (High / Low), saved in the `.smacc`
-([`output_latency`](reference/settings-file.md)):
+([`output_latency`](reference/settings-file.md#chap-reference-settings-file)):
 
 - **High** (default) — PortAudio's robust buffer. Fewer underruns; the safe choice
   for an overnight looping cue, where a glitch in a sleeper's ear is worse than 20 ms.

--- a/docs/reference/annotations-file.md
+++ b/docs/reference/annotations-file.md
@@ -1,6 +1,6 @@
-# Annotations sidecar
+# Annotations sidecar {#chap-reference-annotations-file}
 
-The [EEG Annotator](../eeg-annotator.md) saves annotations as a **TSV + JSON
+The [EEG Annotator](../eeg-annotator.md#chap-eeg-annotator) saves annotations as a **TSV + JSON
 sidecar pair** next to the source recording, which is never modified:
 
 ```

--- a/docs/reference/bids-export.md
+++ b/docs/reference/bids-export.md
@@ -1,6 +1,6 @@
-# BIDS export (`events.tsv` + sidecar)
+# BIDS export (`events.tsv` + sidecar) {#chap-reference-bids-export}
 
-SMACC can convert a session [log](session-log.md) into a
+SMACC can convert a session [log](session-log.md#chap-reference-session-log) into a
 [BIDS](https://bids.neuroimaging.io/) events file — a tab-separated `events.tsv` plus
 a JSON sidecar describing its columns. Export one from the **Analyzer** with its
 **Export events (BIDS)…** button. Only event-marker lines (`" - portcode N"`) become

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,18 +1,18 @@
-# File formats
+# File formats {#chap-reference-index}
 
 SMACC reads and writes a handful of files. This section is the **reference** for
 each one — its on-disk shape, every field, and how it is versioned — as distinct
-from the task-oriented [Overview](../usage.md) guide.
+from the task-oriented [Overview](../usage.md#chap-usage) guide.
 
-| File                                            | What it is                                | Format     | Version              |
-| ----------------------------------------------- | ----------------------------------------- | ---------- | -------------------- |
-| [SMACC file (`.smacc`)](settings-file.md)       | A portable study configuration            | YAML       | `schema_version: 1`  |
-| [`preferences.yaml`](preferences-file.md)       | Per-machine operator preferences          | YAML       | `schema_version: 1`  |
-| [Session `.log`](session-log.md)                | The per-run record (events + settings)    | Text       | —                    |
-| [BIDS export](bids-export.md)                   | `events.tsv` + JSON sidecar               | TSV / JSON | follows BIDS         |
-| [Survey definition](../surveys.md)              | An in-app survey (built-in or custom)     | YAML       | `schema_version: 1`  |
-| [Survey response](../surveys.md#response-files) | One administration's answers              | JSON       | —                    |
-| [Annotations sidecar](annotations-file.md)      | EEG Annotator marks (`*.annotations.tsv`) | TSV / JSON | follows BIDS columns |
+| File                                                                       | What it is                                | Format     | Version              |
+| -------------------------------------------------------------------------- | ----------------------------------------- | ---------- | -------------------- |
+| [SMACC file (`.smacc`)](settings-file.md#chap-reference-settings-file)     | A portable study configuration            | YAML       | `schema_version: 1`  |
+| [`preferences.yaml`](preferences-file.md#chap-reference-preferences-file)  | Per-machine operator preferences          | YAML       | `schema_version: 1`  |
+| [Session `.log`](session-log.md#chap-reference-session-log)                | The per-run record (events + settings)    | Text       | —                    |
+| [BIDS export](bids-export.md#chap-reference-bids-export)                   | `events.tsv` + JSON sidecar               | TSV / JSON | follows BIDS         |
+| [Survey definition](../surveys.md#chap-surveys)                            | An in-app survey (built-in or custom)     | YAML       | `schema_version: 1`  |
+| [Survey response](../surveys.md#response-files)                            | One administration's answers              | JSON       | —                    |
+| [Annotations sidecar](annotations-file.md#chap-reference-annotations-file) | EEG Annotator marks (`*.annotations.tsv`) | TSV / JSON | follows BIDS columns |
 
 ## Where each file lives
 

--- a/docs/reference/preferences-file.md
+++ b/docs/reference/preferences-file.md
@@ -1,11 +1,11 @@
-# Preferences file (`preferences.yaml`)
+# Preferences file (`preferences.yaml`) {#chap-reference-preferences-file}
 
 `preferences.yaml` holds **per-machine operator preferences** — where each window was
 last placed, the Launcher's recent-files list, the live log-preview options, and the
 EEG Annotator's per-machine state (recent labels, last-used folders, rater id,
 quick-mark palette). It is the machine layer, kept
-separate from a portable [SMACC file](settings-file.md) (which a researcher shares
-between rigs) and from a per-run [session log](session-log.md).
+separate from a portable [SMACC file](settings-file.md#chap-reference-settings-file) (which a researcher shares
+between rigs) and from a per-run [session log](session-log.md#chap-reference-session-log).
 
 It lives in the SMACC directory (`$SMACC_DIRECTORY`, else `~/SMACC/preferences.yaml`),
 is loaded at startup, and is written on quit. It must never break the app: a missing
@@ -57,7 +57,7 @@ is current.
 
 ### EEG Annotator keys
 
-The [EEG Annotator](../eeg-annotator.md) runs as its own process but writes its
+The [EEG Annotator](../eeg-annotator.md#chap-eeg-annotator) runs as its own process but writes its
 per-machine state into the same `preferences.yaml`:
 
 | Key                    | Type             | Meaning                                                      |

--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -1,4 +1,4 @@
-# Session log (`.log`)
+# Session log (`.log`) {#chap-reference-session-log}
 
 Every live run writes one plain-text log to its own timestamped folder
 (`smacc-YYYYmmdd-HHMMSS/`) under the study's data directory. It is the session's
@@ -62,7 +62,7 @@ Most markers are stamped when SMACC fires them. **Audio cue and noise** markers 
 the exception: their timestamp — in the log line *and* the LSL stream — is the
 *estimated onset* (the fire time plus the output stream's reported latency), so the
 marker lines up with the sound rather than SMACC's buffer (see
-[Volume & latency](../latency.md)). The raw software-trigger instant rides alongside on a
+[Volume & latency](../latency.md#chap-latency)). The raw software-trigger instant rides alongside on a
 `DEBUG` line:
 
 ```text
@@ -71,7 +71,7 @@ marker lines up with the sound rather than SMACC's buffer (see
 ```
 
 That `DEBUG` line is deliberately **not** a `" - portcode N"` line, so the
-[BIDS export](bids-export.md) counts the event once, at its onset.
+[BIDS export](bids-export.md#chap-reference-bids-export) counts the event once, at its onset.
 
 ### Text-chat transcript
 
@@ -92,7 +92,7 @@ trigger channel and the export stay legible.
 
 The log carries the **complete settings the run used**, so a session stays
 self-documenting even if the study file later changes. The block is the same payload
-as a [`.smacc` file](settings-file.md), but every line is prefixed with `#` and
+as a [`.smacc` file](settings-file.md#chap-reference-settings-file), but every line is prefixed with `#` and
 fenced by sentinels, so log parsers skip it entirely:
 
 ```text

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -1,4 +1,4 @@
-# SMACC file (`.smacc`)
+# SMACC file (`.smacc`) {#chap-reference-settings-file}
 
 A **SMACC file** is a **portable study configuration**: it lets a researcher set
 SMACC up once — cue sounds and volumes, noise, the visual cue, survey selection, event
@@ -6,7 +6,7 @@ codes, device routing, optional hardware triggers — and reload it each session
 stays consistent across nights and researchers. It is plain YAML you can read and
 edit. The user-facing extension is `.smacc`, but the `kind` stays `smacc/settings`.
 
-See [SMACC files](../smacc-files.md) for the task-level
+See [SMACC files](../smacc-files.md#chap-smacc-files) for the task-level
 guide (creating, editing, sharing). This page is the field reference.
 
 ## On-disk shape
@@ -102,30 +102,30 @@ Any key may be omitted — each falls back to its default.
 
 ### Audio, noise, visual, survey, chat, volume
 
-| Key                         | Type                | Meaning                                                                                                                                                                                                                      |
-| --------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cues`                      | list                | One entry per cue slot: `name` (string), `file` (WAV path), `volume` (0–1), `loop` (bool).                                                                                                                                   |
-| `cue_attack`                | seconds             | Fade-in applied to a starting cue.                                                                                                                                                                                           |
-| `cue_release`               | seconds             | Fade-out applied to a stopping cue.                                                                                                                                                                                          |
-| `noise_volume`              | 0–1                 | Background-noise level.                                                                                                                                                                                                      |
-| `noise_color`               | string              | Selected noise colour (as offered in the Noise panel, e.g. `white`).                                                                                                                                                         |
-| `noise_source`              | `builtin` \| `file` | Generated noise, or a WAV file.                                                                                                                                                                                              |
-| `noise_file`                | path                | The noise WAV when `noise_source: file`.                                                                                                                                                                                     |
-| `visual_cues`               | list                | One entry per light slot: `name` (string), `color` (`#rrggbb`), `brightness` (0–1), `pattern` (`steady` \| `pulse` \| `flash`), `rate` (Hz, the pulse/flash speed), `length` (seconds; ignored while `loop`), `loop` (bool). |
-| `visual_attack`             | seconds             | Brightness fade-in applied to a starting visual cue.                                                                                                                                                                         |
-| `visual_release`            | seconds             | Brightness fade-out applied to a stopping visual cue.                                                                                                                                                                        |
-| `survey_url`                | string              | The selected survey: a web URL, or `smacc://survey/<key>` for an in-app survey.                                                                                                                                              |
-| `survey_options`            | mapping             | Named *web* survey presets: label → URL. In-app surveys (built-in or custom) are not persisted here — they come from survey definition files (see [Dream reports & surveys](../surveys.md)).                                 |
-| `chat_font_size`            | integer             | Participant chat window text size, in points (8–72).                                                                                                                                                                         |
-| `chat_red_text`             | boolean             | Red-shifted night text in the participant chat window.                                                                                                                                                                       |
-| `chat_experimenter_presets` | list                | Intercom quick-reply prompts the experimenter sends with one click (verbatim, like a typed message). Omitted → seeded defaults; an empty list is respected.                                                                  |
-| `chat_participant_presets`  | list                | Participant quick replies, shown as numbered chips and sent with the number keys 1–9 (max 9). Omitted → seeded defaults; an empty list is respected.                                                                         |
-| `volume_cap`                | 0–1                 | Master output safety cap multiplied into every stimulus (`1.0` = no cap).                                                                                                                                                    |
-| `output_latency`            | `high` \| `low`     | Output buffer for the cue + noise streams: `high` is robust (default), `low` trims marker-to-sound delay where the device allows it (often unchanged on shared-mode WASAPI). See [Volume & latency](../latency.md).          |
+| Key                         | Type                | Meaning                                                                                                                                                                                                                          |
+| --------------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cues`                      | list                | One entry per cue slot: `name` (string), `file` (WAV path), `volume` (0–1), `loop` (bool).                                                                                                                                       |
+| `cue_attack`                | seconds             | Fade-in applied to a starting cue.                                                                                                                                                                                               |
+| `cue_release`               | seconds             | Fade-out applied to a stopping cue.                                                                                                                                                                                              |
+| `noise_volume`              | 0–1                 | Background-noise level.                                                                                                                                                                                                          |
+| `noise_color`               | string              | Selected noise colour (as offered in the Noise panel, e.g. `white`).                                                                                                                                                             |
+| `noise_source`              | `builtin` \| `file` | Generated noise, or a WAV file.                                                                                                                                                                                                  |
+| `noise_file`                | path                | The noise WAV when `noise_source: file`.                                                                                                                                                                                         |
+| `visual_cues`               | list                | One entry per light slot: `name` (string), `color` (`#rrggbb`), `brightness` (0–1), `pattern` (`steady` \| `pulse` \| `flash`), `rate` (Hz, the pulse/flash speed), `length` (seconds; ignored while `loop`), `loop` (bool).     |
+| `visual_attack`             | seconds             | Brightness fade-in applied to a starting visual cue.                                                                                                                                                                             |
+| `visual_release`            | seconds             | Brightness fade-out applied to a stopping visual cue.                                                                                                                                                                            |
+| `survey_url`                | string              | The selected survey: a web URL, or `smacc://survey/<key>` for an in-app survey.                                                                                                                                                  |
+| `survey_options`            | mapping             | Named *web* survey presets: label → URL. In-app surveys (built-in or custom) are not persisted here — they come from survey definition files (see [Dream reports & surveys](../surveys.md#chap-surveys)).                        |
+| `chat_font_size`            | integer             | Participant chat window text size, in points (8–72).                                                                                                                                                                             |
+| `chat_red_text`             | boolean             | Red-shifted night text in the participant chat window.                                                                                                                                                                           |
+| `chat_experimenter_presets` | list                | Intercom quick-reply prompts the experimenter sends with one click (verbatim, like a typed message). Omitted → seeded defaults; an empty list is respected.                                                                      |
+| `chat_participant_presets`  | list                | Participant quick replies, shown as numbered chips and sent with the number keys 1–9 (max 9). Omitted → seeded defaults; an empty list is respected.                                                                             |
+| `volume_cap`                | 0–1                 | Master output safety cap multiplied into every stimulus (`1.0` = no cap).                                                                                                                                                        |
+| `output_latency`            | `high` \| `low`     | Output buffer for the cue + noise streams: `high` is robust (default), `low` trims marker-to-sound delay where the device allows it (often unchanged on shared-mode WASAPI). See [Volume & latency](../latency.md#chap-latency). |
 
 ### `biocals`
 
-The Biocals window's stack (see [Biocals](../biocals.md)):
+The Biocals window's stack (see [Biocals](../biocals.md#chap-biocals)):
 `voice_volume` (0–1, the shared instruction volume) plus one `rows` entry per
 stack row, in display order. Rows may repeat a biocal (e.g. eyes-closed twice in
 the played sequence). A missing block — or a block without `rows` — loads the
@@ -169,8 +169,8 @@ for TTL-routed codes (LSL carries any code).
 
 ### `devices`
 
-Equipment → device bindings plus action → equipment routing (see [Audio routing](../audio.md)
-and [Devices](../devices.md)).
+Equipment → device bindings plus action → equipment routing (see [Audio routing](../audio.md#chap-audio)
+and [Devices](../devices.md#chap-devices)).
 
 | Key        | Type    | Meaning                                                                                                                                                                                                                                                                   |
 | ---------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -187,7 +187,7 @@ no "system default" pseudo-selection (see
 ### `trigger_output`
 
 Optional hardware TTL trigger output, mirrored alongside the always-on LSL stream
-(see [Markers & port codes](../triggers.md)).
+(see [Markers & port codes](../triggers.md#chap-triggers)).
 
 | Field       | Type                   | Meaning                                                         |
 | ----------- | ---------------------- | --------------------------------------------------------------- |

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,4 +1,4 @@
-# Release notes
+# Release notes {#chap-release-notes}
 
 ::: {.callout-warning title="SMACC is pre-1.0"}
 

--- a/docs/smacc-files.md
+++ b/docs/smacc-files.md
@@ -1,4 +1,4 @@
-# SMACC files
+# SMACC files {#chap-smacc-files}
 
 A **SMACC file** (`.smacc`) is the study's configuration: cue files, volumes,
 noise, visual cues, biocals, survey presets, event markers, the display choices
@@ -11,13 +11,13 @@ A SMACC file is *not* a session file. It is not tied to any particular run:
 opening one **starts a new session** with that configuration, and you can start
 as many sessions from the same file as you like. Sessions never rewrite the
 SMACC file they were started from — what happened in a run is recorded in that
-run's [session log](reference/session-log.md), not in the SMACC file.
+run's [session log](reference/session-log.md#chap-reference-session-log), not in the SMACC file.
 
 It is a single, portable file (plain YAML you can read and edit). Cue/noise
 files and the data directory are stored **relative** to the SMACC file when they
 sit beside it — so a self-contained study folder stays valid if you move, copy,
 or zip it — and **absolute** when they point elsewhere. For the exact on-disk
-format, see the [SMACC file reference](reference/settings-file.md).
+format, see the [SMACC file reference](reference/settings-file.md#chap-reference-settings-file).
 
 ![The SMACC Editor.](assets/screenshot-editor.png){#fig-editor width=100% fig-alt="The SMACC Editor: the editing banner, the Panels column, the data directory, and the save panel."}
 

--- a/docs/surveys.md
+++ b/docs/surveys.md
@@ -1,4 +1,4 @@
-# Dream reports & surveys
+# Dream reports & surveys {#chap-surveys}
 
 After an awakening the participant gives a **dream report**: recorded audio, often
 followed by a questionnaire. SMACC records the audio and can open a survey alongside
@@ -212,4 +212,4 @@ items:
 
 Web survey URLs, by contrast, are saved in the `.smacc` study file
 (`survey_options`) and travel with the study — see the
-[settings-file reference](reference/settings-file.md).
+[settings-file reference](reference/settings-file.md#chap-reference-settings-file).

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -1,4 +1,4 @@
-# Markers & port codes
+# Markers & port codes {#chap-triggers}
 
 This page explains what EEG **triggers** and **port codes** are, the ways SMACC can
 send them, and how to configure each one. If you just want the steps, jump to
@@ -26,21 +26,21 @@ The words *event*, *marker*, *trigger*, and *port code* get used loosely in the
 field; SMACC uses each one for exactly one thing, in the UI, the docs, and the
 session log:
 
-| Term          | Meaning in SMACC                                                                                                                                                                        |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Event**     | A named thing that can happen during a session — a cue started, REM observed, lights off. Each is an entry in the study's event registry, with a label and a port code.                 |
-| **Marker**    | The durable record produced when an event fires. A marker is always a [log line](reference/session-log.md); if the event is routed to a transport, it also carries the port code there. |
-| **Port code** | The 8-bit number (**1–255**) identifying an event on the amplifier's trigger channel. Also called a *trigger code*.                                                                     |
-| **Trigger**   | The act of *sending* a port code over a transport. An event can be logged without being triggered.                                                                                      |
-| **Transport** | A path that carries the code to the recording: the **LSL** marker stream, or a hardware **TTL** line (serial trigger box / parallel port).                                              |
-| **Log level** | The severity tag on a log line (`DEBUG`…`CRITICAL`). The log *file* records every level; levels only filter the live preview. See [log levels](reference/session-log.md#log-levels).    |
+| Term          | Meaning in SMACC                                                                                                                                                                                                   |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Event**     | A named thing that can happen during a session — a cue started, REM observed, lights off. Each is an entry in the study's event registry, with a label and a port code.                                            |
+| **Marker**    | The durable record produced when an event fires. A marker is always a [log line](reference/session-log.md#chap-reference-session-log); if the event is routed to a transport, it also carries the port code there. |
+| **Port code** | The 8-bit number (**1–255**) identifying an event on the amplifier's trigger channel. Also called a *trigger code*.                                                                                                |
+| **Trigger**   | The act of *sending* a port code over a transport. An event can be logged without being triggered.                                                                                                                 |
+| **Transport** | A path that carries the code to the recording: the **LSL** marker stream, or a hardware **TTL** line (serial trigger box / parallel port).                                                                         |
+| **Log level** | The severity tag on a log line (`DEBUG`…`CRITICAL`). The log *file* records every level; levels only filter the live preview. See [log levels](reference/session-log.md#log-levels).                               |
 
 ## Default event codes
 
 These are SMACC's built-in event markers and their default port codes — the
 out-of-the-box [`event_codes`](reference/settings-file.md#event_codes) registry. A
 study can retune any code in the **Markers** window; the change travels in its
-[`.smacc`](reference/settings-file.md) and is written into every session log.
+[`.smacc`](reference/settings-file.md#chap-reference-settings-file) and is written into every session log.
 
 <!-- BEGIN auto:event-codes (kept in lockstep with smacc.events.default_events by tests/test_docs_schema.py) -->
 
@@ -269,7 +269,7 @@ register cleanly.
 1. Click **Apply**.
 
 The whole configuration is saved in your
-[SMACC file](smacc-files.md), so it travels with the rest of your
+[SMACC file](smacc-files.md#chap-smacc-files), so it travels with the rest of your
 setup. Because a COM port name or LPT address is specific to one computer, SMACC
 reports a clear error if the saved port can't be opened on the machine you load it on
 — re-pick it in the Markers window and save again.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,19 +1,19 @@
-# Troubleshooting
+# Troubleshooting {#chap-troubleshooting}
 
 When something goes wrong, start here. Most fixes live on the relevant tool's page;
 this page collects the cross-cutting ones and points to the rest.
 
 ## Common problems
 
-| Symptom                                                                     | Where to look                                                                                           |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| Windows SmartScreen blocks the download or installer                        | [Installation](installation.md) — expected for the unsigned build; **More info → Run anyway**           |
-| "No output/input device found", or a bound device shows **(not connected)** | [Audio routing](audio.md#no-system-default) — rebind in the Devices window and **Refresh devices (F5)** |
-| A cue plays in the control room but maybe not the bedroom                   | [Audio cues](audio-cues.md#is-the-cue-reaching-the-bedroom) — read the *Sending* and *Bedroom* meters   |
-| The BlinkStick isn't listed, or a light won't fire or stays on              | [Visual cues](visual.md#troubleshooting)                                                                |
-| The Hue bridge stopped responding                                           | [Visual cues](visual.md#troubleshooting) — its IP probably changed                                      |
-| Triggers don't register on the amplifier                                    | [Markers & port codes](triggers.md) — check the COM port, baud rate, and pulsed-vs-set-and-hold mode    |
-| A cue is too loud or too quiet                                              | [Volume & latency](latency.md) — the per-cue volume, the safety cap, and the OS stages                  |
+| Symptom                                                                     | Where to look                                                                                                      |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| Windows SmartScreen blocks the download or installer                        | [Installation](installation.md#chap-installation) — expected for the unsigned build; **More info → Run anyway**    |
+| "No output/input device found", or a bound device shows **(not connected)** | [Audio routing](audio.md#no-system-default) — rebind in the Devices window and **Refresh devices (F5)**            |
+| A cue plays in the control room but maybe not the bedroom                   | [Audio cues](audio-cues.md#is-the-cue-reaching-the-bedroom) — read the *Sending* and *Bedroom* meters              |
+| The BlinkStick isn't listed, or a light won't fire or stays on              | [Visual cues](visual.md#troubleshooting)                                                                           |
+| The Hue bridge stopped responding                                           | [Visual cues](visual.md#troubleshooting) — its IP probably changed                                                 |
+| Triggers don't register on the amplifier                                    | [Markers & port codes](triggers.md#chap-triggers) — check the COM port, baud rate, and pulsed-vs-set-and-hold mode |
+| A cue is too loud or too quiet                                              | [Volume & latency](latency.md#chap-latency) — the per-cue volume, the safety cap, and the OS stages                |
 
 ## If SMACC crashes
 
@@ -34,4 +34,4 @@ folder** button that takes you straight to it.
 
 Open an issue on the [SMACC issue tracker](https://github.com/remrama/smacc/issues)
 with what you did, what happened, and the relevant files: `crash.log` together with
-the affected run's folder, or a session [`.log`](reference/session-log.md).
+the affected run's folder, or a session [`.log`](reference/session-log.md#chap-reference-session-log).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,4 +1,4 @@
-# Overview
+# Overview {#chap-usage}
 
 SMACC opens to its **Launcher** — a list of the SMACC tools. Click a tool and SMACC
 asks for the **SMACC file** to use, then opens it. To run a night you open a live
@@ -7,13 +7,13 @@ asks for the **SMACC file** to use, then opens it. To run a night you open a liv
 The Launcher's tools (its title bar reads **SMACC**):
 
 - **Session…** — run a live **Session** for collecting data, the interface for
-  running a night. SMACC prompts for a [SMACC file](smacc-files.md) first.
-- **Editor…** — create or edit a [SMACC file](smacc-files.md) in the **Editor**,
+  running a night. SMACC prompts for a [SMACC file](smacc-files.md#chap-smacc-files) first.
+- **Editor…** — create or edit a [SMACC file](smacc-files.md#chap-smacc-files) in the **Editor**,
   without recording anything.
 - **Analyzer** — inspect a past session.
 - **Audio Cue Designer** — build a tone cue and export it as a WAV.
 - **EEG Annotator** — review and annotate a recorded EEG (see
-  [EEG Annotator](eeg-annotator.md)).
+  [EEG Annotator](eeg-annotator.md#chap-eeg-annotator)).
 
 The **Session** and the **Editor** are the same window in two modes — running a
 night versus authoring a SMACC file.
@@ -30,7 +30,7 @@ dialog with that file preselected. From the Launcher:
   picker lists recent files, the seeded `default`, and **Browse…** for any other),
   confirm the optional subject/session/notes, and click **OK** to start. Runs are
   written to that file's **data directory**; the run folder and log are created only
-  when the session starts. (See [SMACC files](smacc-files.md) for what a SMACC file
+  when the session starts. (See [SMACC files](smacc-files.md#chap-smacc-files) for what a SMACC file
   holds.)
 - **Editor…** — opens the **Open in the Editor** dialog. Choose **New SMACC file**
   for a blank configuration, or an existing file (recents / **Browse…**) to edit.
@@ -43,7 +43,7 @@ dialog with that file preselected. From the Launcher:
 - **Audio Cue Designer** — open the standalone tool to build a simple tone cue and
   export it as a WAV into a study's `cues/` folder (see
   [Audio cues](audio-cues.md#designing-a-cue)).
-- **EEG Annotator** — open the post-hoc [EEG Annotator](eeg-annotator.md) to review a
+- **EEG Annotator** — open the post-hoc [EEG Annotator](eeg-annotator.md#chap-eeg-annotator) to review a
   recorded night and place annotations. It runs as its own window and process, so it
   stays available while a session runs.
 
@@ -75,17 +75,17 @@ the same window, dimmed for a dark control room:
 
 Each tool has its own page:
 
-- [Audio cues](audio-cues.md) — the cue board, the Audio Cue Designer, background
+- [Audio cues](audio-cues.md#chap-audio-cues) — the cue board, the Audio Cue Designer, background
   noise, and confirming a cue reaches the bedroom.
-- [Visual cues](visual.md) — light cues on a BlinkStick or Philips Hue.
-- [Biocals](biocals.md) — timed, marked biocalibration tasks.
-- [Dream reports & surveys](surveys.md) — record a report and administer a survey.
-- [Intercom & chat](intercom.md) — talk, listen, and a typed channel.
-- [Markers & port codes](triggers.md) — the Markers window, the Event logging panel,
+- [Visual cues](visual.md#chap-visual) — light cues on a BlinkStick or Philips Hue.
+- [Biocals](biocals.md#chap-biocals) — timed, marked biocalibration tasks.
+- [Dream reports & surveys](surveys.md#chap-surveys) — record a report and administer a survey.
+- [Intercom & chat](intercom.md#chap-intercom) — talk, listen, and a typed channel.
+- [Markers & port codes](triggers.md#chap-triggers) — the Markers window, the Event logging panel,
   and EEG triggers.
-- [Audio routing](audio.md) and [Devices](devices.md) — bind equipment and route
+- [Audio routing](audio.md#chap-audio) and [Devices](devices.md#chap-devices) — bind equipment and route
   actions to it.
-- [Volume & latency](latency.md) — the output safety cap and stimulus timing.
+- [Volume & latency](latency.md#chap-latency) — the output safety cap and stimulus timing.
 
 ## Event log
 
@@ -93,7 +93,7 @@ Every run writes a detailed `.log` to its own timestamped folder under the SMACC
 file's **data directory** (for example `~/SMACC/data/`), capturing the events and
 settings for that session. Open one later from the Launcher's **Analyzer** to see a
 summary, export its events to BIDS, or recover its settings. For the line format and
-levels, see the [session log reference](reference/session-log.md). If SMACC crashes,
+levels, see the [session log reference](reference/session-log.md#chap-reference-session-log). If SMACC crashes,
 see [Troubleshooting](troubleshooting.md#if-smacc-crashes).
 
 ## Display preferences
@@ -107,12 +107,12 @@ as…** in a Session.
 
 Separately, the machine remembers window positions and sizes and your recent files
 in `~/SMACC/preferences.yaml`, restored on the next launch (see the
-[preferences reference](reference/preferences-file.md)).
+[preferences reference](reference/preferences-file.md#chap-reference-preferences-file)).
 
 ## SMACC files
 
 A **SMACC file** captures your study's whole configuration — cue files, volumes,
 noise, visual cues, survey presets, event markers, display choices, and the **data
 directory** where runs are written — in a single portable `.smacc`. See
-[SMACC files](smacc-files.md) for the full story, and the
-[SMACC file reference](reference/settings-file.md) for the on-disk format.
+[SMACC files](smacc-files.md#chap-smacc-files) for the full story, and the
+[SMACC file reference](reference/settings-file.md#chap-reference-settings-file) for the on-disk format.

--- a/docs/visual.md
+++ b/docs/visual.md
@@ -1,4 +1,4 @@
-# Visual cues
+# Visual cues {#chap-visual}
 
 Light is SMACC's second cueing modality, and it earns its place for two reasons.
 Closed eyelids still transmit light, so a lamp can reach a sleeping (or dreaming)
@@ -10,7 +10,7 @@ bulbs, from one window, with the same marker discipline as audio.
 This page covers the Visual cue board, the patterns, what the markers mean,
 choosing between the two devices, and the safety notes that come with flashing
 light at sleeping people. For plugging the devices in and binding them, see
-[Devices](devices.md).
+[Devices](devices.md#chap-devices).
 
 ## The visual cue board
 

--- a/scripts/check_pdf_links.py
+++ b/scripts/check_pdf_links.py
@@ -1,0 +1,77 @@
+"""Internal-link checker for the single-file PDF manual.
+
+Quarto/Typst emits a cross-chapter link that lacks a ``#fragment`` — e.g.
+``[Installation](installation.md)`` — as an *external* ``/URI`` annotation pointing
+at the bare ``installation.md`` filename, which is nothing in a single combined PDF,
+so the link leads nowhere (#262). Links that carry an explicit anchor
+(``installation.md#installation``) are emitted as internal ``/GoTo`` destinations and
+resolve. ``scripts/check_links.py`` only sees the HTML site, so it never catches this.
+
+This guard closes that gap for the PDF: it walks every ``/Link`` annotation and fails
+on any ``/URI`` that points at a relative ``.md`` (or ``.html``) document — the
+signature of an unresolved intra-book link. Genuine external links (``http(s)://`` …)
+are left alone. Run in CI after the PDF build:
+
+    uv run --extra docs python scripts/check_pdf_links.py docs/_book/SMACC-manual.pdf
+
+Exits non-zero (listing every dead link) if anything dangles.
+"""
+
+import sys
+from collections.abc import Iterator
+
+from pypdf import PdfReader
+from pypdf.generic import ArrayObject, DictionaryObject
+
+# An unresolved intra-book link points at a bare local document file. A real external
+# link is absolute (has a scheme); we only flag relative targets ending in these.
+_DEAD_SUFFIXES = (".md", ".html")
+_EXTERNAL_SCHEMES = ("http://", "https://", "mailto:", "tel:", "data:", "ftp://")
+
+
+def _uris(reader: PdfReader) -> Iterator[tuple[int, str]]:
+    """Yield (page number, /URI) for every link annotation that carries one."""
+    for number, page in enumerate(reader.pages, start=1):
+        if "/Annots" not in page:
+            continue
+        annots = page["/Annots"].get_object()
+        if not isinstance(annots, ArrayObject):
+            continue
+        for ref in annots:
+            annot = ref.get_object()
+            if not isinstance(annot, DictionaryObject):
+                continue
+            if annot.get("/Subtype") != "/Link" or "/A" not in annot:
+                continue
+            action = annot["/A"].get_object()
+            if not isinstance(action, DictionaryObject):
+                continue
+            uri = action.get("/URI")
+            if uri:
+                yield number, str(uri)
+
+
+def _is_dead(uri: str) -> bool:
+    if uri.startswith(_EXTERNAL_SCHEMES):
+        return False
+    target = uri.split("#", 1)[0].lower()
+    return target.endswith(_DEAD_SUFFIXES)
+
+
+def main(path: str) -> int:
+    reader = PdfReader(path)
+    links = list(_uris(reader))
+    dead = sorted({(number, uri) for number, uri in links if _is_dead(uri)})
+
+    if dead:
+        print(f"FAIL: {len(dead)} dead intra-book link(s) in {path}")
+        for number, uri in dead:
+            print(f"  - p.{number}: {uri}")
+        print("  (cross-chapter links need an explicit #anchor; see #262)")
+        return 1
+    print(f"OK: {path} ({len(links)} link annotations, no dead intra-book links)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "docs/_book/SMACC-manual.pdf"))


### PR DESCRIPTION
Closes #262.

Anchorless cross-chapter links — `[Installation](installation.md)` — were emitted by Quarto/Typst as dead external `/URI` annotations in the single-file PDF manual; only anchored links (`installation.md#section`) resolve internally. The HTML site was unaffected, and `scripts/check_links.py` validates HTML only, so it never caught this.

## Changes

- **Anchor every cross-chapter link.** Each chapter title gets a unique `{#chap-…}` id, and every anchorless `.md` link now points at it (`installation.md#chap-installation`). The id is path-derived (`chap-` + path) to stay globally unique in the combined PDF — a plain title slug like `troubleshooting` collides with same-named sections elsewhere and breaks the Typst build.
- **New `scripts/check_pdf_links.py`** — reads the PDF's link annotations and fails on any cross-chapter `/URI` ending in `.md`, with an `http(s)://` exclusion for genuine external links. Wired into the `build` job of `.github/workflows/docs.yml`.
- Documented the check and the explicit-anchor convention in `docs/contributing.md` and the `quarto` skill.

## Verification

All three run clean locally after `quarto render docs`:

- `check_links.py` → OK (proves every new anchor is a real HTML id)
- `check_pdf_links.py` → OK (0 dead intra-book links; was 62 before the fix)
- `check_manual.py` → OK (94 pages, content intact)

The guard's failure path is confirmed: on the pre-fix PDF it reported the 62 dead links.