### PR TITLE
docs: stop PDF manual table columns from overlapping

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -88,6 +88,11 @@ format:
   typst:
     papersize: a4
     number-sections: true
+    # Let Typst size table columns to their content (auto) instead of honouring Pandoc's
+    # dash-derived percentage widths. Those widths starve a narrow column (e.g. a 1.7%
+    # "Version" column next to a wide "Changes" column), and long unbreakable tokens — code
+    # spans in mono, single-word headers — overflow and overlap the neighbouring column.
+    tbl-colwidths: false
     # Bundled brand fonts (the .ttf under assets/fonts, found via a project-relative
     # font-paths — never absolute, and never also TYPST_FONT_PATHS). mainfont/codefont
     # match each font's internal family name. Headings (and the Condensed table cut)


### PR DESCRIPTION
## Problem

Several tables in the exported PDF manual render with their columns **overlapping** — text from one column drawn on top of the next. Examples: the *Version history* table (\"Ve / Changes\" with \"sion\" stacked under it), the *preferences.yaml* field tables (the \`log_preview_*\` keys colliding with the Type and Meaning columns), and the session-log level table.

## Cause

Quarto/Pandoc derives each Typst table's column widths from the Markdown separator dashes and emits them as fixed percentages. mdformat pads the dashes to the column's content width, so a table with one very wide column (e.g. *Changes*, *Meaning*) starves the narrow columns down to near-zero:

- *Version history*: \`columns: (1.72%, 98.28%)\`
- session-log level table: \`columns: (5.05%, 94.95%)\`

A 1.7%-wide column can't fit even a single word. Single-word headers (*Version*, *Level*) and unbreakable mono code spans (\`log_preview_max_lines\`) overflow their cell and overlap the neighbouring column rather than wrapping.

## Fix

Set \`tbl-colwidths: false\` on the typst format. Quarto then emits \`columns: N\` (auto-sized) instead of the dash-derived percentages, and Typst sizes each table to its content — wrapping the wide column instead of starving the narrow ones.

## Verification

- Rendered the manual locally (\`quarto render docs --to typst\`); the previously-overlapping tables now render cleanly, with narrow columns sized to their content and the wide column wrapping.
- \`check_manual.py\` and \`check_pdf_links.py\` both pass (99 pages, all tripwire content present, no dead intra-book links).

Scoped to the table overlap only. The part-divider page overlap (the *Running a session* title over its mini-outline) is left for the planned outline revamp.