### PR TITLE
docs: drop the gfm_auto_identifiers reader override

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -5,11 +5,6 @@
 #
 #   quarto preview docs      # live HTML site while writing
 #   quarto render docs       # build both HTML and PDF into docs/_book/
-#
-# Pandoc reader tweak: GitHub-style heading slugs, so the existing cross-page anchors
-# (authored against Material's GitHub-like slugifier) keep resolving — plain Pandoc
-# keeps periods (e.g. `pulsed-vs.-set-and-hold`) and would break those links.
-from: markdown+gfm_auto_identifiers
 
 project:
   type: book

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -185,8 +185,8 @@ yields one combined PDF. Pages are plain Markdown; admonitions are
 and each screenshot is a numbered figure — a short visible caption, a `#fig-…` id
 (so it can be cross-referenced with `@fig-…`), a `width=` attribute, and its full
 description in `fig-alt` for screen readers.
-Heading slugs use `gfm_auto_identifiers` so the cross-page `#anchor` links resolve
-the same way GitHub renders them.
+Avoid punctuation in headings so the cross-page `#anchor` links resolve to the same
+slug GitHub renders — periods in particular drift between renderers.
 
 The [docs workflow](https://github.com/remrama/smacc/blob/main/.github/workflows/docs.yml)
 renders and checks the docs on every pull request and push, and publishes the live

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -232,7 +232,7 @@ If triggers don't register, a wrong baud rate is one of the first things to chec
 (alongside the COM port and the [pulsed vs. set-and-hold](#pulsed-vs-set-and-hold)
 mode).
 
-## Pulsed vs. set-and-hold
+## Pulsed vs set-and-hold
 
 Amplifiers and trigger boxes differ in how they expect the code to appear on the
 lines, so SMACC offers two modes:


### PR DESCRIPTION
Closes #263.

Drops the `from: markdown+gfm_auto_identifiers` reader override and instead keeps heading slugs stable by avoiding punctuation in headings.

Pandoc's default reader and GitHub's slugifier already agree on every punctuated heading in the tree except periods (Pandoc keeps them, GFM drops them). The only linked heading affected was `## Pulsed vs. set-and-hold`, whose inbound link already pointed at `#pulsed-vs-set-and-hold` — so removing the period makes both slugifiers agree with zero link edits.

- `docs/_quarto.yml`: remove the reader override and its comment.
- `docs/triggers.md`: `Pulsed vs. set-and-hold` -> `Pulsed vs set-and-hold`.
- `docs/contributing.md`: document the no-punctuation-in-headings convention.

`check_links.py` is the safety net for future drift (fails CI on any dead `#anchor`).

Verified locally: `quarto render docs` succeeds and `check_links.py` reports all internal links resolve.

Refs #259, #260.