### PR TITLE
docs: publish llms.txt and per-page markdown from the Quarto book

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -12,6 +12,10 @@ project:
 
 book:
   title: SMACC
+  # Populates the HTML pages' <meta name="description">. The llms.txt summary is read
+  # from a SEPARATE path (website: description below) — Quarto does not share the two,
+  # so the same string lives in both blocks (#294).
+  description: "Sleep Manipulation And Communication Clickything (SMACC) is a control panel for running dream engineering studies."
   # CI OVERRIDES this on the cover via `-M subtitle=…` (docs.yml and release.yml, #261),
   # e.g. "User manual · v0.1.2". `-M` replaces — it does not append — so the "User manual"
   # prefix is duplicated in those two workflows; editing this default alone does NOT change
@@ -68,6 +72,17 @@ book:
     - release-notes.md
     - contributing.md
     - about.md
+
+# A book is internally a Quarto website, but it does NOT re-expose website-level options
+# under book:/project:/format — so `llms-txt` (the only switch that emits llms.txt + the
+# per-page *.llms.md twins) must live in a top-level website: block (#294). Verified: the
+# same flag placed under book:, project:, or format.html is silently ignored. This block
+# does NOT create a second site — it merges into the one HTML site rendered to _book/.
+# Keep llms-txt here; "tidying" it into book: would silently stop the llms output.
+website:
+  # Drives the llms.txt summary line; see the book: description above (the two don't share).
+  description: "Sleep Manipulation And Communication Clickything (SMACC) is a control panel for running dream engineering studies."
+  llms-txt: true
 
 format:
   html:


### PR DESCRIPTION
Closes #294.

Enables Quarto's llms.txt output so the docs site publishes an `llms.txt` index plus a clean Markdown twin (`*.llms.md`) of every page.

`llms-txt` is a website-level option that Quarto does not re-expose under `book:`/`project:`/`format` — the flag is silently ignored in those positions (verified against Quarto 1.9). Since a book is internally a website, the switch is set in a top-level `website:` block that merges into the same single site; the book and PDF are unaffected. The tagline is set as `description` in both `book:` (HTML `<meta description>`) and `website:` (the llms.txt summary line), which Quarto reads from separate paths.

Verified with a full `quarto render docs`: PDF still builds, all pages pass `check_links.py`, and `llms.txt` plus the per-page `*.llms.md` files are emitted (picked up by the existing Pages deploy with no CI change).