### PR TITLE
docs: trim installer narration and collapse cross-chapter duplication

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -123,14 +123,6 @@ source.
 automatically, with no restart needed. You can also force a rescan with the
 **Refresh devices (F5)** button in the Devices window.
 
-## Monitoring and volume
-
-To confirm a cue actually reaches the bedroom, use the Audio cue window's
-**Monitoring** meters — see
-[Audio cues](audio-cues.md#is-the-cue-reaching-the-bedroom). For the output safety
-cap, the per-cue gains, and how the Windows volume stages combine, see
-[Volume & latency](latency.md#chap-latency).
-
 ## Windows only
 
 This device and volume handling is Windows-specific (WASAPI, the volume mixer), and

--- a/docs/biocals.md
+++ b/docs/biocals.md
@@ -42,20 +42,18 @@ Each biocal's *start* code fires when its task window opens. A shared **complete
 code fires when the window runs out, and a shared **cancelled** code fires on an
 early stop (the preceding start code identifies which biocal). A played sequence is
 bracketed by its own start/stop codes and otherwise fires the same per-biocal
-markers. The defaults are sequence start/stop **105**/**106**, cancelled **107**,
-completed **108**, and one start code per biocal in the **110–126** band. All are
-retunable in the **Markers** window like any built-in event (see
-[Markers & port codes](triggers.md#chap-triggers)).
+markers. The default codes (sequence start/stop, cancelled, completed, and one start
+code per biocal) are listed in the [event-code table](triggers.md#default-event-codes)
+and retunable in the **Markers** window like any built-in event.
 
 ## Voice recordings
 
 Voice recordings ship inside SMACC (generated with
 [ElevenLabs](https://elevenlabs.io) text-to-speech) and are read straight from the
-bundle, so they stay current when you upgrade. To use another voice or language,
-drop your own recording under the same name in your SMACC directory's `biocals/`
-folder (for example `~/SMACC/biocals/`); a file there overrides the bundled one. A
-biocal with no recording in either place still runs, just unvoiced, and session
-start warns when that happens.
+bundle. To use another voice or language, drop your own recording under the same name
+in your SMACC directory's `biocals/` folder (for example `~/SMACC/biocals/`); a file
+there overrides the bundled one. A biocal with no recording in either place still
+runs unvoiced (session start warns when one is missing).
 
 The shared **Voice volume** rides the cue route, so the master output cap and the
 control-room monitor fan-out apply to instructions exactly as they do to cues (see

--- a/docs/devices.md
+++ b/docs/devices.md
@@ -19,36 +19,20 @@ sleep and lucid-dreaming experiments.
   [blinkstick.com](https://www.blinkstick.com/). SMACC drives them through the
   [`blinkstick`](https://pypi.org/project/BlinkStick/) Python library, so any
   model that library supports (BlinkStick Square, Strip, Nano, Flex, …) will work.
-- **Nothing else to install.** The BlinkStick driver is bundled inside
-  `SMACC.exe`, so you only need to plug the device into a USB port before
-  launching SMACC.
+- **Nothing else to install.** The BlinkStick driver is bundled inside `SMACC.exe`.
 
 ### Using it in SMACC
 
-1. Plug the BlinkStick into a USB port, then launch SMACC.
-1. Click **Visual cue** in the **Panels** column.
-1. Bind your BlinkStick to the **BlinkStick light** equipment in the **Devices** window
-   (in the **Panels** column). Plug one in after launch and it's detected
-   automatically, or click **Refresh devices (F5)** in the Devices window to rescan.
-1. Configure a light cue — color, brightness, pattern (steady, or a pulse/flash at
-   a rate in Hz), and length (or **Loop** until stopped) — and add more cues with
-   **+ Add cue** if the protocol needs several. See [Visual cues](visual.md#chap-visual) for
-   what each pattern is for.
-1. Click a cue's **Play** to fire it; **Stop** turns the light off early. The rest
-   of SMACC stays responsive while the light is on.
+Plug the BlinkStick into a USB port — it's detected automatically (otherwise click
+**Refresh devices (F5)** in the **Devices** window) — and bind it to the **BlinkStick
+light** equipment. Configure and fire light cues from the **Visual cue** window; see
+[Visual cues](visual.md#chap-visual) for the patterns and
+[Audio routing](audio.md#chap-audio) for the equipment-binding model.
 
 Your chosen device and the whole cue board are saved in the
-[SMACC file](smacc-files.md#chap-smacc-files), so the visual-cue
-setup travels with the rest of your configuration; the device is reconnected by
-serial on the next launch (and flagged if it isn't plugged in).
-
-::: {.callout-note}
-
-If the visual cue window reports that no light is set, open the **Devices**
-window and bind one to **BlinkStick light** (plug it in first; click
-**Refresh devices (F5)** there if it isn't listed). No restart needed.
-
-:::
+[SMACC file](smacc-files.md#chap-smacc-files), so the visual-cue setup travels with
+the rest of your configuration; the device is reconnected by serial on the next
+launch (and flagged if it isn't plugged in).
 
 ## Philips Hue
 

--- a/docs/eeg-annotator.md
+++ b/docs/eeg-annotator.md
@@ -6,9 +6,9 @@ annotations — saved as a small sidecar file next to the recording, which is
 **never modified**. It is a review tool, not a real-time display; nothing
 about it runs during a live session.
 
-It opens from the Launcher's **EEG Annotator** button and always runs as its own
-window and process — so you can keep reviewing last night's file while tonight's
-session runs.
+It is part of SMACC — nothing extra to install — and opens from the Launcher's
+**EEG Annotator** button. It always runs as its own window and process, so you can
+keep reviewing last night's file while tonight's session runs.
 
 **How it differs from a generic EEG viewer.** The Annotator is built for the
 overnight cueing workflow, not for clinical reading:
@@ -27,15 +27,6 @@ overnight cueing workflow, not for clinical reading:
 - Recordings are **memory-mapped**, so an 8-hour high-density night opens in
   seconds and scrolls smoothly regardless of file size.
 
-::: {.callout-note title="Built in, runs in its own process"}
-
-The Annotator is part of SMACC — there is nothing extra to install. It opens
-in its own process, so it can outlive the Launcher and a heavy recording can
-never disturb a running session; that is why it appears as a separate window
-rather than a panel inside the session app.
-
-:::
-
 ## Supported recordings
 
 | Format               | Open via                                        |
@@ -48,9 +39,7 @@ rather than a panel inside the session app.
 
 The open dialog's file filter is generated from this list, so it never drifts
 from what the tool can actually read. An *epoched* `.set` is not a continuous
-recording and is rejected with MNE's own message. Recordings are memory-mapped,
-never loaded whole: an 8-hour high-density night opens in seconds and scrolling
-stays smooth regardless of file size.
+recording and is rejected with MNE's own message.
 
 ## Viewing
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,16 +6,10 @@ then double-click it and click through. The installer:
 
 - installs SMACC **per-user** — no administrator rights or IT involvement needed;
 - adds a **Start menu** entry (and, if you opt in, a desktop shortcut);
-- associates **`.smacc` files**, so double-clicking one opens the **Start a session**
-  dialog with it preselected;
-- includes the **EEG Annotator** — the post-hoc
-  [EEG viewer/annotator](eeg-annotator.md#chap-eeg-annotator), opened from the Launcher;
-- registers an uninstaller — remove SMACC from **Settings › Apps** like any other
-  program. Uninstalling never touches your data: SMACC files, recordings, and
-  logs under `~/SMACC` (or your data directories) all stay put. The
-  uninstaller reminds you of this (and of the folder's location) when it
-  finishes, so finding the folder afterwards is expected — delete it manually
-  if you no longer need the data.
+- associates **`.smacc` files**;
+- registers an uninstaller (**Settings › Apps**) that never removes your data:
+  SMACC files, recordings, and logs under `~/SMACC` (or your data directories) stay
+  put — delete them manually if you no longer need them.
 
 Installing a newer version over an existing one upgrades it in place.
 
@@ -97,9 +91,8 @@ The rest of setup is covered in the relevant chapters:
 
 - **Your study configuration** lives in a portable [SMACC file](smacc-files.md#chap-smacc-files).
   SMACC seeds a `default.smacc` and opens it when you don't pick another, so it
-  works out of the box. The installer associates `.smacc` files; enable or repair
-  the association any time from **File › Associate .smacc files (Windows)** in the
-  Launcher.
+  works out of the box. To enable or repair the `.smacc` file association, see
+  [Opening a SMACC file](smacc-files.md#opening-a-smacc-file).
 - **Audio cues** go in the data directory's `cues/` folder, alongside the seeded
   `demo-*` cues — see [Audio cues](audio-cues.md#chap-audio-cues).
 - **Dream-report surveys** are managed from the Dream recording panel — see

--- a/docs/intercom.md
+++ b/docs/intercom.md
@@ -44,15 +44,14 @@ Clicking back into SMACC takes focus back. The participant window shows a banner
 *"● The keyboard is yours"* or *"○ Waiting"*, so a drowsy participant always knows
 whether typing will land.
 
-**Quick replies.** Canned messages save both sides from typing a full sentence at
-3 a.m., and they travel with the study. Click **Manage quick messages…** on the
+**Quick replies.** Canned messages travel with the study. Click **Manage quick
+messages…** on the
 Intercom panel to edit two lists: *experimenter prompts* (one click sends a
 standardized prompt, such as the lab's dream-report question or *"Are you awake?"*)
 and *participant replies* mapped to the number keys **1–9** (for example *"Got it"*,
 *"I'm awake"*, *"Yes"*, *"No"*). The participant's replies appear as large numbered
 chips; pressing a number sends that reply, but only while their entry box is empty,
-so a typed reply that contains digits still works. A sent preset is logged and
-marked exactly like a typed message.
+so a typed reply that contains digits still works.
 
 **What's recorded.** Every message is written verbatim to the session log as a
 `DEBUG` line (tick *Debug* above the log preview to watch the exchange live). By

--- a/docs/latency.md
+++ b/docs/latency.md
@@ -37,8 +37,7 @@ cap inside SMACC. That way one place, SMACC, determines how loud a cue is.
 
 How long is it from clicking **Play** (or firing a cue) to the participant actually
 hearing the sound or seeing the light, and how well does the event marker line up
-with it? This section answers that, shows how to measure it on your own rig, and
-explains what SMACC does to keep markers honest.
+with it?
 
 ::: {.callout-note title="The short version"}
 

--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -18,13 +18,11 @@ YYYY-MM-DD HH:MM:SS.mmm±HHMM, LEVEL, message
   offset (e.g. `-0500`). The offset lets a reader place the night on an absolute
   timeline — for example when overlaying the log on an EEG recording whose clock
   sits in another zone. Logs written before SMACC recorded the offset are
-  timezone-naive (no `±HHMM`); both forms are read back the same way. The *file*
-  is always 24-hour; the live on-screen preview can optionally show 12-hour
-  (AM/PM) time (Session window → **File → 12-hour clock**), which changes only the
-  display, not what is written.
+  timezone-naive (no `±HHMM`); both forms are read back the same way. The *file* is
+  always 24-hour; the live preview can optionally show 12-hour time (see
+  [`log_preview_clock`](preferences-file.md#preferences)).
 - **LEVEL** — a Python logging level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, or
-  `CRITICAL`. The file records every level; the live on-screen preview shows only a
-  configurable subset.
+  `CRITICAL`.
 - **message** — the log text. An **event-marker** line ends in `" - portcode N"`:
 
 ```text

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -22,9 +22,9 @@ night versus authoring a SMACC file.
 
 ## Opening SMACC
 
-Open the app to get the Launcher. SMACC never drops straight into a session; the one
-exception is double-clicking a `.smacc` file, which opens the **Start a session**
-dialog with that file preselected. From the Launcher:
+Open the app to get the Launcher. SMACC never drops straight into a session, except
+when you double-click a `.smacc` file (see
+[Opening a SMACC file](smacc-files.md#opening-a-smacc-file)). From the Launcher:
 
 - **Session…** — opens the **Start a session** dialog. Pick the **SMACC file** (the
   picker lists recent files, the seeded `default`, and **Browse…** for any other),
@@ -111,8 +111,6 @@ in `~/SMACC/preferences.yaml`, restored on the next launch (see the
 
 ## SMACC files
 
-A **SMACC file** captures your study's whole configuration — cue files, volumes,
-noise, visual cues, survey presets, event markers, display choices, and the **data
-directory** where runs are written — in a single portable `.smacc`. See
-[SMACC files](smacc-files.md#chap-smacc-files) for the full story, and the
+A **SMACC file** holds your study's whole configuration in one portable `.smacc` — see
+[SMACC files](smacc-files.md#chap-smacc-files), and the
 [SMACC file reference](reference/settings-file.md#chap-reference-settings-file) for the on-disk format.


### PR DESCRIPTION
Part of #248 — **phase 3 of the docs-as-manual stack** (stacked on #274). This is the trimming pass the issue originally asked for ("plenty of places where text could be trimmed… no need to say what the installer will do after it's double-clicked").

> Stacked on #274 → #273. Review/merge those first; this branch targets `docs/manual-idioms`.

Scope was **targeted trim of the worst offenders**, not a full rewrite. Net −50 lines, no structural or stylistic churn — narration and cross-chapter duplication only.

## What changed

- **`installation.md`**: collapsed the installer walk-through (the owner's cited example) — dropped the "includes the EEG Annotator" feature bullet and the uninstaller's meta-narration ("the uninstaller reminds you… finding the folder afterwards is expected"), keeping the load-bearing facts (per-user, Start-menu entry + opt-in shortcut, data is never removed). Deferred the `.smacc` association-repair steps to their canonical chapter.
- **Cross-chapter duplication → pointers**: `usage.md`'s re-told SMACC-file enumeration and double-click mechanics → `smacc-files.md`; `biocals.md`'s hard-coded default code numbers (105/106/…/126) → the auto-generated `triggers.md` event-code table (which is kept in lockstep with the code, so the manual can't drift); `audio.md`'s redundant "Monitoring and volume" section (both its links already appear earlier) deleted; `session-log.md`'s 12-hour-clock explanation → the `preferences-file.md` field that owns it.
- **De-duplicated within chapters**: `devices.md`'s 6-step BlinkStick walk-through → two sentences (binding lives in Audio routing, cue patterns in Visual cues) and a thrice-stated "bind it / F5 / no restart" callout removed; `eeg-annotator.md`'s "built-in, own-process" callout folded into the lede and a verbatim-duplicated memory-mapped sentence removed.
- Minor narration tails trimmed in `biocals.md`, `intercom.md`, `latency.md`.

## Verification

`quarto render docs` builds clean; `check_links.py`, `check_pdf_links.py`, `check_manual.py` (99-page manual, all tripwires present), and `mdformat --check` all pass. A three-lens content-loss review (content-loss critic, pointer-accuracy, over-trim/readability) confirmed every "see X" pointer lands on content that actually covers the removed material and no load-bearing fact was orphaned. Its one real finding — the Start-menu bullet was referenced later in the same chapter — is folded back in.
