### PR TITLE
feat: add a standalone Rig setup launcher tool

### DIFF
--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -25,6 +25,7 @@ from .config import display_version
 from .cuedesigner import CueDesignerWindow
 from .gui import SmaccWindow
 from .paths import DEFAULT_DATA_DIR, DEFAULT_SETTINGS_PATH, LOGO_PATH, preferences_path
+from .rigsetup import RigSetupWindow
 from .session import SmaccSession
 from .toolwindow import ToolWindow
 
@@ -116,6 +117,11 @@ class LauncherWindow(QtWidgets.QMainWindow):
             "Audio Cue Designer",
             "Create a tone cue and export it as a WAV file.",
             self.design_cues,
+        )
+        tool_button(
+            "Rig setup",
+            "Bind this machine's equipment to devices (the rig profile); no study needed.",
+            self.setup_rig,
         )
         # The EEG Annotator (#136) opens in its own process so it can outlive a
         # session (see review_eeg). MNE ships inside the one SMACC binary, so the
@@ -264,6 +270,10 @@ class LauncherWindow(QtWidgets.QMainWindow):
     def design_cues(self) -> None:
         """Open the standalone Audio Cue Designer (exports WAVs to the cues folder)."""
         self._open_tool(CueDesignerWindow(DEFAULT_DATA_DIR / "cues"))
+
+    def setup_rig(self) -> None:
+        """Open the standalone Rig setup tool (edits this machine's rig profile, #300)."""
+        self._open_tool(RigSetupWindow())
 
     def analyze_session(self) -> None:
         """Open the Analyzer over the default data directory."""

--- a/src/smacc/panels/devices.py
+++ b/src/smacc/panels/devices.py
@@ -120,6 +120,58 @@ def hue_devices(cfg: hue.HueConfig) -> list[tuple[str, str]]:
         return []
 
 
+def _select_equipment_row(combo: QtWidgets.QComboBox, key: str) -> bool:
+    """Select the row for device ``key`` in ``combo``; index 0 (placeholder) when blank.
+
+    A bound device with no row (not currently connected) is added as an explicit
+    "(not connected)" row carrying ``key`` and selected, so the combo shows the truth
+    rather than the placeholder while the binding — kept, not swapped — still points at
+    the missing device. Returns False in exactly that case so the caller can flag it.
+    """
+    if not key:
+        combo.setCurrentIndex(0)
+        return True
+    if select_saved_device(combo, key):
+        return not combo.itemData(combo.currentIndex(), _MISSING_ROLE)
+    combo.addItem(f"{key} (not connected)", key)
+    index = combo.count() - 1
+    combo.setItemData(index, True, _MISSING_ROLE)
+    combo.setCurrentIndex(index)
+    return False
+
+
+def populate_equipment_combo(
+    combo: QtWidgets.QComboBox,
+    equipment: devices.Equipment,
+    hue_config: hue.HueConfig,
+    bound: str,
+) -> bool:
+    """(Re)fill one equipment dropdown from a fresh enumeration and select ``bound``.
+
+    Shared by the in-session Devices panel and the standalone Rig setup tool (#300).
+    Index 0 reads "(none)" when devices are available and a kind-specific "No … found"
+    when none are. Returns False iff ``bound`` is set but the device isn't currently
+    connected (a "(not connected)" row is shown), so a caller can flag the miss.
+    """
+    combo.blockSignals(True)
+    combo.clear()
+    if equipment.key == "philips_hue_light":
+        entries = hue_devices(hue_config)
+        empty = _NO_LIGHTS_LABEL if hue_config.configured else _NO_BRIDGE_LABEL
+    elif equipment.kind == devices.VISUAL:
+        entries = blinkstick_devices()
+        empty = _EMPTY_LABELS[devices.VISUAL]
+    else:
+        entries = [(name, name) for name in wasapi_devices(equipment.kind)]
+        empty = _EMPTY_LABELS[equipment.kind]
+    combo.addItem(_NONE_LABEL if entries else empty, "")
+    for label, key in entries:
+        combo.addItem(label, key)
+    connected = _select_equipment_row(combo, bound)
+    combo.blockSignals(False)
+    return connected
+
+
 class DevicesWindow(PanelWindow):
     """Bind devices to equipment and route actions to equipment (edits session.devices)."""
 
@@ -270,49 +322,16 @@ class DevicesWindow(PanelWindow):
         kind-specific "No … found" when there are none (#139).
         """
         for equipment in devices.EQUIPMENT:
-            combo = self._equipment_combos[equipment.key]
-            combo.blockSignals(True)
-            combo.clear()
-            if equipment.key == "philips_hue_light":
-                entries = hue_devices(self.session.hue_config)
-                empty = (
-                    _NO_LIGHTS_LABEL
-                    if self.session.hue_config.configured
-                    else _NO_BRIDGE_LABEL
-                )
-            elif equipment.kind == devices.VISUAL:
-                entries = blinkstick_devices()
-                empty = _EMPTY_LABELS[devices.VISUAL]
-            else:
-                entries = [(name, name) for name in wasapi_devices(equipment.kind)]
-                empty = _EMPTY_LABELS[equipment.kind]
-            combo.addItem(_NONE_LABEL if entries else empty, "")
-            for label, key in entries:
-                combo.addItem(label, key)
-            bound = self.session.devices.device_for_equipment(equipment.key)
-            self._select_device_row(combo, bound)
-            combo.blockSignals(False)
+            populate_equipment_combo(
+                self._equipment_combos[equipment.key],
+                equipment,
+                self.session.hue_config,
+                self.session.devices.device_for_equipment(equipment.key),
+            )
 
     def _select_device_row(self, combo: QtWidgets.QComboBox, key: str) -> bool:
-        """Select the row for device ``key``; index 0 (the placeholder) when blank.
-
-        A bound device with no row (not currently connected) is added as an
-        explicit "(not connected)" row carrying ``key`` as its data and selected,
-        so the combo shows the truth instead of displaying the placeholder while
-        the binding — which is kept (flag, don't swap) — still points at the
-        missing device. Returns False in exactly that case so
-        :meth:`reload_from_config` can flag it. A rescan rebuilds the list, so
-        the row disappears once the device is back (or another is picked).
-        """
-        if not key:
-            combo.setCurrentIndex(0)
-            return True
-        if select_saved_device(combo, key):
-            return not combo.itemData(combo.currentIndex(), _MISSING_ROLE)
-        combo.addItem(f"{key} (not connected)", key)
-        index = combo.count() - 1
-        combo.setItemData(index, True, _MISSING_ROLE)
-        combo.setCurrentIndex(index)
+        """Select the row for device ``key`` (see :func:`_select_equipment_row`)."""
+        return _select_equipment_row(combo, key)
         return False
 
     # ----- editing -> session.devices ----------------------------------------

--- a/src/smacc/rigsetup.py
+++ b/src/smacc/rigsetup.py
@@ -1,0 +1,144 @@
+"""Rig setup: bind this machine's equipment to devices, stored in the rig profile.
+
+A launcher tool (#300) for the *physical* half of a device setup, the part that stays
+on this machine: which actual device each piece of equipment (the bedroom speaker, the
+mics, the lights) resolves to, plus the Hue bridge credential. It writes the ``rig``
+block of ``preferences.yaml`` — the same store a session populates as you bind during a
+night — so a fresh rig can be set up once, with no study open, and every study on this
+machine then reuses it.
+
+Action→equipment *routing* is a study concern (it travels in the ``.smacc``), so it is
+deliberately not here — only the equipment→device bindings are.
+"""
+
+from __future__ import annotations
+
+from functools import partial
+
+import sounddevice as sd
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from . import devices, hue, preferences
+from .dialogs import HueBridgeDialog
+from .panels.base import make_section_title
+from .panels.devices import populate_equipment_combo
+from .paths import LOGO_PATH, preferences_path
+from .toolwindow import ToolWindow
+
+
+class RigSetupWindow(ToolWindow):
+    """Bind this machine's equipment to devices, persisted to the rig profile."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        prefs = preferences.load_preferences(preferences_path)
+        self._bindings: dict[str, str] = dict(preferences.rig_bindings(prefs))
+        self._hue = hue.from_dict(preferences.rig_hue(prefs))
+        self._combos: dict[str, QtWidgets.QComboBox] = {}
+        self.setWindowTitle("SMACC — Rig setup")
+        if LOGO_PATH.is_file():
+            self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
+        self._build_menu()
+        self.setCentralWidget(self._build())
+        self._repopulate()
+        self.statusBar()
+        self.show()
+
+    def _build_menu(self) -> None:
+        menu = self.menuBar()
+        assert menu is not None
+        file_menu = menu.addMenu("&File")
+        assert file_menu is not None
+        close_action = QtGui.QAction("&Close", self)
+        close_action.setShortcut("Ctrl+W")
+        close_action.setStatusTip("Close Rig setup and return to the Launcher.")
+        close_action.triggered.connect(self.close)
+        file_menu.addAction(close_action)
+
+    def _build(self) -> QtWidgets.QWidget:
+        form = QtWidgets.QFormLayout()
+        form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        for equipment in devices.EQUIPMENT:
+            combo = QtWidgets.QComboBox(self)
+            combo.setToolTip(equipment.description)
+            combo.setStatusTip(f"The device serving as {equipment.label}.")
+            combo.currentIndexChanged.connect(partial(self._set_binding, equipment.key))
+            self._combos[equipment.key] = combo
+            form.addRow(f"{equipment.label} is:", combo)
+
+        refresh_button = QtWidgets.QPushButton("Refresh devices (F5)", self)
+        refresh_button.setShortcut("F5")
+        refresh_button.setStatusTip(
+            "Rescan for audio devices, BlinkSticks, and Hue lights."
+        )
+        refresh_button.clicked.connect(self._refresh)
+        hue_button = QtWidgets.QPushButton("Set up Philips Hue…", self)
+        hue_button.setStatusTip(
+            "Pair with a Hue bridge so its lights can serve as the visual cue."
+        )
+        hue_button.clicked.connect(self._setup_hue)
+        buttons = QtWidgets.QHBoxLayout()
+        buttons.addWidget(refresh_button)
+        buttons.addWidget(hue_button)
+
+        hint = QtWidgets.QLabel(
+            "Bind each piece of the rig to one of this machine's devices. This is the "
+            "machine's setup — reused by every study and saved as you go. Which "
+            "equipment each action uses (routing) lives in the Editor."
+        )
+        hint.setWordWrap(True)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(make_section_title("Rig setup"))
+        layout.addWidget(hint)
+        layout.addLayout(buttons)
+        layout.addSpacing(8)
+        layout.addLayout(form)
+        layout.addStretch(1)
+        central = QtWidgets.QWidget()
+        central.setContentsMargins(8, 8, 8, 8)
+        central.setLayout(layout)
+        return central
+
+    def _repopulate(self) -> None:
+        """Refresh every dropdown from a live enumeration, selecting the saved binding."""
+        for equipment in devices.EQUIPMENT:
+            populate_equipment_combo(
+                self._combos[equipment.key],
+                equipment,
+                self._hue,
+                self._bindings.get(equipment.key, ""),
+            )
+
+    def _set_binding(self, equipment_key: str) -> None:
+        """An equipment dropdown changed: write that one binding to the rig profile."""
+        key = self._combos[equipment_key].currentData()
+        if key:
+            self._bindings[equipment_key] = key
+        else:  # the "(none)" / "No … found" placeholder rows carry no device key
+            self._bindings.pop(equipment_key, None)
+        preferences.update_rig(preferences_path, {"bindings": self._bindings})
+
+    def _refresh(self) -> None:
+        """Rescan for devices plugged in after launch, then re-list (nothing streams here)."""
+        try:
+            sd._terminate()
+            sd._initialize()  # rebuild PortAudio's cached device list
+        except Exception:
+            pass
+        self._repopulate()
+
+    def _setup_hue(self) -> None:
+        """Pair a Hue bridge; on accept, store the credential in the rig profile."""
+        dialog = HueBridgeDialog(self._hue, parent=self)
+        if not dialog.exec():
+            return
+        self._hue = dialog.get_config()
+        preferences.update_rig(preferences_path, {"hue": self._hue.to_dict()})
+        self._repopulate()
+
+    def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+        """Close and return to the launcher (it reappears via ``closed``)."""
+        if event is not None:
+            event.accept()
+        self.closed.emit()

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -207,3 +207,26 @@ def test_open_editor_existing_opens_that_file(qtbot, tmp_path, monkeypatch):
     qtbot.addWidget(win)
     win._open_editor()
     assert captured["path"] == str(good)
+
+
+# ----- Rig setup: a standalone launcher tool (#300) ---------------------------
+
+
+def test_setup_rig_button_opens_the_rig_setup_tool(
+    qtbot, tmp_path, monkeypatch, mock_devices
+):
+    from smacc import hue, rigsetup
+    from smacc.rigsetup import RigSetupWindow
+
+    _patch_prefs(monkeypatch, tmp_path)
+    monkeypatch.setattr(rigsetup, "preferences_path", tmp_path / "preferences.yaml")
+    monkeypatch.setattr(hue, "targets", lambda cfg: [])  # no Hue network in tests
+    win = LauncherWindow()
+    qtbot.addWidget(win)
+    win.show()
+    win.setup_rig()
+    assert isinstance(win._tool, RigSetupWindow)
+    assert win._tool.isVisible()  # the tool shows itself
+    assert not win.isVisible()  # and the launcher hides until it closes
+    win._tool.close()  # returns control to the launcher (it reappears)
+    assert win.isVisible()

--- a/tests/test_rigsetup.py
+++ b/tests/test_rigsetup.py
@@ -1,0 +1,62 @@
+"""Tests for the standalone Rig setup tool (edits this machine's rig profile, #300)."""
+
+from smacc import devices, hue, preferences, rigsetup
+from smacc.rigsetup import RigSetupWindow
+
+
+def test_lists_all_equipment_and_loads_saved_bindings(
+    qtbot, tmp_path, monkeypatch, mock_devices
+):
+    monkeypatch.setattr(hue, "targets", lambda cfg: [])  # no Hue network in tests
+    prefs_path = tmp_path / "preferences.yaml"
+    preferences.update_rig(
+        prefs_path, {"bindings": {"bedroom_speaker": mock_devices["outputs"][0]}}
+    )
+    monkeypatch.setattr(rigsetup, "preferences_path", prefs_path)
+    window = RigSetupWindow()
+    qtbot.addWidget(window)
+    # One dropdown per piece of equipment, and the saved binding is loaded.
+    assert set(window._combos) == {e.key for e in devices.EQUIPMENT}
+    assert window._bindings["bedroom_speaker"] == mock_devices["outputs"][0]
+
+
+def test_binding_edit_writes_the_rig_profile(
+    qtbot, tmp_path, monkeypatch, mock_devices
+):
+    monkeypatch.setattr(hue, "targets", lambda cfg: [])
+    prefs_path = tmp_path / "preferences.yaml"
+    monkeypatch.setattr(rigsetup, "preferences_path", prefs_path)
+    window = RigSetupWindow()
+    qtbot.addWidget(window)
+    combo = window._combos["bedroom_speaker"]
+    index = combo.findData(mock_devices["outputs"][0])
+    assert index >= 0
+    combo.setCurrentIndex(index)  # fires _set_binding -> update_rig
+    saved = preferences.rig_bindings(preferences.load_preferences(prefs_path))
+    assert saved["bedroom_speaker"] == mock_devices["outputs"][0]
+
+
+def test_selecting_none_clears_the_binding(qtbot, tmp_path, monkeypatch, mock_devices):
+    monkeypatch.setattr(hue, "targets", lambda cfg: [])
+    prefs_path = tmp_path / "preferences.yaml"
+    preferences.update_rig(
+        prefs_path, {"bindings": {"bedroom_speaker": mock_devices["outputs"][0]}}
+    )
+    monkeypatch.setattr(rigsetup, "preferences_path", prefs_path)
+    window = RigSetupWindow()
+    qtbot.addWidget(window)
+    window._combos["bedroom_speaker"].setCurrentIndex(0)  # the "(none)" row
+    saved = preferences.rig_bindings(preferences.load_preferences(prefs_path))
+    assert "bedroom_speaker" not in saved
+
+
+def test_close_emits_closed(qtbot, tmp_path, monkeypatch, mock_devices):
+    monkeypatch.setattr(hue, "targets", lambda cfg: [])
+    prefs_path = tmp_path / "preferences.yaml"
+    monkeypatch.setattr(rigsetup, "preferences_path", prefs_path)
+    window = RigSetupWindow()
+    qtbot.addWidget(window)
+    closed: list[bool] = []
+    window.closed.connect(lambda: closed.append(True))
+    window.close()
+    assert closed == [True]


### PR DESCRIPTION
Adds a **Rig setup** tool to the Launcher: bind this machine's equipment
(speakers, mics, lights) to devices and pair a Hue bridge, with **no study open**.
It writes the `rig` block of `preferences.yaml` — the same store a session
populates as you bind during a night — so a fresh rig can be set up once and every
study on this machine reuses it. The dedicated way to populate the rig profile
(#300), complementing the per-change persistence that already captures binding
edits made during a session.

- New `smacc/rigsetup.py` — `RigSetupWindow(ToolWindow)`: equipment→device
  dropdowns + Refresh + "Set up Philips Hue…", persisting each change to the rig
  profile, and returning to the Launcher on close.
- Extracted `populate_equipment_combo` / `_select_equipment_row` from the Devices
  panel into shared module functions so the in-session panel and the tool fill the
  dropdowns identically (the panel now delegates to them — behavior unchanged, as
  its tests confirm).
- Launcher gains a "Rig setup" button.

Action→equipment **routing** is a study concern, so it stays in the Editor, not
here — the tool shows only the physical bindings. (The hardware trigger's port is
still set in a session's Markers window for now.)

Verified: new `test_rigsetup.py` (lists all equipment, loads saved bindings, a
binding edit/clear writes the rig profile, close returns to the launcher), a
launcher test that the button opens the tool, the Devices-panel tests still pass
after the extraction, full suite green (1171), ruff and mypy clean.

Closes the last slice of #300 (the Rig-setup tool).
