### PR TITLE
refactor: route gather_settings through the StudyConfig model

### DIFF
--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -53,6 +53,7 @@ from .paths import (
 )
 from .qtlog import QtLogHandler
 from .session import SmaccSession
+from .studyconfig import StudyConfig
 from .toolwindow import ToolWindow
 
 # The live log preview's record format; the time field's strftime (24h/12h) comes
@@ -736,6 +737,20 @@ class SmaccWindow(ToolWindow):
     ############################################################################
 
     def gather_settings(self) -> dict:
+        """Collect the window's settings, routed through the StudyConfig model.
+
+        :class:`~smacc.studyconfig.StudyConfig` is the canonical (de)serializer for a
+        ``.smacc``: gathering the flat window state and round-tripping it through the
+        model is an identity for complete live state (proven in tests) and makes any
+        future panel/model drift a test failure rather than a silent mis-save. Loading
+        still applies the *raw* mapping to the panels (see :meth:`apply_settings`), so a
+        partial study keeps its "absent key leaves the current value" semantics.
+        """
+        return StudyConfig.from_settings_dict(
+            self._window_settings()
+        ).to_settings_dict()
+
+    def _window_settings(self) -> dict:
         """Collect each panel's parameters into one serializable settings dict.
 
         Device equipment + routing travel with the settings in a ``devices`` block (see

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -172,6 +172,19 @@ def test_settings_gather_apply_is_a_fixed_point(
     assert second == first
 
 
+def test_gather_settings_routes_through_the_model_unchanged(
+    qtbot, design_session, mock_devices, silence_dialogs
+):
+    # gather_settings() round-trips the window state through StudyConfig; for complete
+    # live state that round-trip is an identity, so routing through the model must
+    # change nothing — the public gather equals the raw window union. This is also a
+    # drift guard: a future gather_state key the model doesn't know would be dropped
+    # here and fail this assertion.
+    window = SmaccWindow(design_session)
+    qtbot.addWidget(window)
+    assert window.gather_settings() == window._window_settings()
+
+
 def test_apply_settings_lands_values(
     qtbot, design_session, mock_devices, silence_dialogs
 ):


### PR DESCRIPTION
Routes `SmaccWindow.gather_settings()` through `StudyConfig`, making the model the
canonical (de)serializer for a `.smacc`. The window's flat state is factored into
`_window_settings()` and round-tripped through `StudyConfig.from_settings_dict(...).to_settings_dict()`.

For complete live state that round-trip is an identity, so this changes nothing
on save — proven by a new test asserting `gather_settings() == _window_settings()`.
The benefit is that the model is now exercised on every real save, and any future
panel/model drift (a `gather_state` key the model doesn't know) becomes a test
failure instead of a silent mis-save.

Scope note: only the **gather** half routes through the model. `apply_settings`
deliberately keeps applying the *raw* mapping to the panels, because a partial
study relies on "absent key leaves the current value", which a model round-trip
(filling scalar defaults) would break. Faithful model-based *apply* only holds for
a complete study, which is the editor's case — so that half moves to #301, and the
log-provenance serializer (commit 5) moves to #300 where bindings become rig-local.

Verified: the new identity test, the existing gather/apply fixed-point test, full
suite green (1152), ruff and mypy clean.

Part of #299 (commit 4, gather half).
