### PR TITLE
refactor: emit cue dicts through the shared studyconfig helpers

### DIFF
--- a/src/smacc/panels/audio.py
+++ b/src/smacc/panels/audio.py
@@ -26,6 +26,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import audio, devices, utils
 from ..session import SmaccSession
+from ..studyconfig import AudioCue, cue_to_dict
 from ..utils import pick_random_demo_cues
 from .base import (
     PanelWindow,
@@ -874,17 +875,21 @@ class AudioCueWindow(PanelWindow):
 
     # ----- settings state ----------------------------------------------------
 
+    def to_cues(self) -> list[AudioCue]:
+        """Read each slot's widgets into an AudioCue (the shared cue model leaf)."""
+        return [
+            AudioCue(
+                name=slot.nameEdit.text(),
+                file=slot.file_path,
+                volume=slot.volumeSpinBox.value(),
+                loop=slot.loopButton.isChecked(),
+            )
+            for slot in self.slots
+        ]
+
     def gather_state(self) -> dict:
         return {
-            "cues": [
-                {
-                    "name": slot.nameEdit.text(),
-                    "file": slot.file_path,
-                    "volume": slot.volumeSpinBox.value(),
-                    "loop": slot.loopButton.isChecked(),
-                }
-                for slot in self.slots
-            ],
+            "cues": [cue_to_dict(cue) for cue in self.to_cues()],
             "cue_attack": self.attackSpinBox.value(),
             "cue_release": self.releaseSpinBox.value(),
         }

--- a/src/smacc/panels/visual.py
+++ b/src/smacc/panels/visual.py
@@ -27,6 +27,7 @@ from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import hue, lights
 from ..session import SmaccSession
+from ..studyconfig import VisualCue, visual_cue_to_dict
 from .base import (
     PanelWindow,
     describe_action,
@@ -621,20 +622,24 @@ class VisualWindow(PanelWindow):
 
     # ----- settings state ----------------------------------------------------
 
+    def to_cues(self) -> list[VisualCue]:
+        """Read each slot's widgets into a VisualCue (the shared cue model leaf)."""
+        return [
+            VisualCue(
+                name=slot.nameEdit.text(),
+                color=_hexcode(slot.rgb),
+                brightness=slot.brightnessSpinBox.value(),
+                pattern=slot.patternCombo.currentData(),
+                rate=slot.rateSpinBox.value(),
+                length=slot.lengthSpinBox.value(),
+                loop=slot.loopCheckBox.isChecked(),
+            )
+            for slot in self.slots
+        ]
+
     def gather_state(self) -> dict:
         return {
-            "visual_cues": [
-                {
-                    "name": slot.nameEdit.text(),
-                    "color": _hexcode(slot.rgb),
-                    "brightness": slot.brightnessSpinBox.value(),
-                    "pattern": slot.patternCombo.currentData(),
-                    "rate": slot.rateSpinBox.value(),
-                    "length": slot.lengthSpinBox.value(),
-                    "loop": slot.loopCheckBox.isChecked(),
-                }
-                for slot in self.slots
-            ],
+            "visual_cues": [visual_cue_to_dict(cue) for cue in self.to_cues()],
             "visual_attack": self.attackSpinBox.value(),
             "visual_release": self.releaseSpinBox.value(),
         }


### PR DESCRIPTION
Has the audio and visual cue panels build the shared `AudioCue`/`VisualCue`
model leaves and emit them through `studyconfig.cue_to_dict` /
`visual_cue_to_dict`, instead of hand-rolling the cue dict inline. The cue wire
shape now lives in exactly one place (the model), closing the drift seam where a
panel and the model could disagree about cue keys.

Each panel also gains a `to_cues()` method (read each slot's widgets into the
model leaf), which the GUI cut-over (commit 4) will consume directly to populate
`StudyConfig` — so this is a small, still-invisible step toward that.

The emitted dicts are unchanged, so behavior and the `.smacc` wire format are
identical. Verified: the existing panel-state and `gather_settings`/`apply`
round-trip tests stay green (the wire shape is what they pin), full suite green
(1151), ruff and mypy clean.

Part of #299 (commit 3 of the landing plan).
