### PR TITLE
docs: render PDF tables in the condensed cut, add CI font-fallback guard

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,18 @@ jobs:
       # catches cross-chapter links that go dead in the PDF (#262).
       - name: Render and check docs
         run: |
-          quarto render docs
+          # Fail the build if Typst can't resolve a font: that is only a *warning*, so
+          # the PDF would otherwise ship in a fallback face and no other check would
+          # notice (the reference tables lost their condensed cut this way, #268).
+          # set -o pipefail so a hard `quarto render` failure isn't masked by the tee —
+          # the default GitHub Actions shell is `bash -e` (errexit only, NO pipefail).
+          # The grep tracks Typst's current warning wording; revisit if Quarto is bumped.
+          set -o pipefail
+          quarto render docs 2>&1 | tee render.log
+          if grep -qi 'unknown font family' render.log; then
+            echo "::error::Typst could not resolve a font; the PDF fell back to a default face. Check docs/typst-preamble.typ and docs/assets/fonts."
+            exit 1
+          fi
           uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf
           uv run python scripts/check_links.py docs/_book
           uv run --extra docs python scripts/check_pdf_links.py docs/_book/SMACC-manual.pdf

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,7 +252,17 @@ jobs:
       - uses: quarto-dev/quarto-actions/setup@v2
       - name: Build the PDF manual
         run: |
-          quarto render docs --to typst
+          # This job renders the same docs and is what attaches the PDF to a release, so
+          # it carries its own copy of docs.yml's font-fallback guard — docs.yml gates
+          # the PR, not this run, and a font that Typst can't resolve is only a warning
+          # (the silent break in #268). set -o pipefail so a render failure isn't masked
+          # by the tee (the default GitHub Actions shell is `bash -e`, no pipefail).
+          set -o pipefail
+          quarto render docs --to typst 2>&1 | tee render.log
+          if grep -qi 'unknown font family' render.log; then
+            echo "::error::Typst could not resolve a font; the PDF fell back to a default face. Check docs/typst-preamble.typ and docs/assets/fonts."
+            exit 1
+          fi
           uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf
       # Attach the manual to the release this run publishes: the tag's release on a
       # tag, or the rolling `dev` pre-release on a main push. `gh release upload` only

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ htmlcov/
 # Quarto docs build output + cache (docs/_book, docs/.quarto)
 _book/
 .quarto/
+# Render log captured by the docs font-fallback guard (.github/workflows/*.yml)
+render.log

--- a/docs/typst-preamble.typ
+++ b/docs/typst-preamble.typ
@@ -81,7 +81,16 @@
   stroke: none,
   fill: (x, y) => if y == 0 { smacc-band } else if calc.even(y) { smacc-zebra },
 )
-#show table: set text(font: "IBM Plex Sans Condensed", size: 9pt)
+// The condensed cut is selected via the `stretch` axis, NOT by family name: Typst
+// groups the condensed faces under the "IBM Plex Sans" family and exposes their width
+// on the stretch axis (usWidthClass 3 = stretch 75%), so there is no "IBM Plex Sans
+// Condensed" family to name. With the old `font: "IBM Plex Sans Condensed"`, that
+// unknown family made Typst fall back to its default serif (Libertinus) — the silent
+// breakage that shipped the reference tables in the wrong face (#268). `stretch: 75%`
+// resolves the bundled condensed .ttf; the y:0 header rule below inherits it, so the
+// header is condensed-SemiBold-indigo. (HTML differs — CSS @font-face matches by name,
+// so smacc-fonts.scss keeps the literal "IBM Plex Sans Condensed".)
+#show table: set text(font: "IBM Plex Sans", stretch: 75%, size: 9pt)
 #show table.cell.where(y: 0): set text(fill: smacc-indigo, weight: 600)
 
 // ===== Headings — the display face, indigo to match the site. orange-book sets


### PR DESCRIPTION
Closes #268.

The last loose end from #268's manual-design work was a post-merge audit of the wide reference tables. Rendering the PDF locally surfaced a real defect: the table rule asked for `font: "IBM Plex Sans Condensed"`, but Typst groups the condensed faces under the `IBM Plex Sans` family and exposes their width on the stretch axis — so that family name is unknown and the PDF tables silently fell back to Typst's default serif (Libertinus), losing the condensed cut (the HTML side was unaffected — CSS `@font-face` matches by name).

## Changes

- `docs/typst-preamble.typ` — select the condensed cut via `stretch: 75%` instead of by family name; the `y:0` header rule inherits the stretch (condensed-SemiBold-indigo). Verified against a real render: the warning is gone and the tables render condensed.
- `.github/workflows/docs.yml` + `release.yml` — a silent font fallback is only a *warning*, so nothing caught it. Both render jobs now fail on an `unknown font family` warning, with `set -o pipefail` so a hard render failure isn't masked by the `tee` (the default Actions shell is `bash -e`, no pipefail).
- `.gitignore` — ignore the `render.log` the guard captures.

The remaining manual polish (version-stamped header, moon-phase dividers, bespoke cover) stays deferred in #278.

## Verification

`quarto render docs` is warning-free; the three doc checks (`check_manual.py`, `check_links.py`, `check_pdf_links.py`) all pass; the widest tables (triggers, settings reference) render condensed and within the A4 column.