### PR TITLE
feat: add machine-local rig profile storage to preferences

### DIFF
--- a/src/smacc/preferences.py
+++ b/src/smacc/preferences.py
@@ -40,6 +40,13 @@ DEFAULTS: dict[str, Any] = {
     # the last one opened, so the launcher can preselect it and offer quick switching.
     "recent_settings": [],
     "last_settings": None,
+    # Rig profile (#300): the physical, this-machine half of a device setup — which
+    # actual device each piece of equipment binds to, plus the hardware trigger's
+    # port/baud/address and the Hue bridge credential. Bound once per rig (in the Rig
+    # setup tool, or auto-bound at session start) and reused by every study on this
+    # machine, so a portable study carries only the logical routing, never a
+    # machine-specific device name. Empty out of the box.
+    "rig": {"bindings": {}, "trigger": {}, "hue": {}},
     # How many lines the Session window's live log preview keeps (oldest dropped
     # first; the log file always keeps everything). Large values cost GUI memory
     # and repaint time over an overnight session.
@@ -167,6 +174,53 @@ def update_window_geometry(
         windows = {}
     windows[window_id] = geometry
     update_preferences(path, {"windows": windows})
+
+
+def rig_profile(prefs: dict[str, Any]) -> dict[str, Any]:
+    """Return the machine's rig profile block (``{}`` if absent or malformed).
+
+    The rig profile is the physical half of a device setup that stays on this machine
+    (see :data:`DEFAULTS` ``rig``): equipment->device bindings, the hardware trigger's
+    port/baud/address, and the Hue bridge credential. A small accessor so callers
+    don't reach into the shape themselves; the sub-accessors below read its parts.
+    """
+    rig = prefs.get("rig")
+    return rig if isinstance(rig, dict) else {}
+
+
+def rig_bindings(prefs: dict[str, Any]) -> dict[str, str]:
+    """Return the rig's equipment->device name bindings (``{}`` if none)."""
+    bindings = rig_profile(prefs).get("bindings")
+    if not isinstance(bindings, dict):
+        return {}
+    return {str(key): str(device) for key, device in bindings.items()}
+
+
+def rig_trigger(prefs: dict[str, Any]) -> dict[str, Any]:
+    """Return the rig's hardware-trigger machine fields (port/baud/address; ``{}`` if none)."""
+    trigger = rig_profile(prefs).get("trigger")
+    return trigger if isinstance(trigger, dict) else {}
+
+
+def rig_hue(prefs: dict[str, Any]) -> dict[str, Any]:
+    """Return the rig's Hue bridge credential (bridge_ip/app_key; ``{}`` if none)."""
+    hue_credential = rig_profile(prefs).get("hue")
+    return hue_credential if isinstance(hue_credential, dict) else {}
+
+
+def update_rig(path: str | Path, changes: dict[str, Any]) -> None:
+    """Merge ``changes`` into the on-disk rig profile (load -> merge -> save).
+
+    Like :func:`update_window_geometry`, this replaces only the named rig sub-keys
+    (``bindings``/``trigger``/``hue``) it is given, leaving the rest of the rig block
+    and the rest of the file untouched. Best-effort: it never raises.
+    """
+    prefs = load_preferences(path)
+    rig = prefs.get("rig")
+    if not isinstance(rig, dict):
+        rig = {}
+    rig.update(changes)
+    update_preferences(path, {"rig": rig})
 
 
 def log_preview_max_lines(prefs: dict[str, Any]) -> int:

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -163,3 +163,53 @@ def test_level_name_int_round_trip():
 
 def test_names_to_levels_drops_unknown():
     assert preferences.names_to_levels(["INFO", "BOGUS"]) == {logging.INFO}
+
+
+# ----- rig profile (#300) ----------------------------------------------------
+
+
+def test_rig_profile_defaults_empty():
+    prefs = preferences.default_preferences()
+    assert preferences.rig_profile(prefs) == {"bindings": {}, "trigger": {}, "hue": {}}
+    assert preferences.rig_bindings(prefs) == {}
+    assert preferences.rig_trigger(prefs) == {}
+    assert preferences.rig_hue(prefs) == {}
+
+
+def test_rig_accessors_are_defensive():
+    # A hand-edited or partial rig block must not break the accessors.
+    assert preferences.rig_profile({"rig": "junk"}) == {}
+    assert preferences.rig_bindings({"rig": {"bindings": "x"}}) == {}
+    assert preferences.rig_bindings(
+        {"rig": {"bindings": {"bedroom_speaker": "Spk"}}}
+    ) == {"bedroom_speaker": "Spk"}
+    assert preferences.rig_trigger({"rig": {}}) == {}
+    assert preferences.rig_hue({}) == {}
+
+
+def test_update_rig_merges_without_clobbering(tmp_path):
+    path = tmp_path / "preferences.yaml"
+    preferences.update_preferences(path, {"last_settings": "/x"})
+    preferences.update_rig(path, {"bindings": {"bedroom_speaker": "Speakers (Demo)"}})
+    preferences.update_rig(path, {"hue": {"bridge_ip": "192.168.1.50", "app_key": "k"}})
+    prefs = preferences.load_preferences(path)
+    # Both rig sub-keys persisted, and the unrelated launcher key is untouched.
+    assert preferences.rig_bindings(prefs) == {"bedroom_speaker": "Speakers (Demo)"}
+    assert preferences.rig_hue(prefs) == {"bridge_ip": "192.168.1.50", "app_key": "k"}
+    assert prefs["last_settings"] == "/x"
+
+
+def test_rig_profile_round_trips(tmp_path):
+    path = tmp_path / "preferences.yaml"
+    preferences.update_rig(
+        path,
+        {
+            "bindings": {"bedroom_speaker": "Spk", "philips_hue_light": "light:1"},
+            "trigger": {"port": "COM3", "baud": 115200, "address": "0x378"},
+            "hue": {"bridge_ip": "10.0.0.2", "app_key": "abc"},
+        },
+    )
+    prefs = preferences.load_preferences(path)
+    assert preferences.rig_bindings(prefs)["philips_hue_light"] == "light:1"
+    assert preferences.rig_trigger(prefs)["port"] == "COM3"
+    assert preferences.rig_hue(prefs)["app_key"] == "abc"


### PR DESCRIPTION
Adds a machine-local **rig profile** to `preferences.yaml` (new `rig` block:
`bindings`, `trigger` port/baud/address, `hue` bridge credential), with the
accessors `rig_profile` / `rig_bindings` / `rig_trigger` / `rig_hue` and an
`update_rig` writer that merges per-sub-key without clobbering the rest of the
file (mirroring `update_window_geometry`).

This is the storage foundation for the study/rig device split: the physical,
this-machine half of a device setup (which actual device each piece of equipment
binds to, the trigger port, the Hue credential) lives here, bound once per rig and
reused by every study — so a portable study can carry only the logical routing.

Additive and invisible: nothing reads the rig profile yet. The accessors are
defensive against a hand-edited/partial block, and the existing
defaults/round-trip preferences tests still pass with the new key.

Verified: new rig-profile tests, full suite green (1156), ruff and mypy clean.

Part of #300 (slice 1 of the decomposition: rig-profile storage).
