### PR TITLE
feat: persist and reuse device bindings via the rig profile

### DIFF
--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -135,6 +135,12 @@ class SmaccWindow(ToolWindow):
             markers_window.reload_from_session
         )
         self.devices_window.changed.connect(self._refresh_device_indicators)
+        # An operator binding edit persists to the rig profile, so binding a device
+        # once is reused by every later study on this machine (#300). This uses the
+        # dedicated ``binding_edited`` signal (only a manual equipment-binding edit),
+        # not ``changed`` — which also fires on autobind and would otherwise clobber
+        # the rig's manual bindings with the autobound defaults mid-load.
+        self.devices_window.binding_edited.connect(self._persist_rig_bindings)
         # The Devices window's Refresh button (and its F5 shortcut) runs this rescan
         # (PortAudio re-init + BlinkStick scan); it's the only entry point now.
         self.devices_window.refresh_requested.connect(self.refresh_all_devices)
@@ -1159,6 +1165,21 @@ class SmaccWindow(ToolWindow):
         }
         preferences.update_rig(preferences_path, rig)
         self._prefs["rig"] = rig
+
+    def _persist_rig_bindings(self) -> None:
+        """Persist just the equipment->device bindings to the rig profile (#300).
+
+        Connected to the Devices window's ``changed`` signal so a binding made in one
+        session is reused by every later study on this machine, without needing a Save.
+        Writes only the ``bindings`` sub-key (leaving the rig's trigger/hue intact) and
+        keeps the in-memory prefs in sync so a later load reads the new binding.
+        Sessions only — the editor authors a study, not this machine's rig.
+        """
+        if self.design:
+            return
+        bindings = dict(self.session.devices.bindings)
+        preferences.update_rig(preferences_path, {"bindings": bindings})
+        self._prefs.setdefault("rig", {})["bindings"] = bindings
 
     def load_settings(self) -> None:
         """Prompt for a .smacc settings file and apply it."""

--- a/src/smacc/panels/devices.py
+++ b/src/smacc/panels/devices.py
@@ -127,6 +127,10 @@ class DevicesWindow(PanelWindow):
 
     # Fired whenever a binding/route changes, so the window can refresh indicators.
     changed = QtCore.pyqtSignal()
+    # Fired only by an operator's equipment-binding edit — not routing, not autobind,
+    # not the programmatic reload — so the session can persist that binding to the
+    # machine's rig profile without the autobound defaults clobbering it (#300).
+    binding_edited = QtCore.pyqtSignal()
     # Fired by the Refresh button (and its F5 shortcut); the session window runs the
     # rescan (PortAudio re-init + a live BlinkStick scan).
     refresh_requested = QtCore.pyqtSignal()
@@ -325,6 +329,7 @@ class DevicesWindow(PanelWindow):
         )
         self.refresh_device_indicator()
         self.changed.emit()
+        self.binding_edited.emit()  # operator edit → persist to the rig profile (#300)
 
     def _set_routing(self, action_key: str) -> None:
         """An action's equipment dropdown changed: write just that route."""

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -221,6 +221,32 @@ def test_rig_profile_overlays_device_bindings(
     window.session.close()
 
 
+def test_binding_edit_persists_to_the_rig_profile(
+    qtbot, tmp_path, monkeypatch, mock_devices, silence_dialogs
+):
+    # An operator binding edit in a session is written straight to the rig profile
+    # (preferences), so the next study on this machine reuses it without a Save (#300).
+    prefs_path = tmp_path / "preferences.yaml"
+    monkeypatch.setattr(gui, "preferences_path", prefs_path)
+
+    from smacc.session import SmaccSession
+
+    monkeypatch.setattr(
+        SmaccSession,
+        "init_lsl_stream",
+        lambda self, *a, **k: setattr(self, "outlet", None),
+    )
+    window = SmaccWindow(SmaccSession(tmp_path / "data", design=False))
+    qtbot.addWidget(window)
+    # Simulate binding the control-room speaker: the edit mutates the live config and
+    # fires the binding_edited signal (as a real equipment-dropdown edit would).
+    window.session.devices.bindings["control_speaker"] = "My Speaker"
+    window.devices_window.binding_edited.emit()
+    saved = preferences.rig_bindings(preferences.load_preferences(prefs_path))
+    assert saved["control_speaker"] == "My Speaker"
+    window.session.close()
+
+
 def test_apply_settings_lands_values(
     qtbot, design_session, mock_devices, silence_dialogs
 ):


### PR DESCRIPTION
Completes the "bind once per rig, reused by every study" promise of the device
split (#300): an operator's equipment-binding edit in a session is now written
straight to the machine-local rig profile (`preferences.yaml`), so the next study
on this machine reuses it without needing a Save.

- New `DevicesWindow.binding_edited` signal, fired **only** by a manual
  equipment-binding edit. `SmaccWindow._persist_rig_bindings` listens and writes
  just the `bindings` sub-key of the rig profile.
- Deliberately **not** wired to the existing `changed` signal: that also fires on
  `autobind_defaults`, so persisting on it would clobber the rig's manually-bound
  (non-autobound) equipment with the autobound audio defaults on every load. The
  `test_rig_profile_overlays_device_bindings` test guards against exactly that.

Editor (design mode) is excluded — it authors a study, not this machine's rig.

Verified: a new test that a binding edit lands in the rig profile, the
overlay/clobber-guard test, full suite green (1166), ruff and mypy clean.

Part of #300 (in-session re-bind / per-change rig persistence).
