### PR TITLE
feat: split device config into a portable study and a rig-local profile

### DIFF
--- a/src/smacc/devices.py
+++ b/src/smacc/devices.py
@@ -261,6 +261,16 @@ class DeviceConfig:
         """Serialize to the persisted ``devices`` mapping."""
         return {"bindings": dict(self.bindings), "routing": dict(self.routing)}
 
+    def to_study_dict(self) -> dict:
+        """Serialize the *portable* half: action->equipment routing only.
+
+        The equipment->device bindings are machine-specific and live in the rig
+        profile (preferences), not the portable study, so they are omitted here
+        (#300). :func:`from_study_and_rig` recombines this routing with the rig's
+        bindings to rebuild the live config.
+        """
+        return {"routing": dict(self.routing)}
+
 
 def default_config() -> DeviceConfig:
     """A config with each action on its default equipment and no devices bound yet."""
@@ -296,6 +306,22 @@ def load(settings: dict) -> DeviceConfig:
     block the same way.
     """
     return from_dict(settings.get("devices"))
+
+
+def from_study_and_rig(settings: dict, rig_bindings: dict[str, str]) -> DeviceConfig:
+    """Build the live device config from a study's routing + the rig's bindings (#300).
+
+    Routing travels with the portable study; the equipment->device bindings are
+    machine-local (the rig profile in :mod:`smacc.preferences`). A rig binding wins
+    over any a legacy study still carries, so the machine's actual devices are
+    authoritative. Unknown equipment keys are dropped, like :func:`from_dict`.
+    """
+    cfg = from_dict(settings.get("devices"))
+    if isinstance(rig_bindings, dict):
+        for equipment_key, device in rig_bindings.items():
+            if equipment_key in EQUIPMENT_BY_KEY and isinstance(device, str):
+                cfg.bindings[equipment_key] = device
+    return cfg
 
 
 def autobind(

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -175,7 +175,7 @@ class SmaccWindow(ToolWindow):
         if not self.design:
             # Panels (and any launch-file overrides) are in place, so capture the
             # initial state into the log header (also emits the "Opened SMACC" line).
-            self.session.begin_log(self.gather_settings())
+            self.session.begin_log(self._window_settings())
             self._notify_missing_biocal_voices()
             # Startup widget setup is done; from here on, log soft interactions.
             self.session.log_interactions = True
@@ -1130,6 +1130,11 @@ class SmaccWindow(ToolWindow):
             self.show_error_popup("Could not save settings.", str(exc))
             return False
         self.settings_path = path  # subsequent saves update this file
+        # The physical half of the device setup is machine-local, so persist it to the
+        # rig profile (preferences), not the portable study (#300). Sessions only — the
+        # editor authors a study, not this machine's rig.
+        if not self.design:
+            self._persist_rig_profile()
         if self.design:
             self._saved_snapshot = self._design_snapshot()  # editor is clean again
         self.session.log_debug_msg(f"Saved settings to {path}")
@@ -1138,6 +1143,22 @@ class SmaccWindow(ToolWindow):
         assert status_bar is not None
         status_bar.showMessage(f"Saved settings to {Path(path).name}", 5000)
         return True
+
+    def _persist_rig_profile(self) -> None:
+        """Persist this machine's physical device setup to the rig profile (#300).
+
+        The equipment->device bindings, the hardware trigger's port/baud/address, and
+        the Hue bridge credential are machine-local: they belong in ``preferences.yaml``,
+        not the portable study. Saving a session captures the current rig so the next
+        study on this machine reuses it (the Rig setup tool will be the dedicated path).
+        """
+        rig = {
+            "bindings": dict(self.session.devices.bindings),
+            "trigger": self.session.trigger_config.to_rig_dict(),
+            "hue": self.session.hue_config.to_dict(),
+        }
+        preferences.update_rig(preferences_path, rig)
+        self._prefs["rig"] = rig
 
     def load_settings(self) -> None:
         """Prompt for a .smacc settings file and apply it."""
@@ -1303,7 +1324,7 @@ class SmaccWindow(ToolWindow):
             self._teardown_panels()
             self.session.log_info_msg("Session ended")
             # Record the final settings (incl. any mid-session edits) as the tail.
-            self.session.end_log(self.gather_settings())
+            self.session.end_log(self._window_settings())
             # Detach this window's preview handler and release the session's log
             # handler + outlet so the next session in this process starts clean.
             self.session.logger.removeHandler(self.preview_handler)

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -806,8 +806,15 @@ class SmaccWindow(ToolWindow):
         was_logging = self.session.log_interactions
         self.session.log_interactions = False
         self.session.missing_devices = []  # filled by the Devices reload below
-        # Device equipment/routing first, so panels resolve their device against it.
-        self.session.devices = devices.load(state)
+        # The rig profile (machine-local, in preferences) supplies the physical half
+        # of the device setup — equipment->device bindings, the trigger port, and the
+        # Hue credential — that a portable study no longer carries (#300). Empty out of
+        # the box, so this is a no-op until a rig is bound.
+        rig = self._prefs
+        # Device routing (study) + bindings (rig) first, so panels resolve against it.
+        self.session.devices = devices.from_study_and_rig(
+            state, preferences.rig_bindings(rig)
+        )
         trigger_error: str | None = None
         try:
             for panel in self.panels.values():
@@ -819,11 +826,16 @@ class SmaccWindow(ToolWindow):
             )
             # Optional hardware-trigger config (disabled when the study omits it).
             # Open the transport now so a bad port/driver is reported at load.
-            self.session.trigger_config = triggers.load(state)
+            self.session.trigger_config = triggers.from_study_and_rig(
+                state, preferences.rig_trigger(rig)
+            )
             trigger_error = self.session.set_trigger_output(self.session.trigger_config)
             # Hue bridge config before the Devices reload: the Hue equipment dropdown
-            # enumerates from the (newly loaded) bridge, so a bound light matches.
-            self.session.hue_config = hue.load(state)
+            # enumerates from the (newly loaded) bridge, so a bound light matches. The
+            # bridge credential is rig-local (#300); a study value is a legacy fallback.
+            self.session.hue_config = hue.from_dict(
+                {**(state.get("hue") or {}), **preferences.rig_hue(rig)}
+            )
             self.devices_window.refresh_device_lists()
             # A study with unbound required equipment (e.g. one authored in the
             # editor on another machine) gets *this* rig's current defaults

--- a/src/smacc/studyconfig.py
+++ b/src/smacc/studyconfig.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
-from . import biocals, devices, events, hue, triggers
+from . import biocals, devices, events, triggers
 
 # ---------------------------------------------------------------------------
 # Lenient coercion helpers (mirror each panel's apply_state tolerance)
@@ -255,10 +255,11 @@ class StudyConfig:
     markers: MarkersConfig = field(default_factory=MarkersConfig)
     surveys: SurveysConfig = field(default_factory=SurveysConfig)
     interface: InterfaceConfig = field(default_factory=InterfaceConfig)
-    # Reused pure sub-models at the root (their rig-local fields stay isolated
-    # inside them for the study/rig carve in #300).
+    # The reused device model. Only its routing is portable; the equipment->device
+    # bindings are machine-local (the rig profile, #300) and dropped on emit. The
+    # Hue credential and the trigger's port/baud/address are rig-local too — Hue has
+    # no portable half, so it is not a study field at all.
     devices: devices.DeviceConfig = field(default_factory=devices.default_config)
-    hue: hue.HueConfig = field(default_factory=hue.HueConfig)
     data_directory: str = "data"  # path-bearing, str
 
     def to_settings_dict(self) -> dict[str, Any]:
@@ -313,11 +314,13 @@ class StudyConfig:
         out["output_latency"] = self.interface.output_latency
 
         # --- window-level blocks, in gather_settings order ---
-        out["devices"] = self.devices.to_dict()
+        # Devices: routing only (bindings are rig-local, #300). Trigger: behavior
+        # only (port/baud/address are rig-local). No hue block — the bridge
+        # credential is entirely rig-local.
+        out["devices"] = self.devices.to_study_dict()
         out["event_codes"] = events.events_to_list(self.markers.event_codes)
         out["event_code_safe_max"] = self.markers.event_code_safe_max
-        out["trigger_output"] = self.markers.trigger.to_dict()
-        out["hue"] = self.hue.to_dict()
+        out["trigger_output"] = self.markers.trigger.to_study_dict()
         out["data_directory"] = self.data_directory
         out["preview_levels"] = list(self.interface.preview_levels)
         out["always_on_top"] = self.interface.always_on_top
@@ -420,6 +423,5 @@ class StudyConfig:
             surveys=surveys,
             interface=interface,
             devices=devices.from_dict(s.get("devices")),
-            hue=hue.from_dict(s.get("hue")),
             data_directory=str(s.get("data_directory") or "data"),
         )

--- a/src/smacc/triggers.py
+++ b/src/smacc/triggers.py
@@ -89,6 +89,23 @@ class TriggerConfig:
         """Serialize to the plain mapping persisted in a study file."""
         return {f.name: getattr(self, f.name) for f in fields(self)}
 
+    def to_study_dict(self) -> dict[str, Any]:
+        """The *portable* trigger fields: enabled plus the behavior (transport/mode/pulse).
+
+        The machine-specific port/baud/address live in the rig profile, not the
+        portable study (#300); :func:`from_study_and_rig` recombines the two.
+        """
+        return {
+            "enabled": self.enabled,
+            "transport": self.transport,
+            "mode": self.mode,
+            "pulse_ms": self.pulse_ms,
+        }
+
+    def to_rig_dict(self) -> dict[str, Any]:
+        """The machine-specific trigger fields for the rig profile (#300)."""
+        return {"port": self.port, "baud": self.baud, "address": self.address}
+
     def summary(self) -> str:
         """A one-line human description for logs and the dialog (e.g. on a change)."""
         if not self.enabled:
@@ -133,6 +150,24 @@ def from_dict(data: object) -> TriggerConfig:
     if data.get("mode") in MODES:
         cfg.mode = data["mode"]
     cfg.pulse_ms = max(1, _coerce_int(data.get("pulse_ms"), DEFAULT_PULSE_MS))
+    return cfg
+
+
+def from_study_and_rig(settings: dict, rig_trigger: dict) -> TriggerConfig:
+    """Build the live trigger config from a study's behavior fields + the rig's machine fields.
+
+    The study carries enabled/transport/mode/pulse_ms; the machine-specific
+    port/baud/address come from the rig profile (#300). A rig field overrides the
+    study's; an absent rig field leaves the value from :func:`from_dict` in place.
+    """
+    cfg = from_dict(settings.get("trigger_output"))
+    if not isinstance(rig_trigger, dict):
+        return cfg
+    if rig_trigger.get("port") is not None:
+        cfg.port = str(rig_trigger.get("port") or "")
+    cfg.baud = _coerce_int(rig_trigger.get("baud"), cfg.baud)
+    if rig_trigger.get("address"):
+        cfg.address = str(rig_trigger["address"])
     return cfg
 
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -187,3 +187,39 @@ def test_every_equipment_and_action_carries_a_description():
     # the window's self-documentation.
     assert all(equipment.description for equipment in devices.EQUIPMENT)
     assert all(action.description for action in devices.ACTIONS)
+
+
+# ----- study/rig split (#300) ------------------------------------------------
+
+
+def test_to_study_dict_omits_bindings():
+    cfg = devices.default_config()
+    cfg.bindings["bedroom_speaker"] = "Speakers (Demo)"
+    study = cfg.to_study_dict()
+    assert "bindings" not in study  # bindings are rig-local
+    assert study["routing"]["play_audio_cue"] == "bedroom_speaker"
+
+
+def test_from_study_and_rig_overlays_rig_bindings():
+    study = {"devices": {"routing": {"play_audio_cue": "control_speaker"}}}
+    cfg = devices.from_study_and_rig(
+        study, {"control_speaker": "Rig Speaker", "bogus_equipment": "x"}
+    )
+    # Routing comes from the study; the binding comes from the rig profile.
+    assert cfg.equipment_for("play_audio_cue") == "control_speaker"
+    assert cfg.device_for_equipment("control_speaker") == "Rig Speaker"
+    assert "bogus_equipment" not in cfg.bindings  # unknown equipment dropped
+
+
+def test_from_study_and_rig_empty_rig_equals_from_dict():
+    study = {"devices": {"bindings": {"bedroom_speaker": "Legacy"}, "routing": {}}}
+    assert (
+        devices.from_study_and_rig(study, {}).bindings
+        == devices.from_dict(study["devices"]).bindings
+    )
+
+
+def test_from_study_and_rig_rig_wins_over_legacy_study_binding():
+    study = {"devices": {"bindings": {"bedroom_speaker": "Legacy"}, "routing": {}}}
+    cfg = devices.from_study_and_rig(study, {"bedroom_speaker": "Rig"})
+    assert cfg.device_for_equipment("bedroom_speaker") == "Rig"

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -172,17 +172,23 @@ def test_settings_gather_apply_is_a_fixed_point(
     assert second == first
 
 
-def test_gather_settings_routes_through_the_model_unchanged(
+def test_gather_settings_emits_the_study_half(
     qtbot, design_session, mock_devices, silence_dialogs
 ):
-    # gather_settings() round-trips the window state through StudyConfig; for complete
-    # live state that round-trip is an identity, so routing through the model must
-    # change nothing — the public gather equals the raw window union. This is also a
-    # drift guard: a future gather_state key the model doesn't know would be dropped
-    # here and fail this assertion.
+    # gather_settings() routes the window state through StudyConfig, which emits the
+    # PORTABLE half: routing but not machine-local bindings, trigger behavior but not
+    # the port/baud/address, and no Hue credential (all rig-local, #300). Everything
+    # else is unchanged from the full window state (_window_settings).
     window = SmaccWindow(design_session)
     qtbot.addWidget(window)
-    assert window.gather_settings() == window._window_settings()
+    full = window._window_settings()
+    study = window.gather_settings()
+    assert "bindings" not in study["devices"]
+    assert study["devices"]["routing"] == full["devices"]["routing"]
+    assert set(study["trigger_output"]) == {"enabled", "transport", "mode", "pulse_ms"}
+    assert "hue" not in study
+    for key in ("cues", "visual_cues", "event_codes", "volume_cap", "preview_levels"):
+        assert study[key] == full[key]
 
 
 def test_rig_profile_overlays_device_bindings(
@@ -241,7 +247,13 @@ def test_apply_settings_lands_values(
     assert got["visual_cues"][0]["name"] == "Glow"
     assert got["visual_cues"][0]["color"] == "#abcdef"
     assert got["cues"][0]["name"] == "Buzz"
-    assert got["devices"]["bindings"]["bedroom_speaker"] == mock_devices["outputs"][0]
+    # Bindings are rig-local now (#300), so they no longer ride in the gathered study;
+    # the applied study bindings land on the live session config instead.
+    assert "bindings" not in got["devices"]
+    assert (
+        window.session.devices.device_for_equipment("bedroom_speaker")
+        == mock_devices["outputs"][0]
+    )
     # The bound devices all match advertised hardware, so none are flagged missing.
     assert design_session.missing_devices == []
 
@@ -262,8 +274,11 @@ def test_markers_window_applies_and_persists_trigger_config(
     markers.apply()
     assert window.session.trigger_config.enabled is True
     assert window.session.trigger_config.port == "COM4"
-    # The chosen config travels with the rest of the settings.
-    assert window.gather_settings()["trigger_output"]["port"] == "COM4"
+    # The trigger behavior travels with the study; the machine port is rig-local (#300).
+    study_trigger = window.gather_settings()["trigger_output"]
+    assert study_trigger["enabled"] is True
+    assert "port" not in study_trigger
+    assert window.session.trigger_config.to_rig_dict()["port"] == "COM4"
 
 
 def test_markers_apply_rebuilds_the_event_grid(
@@ -464,7 +479,7 @@ def test_tool_window_geometry_persists_and_restores(
     second.session.close()
 
 
-def test_hue_config_round_trips_through_settings(
+def test_hue_credential_applies_from_study_but_is_rig_local(
     qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
 ):
     from smacc import hue
@@ -473,12 +488,17 @@ def test_hue_config_round_trips_through_settings(
     monkeypatch.setattr(hue, "targets", lambda cfg: [])
     window = SmaccWindow(design_session)
     qtbot.addWidget(window)
+    # The Hue bridge credential is rig-local (#300): the portable study no longer
+    # carries a hue block.
+    assert "hue" not in window.gather_settings()
+    # A (legacy) study hue block is still applied to the live session…
     state = window.gather_settings()
-    assert state["hue"] == {"bridge_ip": "", "app_key": ""}
     state["hue"] = {"bridge_ip": "192.168.1.50", "app_key": "k"}
     window.apply_settings(state)
-    assert window.gather_settings()["hue"]["bridge_ip"] == "192.168.1.50"
     assert design_session.hue_config.configured
+    assert design_session.hue_config.bridge_ip == "192.168.1.50"
+    # …but it is not written back into the portable study.
+    assert "hue" not in window.gather_settings()
 
 
 # ----- editor close prompts only when there are unsaved changes (#183) --------

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -185,6 +185,36 @@ def test_gather_settings_routes_through_the_model_unchanged(
     assert window.gather_settings() == window._window_settings()
 
 
+def test_rig_profile_overlays_device_bindings(
+    qtbot, tmp_path, monkeypatch, mock_devices, silence_dialogs
+):
+    # The machine-local rig profile (preferences) supplies device bindings a portable
+    # study no longer carries (#300). A binding in the rig is applied to the session
+    # even when the study provides none. control_speaker is optional, so autobind
+    # never touches it — the rig profile is its only source.
+    prefs_path = tmp_path / "preferences.yaml"
+    preferences.update_rig(
+        prefs_path, {"bindings": {"control_speaker": "Rig Control Speaker"}}
+    )
+    monkeypatch.setattr(gui, "preferences_path", prefs_path)
+
+    from smacc.session import SmaccSession
+
+    monkeypatch.setattr(
+        SmaccSession,
+        "init_lsl_stream",
+        lambda self, *a, **k: setattr(self, "outlet", None),
+    )
+    window = SmaccWindow(SmaccSession(tmp_path / "data", design=False))
+    qtbot.addWidget(window)
+    window.apply_settings(window.gather_settings())
+    assert (
+        window.session.devices.device_for_equipment("control_speaker")
+        == "Rig Control Speaker"
+    )
+    window.session.close()
+
+
 def test_apply_settings_lands_values(
     qtbot, design_session, mock_devices, silence_dialogs
 ):

--- a/tests/test_studyconfig.py
+++ b/tests/test_studyconfig.py
@@ -23,7 +23,7 @@ from pathlib import Path
 import yaml
 
 import smacc
-from smacc import biocals, devices, events, hue, settings, studyconfig, triggers
+from smacc import biocals, devices, events, settings, studyconfig, triggers
 from smacc.studyconfig import StudyConfig
 
 DEFAULT_SMACC = Path(smacc.__file__).parent / "assets" / "default.smacc"
@@ -53,7 +53,6 @@ EXPECTED_ORDER = [
     "event_codes",
     "event_code_safe_max",
     "trigger_output",
-    "hue",
     "data_directory",
     "preview_levels",
     "always_on_top",
@@ -69,8 +68,6 @@ def _full_settings() -> dict:
     a round-trip is expected to reproduce it byte-for-byte.
     """
     dev = devices.default_config()  # complete routing, so from_dict round-trips
-    dev.bindings["bedroom_speaker"] = "Speakers (Demo)"
-    dev.bindings["bedroom_mic_1"] = "Microphone (Demo)"
     custom = events.EventDef(
         key="DoorKnock",
         label="Door knock",
@@ -109,11 +106,12 @@ def _full_settings() -> dict:
         "chat_red_text": True,
         "volume_cap": 0.8,
         "output_latency": "low",
-        "devices": dev.to_dict(),
+        "devices": dev.to_study_dict(),  # routing only; bindings are rig-local (#300)
         "event_codes": events.events_to_list([*events.default_events(), custom]),
         "event_code_safe_max": 200,
-        "trigger_output": triggers.TriggerConfig(enabled=True, port="COM3").to_dict(),
-        "hue": hue.HueConfig(bridge_ip="192.168.1.50", app_key="abc123").to_dict(),
+        "trigger_output": triggers.TriggerConfig(
+            enabled=True, mode="hold", pulse_ms=5
+        ).to_study_dict(),  # behavior only; port/baud/address are rig-local
         "data_directory": "data",
         "preview_levels": ["DEBUG", "INFO"],
         "always_on_top": True,
@@ -148,10 +146,12 @@ def test_fresh_config_serializes_to_documented_defaults():
     assert out["preview_levels"] == ["INFO", "WARNING", "ERROR", "CRITICAL"]
     assert out["always_on_top"] is False
     assert out["tool_always_on_top"] == {}
-    # Reused sub-models serialize exactly like their own emitters.
-    assert out["devices"] == devices.default_config().to_dict()
-    assert out["trigger_output"] == triggers.TriggerConfig().to_dict()
-    assert out["hue"] == {"bridge_ip": "", "app_key": ""}
+    # The study carries only the portable half of devices/trigger; bindings, the
+    # trigger port, and the Hue credential are rig-local (#300).
+    assert out["devices"] == devices.default_config().to_study_dict()
+    assert "bindings" not in out["devices"]
+    assert out["trigger_output"] == triggers.TriggerConfig().to_study_dict()
+    assert "hue" not in out
     assert out["event_codes"] == events.events_to_list(events.default_events())
 
 
@@ -209,12 +209,13 @@ def test_default_smacc_loads_and_is_idempotent():
         "output_latency",
         "devices",
         "trigger_output",
-        "hue",
         "preview_levels",
         "always_on_top",
         "tool_always_on_top",
     ):
         assert key in out1
+    assert "hue" not in out1  # the Hue credential is rig-local now (#300)
+    assert "bindings" not in out1["devices"]  # bindings are rig-local
 
 
 # ----- leniency (mirrors each panel's apply_state tolerance) -----------------

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -175,3 +175,53 @@ def test_parallel_driver_available_reflects_dll_load(monkeypatch):
     assert triggers.parallel_driver_available() is False
     monkeypatch.setattr(triggers, "_load_inpout", lambda: object())
     assert triggers.parallel_driver_available() is True
+
+
+# ----- study/rig split (#300) ------------------------------------------------
+
+
+def test_to_study_dict_omits_machine_fields():
+    cfg = triggers.TriggerConfig(
+        enabled=True, transport="serial", port="COM3", baud=9600, address="0x278"
+    )
+    study = cfg.to_study_dict()
+    assert study == {
+        "enabled": True,
+        "transport": "serial",
+        "mode": "pulsed",
+        "pulse_ms": 10,
+    }
+    assert not {"port", "baud", "address"} & set(study)  # machine fields omitted
+
+
+def test_to_rig_dict_is_machine_fields_only():
+    cfg = triggers.TriggerConfig(port="COM3", baud=9600, address="0x278")
+    assert cfg.to_rig_dict() == {"port": "COM3", "baud": 9600, "address": "0x278"}
+
+
+def test_from_study_and_rig_combines_behavior_and_machine():
+    study = {
+        "trigger_output": {
+            "enabled": True,
+            "transport": "serial",
+            "mode": "pulsed",
+            "pulse_ms": 5,
+        }
+    }
+    cfg = triggers.from_study_and_rig(
+        study, {"port": "COM7", "baud": 9600, "address": "0x3F8"}
+    )
+    assert cfg.enabled is True
+    assert cfg.transport == "serial"
+    assert cfg.pulse_ms == 5
+    assert cfg.port == "COM7"
+    assert cfg.baud == 9600
+    assert cfg.address == "0x3F8"
+
+
+def test_from_study_and_rig_empty_rig_leaves_study_values():
+    study = {"trigger_output": {"enabled": True, "port": "COM1"}}
+    cfg = triggers.from_study_and_rig(study, {})
+    # No rig machine fields → keep whatever from_dict produced (defaults / legacy).
+    assert cfg.port == "COM1"  # a legacy study port survives when the rig has none
+    assert cfg.baud == triggers.DEFAULT_BAUD


### PR DESCRIPTION
Splits a study's device configuration into a **portable study** (logical) and a
**machine-local rig profile** (physical), so a `.smacc` carries no machine-specific
device names and transfers cleanly between rigs (#300).

**What moves where**

| | Portable study (`.smacc`) | Rig profile (`preferences.yaml`) |
|---|---|---|
| Devices | action→equipment routing | equipment→device bindings |
| Trigger | enabled, transport, mode, pulse | port / baud / address |
| Hue | (routing is in `devices`) | bridge IP + app key |

**How it works**

- **Load** — `apply_settings` builds the live device/trigger/Hue config from the
  study (routing/behavior) overlaid with the rig profile (bindings/port/creds), via
  new pure `devices.from_study_and_rig` / `triggers.from_study_and_rig` combiners. A
  rig value wins over anything a legacy study still carries.
- **Save/gather** — `StudyConfig.to_settings_dict` (which `gather_settings` routes
  through) emits the **study-half**: routing-only `devices`, behavior-only
  `trigger_output`, and no `hue` block. On save, the rig-half is written to the rig
  profile (`preferences.update_rig`).
- **Session log** — keeps the **full resolved config** (it now serializes
  `_window_settings()`, the pre-model dict), so the record still shows which device
  actually played.

The equipment vocabulary stays global (`devices.EQUIPMENT`), which is what lets a
study's routing and a rig's bindings refer to the same equipment without a
cross-file handshake.

**Not in this PR** (separate #300 slices): the load-time "this rig isn't bound for
this study" safety gate, the launcher Rig-setup tool, in-session re-binding, and
persisting a binding to the rig the moment it changes (today the rig is captured on
save). The editor's device bindings become ephemeral until the hardware-free editor
lands (#301).

Verified: pure unit tests for the projections/combiners, updated `StudyConfig` and
GUI tests for the study-half shape, a GUI test that a rig binding overlays the
study, full suite green (1165), ruff and mypy clean.

Closes the load + save halves of the carve in #300.
