### PR TITLE
docs: use book phrasing over web-page idioms and inline download links

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -7,7 +7,7 @@ more than one physical device and two rooms. On Windows, the same speaker can al
 appear under several names, and the level that reaches the participant is the product
 of several controls spread across the OS.
 
-This page describes how SMACC handles devices and routing. For the output safety cap
+This chapter describes how SMACC handles devices and routing. For the output safety cap
 and stimulus timing, see [Volume & latency](latency.md#chap-latency).
 
 ## Equipment and actions

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@
 
 ::: {.callout-note title="For both human and AI contributors"}
 
-This page is the canonical development guide for SMACC. It is written for both
+This is the canonical development guide for SMACC. It is written for both
 human contributors and AI coding assistants — AI agents are pointed here from
 [`AGENTS.md`](https://github.com/remrama/smacc/blob/main/AGENTS.md), so the
 instructions live here once rather than being duplicated across files.
@@ -160,7 +160,7 @@ which checks the tag against `smacc.__version__`, builds the onedir
 wraps it in an Inno Setup installer (`tools/smacc.iss` → `SMACC-Setup.exe`),
 smoke-tests the app (`--version` and `--eeg --selftest`) and the installer, and
 attaches `SMACC-Setup.exe` to the GitHub Release. The installer's asset name is a
-stable contract — the docs' download button links
+stable contract — the docs' download link points at
 `releases/latest/download/SMACC-Setup.exe` — so don't rename it. The installer's
 `[Registry]` section must mirror `winassoc.association_entries()` exactly (so an
 installed build sees the association as already registered);
@@ -237,7 +237,7 @@ SMACC follows [semantic versioning](https://semver.org/).
 There are three kinds of build:
 
 - **Stable — `vX.Y.Z`** (no suffix): a full GitHub release, badged *Latest*. The
-  homepage download button, `/releases/latest`, and the in-app update check all
+  docs' download link, `/releases/latest`, and the in-app update check all
   resolve to it. `__version__` equals `X.Y.Z`.
 - **Pre-release — `vX.Y.Z-rc.N`** (also `-alpha.N`/`-beta.N`): a tagged candidate for
   the upcoming `X.Y.Z`. Any tag with a hyphen is marked *Pre-release* on GitHub, so

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -1,6 +1,6 @@
 # Compatible devices {#chap-devices}
 
-SMACC can drive a small number of external devices for cueing. This page lists
+SMACC can drive a small number of external devices for cueing. This chapter lists
 the supported hardware and what each one needs. For how SMACC *assigns and routes*
 devices — equipment, the Devices window, and volume — see
 [Audio routing](audio.md#chap-audio); for using the light devices — patterns,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,9 +1,8 @@
 # Installation {#chap-installation}
 
-[Download SMACC](https://github.com/remrama/smacc/releases/latest/download/SMACC-Setup.exe){.btn .btn-primary role="button"}
-
-The button above always downloads the installer for the **latest** version —
-double-click `SMACC-Setup.exe` and click through. The installer:
+SMACC is distributed as a Windows installer.
+[Download the latest `SMACC-Setup.exe`](https://github.com/remrama/smacc/releases/latest/download/SMACC-Setup.exe),
+then double-click it and click through. The installer:
 
 - installs SMACC **per-user** — no administrator rights or IT involvement needed;
 - adds a **Start menu** entry (and, if you opt in, a desktop shortcut);
@@ -74,9 +73,8 @@ Every code change merged to `main` is rebuilt and published as a single rolling
 **development build**, so you can try an unreleased fix or feature before the next
 stable release.
 
-[Download the development build](https://github.com/remrama/smacc/releases/download/dev/SMACC-dev.zip){.btn .btn-secondary role="button"}
-
-Unzip it and run `SMACC.exe` from the extracted `SMACC` folder. It's portable, so it
+[Download the development build](https://github.com/remrama/smacc/releases/download/dev/SMACC-dev.zip),
+unzip it, and run `SMACC.exe` from the extracted `SMACC` folder. It's portable, so it
 runs without installing and leaves any installed copy of SMACC untouched.
 
 ::: {.callout-warning title="For testing only"}
@@ -84,7 +82,7 @@ runs without installing and leaves any installed copy of SMACC untouched.
 The development build is unsigned, unreleased, and **not tested**, and it is
 overwritten every time `main` changes — so it's a moving target, not a fixed
 version. Don't use it to run a study; pin a stable release for that. The
-**Download SMACC** button at the top of this page and the in-app **File › Check
+stable installer linked at the top of this chapter and the in-app **File › Check
 for updates…** always point at the latest *stable* release, never this build.
 
 :::
@@ -95,7 +93,7 @@ By default SMACC stores everything under `~/SMACC`. To use a different location,
 the environment variable `SMACC_DIRECTORY` to the directory you want; SMACC creates
 it and its subfolders on first run.
 
-The rest of setup is covered on the relevant pages:
+The rest of setup is covered in the relevant chapters:
 
 - **Your study configuration** lives in a portable [SMACC file](smacc-files.md#chap-smacc-files).
   SMACC seeds a `default.smacc` and opens it when you don't pick another, so it

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -2,7 +2,7 @@
 
 The **Volume** window holds two things that shape every cue: how loud it can get
 (the output safety cap and the visible OS volume stages) and the output **latency**
-setting. This page covers both.
+setting. This chapter covers both.
 
 ## Volume
 

--- a/docs/reference/settings-file.md
+++ b/docs/reference/settings-file.md
@@ -7,7 +7,7 @@ stays consistent across nights and researchers. It is plain YAML you can read an
 edit. The user-facing extension is `.smacc`, but the `kind` stays `smacc/settings`.
 
 See [SMACC files](../smacc-files.md#chap-smacc-files) for the task-level
-guide (creating, editing, sharing). This page is the field reference.
+guide (creating, editing, sharing). This chapter is the field reference.
 
 ## On-disk shape
 

--- a/docs/triggers.md
+++ b/docs/triggers.md
@@ -1,8 +1,8 @@
 # Markers & port codes {#chap-triggers}
 
-This page explains what EEG **triggers** and **port codes** are, the ways SMACC can
-send them, and how to configure each one. If you just want the steps, jump to
-[Configuring trigger output in SMACC](#configuring-trigger-output-in-smacc).
+This chapter explains what EEG **triggers** and **port codes** are, the ways SMACC
+can send them, and how to configure each one. For the configuration steps alone,
+see [Configuring trigger output in SMACC](#configuring-trigger-output-in-smacc).
 
 ## What are port codes and triggers?
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,7 +1,7 @@
 # Troubleshooting {#chap-troubleshooting}
 
-When something goes wrong, start here. Most fixes live on the relevant tool's page;
-this page collects the cross-cutting ones and points to the rest.
+When something goes wrong, start here. Most fixes live in the relevant tool's chapter;
+this chapter collects the cross-cutting ones and points to the rest.
 
 ## Common problems
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,7 +2,7 @@
 
 SMACC opens to its **Launcher** — a list of the SMACC tools. Click a tool and SMACC
 asks for the **SMACC file** to use, then opens it. To run a night you open a live
-**Session**. This page orients you; each tool then has its own page.
+**Session**. This chapter orients you; each tool then has its own chapter.
 
 The Launcher's tools (its title bar reads **SMACC**):
 
@@ -73,7 +73,7 @@ the same window, dimmed for a dark control room:
 
 ## The tools
 
-Each tool has its own page:
+Each tool has its own chapter:
 
 - [Audio cues](audio-cues.md#chap-audio-cues) — the cue board, the Audio Cue Designer, background
   noise, and confirming a cue reaches the bedroom.

--- a/docs/visual.md
+++ b/docs/visual.md
@@ -7,7 +7,7 @@ signal. And light is silent, so it layers over masking noise or an auditory prot
 without touching the soundscape. SMACC drives light cues on a USB **BlinkStick** or on **Philips Hue**
 bulbs, from one window, with the same marker discipline as audio.
 
-This page covers the Visual cue board, the patterns, what the markers mean,
+This chapter covers the Visual cue board, the patterns, what the markers mean,
 choosing between the two devices, and the safety notes that come with flashing
 light at sleeping people. For plugging the devices in and binding them, see
 [Devices](devices.md#chap-devices).


### PR DESCRIPTION
Part of #248 — **phase 2 of the docs-as-manual stack** (stacked on #273). This pass converts web-page idioms into book idioms now that the docs are one Quarto Book rendering both an HTML site and a single PDF manual.

> Stacked on #273 (phase 1). Review/merge that first; this branch targets `docs/manual-structure`.

## What changed

- **`this page` → `this chapter`** across nine chapters (audio, devices, latency, visual, usage, troubleshooting, triggers, settings reference, developer guide), plus `each tool has its own page` → `…chapter` and `the relevant tool's page` → `…chapter`.
- **`triggers.md`** intro: the click-only "If you just want the steps, jump to …" reworded as a print-friendly cross-reference ("For the configuration steps alone, see …").
- **`installation.md`**: both `.btn` download buttons folded into inline prose links, so the Installation chapter reads identically in the HTML site and the PDF (where a styled button is only a link anyway). The two back-references to the removed leading button ("The button above…", "…button at the top of this page") were rewritten to format-neutral wording.
- **`contributing.md`**: two stale "download button" references (the install-asset note and the versioning note) updated to "download link" now that the buttons are gone.

No structural or content changes — that is phases 1 and 3. Same set of files reads the same in both outputs.

## Verification

`quarto render docs` builds clean; `check_links.py`, `check_pdf_links.py`, `check_manual.py`, and `mdformat --check` all pass. Put through a two-lens review (sweep correctness/completeness, de-buttoning integrity); the findings (the two stale "download button" references) are folded in.
