### PR TITLE
feat: add a pure StudyConfig model and .smacc serializers

### DIFF
--- a/src/smacc/studyconfig.py
+++ b/src/smacc/studyconfig.py
@@ -1,0 +1,425 @@
+"""StudyConfig: the in-memory model of a study's configuration (a ``.smacc``).
+
+Pure and Qt-free — no widgets, no I/O, no YAML. A domain-grouped dataclass tree
+that is the single source of truth for a study's settings, with a flat-wire
+projection that round-trips the ``.smacc`` *settings* mapping.
+
+The tree groups settings by domain (cueing, markers, surveys, interface) for
+authoring, but :meth:`StudyConfig.to_settings_dict` /
+:meth:`StudyConfig.from_settings_dict` speak the historical *flat* layout that
+:mod:`smacc.settings` reads and writes, emitting keys in the exact order
+``SmaccWindow.gather_settings`` produces them. The four existing pure models
+(:class:`smacc.devices.DeviceConfig`, :class:`smacc.triggers.TriggerConfig`,
+:class:`smacc.hue.HueConfig`, and the :mod:`smacc.events` registry) are reused as
+sub-models, never reinvented, and each block is serialized through its owning
+module's emitter.
+
+Two fields use a ``None`` sentinel to mean *unspecified*: ``biocals.rows`` and the
+two chat-preset lists. A study that omits them keeps the panels' seeded defaults
+on load (matching today's ``apply_state``), so the model preserves the absence
+rather than inventing a value; a real list (even empty) is honored verbatim.
+
+Metadata (subject/session/notes) is deliberately *not* part of a StudyConfig: it
+rides at the settings *envelope* level (see :func:`smacc.settings.build_payload`),
+so one configuration re-runs under a new subject.
+
+Paths stay plain ``str`` at every layer: :mod:`smacc.settings` relativizes and
+resolves the three path-bearing slots (``cues[*].file``, ``noise_file``,
+``data_directory``) on the flat dict, before/after this model ever sees it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from . import biocals, devices, events, hue, triggers
+
+# ---------------------------------------------------------------------------
+# Lenient coercion helpers (mirror each panel's apply_state tolerance)
+# ---------------------------------------------------------------------------
+
+
+def _coerce_float(value: object, default: float) -> float:
+    """Best-effort float; ``default`` on a bool or anything unparseable."""
+    if isinstance(value, bool):  # bool is an int subclass; never a real scalar here
+        return default
+    try:
+        return float(value)  # type: ignore[arg-type]  # guarded by except
+    except (TypeError, ValueError):
+        return default
+
+
+def _coerce_int(value: object, default: int) -> int:
+    """Best-effort int; ``default`` on a bool or anything unparseable."""
+    if isinstance(value, bool):
+        return default
+    try:
+        return int(value)  # type: ignore[call-overload]  # guarded by except
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_list(value: object) -> list:
+    """Return ``value`` if it is a list, else an empty list."""
+    return value if isinstance(value, list) else []
+
+
+def _presets_from(settings: dict, key: str) -> list[str] | None:
+    """Read a chat-preset list: present -> list of str, absent -> ``None`` sentinel."""
+    if key not in settings:
+        return None
+    value = settings[key]
+    if not isinstance(value, list):
+        return []  # present but malformed reads as a deliberate clear
+    return [str(item) for item in value]
+
+
+# ---------------------------------------------------------------------------
+# Cueing leaves
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AudioCue:
+    """One audio-cue slot (an entry of the flat ``cues`` list)."""
+
+    name: str = ""
+    file: str = ""  # path-bearing; relativized by smacc.settings, kept as str
+    volume: float = 0.2
+    loop: bool = False
+
+
+@dataclass
+class VisualCue:
+    """One visual-cue slot (an entry of the flat ``visual_cues`` list)."""
+
+    name: str = ""
+    color: str = "#ff0000"
+    brightness: float = 1.0
+    pattern: str = "steady"
+    rate: float = 1.0
+    length: float = 1.0
+    loop: bool = False
+
+
+def cue_to_dict(cue: AudioCue) -> dict[str, Any]:
+    """Serialize one audio cue to its ``cues`` wire dict (shared with the panel)."""
+    return {
+        "name": cue.name,
+        "file": cue.file,
+        "volume": cue.volume,
+        "loop": cue.loop,
+    }
+
+
+def cue_from_dict(data: dict) -> AudioCue:
+    """Build an :class:`AudioCue` from a ``cues`` wire dict (lenient)."""
+    return AudioCue(
+        name=str(data.get("name", "")),
+        file=str(data.get("file", "")),
+        volume=_coerce_float(data.get("volume"), 0.2),
+        loop=bool(data.get("loop", False)),
+    )
+
+
+def visual_cue_to_dict(cue: VisualCue) -> dict[str, Any]:
+    """Serialize one visual cue to its ``visual_cues`` wire dict (shared with panel)."""
+    return {
+        "name": cue.name,
+        "color": cue.color,
+        "brightness": cue.brightness,
+        "pattern": cue.pattern,
+        "rate": cue.rate,
+        "length": cue.length,
+        "loop": cue.loop,
+    }
+
+
+def visual_cue_from_dict(data: dict) -> VisualCue:
+    """Build a :class:`VisualCue` from a ``visual_cues`` wire dict (lenient)."""
+    return VisualCue(
+        name=str(data.get("name", "")),
+        color=str(data.get("color", "#ff0000")),
+        brightness=_coerce_float(data.get("brightness"), 1.0),
+        pattern=str(data.get("pattern", "steady")),
+        rate=_coerce_float(data.get("rate"), 1.0),
+        length=_coerce_float(data.get("length"), 1.0),
+        loop=bool(data.get("loop", False)),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cueing sections
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AudioConfig:
+    cues: list[AudioCue] = field(default_factory=list)
+    attack: float = 0.0  # wire: cue_attack
+    release: float = 0.0  # wire: cue_release
+
+
+@dataclass
+class VisualConfig:
+    cues: list[VisualCue] = field(default_factory=list)
+    attack: float = 0.0  # wire: visual_attack
+    release: float = 0.0  # wire: visual_release
+
+
+@dataclass
+class NoiseConfig:
+    volume: float = 0.2  # wire: noise_volume
+    color: str = "white"  # wire: noise_color
+    source: str = "builtin"  # wire: noise_source ("builtin" | "file")
+    file: str = ""  # wire: noise_file (path-bearing, str)
+
+
+@dataclass
+class BiocalsConfig:
+    voice_volume: float = 0.5
+    # None == "unspecified": emit only voice_volume (matching a trimmed file) and,
+    # on apply, keep the panel's default stack. A real (possibly empty) list is
+    # honored verbatim through biocals.rows_to_list / rows_from_list.
+    rows: list[biocals.BiocalRow] | None = None
+
+
+@dataclass
+class CueingConfig:
+    audio: AudioConfig = field(default_factory=AudioConfig)
+    visual: VisualConfig = field(default_factory=VisualConfig)
+    noise: NoiseConfig = field(default_factory=NoiseConfig)
+    biocals: BiocalsConfig = field(default_factory=BiocalsConfig)
+
+
+# ---------------------------------------------------------------------------
+# Markers domain (registry + hardware trigger)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MarkersConfig:
+    # The registry is held as typed EventDefs; events_to_list / merge_event_codes
+    # convert both directions, giving a future validator typed access to the
+    # safety-critical port-code block.
+    event_codes: list[events.EventDef] = field(default_factory=events.default_events)
+    event_code_safe_max: int = events.DEFAULT_SAFE_MAX
+    # Trigger machine fields (port/baud/address) vs behavior fields are already
+    # separable inside TriggerConfig, pre-staging the study/rig carve (#300).
+    trigger: triggers.TriggerConfig = field(default_factory=triggers.TriggerConfig)
+
+
+# ---------------------------------------------------------------------------
+# Surveys domain
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SurveysConfig:
+    url: str = ""  # wire: survey_url
+    options: dict[str, str] = field(default_factory=dict)  # wire: survey_options
+
+
+# ---------------------------------------------------------------------------
+# Interface domain (UI choices that travel with the study)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InterfaceConfig:
+    # None == "unspecified": keep the panels' seeded presets on apply, omit on emit.
+    chat_experimenter_presets: list[str] | None = None
+    chat_participant_presets: list[str] | None = None
+    chat_font_size: int = 18  # FONT_DEFAULT; clamped to [8, 72]
+    chat_red_text: bool = False
+    volume_cap: float = 1.0
+    output_latency: str = "high"  # "high" | "low"
+    preview_levels: list[str] = field(
+        default_factory=lambda: ["INFO", "WARNING", "ERROR", "CRITICAL"]
+    )
+    always_on_top: bool = False
+    tool_always_on_top: dict[str, bool] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Root
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class StudyConfig:
+    """The whole configuration of one study (the contents of a ``.smacc``)."""
+
+    cueing: CueingConfig = field(default_factory=CueingConfig)
+    markers: MarkersConfig = field(default_factory=MarkersConfig)
+    surveys: SurveysConfig = field(default_factory=SurveysConfig)
+    interface: InterfaceConfig = field(default_factory=InterfaceConfig)
+    # Reused pure sub-models at the root (their rig-local fields stay isolated
+    # inside them for the study/rig carve in #300).
+    devices: devices.DeviceConfig = field(default_factory=devices.default_config)
+    hue: hue.HueConfig = field(default_factory=hue.HueConfig)
+    data_directory: str = "data"  # path-bearing, str
+
+    def to_settings_dict(self) -> dict[str, Any]:
+        """Project the tree to the flat ``settings`` mapping, in gather order.
+
+        Keys are emitted by explicit sequential statements in the exact order
+        ``SmaccWindow.gather_settings`` produces them (panel registration order,
+        then the window-level blocks), so a model-written file matches one the
+        live session writes. Every block is delegated to its owning module's
+        emitter; nothing is re-rolled here except via the shared cue helpers.
+        """
+        out: dict[str, Any] = {}
+
+        # --- panels, in registration order (events emits nothing) ---
+        biocals_block: dict[str, Any] = {
+            "voice_volume": self.cueing.biocals.voice_volume
+        }
+        if self.cueing.biocals.rows is not None:
+            biocals_block["rows"] = biocals.rows_to_list(self.cueing.biocals.rows)
+        out["biocals"] = biocals_block
+
+        out["visual_cues"] = [visual_cue_to_dict(c) for c in self.cueing.visual.cues]
+        out["visual_attack"] = self.cueing.visual.attack
+        out["visual_release"] = self.cueing.visual.release
+
+        out["cues"] = [cue_to_dict(c) for c in self.cueing.audio.cues]
+        out["cue_attack"] = self.cueing.audio.attack
+        out["cue_release"] = self.cueing.audio.release
+
+        out["noise_volume"] = self.cueing.noise.volume
+        out["noise_color"] = self.cueing.noise.color
+        out["noise_source"] = self.cueing.noise.source
+        out["noise_file"] = self.cueing.noise.file
+
+        out["survey_url"] = self.surveys.url
+        out["survey_options"] = dict(self.surveys.options)
+
+        if self.interface.chat_experimenter_presets is not None:
+            out["chat_experimenter_presets"] = list(
+                self.interface.chat_experimenter_presets
+            )
+        if self.interface.chat_participant_presets is not None:
+            out["chat_participant_presets"] = list(
+                self.interface.chat_participant_presets
+            )
+
+        out["chat_font_size"] = self.interface.chat_font_size
+        out["chat_red_text"] = self.interface.chat_red_text
+
+        # (devices and markers panels emit nothing; their state is window-level)
+        out["volume_cap"] = self.interface.volume_cap
+        out["output_latency"] = self.interface.output_latency
+
+        # --- window-level blocks, in gather_settings order ---
+        out["devices"] = self.devices.to_dict()
+        out["event_codes"] = events.events_to_list(self.markers.event_codes)
+        out["event_code_safe_max"] = self.markers.event_code_safe_max
+        out["trigger_output"] = self.markers.trigger.to_dict()
+        out["hue"] = self.hue.to_dict()
+        out["data_directory"] = self.data_directory
+        out["preview_levels"] = list(self.interface.preview_levels)
+        out["always_on_top"] = self.interface.always_on_top
+        out["tool_always_on_top"] = dict(self.interface.tool_always_on_top)
+        return out
+
+    @classmethod
+    def from_settings_dict(cls, settings: object) -> StudyConfig:
+        """Build a StudyConfig from a flat ``settings`` mapping (lenient inverse).
+
+        Each block is read with ``.get`` and parsed by its module's tolerant
+        parser; a missing block falls back to that sub-model's default, and a
+        malformed value falls back field-by-field, never raising — mirroring how
+        each panel's ``apply_state`` ignores junk today.
+        """
+        s = settings if isinstance(settings, dict) else {}
+
+        biocals_block = s.get("biocals")
+        if not isinstance(biocals_block, dict):
+            biocals_block = {}
+        cueing = CueingConfig(
+            audio=AudioConfig(
+                cues=[
+                    cue_from_dict(c)
+                    for c in _as_list(s.get("cues"))
+                    if isinstance(c, dict)
+                ],
+                attack=_coerce_float(s.get("cue_attack"), 0.0),
+                release=_coerce_float(s.get("cue_release"), 0.0),
+            ),
+            visual=VisualConfig(
+                cues=[
+                    visual_cue_from_dict(c)
+                    for c in _as_list(s.get("visual_cues"))
+                    if isinstance(c, dict)
+                ],
+                attack=_coerce_float(s.get("visual_attack"), 0.0),
+                release=_coerce_float(s.get("visual_release"), 0.0),
+            ),
+            noise=NoiseConfig(
+                volume=_coerce_float(s.get("noise_volume"), 0.2),
+                color=str(s.get("noise_color") or "white"),
+                source=(
+                    src
+                    if (src := s.get("noise_source")) in ("builtin", "file")
+                    else "builtin"
+                ),
+                file=str(s.get("noise_file") or ""),
+            ),
+            biocals=BiocalsConfig(
+                voice_volume=_coerce_float(biocals_block.get("voice_volume"), 0.5),
+                rows=biocals.rows_from_list(biocals_block.get("rows")),
+            ),
+        )
+
+        markers = MarkersConfig(
+            event_codes=events.merge_event_codes(s.get("event_codes")),
+            event_code_safe_max=_coerce_int(
+                s.get("event_code_safe_max"), events.DEFAULT_SAFE_MAX
+            ),
+            trigger=triggers.from_dict(s.get("trigger_output")),
+        )
+
+        survey_options = s.get("survey_options")
+        surveys = SurveysConfig(
+            url=str(s.get("survey_url") or ""),
+            options=(
+                {str(k): str(v) for k, v in survey_options.items()}
+                if isinstance(survey_options, dict)
+                else {}
+            ),
+        )
+
+        tool_aot = s.get("tool_always_on_top")
+        interface = InterfaceConfig(
+            chat_experimenter_presets=_presets_from(s, "chat_experimenter_presets"),
+            chat_participant_presets=_presets_from(s, "chat_participant_presets"),
+            chat_font_size=max(8, min(72, _coerce_int(s.get("chat_font_size"), 18))),
+            chat_red_text=bool(s.get("chat_red_text", False)),
+            volume_cap=_coerce_float(s.get("volume_cap"), 1.0),
+            output_latency=(
+                lat if (lat := s.get("output_latency")) in ("high", "low") else "high"
+            ),
+            preview_levels=(
+                [str(x) for x in s["preview_levels"]]
+                if isinstance(s.get("preview_levels"), list)
+                else ["INFO", "WARNING", "ERROR", "CRITICAL"]
+            ),
+            always_on_top=bool(s.get("always_on_top", False)),
+            tool_always_on_top=(
+                {str(k): bool(v) for k, v in tool_aot.items()}
+                if isinstance(tool_aot, dict)
+                else {}
+            ),
+        )
+
+        return cls(
+            cueing=cueing,
+            markers=markers,
+            surveys=surveys,
+            interface=interface,
+            devices=devices.from_dict(s.get("devices")),
+            hue=hue.from_dict(s.get("hue")),
+            data_directory=str(s.get("data_directory") or "data"),
+        )

--- a/tests/test_studyconfig.py
+++ b/tests/test_studyconfig.py
@@ -1,0 +1,281 @@
+"""Tests for the pure :class:`smacc.studyconfig.StudyConfig` model.
+
+No Qt, no GUI: the model is pure data, so these run without the offscreen Qt
+platform the panel tests need. The contract is that ``to_settings_dict`` /
+``from_settings_dict`` are a faithful, idempotent serializer pair for the flat
+``.smacc`` *settings* mapping, emitted in the exact order
+``SmaccWindow.gather_settings`` produces.
+
+Note on the shipped ``default.smacc``: it is a hand-trimmed seed in an older key
+order that omits every block the live ``gather_settings`` fills in by default
+(``cues``, the chat presets, ``volume_cap``, ``devices``, ``trigger_output``,
+``hue`` …). So ``from_settings_dict(raw).to_settings_dict() == raw`` is *not*
+achievable, and is not the contract — the model upgrades a trimmed seed to a
+complete mapping, exactly as the app does on save. The true
+``gather_settings() == to_settings_dict()`` equivalence is proven at the GUI
+cut-over, against a built window.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+import smacc
+from smacc import biocals, devices, events, hue, settings, studyconfig, triggers
+from smacc.studyconfig import StudyConfig
+
+DEFAULT_SMACC = Path(smacc.__file__).parent / "assets" / "default.smacc"
+
+# The exact flat key order SmaccWindow.gather_settings emits, for a config with
+# no chat presets set (the two preset keys slot in after survey_options when
+# present — see test_presets_emit_in_gather_order).
+EXPECTED_ORDER = [
+    "biocals",
+    "visual_cues",
+    "visual_attack",
+    "visual_release",
+    "cues",
+    "cue_attack",
+    "cue_release",
+    "noise_volume",
+    "noise_color",
+    "noise_source",
+    "noise_file",
+    "survey_url",
+    "survey_options",
+    "chat_font_size",
+    "chat_red_text",
+    "volume_cap",
+    "output_latency",
+    "devices",
+    "event_codes",
+    "event_code_safe_max",
+    "trigger_output",
+    "hue",
+    "data_directory",
+    "preview_levels",
+    "always_on_top",
+    "tool_always_on_top",
+]
+
+
+def _full_settings() -> dict:
+    """A self-consistent kitchen-sink mapping with every block populated.
+
+    Each block is built through its owning module's emitter (or the model's cue
+    helpers), so the fixture is exactly what ``to_settings_dict`` would emit and
+    a round-trip is expected to reproduce it byte-for-byte.
+    """
+    dev = devices.default_config()  # complete routing, so from_dict round-trips
+    dev.bindings["bedroom_speaker"] = "Speakers (Demo)"
+    dev.bindings["bedroom_mic_1"] = "Microphone (Demo)"
+    custom = events.EventDef(
+        key="DoorKnock",
+        label="Door knock",
+        code=150,
+        category="manual",
+        builtin=False,
+    )
+    return {
+        "biocals": {
+            "voice_volume": 0.4,
+            "rows": biocals.rows_to_list(biocals.default_rows()),
+        },
+        "visual_cues": [
+            studyconfig.visual_cue_to_dict(
+                studyconfig.VisualCue("Glow", "#00ff00", 0.8, "pulse", 2.0, 0.5, True)
+            )
+        ],
+        "visual_attack": 0.1,
+        "visual_release": 0.2,
+        "cues": [
+            studyconfig.cue_to_dict(
+                studyconfig.AudioCue("Buzz", "cues/buzz.wav", 0.3, True)
+            )
+        ],
+        "cue_attack": 0.05,
+        "cue_release": 0.15,
+        "noise_volume": 0.3,
+        "noise_color": "pink",
+        "noise_source": "file",
+        "noise_file": "noise/pink.wav",
+        "survey_url": "smacc://survey/lusk",
+        "survey_options": {"Morning report": "https://example.com/m"},
+        "chat_experimenter_presets": ["How asleep were you?"],
+        "chat_participant_presets": ["1", "2"],
+        "chat_font_size": 22,
+        "chat_red_text": True,
+        "volume_cap": 0.8,
+        "output_latency": "low",
+        "devices": dev.to_dict(),
+        "event_codes": events.events_to_list([*events.default_events(), custom]),
+        "event_code_safe_max": 200,
+        "trigger_output": triggers.TriggerConfig(enabled=True, port="COM3").to_dict(),
+        "hue": hue.HueConfig(bridge_ip="192.168.1.50", app_key="abc123").to_dict(),
+        "data_directory": "data",
+        "preview_levels": ["DEBUG", "INFO"],
+        "always_on_top": True,
+        "tool_always_on_top": {"events": True},
+    }
+
+
+def _yaml(mapping: dict) -> str:
+    return yaml.safe_dump(
+        mapping, sort_keys=False, default_flow_style=False, allow_unicode=True
+    )
+
+
+# ----- fresh defaults --------------------------------------------------------
+
+
+def test_fresh_config_serializes_to_documented_defaults():
+    out = StudyConfig().to_settings_dict()
+    assert out["noise_volume"] == 0.2
+    assert out["noise_color"] == "white"
+    assert out["noise_source"] == "builtin"
+    assert out["cue_attack"] == 0.0
+    assert out["volume_cap"] == 1.0
+    assert out["output_latency"] == "high"
+    assert out["chat_font_size"] == 18
+    assert out["chat_red_text"] is False
+    assert out["cues"] == []
+    assert out["visual_cues"] == []
+    assert out["biocals"] == {"voice_volume": 0.5}  # rows unspecified -> omitted
+    assert out["data_directory"] == "data"
+    assert out["event_code_safe_max"] == 255
+    assert out["preview_levels"] == ["INFO", "WARNING", "ERROR", "CRITICAL"]
+    assert out["always_on_top"] is False
+    assert out["tool_always_on_top"] == {}
+    # Reused sub-models serialize exactly like their own emitters.
+    assert out["devices"] == devices.default_config().to_dict()
+    assert out["trigger_output"] == triggers.TriggerConfig().to_dict()
+    assert out["hue"] == {"bridge_ip": "", "app_key": ""}
+    assert out["event_codes"] == events.events_to_list(events.default_events())
+
+
+def test_emission_order_matches_gather_settings():
+    assert list(StudyConfig().to_settings_dict().keys()) == EXPECTED_ORDER
+
+
+def test_empty_mapping_yields_defaults():
+    assert StudyConfig.from_settings_dict({}).to_settings_dict() == (
+        StudyConfig().to_settings_dict()
+    )
+
+
+# ----- the round-trip contract ----------------------------------------------
+
+
+def test_kitchen_sink_round_trips_exactly():
+    full = _full_settings()
+    out = StudyConfig.from_settings_dict(full).to_settings_dict()
+    assert out == full
+
+
+def test_round_trip_is_byte_stable():
+    full = _full_settings()
+    pass1 = StudyConfig.from_settings_dict(full).to_settings_dict()
+    pass2 = StudyConfig.from_settings_dict(pass1).to_settings_dict()
+    assert _yaml(pass1) == _yaml(pass2)  # deterministic order + stable values
+
+
+# ----- the shipped default.smacc --------------------------------------------
+
+
+def test_default_smacc_loads_and_is_idempotent():
+    raw, _meta = settings.load_settings(str(DEFAULT_SMACC))
+    out1 = StudyConfig.from_settings_dict(raw).to_settings_dict()
+    out2 = StudyConfig.from_settings_dict(out1).to_settings_dict()
+    assert out1 == out2  # a second round-trip changes nothing
+
+    # Values the seed does carry are preserved.
+    assert out1["visual_cues"] == raw["visual_cues"]
+    assert out1["noise_color"] == "white"
+    assert out1["biocals"]["voice_volume"] == 0.5
+    assert out1["event_code_safe_max"] == 255
+    assert out1["data_directory"] == "data"
+
+    # Omissions in the seed stay omitted (the None sentinels).
+    assert "rows" not in out1["biocals"]
+    assert "chat_experimenter_presets" not in out1
+    assert "chat_participant_presets" not in out1
+
+    # Blocks the live gather always emits are filled in (the seed upgrades).
+    for key in (
+        "cues",
+        "volume_cap",
+        "output_latency",
+        "devices",
+        "trigger_output",
+        "hue",
+        "preview_levels",
+        "always_on_top",
+        "tool_always_on_top",
+    ):
+        assert key in out1
+
+
+# ----- leniency (mirrors each panel's apply_state tolerance) -----------------
+
+
+def test_malformed_scalars_fall_back_to_defaults():
+    out = StudyConfig.from_settings_dict(
+        {
+            "noise_volume": "loud",
+            "chat_font_size": "big",
+            "volume_cap": None,
+            "output_latency": "full",  # not in {high, low}
+            "noise_source": "tape",  # not in {builtin, file}
+            "event_code_safe_max": "x",
+        }
+    ).to_settings_dict()
+    assert out["noise_volume"] == 0.2
+    assert out["chat_font_size"] == 18
+    assert out["volume_cap"] == 1.0
+    assert out["output_latency"] == "high"
+    assert out["noise_source"] == "builtin"
+    assert out["event_code_safe_max"] == 255
+
+
+def test_chat_font_size_is_clamped():
+    assert (
+        StudyConfig.from_settings_dict({"chat_font_size": 999}).interface.chat_font_size
+        == 72
+    )
+    assert (
+        StudyConfig.from_settings_dict({"chat_font_size": 1}).interface.chat_font_size
+        == 8
+    )
+
+
+def test_present_empty_presets_are_a_deliberate_clear():
+    out = StudyConfig.from_settings_dict(
+        {"chat_experimenter_presets": []}
+    ).to_settings_dict()
+    assert out["chat_experimenter_presets"] == []  # present-and-empty is honored
+    assert "chat_participant_presets" not in out  # still absent -> omitted
+
+
+def test_absent_biocal_rows_keep_voice_volume_only():
+    out = StudyConfig.from_settings_dict({"biocals": {"voice_volume": 0.7}})
+    block = out.to_settings_dict()["biocals"]
+    assert block == {"voice_volume": 0.7}
+
+
+def test_present_biocal_rows_round_trip():
+    rows = biocals.rows_to_list(biocals.default_rows())
+    out = StudyConfig.from_settings_dict(
+        {"biocals": {"voice_volume": 0.5, "rows": rows}}
+    )
+    assert out.to_settings_dict()["biocals"]["rows"] == rows
+
+
+def test_paths_stay_plain_strings():
+    out = StudyConfig.from_settings_dict(
+        {"cues": [{"name": "c", "file": "cues/c.wav"}], "noise_file": "n/x.wav"}
+    )
+    assert out.cueing.audio.cues[0].file == "cues/c.wav"
+    assert isinstance(out.cueing.audio.cues[0].file, str)
+    assert out.cueing.noise.file == "n/x.wav"


### PR DESCRIPTION
Adds `src/smacc/studyconfig.py`: a pure, Qt-free `StudyConfig` dataclass tree
(cueing / markers / surveys / interface, plus the reused `DeviceConfig`,
`TriggerConfig`, `HueConfig`, and events registry) with
`to_settings_dict`/`from_settings_dict` that round-trip the flat `.smacc`
*settings* mapping. Keys are emitted in the exact order `gather_settings`
produces, each block is delegated to its owning module's emitter, and the audio
and visual cue dicts are built by shared `cue_to_dict`/`visual_cue_to_dict`
helpers.

This is the invisible foundation for the config decoupling (toward #299 / #298):
nothing imports the module yet, so the app is unchanged. The GUI cut-over
(`gather_settings`/`apply_settings` over to the model) and the panel cue-helper
extraction are follow-ups.

`settings.py` is untouched, metadata stays at the envelope level, and
`SCHEMA_VERSION` is unchanged.

**Tests** (`tests/test_studyconfig.py`, no Qt): emission-order pin, a
self-consistent kitchen-sink round-trip, YAML byte-stability, `default.smacc`
idempotence, leniency, and the `None`-sentinel behavior. A byte-diff against the
shipped `default.smacc` is intentionally *not* the contract — it is a trimmed
seed in an older key order that omits blocks `gather_settings` always emits, so
the model upgrades it to a complete mapping (see #299). Full suite green; ruff
and mypy clean.

Part of #299.
