### PR TITLE
docs: stamp the release on the manual cover

### DIFF
--- a/.claude/skills/quarto/SKILL.md
+++ b/.claude/skills/quarto/SKILL.md
@@ -113,3 +113,12 @@ injected the cover/footer version), and table styling. The brand color is
 Because the PDF engine is Typst, that custom cover/template work — and the screenshot
 framing, which must match in both outputs — will be authored in **Typst**, not
 CSS/Paged.js or LaTeX.
+
+The cover now carries the **release** (#261): CI appends it to the `subtitle` via
+`quarto render -M subtitle="User manual · v…"` in both `docs.yml` and `release.yml`
+(the version is read from the `__version__` literal with `sed` — no import; a tag shows
+the tag, any other ref shows `v…-dev+<sha>`, the `+<sha>` being PEP 440 / semver
+build-metadata for the commit the dev binary is also stamped with).
+No Typst fork — a local `quarto render` keeps the plain `subtitle` default. A per-page
+running header, moon part dividers, and a bespoke illustrated cover were declined
+(#278, closed not planned).

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,6 +36,22 @@ jobs:
       # catches cross-chapter links that go dead in the PDF (#262).
       - name: Render and check docs
         run: |
+          # Stamp the cover with the release this build represents (#261). This unscoped
+          # render stamps both the PDF and the HTML book cover; the HTML copy reaches Pages
+          # only on a stable tag (a dev string never deploys). A tagged
+          # build shows the tag (v0.1.2, v0.1.2-rc.1, … — the full literal, which always
+          # equals "v" + smacc.__version__ per the build-exe tag check); every other ref is
+          # a rolling dev build, carrying the commit as build metadata (v0.1.2-dev+<sha>,
+          # the +<sha> being PEP 440 / semver local-version syntax — the same <sha> the dev
+          # binary is stamped with). Read the version from the source literal, not via
+          # `uv run`/import — this lean job never syncs the smacc dependency tree. Mirrored
+          # in release.yml's build-pdf job (which ships the per-release PDF); keep in step.
+          version=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' src/smacc/__init__.py)
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            release="v$version"
+          else
+            release="v$version-dev+${GITHUB_SHA:0:7}"
+          fi
           # Fail the build if Typst can't resolve a font: that is only a *warning*, so
           # the PDF would otherwise ship in a fallback face and no other check would
           # notice (the reference tables lost their condensed cut this way, #268).
@@ -43,7 +59,7 @@ jobs:
           # the default GitHub Actions shell is `bash -e` (errexit only, NO pipefail).
           # The grep tracks Typst's current warning wording; revisit if Quarto is bumped.
           set -o pipefail
-          quarto render docs 2>&1 | tee render.log
+          quarto render docs -M subtitle="User manual · $release" 2>&1 | tee render.log
           if grep -qi 'unknown font family' render.log; then
             echo "::error::Typst could not resolve a font; the PDF fell back to a default face. Check docs/typst-preamble.typ and docs/assets/fonts."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,13 +252,24 @@ jobs:
       - uses: quarto-dev/quarto-actions/setup@v2
       - name: Build the PDF manual
         run: |
+          # Stamp the cover with the release this PDF is attached to (#261): the tag on a
+          # tag run, or "v<version>-dev+<sha>" on a main push (the +<sha> being PEP 440 /
+          # semver build-metadata syntax — the same <sha> the dev binary is stamped with).
+          # Mirrors the block in docs.yml's build job (read straight from the source literal
+          # — this job never syncs the smacc dependency tree); keep the two in step.
+          version=$(sed -n 's/^__version__ = "\(.*\)"/\1/p' src/smacc/__init__.py)
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            release="v$version"
+          else
+            release="v$version-dev+${GITHUB_SHA:0:7}"
+          fi
           # This job renders the same docs and is what attaches the PDF to a release, so
           # it carries its own copy of docs.yml's font-fallback guard — docs.yml gates
           # the PR, not this run, and a font that Typst can't resolve is only a warning
           # (the silent break in #268). set -o pipefail so a render failure isn't masked
           # by the tee (the default GitHub Actions shell is `bash -e`, no pipefail).
           set -o pipefail
-          quarto render docs --to typst 2>&1 | tee render.log
+          quarto render docs --to typst -M subtitle="User manual · $release" 2>&1 | tee render.log
           if grep -qi 'unknown font family' render.log; then
             echo "::error::Typst could not resolve a font; the PDF fell back to a default face. Check docs/typst-preamble.typ and docs/assets/fonts."
             exit 1

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -12,6 +12,10 @@ project:
 
 book:
   title: SMACC
+  # CI OVERRIDES this on the cover via `-M subtitle=…` (docs.yml and release.yml, #261),
+  # e.g. "User manual · v0.1.2". `-M` replaces — it does not append — so the "User manual"
+  # prefix is duplicated in those two workflows; editing this default alone does NOT change
+  # the CI cover (keep the three in sync). A local `quarto render` keeps this default.
   subtitle: User manual
   author: Remington Mallett
   favicon: assets/icon.png


### PR DESCRIPTION
Stamps the SMACC release onto the PDF manual cover (and, on a stable tag, the live HTML site cover), closing #261.

Both doc-render jobs (`docs.yml` build, `release.yml` build-pdf) read the release from the `__version__` literal and pass it to Quarto via `-M subtitle="User manual · $release"`:

- a tag shows the tag — `v0.1.2`, `v0.1.2-rc.1`, … (the literal always equals `v` + `__version__`);
- any other ref is a rolling dev build and carries the commit as build metadata — `v0.1.2-dev+<sha>` (PEP 440 / semver local-version syntax, the same `<sha>` the dev binary is stamped with).

No Typst template fork: a local `quarto render` keeps the plain "User manual" default. The deferred decorative polish in #278 (per-page running header, moon part dividers, bespoke illustrated cover) is declined and that issue is closed not-planned.

Verified locally: full `quarto render docs` plus `check_manual` / `check_links` / `check_pdf_links` all pass with the dev-style subtitle, the `·` glyph renders (not tofu), and the font-fallback guard stays clean.