### PR TITLE
refactor: name run log session.log instead of repeating the folder timestamp

### DIFF
--- a/docs/reference/session-log.md
+++ b/docs/reference/session-log.md
@@ -1,7 +1,7 @@
 # Session log (`.log`) {#chap-reference-session-log}
 
-Every live run writes one plain-text log to its own timestamped folder
-(`smacc-YYYYmmdd-HHMMSS/`) under the study's data directory. It is the session's
+Every live run writes one plain-text log (`session.log`) to its own timestamped
+folder (`smacc-YYYYmmdd-HHMMSS/`) under the study's data directory. It is the session's
 record: every event marker, the soft interactions (volume / colour / device changes),
 and two embedded snapshots of the full settings the run used. The **Editor**
 (which records nothing) writes no log.

--- a/docs/smacc-files.md
+++ b/docs/smacc-files.md
@@ -48,8 +48,8 @@ data directory you like (they can share one).
 
 Every SMACC file names a **data directory** — where its runs are written. Each
 session started from the file gets its own timestamped folder under that
-directory (e.g. `smacc-20260607-223015/`) holding the run's `.log`,
-dream-report recordings, survey responses, and any exports. Set it in the
+directory (e.g. `smacc-20260607-223015/`) holding the run's log
+(`session.log`), dream-report recordings, survey responses, and any exports. Set it in the
 Editor (**Change data directory…**); choose it deliberately, since it
 determines where a night's data ends up.
 

--- a/src/smacc/analyze.py
+++ b/src/smacc/analyze.py
@@ -39,17 +39,18 @@ def format_duration(seconds: float) -> str:
 
 
 def find_log_in_dir(folder: Path, *, recursive: bool = False) -> Path | None:
-    """Return the SMACC ``.log`` in ``folder`` (prefer the one named like it), or None.
+    """Return the SMACC ``.log`` in ``folder`` (prefer ``session.log``), or None.
 
-    ``recursive`` searches subfolders too (used for an extracted zip, where the log
-    may sit under ``sessions/<stem>/``).
+    A run writes its log as ``session.log`` (#286); that name wins when present,
+    otherwise the first ``.log`` found is used. ``recursive`` searches subfolders
+    too (used for an extracted zip, where the log may sit under ``sessions/<stem>/``).
     """
     globber = folder.rglob if recursive else folder.glob
     logs = sorted(globber("*.log"))
     if not logs:
         return None
-    named = folder / f"{folder.name}.log"
-    return named if named in logs else logs[0]
+    preferred = folder / "session.log"
+    return preferred if preferred in logs else logs[0]
 
 
 def extract_zip(zip_path: Path, dest: Path) -> None:

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -150,15 +150,15 @@ class SmaccSession:
         if design:
             # No run artifacts: a logger that records nothing, no folder, no outlet.
             self.session_dir: Path | None = None
-            self.stem: str | None = None
             self.log_path: Path | None = None
             self.outlet: StreamOutlet | None = None
             self.init_design_logger()
         else:
             session_dir = make_session_dir(self.data_dir, now)
             self.session_dir = session_dir
-            self.stem = session_dir.name
-            log_path = session_dir / f"{session_dir.name}.log"
+            # The run folder already carries the launch timestamp, so the log is a
+            # fixed name inside it (#286) rather than repeating the timestamp.
+            log_path = session_dir / "session.log"
             self.log_path = log_path
             self.init_logger(log_path)
             # Breadcrumb in the persistent crash log: a faulthandler dump has

--- a/tests/test_analyze.py
+++ b/tests/test_analyze.py
@@ -18,11 +18,11 @@ def test_format_duration_drops_leading_zero_units():
     assert analyze.format_duration(3661) == "1h 1m 1s"
 
 
-def test_find_log_in_dir_prefers_the_log_named_like_the_folder(tmp_path):
+def test_find_log_in_dir_prefers_session_log(tmp_path):
     folder = tmp_path / "smacc-20260101-000000"
     folder.mkdir()
     (folder / "other.log").write_text("x", encoding="utf-8")
-    named = folder / "smacc-20260101-000000.log"
+    named = folder / "session.log"
     named.write_text("x", encoding="utf-8")
     assert analyze.find_log_in_dir(folder) == named
 
@@ -34,7 +34,7 @@ def test_find_log_in_dir_returns_none_when_absent(tmp_path):
 def test_find_log_in_dir_recursive_finds_nested_log(tmp_path):
     nested = tmp_path / "sessions" / "smacc-x"
     nested.mkdir(parents=True)
-    log = nested / "smacc-x.log"
+    log = nested / "session.log"
     log.write_text("x", encoding="utf-8")
     assert analyze.find_log_in_dir(tmp_path, recursive=True) == log
     assert analyze.find_log_in_dir(tmp_path) is None  # not at the top level
@@ -91,7 +91,7 @@ def test_window_shows_itself_on_construction(analyze_window):
 def test_open_in_annotator_launches_with_the_log(analyze_window, tmp_path, monkeypatch):
     calls: list[list[str] | None] = []
     monkeypatch.setattr(eeg, "launch", lambda args=None: calls.append(args) or True)
-    log = tmp_path / "smacc-x.log"
+    log = tmp_path / "session.log"
     log.write_text(A_LOG, encoding="utf-8")
     analyze_window._load_log(log, log.parent)
     assert analyze_window.annotateButton.isEnabled()
@@ -103,7 +103,7 @@ def test_annotate_button_disabled_until_a_session_loads(analyze_window, tmp_path
     # The handoff has nothing to hand off until a session is loaded; the EEG
     # Annotator itself is always present (it ships inside the one SMACC binary).
     assert not analyze_window.annotateButton.isEnabled()
-    log = tmp_path / "smacc-y.log"
+    log = tmp_path / "session.log"
     log.write_text(A_LOG, encoding="utf-8")
     analyze_window._load_log(log, log.parent)
     assert analyze_window.annotateButton.isEnabled()
@@ -119,7 +119,7 @@ def test_handoff_copies_a_zip_extracted_log_out_of_temp(
     monkeypatch.setattr(eeg, "launch", lambda args=None: launched.append(args) or True)
     temp = tmp_path / "smacc-analyze-xyz"
     temp.mkdir()
-    log = temp / "smacc-x.log"
+    log = temp / "session.log"
     log.write_text(A_LOG, encoding="utf-8")
     analyze_window._load_log(log, temp)
     analyze_window._temp_dirs.append(temp)  # as _load_zip records it
@@ -137,7 +137,7 @@ def test_handoff_passes_a_real_log_path_through_unchanged(
 ):
     launched: list[list[str] | None] = []
     monkeypatch.setattr(eeg, "launch", lambda args=None: launched.append(args) or True)
-    log = tmp_path / "smacc-z.log"
+    log = tmp_path / "session.log"
     log.write_text(A_LOG, encoding="utf-8")
     analyze_window._load_log(log, log.parent)  # not under a temp dir
     analyze_window.open_in_annotator()

--- a/tests/test_bids.py
+++ b/tests/test_bids.py
@@ -132,7 +132,7 @@ def test_summarize_log_empty():
 
 
 def test_convert_log_file_writes_tsv_and_sidecar(tmp_path):
-    log = tmp_path / "smacc-20260605-220000.log"
+    log = tmp_path / "session.log"
     log.write_text(SAMPLE_LOG, encoding="utf-8")
     out = tmp_path / "events.tsv"
     count = bids.convert_log_file(log, out)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -33,10 +33,6 @@ def test_make_session_dir_uses_timestamp_stem(tmp_path):
     assert session_dir.name == "smacc-20260607-223015"
     assert session_dir.is_dir()
     assert session_dir.parent == tmp_path
-    # The log filename keeps the smacc- prefix and .log extension (issue #40).
-    log_path = session_dir / f"{session_dir.name}.log"
-    assert log_path.name.startswith("smacc-")
-    assert log_path.suffix == ".log"
 
 
 def test_make_session_dir_resolves_same_second_collision(tmp_path):
@@ -51,6 +47,16 @@ def test_make_session_dir_resolves_same_second_collision(tmp_path):
 
 
 # ----- design-mode sessions (study designer) --------------------------------
+
+
+def test_live_session_log_is_named_session_log(live_session):
+    # The run folder carries the launch timestamp; the log is a fixed name inside
+    # it rather than repeating the timestamp (#286).
+    log_path = live_session.log_path
+    assert log_path is not None
+    assert log_path.name == "session.log"
+    assert log_path.parent == live_session.session_dir
+    assert log_path.is_file()
 
 
 def test_design_session_creates_no_run_artifacts(tmp_path):


### PR DESCRIPTION
Closes #286.

A run folder is already named by the launch timestamp (`smacc-YYYYmmdd-HHMMSS/`), so naming the log after the folder repeated the timestamp in the path (`smacc-…/smacc-….log`). The log is now a fixed `session.log` inside the folder — nothing identifying is lost, and the path is easier to reference. (The `smacc-`/timestamp filename came from #40, when logs lived flat in one directory; per-run folders made it redundant.)

- `session.py`: log is `session_dir / "session.log"`; dropped the dead `self.stem` attribute (set but never read).
- `analyze.py`: `find_log_in_dir` prefers `session.log`, falling back to the first `.log` found.
- Docs (`session-log.md`, `smacc-files.md`) name the file.
- Tests updated; old run-log-naming fixtures across `test_analyze.py`/`test_bids.py`/`test_session.py` switched to `session.log`, plus a live-session test asserting the real filename.

Verified: `pytest tests/test_session.py tests/test_analyze.py tests/test_bids.py tests/test_panels_chat.py` passes; ruff format/lint clean.