### PR TITLE
docs: restructure the manual into a numbered book with appendices

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ routing, volume).
 ## Development
 
 The full development guide — environment setup, running the app, tests, linting,
-building the executable, and building the docs — lives in the Contributing page
+building the executable, and building the docs — lives in the Developer guide
 so it is not duplicated here: [docs/contributing.md](./docs/contributing.md).
 
 See the [README](./README.md) for user-facing project information.

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -39,14 +39,15 @@ book:
         - surveys.md
         - intercom.md
         - triggers.md
-    - part: Devices & routing
+    - part: Devices, volume & timing
       chapters:
         - audio.md
         - devices.md
-    - latency.md
-    - eeg-annotator.md
-    - troubleshooting.md
-    - release-notes.md
+        - latency.md
+    - part: After the night
+      chapters:
+        - eeg-annotator.md
+        - troubleshooting.md
     - part: Reference
       chapters:
         - reference/index.md
@@ -55,14 +56,24 @@ book:
         - reference/session-log.md
         - reference/bids-export.md
         - reference/annotations-file.md
+  # Back matter. Appendices render after the numbered parts and are lettered
+  # (Appendix A, B, …): a reader-facing glossary and release notes, then the
+  # developer guide and credits.
+  appendices:
+    - glossary.md
+    - release-notes.md
     - contributing.md
+    - about.md
 
 format:
   html:
     theme:
       light: pulse
       dark: darkly
-    number-sections: false
+    # Number the chapters and sections so the HTML site and the PDF manual read as one
+    # numbered book (and figure numbers line up with their sections). Parts stay
+    # unnumbered; the preface and appendices are handled by Quarto's book template.
+    number-sections: true
   typst:
     papersize: a4
-    number-sections: false
+    number-sections: true

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,27 @@
+# About & credits {#chap-about}
+
+SMACC is developed by Remington Mallett and released as free software. This appendix
+lists the labs and publications that use SMACC, and states the license.
+
+## Used by
+
+SMACC is used in dream engineering research, including by:
+
+- [Ken Paller's Cognitive Neuroscience Lab](https://sites.northwestern.edu/pallerlab/)
+  at Northwestern University
+  - Torres-Platas et al. (2026). Intentional lucid dreaming with a transformative learning agenda. *Research Square* doi:[10.21203/rs.3.rs-8745420/v1](https://doi.org/10.21203/rs.3.rs-8745420/v1)
+  - Konkoly et al. (2026). Using real-time reporting to investigate visual experiences in dreams. *J Cogn Neurosci* doi:[10.1162/jocn.a.107](https://doi.org/10.1162/JOCN.a.107)
+  - Morris et al. (2026). Inducing lucid dreaming based on a contemplative practice of compassion. *Brain Sci* doi:[10.3390/brainsci16030315](https://doi.org/10.3390/brainsci16030315)
+  - Konkoly et al. (2026). Creative problem-solving after experimentally provoking dreams of unsolved puzzles during REM sleep. *Neurosci Conscious* doi:[10.1093/nc/niaf067](https://doi.org/10.1093/nc/niaf067)
+  - Konkoly et al. (2025). Investigating dreams by strategically presenting sounds during REM sleep to reactivate waking experiences. *Neuropsychologia* doi:[10.1016/j.neuropsychologia.2025.109229](https://doi.org/10.1016/j.neuropsychologia.2025.109229)
+  - Morris et al. (2025). Lucid dreaming of a prior virtual-reality experience with ego-transcendent qualities: A proof-of-concept study. *Neurosci Conscious* doi:[10.1093/nc/niaf017](https://doi.org/10.1093/nc/niaf017)
+  - Mundt et al. (2024). Treating narcolepsy-related nightmares with cognitive behavioural therapy and targeted lucidity reactivation: A pilot study. *J Sleep Res* doi:[10.1111/jsr.14384](https://doi.org/10.1111/jsr.14384)
+  - Wolk et al. (2024). Lucid dreams from reactivating mindfulness during REM sleep: A pilot study. *Int J Dream Res* doi:[10.11588/ijodr.2024.2.98233](https://doi.org/10.11588/ijodr.2024.2.98233)
+- [Michelle Carr's Dream Engineering Lab](https://www.dreamengineeringlab.com/)
+  at the University of Montreal and the Center for Advanced Research in Sleep Medicine
+  - Jafarzadeh Esfahani et al. (2024). Highly effective verified lucid dream induction using combined cognitive-sensory training and wearable EEG: A multi-centre study. *bioRxiv* doi:[10.1101/2024.06.21.600133](https://doi.org/10.1101/2024.06.21.600133)
+
+## License
+
+SMACC is free software released under the
+[GPL-3.0-or-later](https://github.com/remrama/smacc/blob/main/LICENSE.txt) license.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,4 +1,4 @@
-# Contributing {#chap-contributing}
+# Developer guide {#chap-contributing}
 
 ::: {.callout-note title="For both human and AI contributors"}
 
@@ -24,7 +24,7 @@ first.
   dependencies. Never `pip install` or run naked `python`.
 - Use the marker vocabulary consistently in UI text, docs, and docstrings — *event*,
   *marker*, *port code*, *trigger*, *transport* each mean exactly one thing; see the
-  [terminology table](triggers.md#terminology).
+  [Glossary](glossary.md#chap-glossary).
 - Write the docs as **reference**, not marketing: lead with the fact, keep pages
   scannable (short paragraphs, tables, steps), and go easy on em-dashes and the
   "not X, but Y" construction. Page filenames are stable, so cross-link with

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,59 @@
+# Glossary {#chap-glossary}
+
+SMACC uses a precise vocabulary in its interface, this manual, and the session log —
+each of these terms means exactly one thing. The event-signaling words (*event*,
+*marker*, *port code*, *trigger*, *transport*) are the ones most often used loosely
+in the field; SMACC keeps them distinct.
+
+- **Action** — Something SMACC does with a device, such as *Play audio cue* or
+  *Record dream report*. Each action is routed to a piece of equipment in the Devices
+  window. See [Audio routing](audio.md#chap-audio).
+- **Biocal (biocalibration)** — A scripted participant action (eyes open, look
+  left/right, hold breath, …) with a known physiological signature, run as a timed,
+  marked task to verify the recording channels. See [Biocals](biocals.md#chap-biocals).
+- **Cue** — A stimulus delivered to the participant: an **audio cue** (a sound) or a
+  **visual cue** (light on a BlinkStick or Philips Hue).
+- **Data directory** — The folder a SMACC file writes its runs to. Each run gets its
+  own timestamped subfolder. See [SMACC files](smacc-files.md#chap-smacc-files).
+- **Equipment** — A physical endpoint of the rig, named by place (Bedroom speaker,
+  Bedroom mic 1, Control-room mic, …) and bound once to a device in the Devices
+  window. See [Audio routing](audio.md#chap-audio).
+- **Event** — A named thing that can happen during a session — a cue started, REM
+  observed, lights off. Each is an entry in the study's event registry, with a label
+  and a port code.
+- **LSL (Lab Streaming Layer)** — The network marker stream SMACC always emits,
+  recorded by an LSL-aware recorder (e.g. LabRecorder). See
+  [Markers & port codes](triggers.md#chap-triggers).
+- **Log level** — The severity tag on a session-log line (`DEBUG`, `INFO`, `WARNING`,
+  `ERROR`, `CRITICAL`). The log file records every level; levels only filter the live
+  preview. See [Session log](reference/session-log.md#log-levels).
+- **Marker** — The durable record produced when an event fires. A marker is always a
+  [log line](reference/session-log.md#chap-reference-session-log); if the event is
+  routed to a transport, it also carries the port code there.
+- **Port code** — The 8-bit number (1–255) identifying an event on the amplifier's
+  trigger channel. Also called a *trigger code*.
+- **Rater** — A reviewer in the EEG Annotator. A *rater id* keeps each reviewer's
+  annotations in a separate sidecar, for blind, multi-rater scoring. See
+  [EEG Annotator](eeg-annotator.md#multiple-raters).
+- **Route / routing** — Pointing an action at a piece of equipment in the Devices
+  window, so SMACC knows which device performs it. See
+  [Audio routing](audio.md#chap-audio).
+- **Run** — One recorded execution of a session: a timestamped folder holding the
+  session's log, recordings, survey responses, and exports. Each session produces one
+  run.
+- **Scoring epoch** — In the EEG Annotator, the fixed-length window (30 s by default)
+  that one sleep stage is assigned to, kept separate from the on-screen view. See
+  [EEG Annotator](eeg-annotator.md#the-epoch-model).
+- **Session** — A live run of SMACC for collecting data, opened from the Launcher's
+  **Session…** tool. A SMACC file can start any number of sessions, each writing its
+  own run. See [Overview](usage.md#chap-usage).
+- **SMACC file (`.smacc`)** — A portable study configuration (cues, volumes, event
+  codes, device routing, …) plus the data directory its runs are written to. See
+  [SMACC files](smacc-files.md#chap-smacc-files).
+- **Transport** — A path that carries a port code to the recording: the LSL marker
+  stream, or a hardware TTL line (serial trigger box or parallel port).
+- **Trigger** — The act of sending a port code over a transport. An event can be
+  logged without being triggered.
+- **TTL** — A hardware trigger line (a serial USB trigger box or a parallel/LPT port)
+  that mirrors a port code onto physical pins for an amplifier that does not read LSL.
+  See [Markers & port codes](triggers.md#chap-triggers).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# SMACC {#chap-index}
+# Preface {#chap-index .unnumbered}
 
 **Sleep Manipulation And Communication Clickything** (SMACC) is a Windows desktop
 app for running sleep and dream studies — presenting cues to a sleeping participant,
@@ -10,14 +10,6 @@ sleeper, and collect a dream report — all from a dark control room, late at ni
 whatever hardware the lab has. SMACC is the clickable control surface for that work:
 one window per job, glanceable in the dark, with a volume safety cap and explicit
 device routing so a misclick can't blast or mislead a sleeping participant.
-
-[Download SMACC](https://github.com/remrama/smacc/releases/latest/download/SMACC-Setup.exe){.btn .btn-primary role="button"}
-[Installation guide](installation.md#chap-installation){.btn .btn-secondary role="button"}
-
-The button downloads the installer (`SMACC-Setup.exe`) for the latest version, which
-installs per-user (no admin rights) and runs on 64-bit Windows 10 or later. See
-[Installation](installation.md#chap-installation), which also covers the Windows SmartScreen warning on
-the unsigned download and how to get older versions.
 
 ## What SMACC does
 
@@ -31,48 +23,43 @@ the unsigned download and how to get older versions.
 - Review and score recordings in the **EEG Annotator**
 - Save a detailed **event log** for every run
 
-## Get started
+## How this manual is organized
 
-**Getting started**
+This is the SMACC user manual, published two ways from a single source: a live
+website that tracks the current stable release, and a PDF attached to every release
+for offline and historical reference. Both have identical content.
 
-- [Installation](installation.md#chap-installation) — download and run SMACC.
-- [SMACC files](smacc-files.md#chap-smacc-files) — create and reuse a study's configuration (`.smacc`).
+The manual is a book in five parts:
 
-**Running a session**
+- **Getting started** installs SMACC and explains the `.smacc` study file that every
+  session is configured from.
+- **Running a session** is the core: the Launcher and Session window, then a chapter
+  per tool — audio cues, visual cues, biocals, dream reports and surveys, the
+  intercom, and EEG markers.
+- **Devices, volume & timing** covers binding equipment, routing it to the tools, and
+  the volume cap and stimulus latency that govern what the participant actually
+  receives.
+- **After the night** is the post-hoc side: the EEG Annotator, and troubleshooting.
+- **Reference** documents every file SMACC reads and writes, field by field.
 
-- [Overview](usage.md#chap-usage) — the Launcher, the Session window, and the tools.
-- [Audio cues](audio-cues.md#chap-audio-cues) · [Visual cues](visual.md#chap-visual) · [Biocals](biocals.md#chap-biocals) ·
-  [Dream reports & surveys](surveys.md#chap-surveys) · [Intercom & chat](intercom.md#chap-intercom) ·
-  [Markers & port codes](triggers.md#chap-triggers)
+The appendices hold a [glossary](glossary.md#chap-glossary), the
+[release notes](release-notes.md#chap-release-notes), the
+[developer guide](contributing.md#chap-contributing), and
+[credits](about.md#chap-about). A first-time user should read **Getting started** and
+**Running a session** in order; the rest is there to reach for as needed.
 
-**Devices, volume & timing**
+## Conventions
 
-- [Audio routing](audio.md#chap-audio) · [Compatible devices](devices.md#chap-devices) ·
-  [Volume & latency](latency.md#chap-latency)
+- **Bold** marks the parts of the interface you act on — window names, buttons, and
+  fields (the **Markers** window, **Apply**). Monospace marks filenames, paths, and
+  literal values (`.smacc`, `COM3`).
+- Notes, tips, and warnings appear as callouts. A **warning** flags something that can
+  wake a participant, lose data, or mislead an analysis — read those before relying on
+  a feature.
+- Screenshots are numbered figures, captioned beneath the image.
+- SMACC uses a precise vocabulary for event signaling: *event*, *marker*, *port
+  code*, *trigger*, and *transport*, each meaning exactly one thing. The
+  [Glossary](glossary.md#chap-glossary) defines these and the other recurring terms.
 
-**After the night**
-
-- [EEG Annotator](eeg-annotator.md#chap-eeg-annotator) — review and score recorded EEG.
-- [Troubleshooting](troubleshooting.md#chap-troubleshooting) · [Reference](reference/index.md#chap-reference-index) ·
-  [Contributing](contributing.md#chap-contributing)
-
-## Used by
-
-SMACC is used in dream engineering research, including by:
-
-- [Ken Paller's Cognitive Neuroscience Lab](https://sites.northwestern.edu/pallerlab/)
-  at Northwestern University
-  - Torres-Platas et al. (2026). Intentional lucid dreaming with a transformative learning agenda. *Research Square* doi:[10.21203/rs.3.rs-8745420/v1](https://doi.org/10.21203/rs.3.rs-8745420/v1)
-  - Konkoly et al. (2026). Using real-time reporting to investigate visual experiences in dreams. *J Cogn Neurosci* doi:[10.1162/jocn.a.107](https://doi.org/10.1162/JOCN.a.107)
-  - Morris et al. (2026). Inducing lucid dreaming based on a contemplative practice of compassion. *Brain Sci* doi:[10.3390/brainsci16030315](https://doi.org/10.3390/brainsci16030315)
-  - Konkoly et al. (2026). Creative problem-solving after experimentally provoking dreams of unsolved puzzles during REM sleep. *Neurosci Conscious* doi:[10.1093/nc/niaf067](https://doi.org/10.1093/nc/niaf067)
-  - Konkoly et al. (2025). Investigating dreams by strategically presenting sounds during REM sleep to reactivate waking experiences. *Neuropsychologia* doi:[10.1016/j.neuropsychologia.2025.109229](https://doi.org/10.1016/j.neuropsychologia.2025.109229)
-  - Morris et al. (2025). Lucid dreaming of a prior virtual-reality experience with ego-transcendent qualities: A proof-of-concept study. *Neurosci Conscious* doi:[10.1093/nc/niaf017](https://doi.org/10.1093/nc/niaf017)
-  - Mundt et al. (2024). Treating narcolepsy-related nightmares with cognitive behavioural therapy and targeted lucidity reactivation: A pilot study. *J Sleep Res* doi:[10.1111/jsr.14384](https://doi.org/10.1111/jsr.14384)
-  - Wolk et al. (2024). Lucid dreams from reactivating mindfulness during REM sleep: A pilot study. *Int J Dream Res* doi:[10.11588/ijodr.2024.2.98233](https://doi.org/10.11588/ijodr.2024.2.98233)
-- [Michelle Carr's Dream Engineering Lab](https://www.dreamengineeringlab.com/)
-  at the University of Montreal and the Center for Advanced Research in Sleep Medicine
-  - Jafarzadeh Esfahani et al. (2024). Highly effective verified lucid dream induction using combined cognitive-sensory training and wearable EEG: A multi-centre study. *bioRxiv* doi:[10.1101/2024.06.21.600133](https://doi.org/10.1101/2024.06.21.600133)
-
-SMACC is free software released under the
-[GPL-3.0-or-later](https://github.com/remrama/smacc/blob/main/LICENSE.txt) license.
+SMACC runs on 64-bit Windows 10 or later and installs per-user, with no administrator
+rights. To download and install it, see [Installation](installation.md#chap-installation).

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -9,14 +9,16 @@ compatibility shims. Pin one version for the duration of a study. See the
 
 :::
 
-<!-- Newest release first. Set the date when a version is tagged. -->
+<!-- Newest release first. Set the date when a version is tagged. Each version
+     heading carries {.unnumbered} so the numbered book does not prefix it with a
+     section number (e.g. 'B.1'); keep that on new entries (#248). -->
 
-## 0.1.1 — 2026-06-15
+## 0.1.1 — 2026-06-15 {.unnumbered}
 
 - Fixed the Analyzer vanishing on open — clicking **Analyzer** hid the
   launcher but never showed the Analyzer window.
 
-## 0.1.0 — 2026-06-15
+## 0.1.0 — 2026-06-15 {.unnumbered}
 
 The first published release of SMACC — a Windows control surface for running
 sleep and dream studies. It includes:

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -23,17 +23,16 @@ and edit which event sends which code.
 ## Terminology
 
 The words *event*, *marker*, *trigger*, and *port code* get used loosely in the
-field; SMACC uses each one for exactly one thing, in the UI, the docs, and the
-session log:
+field; SMACC keeps each one distinct, in the UI, this manual, and the session log:
 
-| Term          | Meaning in SMACC                                                                                                                                                                                                   |
-| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Event**     | A named thing that can happen during a session — a cue started, REM observed, lights off. Each is an entry in the study's event registry, with a label and a port code.                                            |
-| **Marker**    | The durable record produced when an event fires. A marker is always a [log line](reference/session-log.md#chap-reference-session-log); if the event is routed to a transport, it also carries the port code there. |
-| **Port code** | The 8-bit number (**1–255**) identifying an event on the amplifier's trigger channel. Also called a *trigger code*.                                                                                                |
-| **Trigger**   | The act of *sending* a port code over a transport. An event can be logged without being triggered.                                                                                                                 |
-| **Transport** | A path that carries the code to the recording: the **LSL** marker stream, or a hardware **TTL** line (serial trigger box / parallel port).                                                                         |
-| **Log level** | The severity tag on a log line (`DEBUG`…`CRITICAL`). The log *file* records every level; levels only filter the live preview. See [log levels](reference/session-log.md#log-levels).                               |
+- an **event** is a named thing that can happen during a session;
+- a **marker** is the durable record it produces;
+- a **port code** is the 8-bit number (1–255) that identifies it on the trigger
+  channel;
+- a **trigger** is the act of sending that code over a **transport** — the LSL
+  stream or a hardware TTL line.
+
+The [Glossary](glossary.md#chap-glossary) gives the full definitions.
 
 ## Default event codes
 


### PR DESCRIPTION
Part of #248 — reframing the docs as a software **manual/book** now that Quarto renders one HTML site and one PDF from the same source. This is **phase 1 of a planned 3-PR stack**: structure and front matter. (Phase 2 = book-idiom sweep; phase 3 = targeted trimming.)

## What changed

- **`_quarto.yml`** — every chapter now sits inside a part (no more orphan chapters): `latency` joins **Devices, volume & timing**; `eeg-annotator` + `troubleshooting` form **After the night**. `release-notes` and `contributing` move into new back-matter `appendices:` alongside two new chapters. `number-sections: true` for both HTML and Typst, so the site and the PDF read as one numbered book.
- **`index.md` → Preface** (unnumbered front matter) — dropped the two download buttons and the duplicated "Get started" table-of-contents; added "How this manual is organized" and a "Conventions" section. The "Used by" citations and license move out to a new **About & credits** appendix.
- **New `glossary.md`** (Appendix A) — promotes the marker vocabulary that was a wide table in `triggers.md`, plus the recurring cross-manual terms (equipment, action, route, run/session, scoring epoch, …). `triggers.md` keeps a short, scannable orientation that points here.
- **New `about.md`** (About & credits) — the relocated "Used by" labs/citations and the license.
- **`contributing.md`** retitled **Developer guide** (anchor unchanged); `AGENTS.md` prose updated to match.

Resulting manual: **Preface → chapters 1–20 across five parts → Appendices A–D** (Glossary, Release notes, Developer guide, About & credits), 101 pages.

## Verification

`quarto render docs` builds clean; `scripts/check_links.py`, `scripts/check_pdf_links.py`, `scripts/check_manual.py`, and `mdformat --check` all pass. The restructure was put through a multi-lens review (link integrity, content fidelity, structure/parity, manual voice, completeness) and the findings folded in — notably reconciling the glossary's session/run wording with the rest of the manual and keeping the changelog version headings unnumbered.
