### PR TITLE
docs: render the manual body, cover, and code in IBM Plex

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,11 +29,12 @@ jobs:
       - uses: quarto-dev/quarto-actions/setup@v2
 
       # Render the HTML site and the single-file PDF manual from docs/, on every PR
-      # and push, so docs breakage is caught early. Three guards replace
+      # and push, so docs breakage is caught early. Four guards replace
       # `mkdocs build --strict`: check_manual catches a renderer silently truncating
       # the PDF (#250); check_links validates every internal cross-link and heading
       # anchor in the HTML site (the main migration footgun, #259); check_pdf_links
-      # catches cross-chapter links that go dead in the PDF (#262).
+      # catches cross-chapter links that go dead in the PDF (#262); check_pdf_fonts
+      # catches body/code text silently falling back off IBM Plex (#283).
       - name: Render and check docs
         run: |
           # Stamp the cover with the release this build represents (#261). This unscoped
@@ -67,6 +68,7 @@ jobs:
           uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf
           uv run python scripts/check_links.py docs/_book
           uv run --extra docs python scripts/check_pdf_links.py docs/_book/SMACC-manual.pdf
+          uv run --extra docs python scripts/check_pdf_fonts.py docs/_book/SMACC-manual.pdf
 
       # Only a stable release (a `vX.Y.Z` tag with no pre-release suffix) publishes the
       # live site, so it always reflects the current stable version — never a dev or

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,10 +264,12 @@ jobs:
             release="v$version-dev+${GITHUB_SHA:0:7}"
           fi
           # This job renders the same docs and is what attaches the PDF to a release, so
-          # it carries its own copy of docs.yml's font-fallback guard — docs.yml gates
-          # the PR, not this run, and a font that Typst can't resolve is only a warning
-          # (the silent break in #268). set -o pipefail so a render failure isn't masked
-          # by the tee (the default GitHub Actions shell is `bash -e`, no pipefail).
+          # it carries its own copy of docs.yml's font guards — docs.yml gates the PR, not
+          # this run. The grep catches a font Typst can't resolve (only a warning — the
+          # silent break in #268); check_pdf_fonts catches text that resolves but renders
+          # off IBM Plex (the orange-book mainfont gap, #283). set -o pipefail so a render
+          # failure isn't masked by the tee (the default GitHub Actions shell is `bash -e`,
+          # no pipefail).
           set -o pipefail
           quarto render docs --to typst -M subtitle="User manual · $release" 2>&1 | tee render.log
           if grep -qi 'unknown font family' render.log; then
@@ -275,6 +277,7 @@ jobs:
             exit 1
           fi
           uv run --extra docs python scripts/check_manual.py docs/_book/SMACC-manual.pdf
+          uv run --extra docs python scripts/check_pdf_fonts.py docs/_book/SMACC-manual.pdf
       # Attach the manual to the release this run publishes: the tag's release on a
       # tag, or the rolling `dev` pre-release on a main push. `gh release upload` only
       # adds/replaces the asset and never touches release metadata — build-exe owns

--- a/docs/typst-preamble.typ
+++ b/docs/typst-preamble.typ
@@ -15,6 +15,17 @@
 #let smacc-band = rgb("#eef0fb")
 #let smacc-zebra = rgb("#f4f5fc")
 
+// ===== Base fonts — orange-book's `book()` sets text SIZE but never a font FAMILY, and
+// takes no `font`/`mainfont` argument, so Quarto's `mainfont`/`codefont` (_quarto.yml) are
+// silently dropped: the body, the cover/title page, and code all fall back to Typst's
+// defaults (Libertinus Serif + DejaVu Mono). `include-in-header` runs before `book.with`,
+// so setting the base here makes it the document default that `book()` preserves (it only
+// overrides size). THIS is what puts IBM Plex on the body and cover — the `#show heading`
+// and `#show table` rules below only reach those elements. (HTML is unaffected; that path
+// honours mainfont/codefont directly.)
+#set text(font: "IBM Plex Sans")
+#show raw: set text(font: "IBM Plex Mono")
+
 // ===== Callouts — remap Quarto's per-type colours to the SMACC palette and reshape
 // to match the HTML site: rounded, a soft tint fill, a 4pt left accent bar, bold
 // title. Quarto passes the type's colour as `icon_color` — note is already indigo

--- a/scripts/check_pdf_fonts.py
+++ b/scripts/check_pdf_fonts.py
@@ -1,0 +1,73 @@
+"""IBM Plex enforcement for the single-file PDF manual.
+
+orange-book's ``book()`` sets text *size* but never a font *family* and takes no
+``mainfont``/``codefont`` argument, so unless ``docs/typst-preamble.typ`` sets the base
+font explicitly, the body, cover, and code silently fall back to Typst's defaults
+(Libertinus Serif / DejaVu Sans Mono). That fallback raises no ``unknown font family``
+warning, so it shipped twice unnoticed — the condensed tables (#268), then the whole
+body (#283) — which the existing warning-grep guard could not catch.
+
+This guard reads the font behind every text span in the rendered PDF and fails if any
+*letter or digit* is drawn in a non-IBM-Plex font: Plex covers every ASCII alphanumeric,
+so an alphanumeric in another font is the signature of the fallback bug. Symbol glyphs
+Plex genuinely lacks (the ▲▼ / ●○ / ✕ UI markers, callout icons, …) are allowed to fall
+back, which also keeps the check platform-independent — the bundled Plex faces render
+identically on every runner, and only those symbol fallbacks vary by OS (e.g. Segoe UI
+Emoji locally vs DejaVu on Linux), but they never carry alphanumeric text. Run in CI
+after the PDF build:
+
+    uv run --extra docs python scripts/check_pdf_fonts.py docs/_book/SMACC-manual.pdf
+
+Exits non-zero (listing the offending fonts and a sample) if any text is not Plex.
+"""
+
+import re
+import sys
+
+from pypdf import PdfReader
+
+# A subset-embedded font carries a six-letter tag like ``ABCDEF+``; strip it to the
+# family. Every bundled face — Sans, Mono, Sans Condensed, all weights/styles — shares
+# the ``IBMPlex`` stem, so a single substring test covers them all.
+_SUBSET = re.compile(r"^/[A-Z]{6}\+")
+_PLEX = "IBMPlex"
+
+
+def _offenders(reader: PdfReader) -> dict[str, tuple[int, str]]:
+    """Map each non-Plex font drawing alphanumerics to its first (page, sample)."""
+    hits: dict[str, tuple[int, str]] = {}
+    for number, page in enumerate(reader.pages, start=1):
+
+        def visit(text, cm, tm, font, size, _n=number):
+            if not font:
+                return
+            family = _SUBSET.sub("", str(font.get("/BaseFont", "")))
+            if _PLEX in family:
+                return
+            # Plex has every ASCII letter/digit, so one drawn in another font is the
+            # fallback bug; symbol-only spans (shapes, icons, emoji) are legitimate.
+            if any(c.isascii() and c.isalnum() for c in text):
+                hits.setdefault(family, (_n, text.strip()[:50]))
+
+        page.extract_text(visitor_text=visit)
+    return hits
+
+
+def main(path: str) -> int:
+    hits = _offenders(PdfReader(path))
+    if hits:
+        print(
+            f"FAIL: {path} draws text in non-IBM-Plex fonts (mainfont/codefont not applied?)"
+        )
+        for family, (number, sample) in sorted(hits.items()):
+            print(f"  - {family}  p.{number}  «{sample}»")
+        print(
+            "  (set the base font in docs/typst-preamble.typ; orange-book ignores mainfont)"
+        )
+        return 1
+    print(f"OK: {path} (all alphanumeric text is IBM Plex; symbol fallbacks allowed)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "docs/_book/SMACC-manual.pdf"))


### PR DESCRIPTION
The manual's body text, title page, and code were silently rendering in Typst's default fonts — Libertinus Serif and DejaVu Sans Mono — instead of IBM Plex.

**Root cause.** orange-book's `book()` sets text *size* but never a font *family*, and takes no `font`/`mainfont` argument, so the `mainfont: "IBM Plex Sans"` / `codefont: "IBM Plex Mono"` in `docs/_quarto.yml` are dropped on the Typst path. Only headings and tables looked right, because `docs/typst-preamble.typ` set those explicitly via `#show` rules; the body, cover, and `raw` (code) fell through to Typst's defaults. No font-fallback warning fires — IBM Plex resolves fine, it was just never applied to the body — so the existing `unknown font family` CI guard could not catch it.

**Fix.** Set the base font in `typst-preamble.typ`, which `include-in-header` injects before `book.with`, so `book()`'s size-only rule preserves it:

- `#set text(font: "IBM Plex Sans")` — body + cover/title page
- `#show raw: set text(font: "IBM Plex Mono")` — inline + block code

**Regression guard.** Added `scripts/check_pdf_fonts.py`, wired into both `docs.yml` and `release.yml`'s `build-pdf`. It reads the font behind every text span in the rendered PDF and fails if any **letter or digit** is drawn in a non-IBM-Plex font — the exact signature of this bug, since Plex covers all ASCII alphanumerics. Symbol glyphs Plex genuinely lacks (the ▲▼ / ●○ / ✕ UI markers in the prose, callout icons, …) are allowed to fall back, which also keeps the check platform-independent (the bundled Plex faces render identically on every runner; only those symbol fallbacks vary by OS, and they never carry text). The existing `unknown font family` grep couldn't see this class — it catches a *missing* font, not one that resolves but is never *applied*.

**Where it was introduced.** #277 (commit 6ff2f94), which added `mainfont`/`codefont` and created the preamble on the assumption they reached the body. Same "orange-book ignores the font → silent Libertinus fallback" failure mode as the condensed-table bug fixed in #280 (#268) — now on the body and cover.

**Verified locally:** every page of the rendered PDF embeds only IBM Plex for text; the new guard passes on the fixed PDF and fails (exit 1, naming Libertinus/DejaVu) on a render with the fix reverted; `check_manual` / `check_links` / `check_pdf_links` / `check_pdf_fonts` all pass; font-fallback grep clean.