### PR TITLE
refactor: rename SmaccSession's design flag to headless

### DIFF
--- a/scripts/screenshots.py
+++ b/scripts/screenshots.py
@@ -178,25 +178,25 @@ def main(out_dir: Path = ASSETS) -> None:
 
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
         root = Path(tmp)
-        design = SmaccSession(root / "study", design=True)
-        live = SmaccSession(root / "data", design=False)
-        _bind_devices(design)
+        headless = SmaccSession(root / "study", headless=True)
+        live = SmaccSession(root / "data", headless=False)
+        _bind_devices(headless)
 
         print("Capturing light-theme windows:")
         _capture(app, LauncherWindow(), "launcher")
         _capture(app, SmaccWindow(live), "session", size=(1000, 680))
 
-        editor = SmaccWindow(design)
+        editor = SmaccWindow(headless)
         editor.dataDirLabel.setText(DOC_DATA_DIR)  # don't leak the temp path
         _capture(app, editor, "editor", size=(1000, 680))
-        _capture(app, DevicesWindow(design), "devices")
-        _capture(app, BiocalsWindow(design), "biocals")
-        _capture(app, AudioCueWindow(design), "audio-cue")
-        _capture(app, VisualWindow(design), "visual")
-        _capture(app, ChatWindow(design), "intercom")
-        _capture(app, ParticipantChatWindow(design), "chat")
-        _capture(app, VolumeWindow(design), "volume")
-        _capture(app, RecordingWindow(design), "recording")
+        _capture(app, DevicesWindow(headless), "devices")
+        _capture(app, BiocalsWindow(headless), "biocals")
+        _capture(app, AudioCueWindow(headless), "audio-cue")
+        _capture(app, VisualWindow(headless), "visual")
+        _capture(app, ChatWindow(headless), "intercom")
+        _capture(app, ParticipantChatWindow(headless), "chat")
+        _capture(app, VolumeWindow(headless), "volume")
+        _capture(app, RecordingWindow(headless), "recording")
         _capture(app, CueDesignerWindow(), "cue-designer")
 
         live.close()
@@ -204,14 +204,14 @@ def main(out_dir: Path = ASSETS) -> None:
         # The one dark shot: drive the lights-off toggle to document night mode. A
         # fresh session — the one above was closed by its window's "end session" path.
         print("Capturing the dark (lights-off) session:")
-        night = SmaccSession(root / "night", design=False)
+        night = SmaccSession(root / "night", headless=False)
         dark = SmaccWindow(night)
         dark.set_lights(False)
         app.processEvents()
         _capture(app, dark, "session-dark", size=(1000, 680))
         QtGui.QGuiApplication.styleHints().setColorScheme(QtCore.Qt.ColorScheme.Light)
 
-        design.close()
+        headless.close()
         night.close()
 
 

--- a/src/smacc/gui.py
+++ b/src/smacc/gui.py
@@ -74,7 +74,7 @@ class SmaccWindow(ToolWindow):
         # Design mode reuses this window to edit a settings file (no live run): the
         # log preview, lights, and recording are hidden/disabled, and the right
         # column becomes the settings-editor panel. Derived from the session.
-        self.design = session.design
+        self.design = session.headless
         # The .smacc this window loaded/edits (None until saved), so saving can
         # write back to it rather than prompting every time.
         self.settings_path = settings_path

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -264,7 +264,7 @@ class LauncherWindow(QtWidgets.QMainWindow):
             if path
             else DEFAULT_DATA_DIR
         )
-        session = SmaccSession(data_dir, design=True)
+        session = SmaccSession(data_dir, headless=True)
         self._open_tool(SmaccWindow(session, settings_path=path))
 
     def design_cues(self) -> None:

--- a/src/smacc/panels/devices.py
+++ b/src/smacc/panels/devices.py
@@ -426,7 +426,7 @@ class DevicesWindow(PanelWindow):
         nothing. Each fill is logged ungated — which physical device a night
         actually used is provenance, not chatter.
         """
-        if self.session.design:
+        if self.session.headless:
             return
         defaults = {
             kind: default_wasapi_device(kind)

--- a/src/smacc/session.py
+++ b/src/smacc/session.py
@@ -69,7 +69,7 @@ class SmaccSession:
     """Shared session context: run folder, optional metadata, logger, LSL outlet.
 
     A live run records to a per-run folder under its study and emits markers on an
-    LSL outlet. ``design=True`` backs the study designer instead: it configures a
+    LSL outlet. ``headless=True`` backs the study designer instead: it configures a
     study without recording a run, so it creates no run folder, log, or outlet and
     emits no markers (cue/noise previews still work). Use :meth:`close` to release a
     live session's log handler and outlet so the launcher can open many in one run.
@@ -80,7 +80,7 @@ class SmaccSession:
         data_dir: str | Path,
         metadata: dict | None = None,
         *,
-        design: bool = False,
+        headless: bool = False,
     ) -> None:
         now = datetime.now()
         # The data directory this session belongs to: where its cue/noise pickers
@@ -88,9 +88,9 @@ class SmaccSession:
         # created. Comes from the loaded settings file (or the default data dir).
         self.data_dir = Path(data_dir)
         self.cues_dir = self.data_dir / "cues"
-        self.design = design
+        self.headless = headless
         # Recording a dream report needs a run folder; the designer has none.
-        self.can_record = not design
+        self.can_record = not headless
         # Subject/session/notes are optional metadata recorded inside the log and
         # exports (blank by default); they no longer drive filenames.
         self.metadata = {
@@ -104,7 +104,7 @@ class SmaccSession:
         # Optional hardware TTL trigger output alongside LSL (#28). ``trigger_config``
         # is the configured intent (persisted with the study, edited in the Trigger
         # output dialog); ``trigger_out`` is the live transport opened from it, or
-        # None when disabled, unconfigured, or in design mode. Each marker fires on
+        # None when disabled, unconfigured, or in headless mode. Each marker fires on
         # both LSL and this transport from the single emit_event path.
         self.trigger_config = triggers.TriggerConfig()
         self.trigger_out: triggers.TriggerOutput | None = None
@@ -144,15 +144,15 @@ class SmaccSession:
         # main window finishes startup, so construction and study loads don't
         # spam the log; the window flips this on afterwards.
         self.log_interactions = False
-        # The file handler this session owns (None in design mode), tracked so
+        # The file handler this session owns (None in headless mode), tracked so
         # close() can detach and close it without disturbing other handlers.
         self._file_handler: logging.FileHandler | None = None
-        if design:
+        if headless:
             # No run artifacts: a logger that records nothing, no folder, no outlet.
             self.session_dir: Path | None = None
             self.log_path: Path | None = None
             self.outlet: StreamOutlet | None = None
-            self.init_design_logger()
+            self.init_headless_logger()
         else:
             session_dir = make_session_dir(self.data_dir, now)
             self.session_dir = session_dir
@@ -184,8 +184,8 @@ class SmaccSession:
         self.logger.addHandler(fh)
         self._file_handler = fh
 
-    def init_design_logger(self) -> None:
-        """Set up a no-output logger for design mode (a study run records nothing)."""
+    def init_headless_logger(self) -> None:
+        """Set up a no-output logger for headless mode (a study run records nothing)."""
         self.logger = logging.getLogger("smacc")
         self.logger.setLevel(logging.DEBUG)
         self.logger.propagate = False
@@ -206,7 +206,7 @@ class SmaccSession:
 
         Lets the launcher run many sessions in one process without leaking open log
         files or marker outlets (the 'smacc' logger is a shared singleton). Safe to
-        call on a design session (it owns neither).
+        call on a headless session (it owns neither).
         """
         if self._file_handler is not None:
             try:
@@ -293,7 +293,7 @@ class SmaccSession:
             )
         label = f"{event.label}: {detail}" if detail else event.label
         line = f"{label} - portcode {code}" if event.triggered else label
-        # In design mode there is no outlet, so triggers are logged but not sent.
+        # In headless mode there is no outlet, so triggers are logged but not sent.
         # LSL and the hardware line are written back-to-back (before any pulse-down
         # sleep) so both edges land as close together as possible. LSL is stamped at
         # the estimated onset (now + onset_offset) so it lines up with the stimulus;
@@ -404,12 +404,12 @@ class SmaccSession:
         Closes any existing transport first, then opens the new one. Returns an
         error message when an *enabled* transport can't be opened (the window shows
         it to the operator), or None on success or when disabled. Never raises: a
-        design session or a disabled config simply ends with no transport.
+        headless session or a disabled config simply ends with no transport.
         """
         if self.trigger_out is not None:
             self.trigger_out.close()
             self.trigger_out = None
-        if self.design or not config.enabled:
+        if self.headless or not config.enabled:
             return None
         try:
             self.trigger_out = triggers.open_trigger(config)
@@ -452,7 +452,7 @@ class SmaccSession:
 
     def _restore_trigger_output(self) -> None:
         """Best-effort reopen of the applied trigger config (used after a test)."""
-        if self.design or not self.trigger_config.enabled:
+        if self.headless or not self.trigger_config.enabled:
             return
         try:
             self.trigger_out = triggers.open_trigger(self.trigger_config)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -144,9 +144,9 @@ def silence_dialogs(monkeypatch):
 
 
 @pytest.fixture
-def design_session(tmp_path):
+def headless_session(tmp_path):
     """A study-designer session: no run folder, no hardware, no log file."""
-    session = SmaccSession(tmp_path / "study", design=True)
+    session = SmaccSession(tmp_path / "study", headless=True)
     yield session
     session.close()
 
@@ -164,6 +164,6 @@ def live_session(tmp_path, monkeypatch):
         "init_lsl_stream",
         lambda self, *a, **k: setattr(self, "outlet", None),
     )
-    session = SmaccSession(tmp_path / "data", design=False)
+    session = SmaccSession(tmp_path / "data", headless=False)
     yield session
     session.close()

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -26,9 +26,9 @@ def _stub_winvolume(monkeypatch):
 
 
 def test_window_builds_in_design_mode(
-    qtbot, design_session, mock_devices, silence_dialogs
+    qtbot, headless_session, mock_devices, silence_dialogs
 ):
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     assert window.design is True
     state = window.gather_settings()
@@ -136,11 +136,11 @@ def test_is_default_settings_distinguishes_paths(tmp_path):
 
 
 def test_editor_save_of_default_redirects_to_save_as(
-    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+    qtbot, headless_session, mock_devices, silence_dialogs, monkeypatch
 ):
     # Editing the seeded default and hitting Save must go to Save-As, never an
     # in-place overwrite of default.smacc (it's SMACC's known-good template).
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     window.settings_path = str(paths.DEFAULT_SETTINGS_PATH)
     called: list[bool] = []
@@ -150,10 +150,10 @@ def test_editor_save_of_default_redirects_to_save_as(
 
 
 def test_write_settings_refuses_the_default_path(
-    qtbot, design_session, mock_devices, silence_dialogs
+    qtbot, headless_session, mock_devices, silence_dialogs
 ):
     # Even if default.smacc is hand-picked in the Save-As dialog, writing is refused.
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     assert window._write_settings(str(paths.DEFAULT_SETTINGS_PATH)) is False
 
@@ -162,9 +162,9 @@ def test_write_settings_refuses_the_default_path(
 
 
 def test_settings_gather_apply_is_a_fixed_point(
-    qtbot, design_session, mock_devices, silence_dialogs
+    qtbot, headless_session, mock_devices, silence_dialogs
 ):
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     first = window.gather_settings()
     window.apply_settings(first)
@@ -173,13 +173,13 @@ def test_settings_gather_apply_is_a_fixed_point(
 
 
 def test_gather_settings_emits_the_study_half(
-    qtbot, design_session, mock_devices, silence_dialogs
+    qtbot, headless_session, mock_devices, silence_dialogs
 ):
     # gather_settings() routes the window state through StudyConfig, which emits the
     # PORTABLE half: routing but not machine-local bindings, trigger behavior but not
     # the port/baud/address, and no Hue credential (all rig-local, #300). Everything
     # else is unchanged from the full window state (_window_settings).
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     full = window._window_settings()
     study = window.gather_settings()
@@ -211,7 +211,7 @@ def test_rig_profile_overlays_device_bindings(
         "init_lsl_stream",
         lambda self, *a, **k: setattr(self, "outlet", None),
     )
-    window = SmaccWindow(SmaccSession(tmp_path / "data", design=False))
+    window = SmaccWindow(SmaccSession(tmp_path / "data", headless=False))
     qtbot.addWidget(window)
     window.apply_settings(window.gather_settings())
     assert (
@@ -236,7 +236,7 @@ def test_binding_edit_persists_to_the_rig_profile(
         "init_lsl_stream",
         lambda self, *a, **k: setattr(self, "outlet", None),
     )
-    window = SmaccWindow(SmaccSession(tmp_path / "data", design=False))
+    window = SmaccWindow(SmaccSession(tmp_path / "data", headless=False))
     qtbot.addWidget(window)
     # Simulate binding the control-room speaker: the edit mutates the live config and
     # fires the binding_edited signal (as a real equipment-dropdown edit would).
@@ -248,9 +248,9 @@ def test_binding_edit_persists_to_the_rig_profile(
 
 
 def test_apply_settings_lands_values(
-    qtbot, design_session, mock_devices, silence_dialogs
+    qtbot, headless_session, mock_devices, silence_dialogs
 ):
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     settings = window.gather_settings()
     settings["volume_cap"] = 0.5
@@ -281,17 +281,17 @@ def test_apply_settings_lands_values(
         == mock_devices["outputs"][0]
     )
     # The bound devices all match advertised hardware, so none are flagged missing.
-    assert design_session.missing_devices == []
+    assert headless_session.missing_devices == []
 
 
 def test_markers_window_applies_and_persists_trigger_config(
-    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+    qtbot, headless_session, mock_devices, silence_dialogs, monkeypatch
 ):
     # The Markers tool window owns the transport config now (no menu dialog).
     monkeypatch.setattr(
         triggers, "list_serial_ports", lambda: [("COM4", "Trigger box")]
     )
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     markers = window.panels["markers"]
     markers._load_trigger_config(
@@ -308,11 +308,11 @@ def test_markers_window_applies_and_persists_trigger_config(
 
 
 def test_markers_apply_rebuilds_the_event_grid(
-    qtbot, design_session, mock_devices, silence_dialogs
+    qtbot, headless_session, mock_devices, silence_dialogs
 ):
     # Applying a registry change in the Markers window re-renders the event grid
     # (its buttons' tooltips carry each event's code + routing).
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     markers = window.panels["markers"]
     i = next(i for i, e in enumerate(markers._events) if e.key == "REMDetected")
@@ -329,11 +329,11 @@ def test_markers_apply_rebuilds_the_event_grid(
 
 
 def test_grid_add_event_refreshes_the_markers_staging(
-    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+    qtbot, headless_session, mock_devices, silence_dialogs, monkeypatch
 ):
     from smacc import dialogs
 
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     monkeypatch.setattr(dialogs.AddEventDialog, "exec", lambda self: True)
     monkeypatch.setattr(
@@ -382,7 +382,7 @@ def test_preview_clock_toggle_switches_format_and_persists(
         "init_lsl_stream",
         lambda self, *a, **k: setattr(self, "outlet", None),
     )
-    window = SmaccWindow(SmaccSession(tmp_path / "data", design=False))
+    window = SmaccWindow(SmaccSession(tmp_path / "data", headless=False))
     qtbot.addWidget(window)
 
     # Defaults to 24-hour: the menu item is unchecked and the formatter is 24h.
@@ -457,11 +457,11 @@ def test_interface_choices_round_trip_through_settings(
 
 
 def test_editor_preserves_preview_levels_round_trip(
-    qtbot, design_session, mock_devices, silence_dialogs
+    qtbot, headless_session, mock_devices, silence_dialogs
 ):
     # The editor has no live preview pane, but it must not wipe a study's
     # preview_levels on save — it round-trips the loaded value verbatim.
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     state = window.gather_settings()
     state["preview_levels"] = ["DEBUG", "WARNING"]
@@ -488,7 +488,7 @@ def test_tool_window_geometry_persists_and_restores(
         lambda self, *a, **k: setattr(self, "outlet", None),
     )
 
-    first = SmaccWindow(SmaccSession(tmp_path / "data", design=False))
+    first = SmaccWindow(SmaccSession(tmp_path / "data", headless=False))
     qtbot.addWidget(first)
     first._open_panel("volume")  # places + marks it positioned
     first.panels["volume"].move(321, 234)
@@ -496,7 +496,7 @@ def test_tool_window_geometry_persists_and_restores(
     first.session.close()
 
     # A fresh window reads the saved geometry and reopens the tool there.
-    second = SmaccWindow(SmaccSession(tmp_path / "data", design=False))
+    second = SmaccWindow(SmaccSession(tmp_path / "data", headless=False))
     qtbot.addWidget(second)
     second._open_panel("volume")
     assert second.panels["volume"].x() == 321
@@ -506,13 +506,13 @@ def test_tool_window_geometry_persists_and_restores(
 
 
 def test_hue_credential_applies_from_study_but_is_rig_local(
-    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+    qtbot, headless_session, mock_devices, silence_dialogs, monkeypatch
 ):
     from smacc import hue
 
     # The post-load device re-enumeration must not hit the network.
     monkeypatch.setattr(hue, "targets", lambda cfg: [])
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     # The Hue bridge credential is rig-local (#300): the portable study no longer
     # carries a hue block.
@@ -521,8 +521,8 @@ def test_hue_credential_applies_from_study_but_is_rig_local(
     state = window.gather_settings()
     state["hue"] = {"bridge_ip": "192.168.1.50", "app_key": "k"}
     window.apply_settings(state)
-    assert design_session.hue_config.configured
-    assert design_session.hue_config.bridge_ip == "192.168.1.50"
+    assert headless_session.hue_config.configured
+    assert headless_session.hue_config.bridge_ip == "192.168.1.50"
     # …but it is not written back into the portable study.
     assert "hue" not in window.gather_settings()
 
@@ -543,9 +543,9 @@ def _watch_close_prompt(monkeypatch):
 
 
 def test_editor_close_without_changes_skips_prompt(
-    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+    qtbot, headless_session, mock_devices, silence_dialogs, monkeypatch
 ):
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     prompts = _watch_close_prompt(monkeypatch)
     assert window.close() is True
@@ -553,9 +553,9 @@ def test_editor_close_without_changes_skips_prompt(
 
 
 def test_editor_close_after_edit_prompts(
-    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+    qtbot, headless_session, mock_devices, silence_dialogs, monkeypatch
 ):
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     # Session metadata is part of the saved file (File → Session info…).
     window.session.metadata["notes"] = "tweaked"
@@ -565,11 +565,11 @@ def test_editor_close_after_edit_prompts(
 
 
 def test_editor_close_after_undone_edit_skips_prompt(
-    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+    qtbot, headless_session, mock_devices, silence_dialogs, monkeypatch
 ):
     # State equality (not an edit-signal flag) is the dirty check, so editing
     # and then undoing back to the original counts as clean.
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     original = window.session.metadata.get("notes", "")
     window.session.metadata["notes"] = "tweaked"
@@ -580,9 +580,9 @@ def test_editor_close_after_undone_edit_skips_prompt(
 
 
 def test_editor_save_marks_clean(
-    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch, tmp_path
+    qtbot, headless_session, mock_devices, silence_dialogs, monkeypatch, tmp_path
 ):
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     window.session.metadata["notes"] = "tweaked"
     assert window._write_settings(str(tmp_path / "study.smacc")) is True
@@ -611,11 +611,11 @@ def test_live_session_keeps_prompted_metadata_over_file_metadata(
 
 
 def test_editor_adopts_loaded_file_metadata(
-    qtbot, design_session, mock_devices, silence_dialogs
+    qtbot, headless_session, mock_devices, silence_dialogs
 ):
     # The editor has no start prompt; a loaded file's metadata lands so it can
     # be viewed/edited and saved back.
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     window._apply_loaded_settings(window.gather_settings(), {"subject": "template"})
-    assert design_session.metadata["subject"] == "template"
+    assert headless_session.metadata["subject"] == "template"

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -165,7 +165,7 @@ def test_open_editor_new_opens_a_blank_editor(qtbot, tmp_path, monkeypatch):
     _patch_prefs(monkeypatch, tmp_path)
     captured = {}
     monkeypatch.setattr(
-        launcher, "SmaccSession", lambda data_dir, design=False: object()
+        launcher, "SmaccSession", lambda data_dir, headless=False: object()
     )
     monkeypatch.setattr(
         launcher,
@@ -191,7 +191,7 @@ def test_open_editor_existing_opens_that_file(qtbot, tmp_path, monkeypatch):
     settings.save_settings(good, {}, {})
     captured = {}
     monkeypatch.setattr(
-        launcher, "SmaccSession", lambda data_dir, design=False: object()
+        launcher, "SmaccSession", lambda data_dir, headless=False: object()
     )
     monkeypatch.setattr(
         launcher,

--- a/tests/test_panels_audio.py
+++ b/tests/test_panels_audio.py
@@ -54,8 +54,8 @@ class _FakeInput:
         self.closed = True
 
 
-def test_volume_fader_and_spinbox_stay_in_sync(qtbot, design_session):
-    panel = AudioCueWindow(design_session)
+def test_volume_fader_and_spinbox_stay_in_sync(qtbot, headless_session):
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     slot = panel.slots[0]
     # Dragging the fader drives the (precise) spinbox...
@@ -66,8 +66,8 @@ def test_volume_fader_and_spinbox_stay_in_sync(qtbot, design_session):
     assert slot.volumeSlider.value() == 30
 
 
-def test_set_slot_file_labels_button_and_decodes(qtbot, design_session, tmp_path):
-    panel = AudioCueWindow(design_session)
+def test_set_slot_file_labels_button_and_decodes(qtbot, headless_session, tmp_path):
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     slot = panel.slots[0]
     wav = _write_wav(tmp_path / "chime.wav")
@@ -83,8 +83,8 @@ def test_set_slot_file_labels_button_and_decodes(qtbot, design_session, tmp_path
     assert "Choose" in slot.fileButton.text()
 
 
-def test_audio_panel_round_trips_the_file_path(qtbot, design_session, tmp_path):
-    panel = AudioCueWindow(design_session)
+def test_audio_panel_round_trips_the_file_path(qtbot, headless_session, tmp_path):
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     wav = _write_wav(tmp_path / "cue.wav")
     panel.apply_state({"cues": [{"name": "Cue 1", "file": str(wav), "volume": 0.5}]})
@@ -94,9 +94,9 @@ def test_audio_panel_round_trips_the_file_path(qtbot, design_session, tmp_path):
 
 
 def test_loop_button_is_a_checkable_toggle_that_drives_the_loop_flag(
-    qtbot, design_session
+    qtbot, headless_session
 ):
-    panel = AudioCueWindow(design_session)
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     slot = panel.slots[0]
     assert slot.loopButton.isCheckable()
@@ -107,8 +107,8 @@ def test_loop_button_is_a_checkable_toggle_that_drives_the_loop_flag(
     assert panel.gather_state()["cues"][0]["loop"] is True
 
 
-def test_transport_buttons_are_icon_only(qtbot, design_session):
-    panel = AudioCueWindow(design_session)
+def test_transport_buttons_are_icon_only(qtbot, headless_session):
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     slot = panel.slots[0]
     for button in (
@@ -121,19 +121,19 @@ def test_transport_buttons_are_icon_only(qtbot, design_session):
         assert button.text() == ""  # icon-only, no label text
 
 
-def test_every_transport_glyph_is_painted(qtbot, design_session):
+def test_every_transport_glyph_is_painted(qtbot, headless_session):
     # Guards against a key/branch mismatch (#289): a transparent pixmap is not a
     # null icon, so isNull() alone would miss an unpainted glyph.
-    panel = AudioCueWindow(design_session)
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     for kind, icon in panel._transport_icons.items():
         assert _is_painted(icon), f"{kind} icon is blank"
 
 
-def test_transport_icons_repaint_on_theme_change(qtbot, design_session):
+def test_transport_icons_repaint_on_theme_change(qtbot, headless_session):
     # The lights-off dark theme flips the app palette; the painted glyphs must be
     # rebuilt for it (a baked pixmap won't follow the palette on its own) (#289).
-    panel = AudioCueWindow(design_session)
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     before = panel._transport_icons["play"]
     QtCore.QCoreApplication.sendEvent(
@@ -143,8 +143,8 @@ def test_transport_icons_repaint_on_theme_change(qtbot, design_session):
     assert _is_painted(panel.slots[0].playButton.icon())  # button got the fresh glyph
 
 
-def test_transport_buttons_are_stacked_loop_play_stop_remove(qtbot, design_session):
-    panel = AudioCueWindow(design_session)
+def test_transport_buttons_are_stacked_loop_play_stop_remove(qtbot, headless_session):
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     slot = panel.slots[0]
     box = slot.strip.layout()
@@ -157,8 +157,8 @@ def test_transport_buttons_are_stacked_loop_play_stop_remove(qtbot, design_sessi
     assert order == sorted(order)  # loop on top of play, then stop, then remove
 
 
-def test_play_button_depresses_only_the_playing_strip(qtbot, design_session):
-    panel = AudioCueWindow(design_session)
+def test_play_button_depresses_only_the_playing_strip(qtbot, headless_session):
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     assert not hasattr(panel, "nowPlayingLabel")  # the text indicator is gone
     assert panel.slots[0].playButton.isCheckable()
@@ -173,8 +173,8 @@ def test_play_button_depresses_only_the_playing_strip(qtbot, design_session):
     assert not any(s.playButton.isChecked() for s in panel.slots)
 
 
-def test_add_and_remove_strips_keeps_the_lone_strip(qtbot, design_session):
-    panel = AudioCueWindow(design_session)
+def test_add_and_remove_strips_keeps_the_lone_strip(qtbot, headless_session):
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     assert len(panel.slots) == INITIAL_CUE_SLOTS == 2  # a fresh study opens with two
     assert all(s.removeButton.isEnabled() for s in panel.slots)
@@ -188,15 +188,15 @@ def test_add_and_remove_strips_keeps_the_lone_strip(qtbot, design_session):
     assert not panel._addButton.isEnabled()  # capped
 
 
-def test_monitor_device_label_shows_the_room_monitor_route(qtbot, design_session):
-    panel = AudioCueWindow(design_session)
+def test_monitor_device_label_shows_the_room_monitor_route(qtbot, headless_session):
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     # monitor_bedroom_noise defaults to Bedroom mic 1 (reads "(not set)" until bound).
     assert "Bedroom mic 1" in panel.monitorDeviceLabel.text()
 
 
-def test_output_meter_reflects_the_sent_level(qtbot, design_session):
-    panel = AudioCueWindow(design_session)
+def test_output_meter_reflects_the_sent_level(qtbot, headless_session):
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     assert panel.outMeter.value() == 0  # nothing playing yet
     panel._out_level_db = -6.0  # as if the cue callback measured a block
@@ -205,11 +205,11 @@ def test_output_meter_reflects_the_sent_level(qtbot, design_session):
 
 
 def test_room_monitor_toggle_opens_and_closes_and_gates_streaming(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
     monkeypatch.setattr(meter.sd, "InputStream", _FakeInput)
-    design_session.devices.bindings["bedroom_mic_1"] = "Mic (Test)"
-    panel = AudioCueWindow(design_session)
+    headless_session.devices.bindings["bedroom_mic_1"] = "Mic (Test)"
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     assert not panel.is_streaming()
     panel.monitorCheckBox.setChecked(True)  # -> toggle_room_monitor(True)
@@ -221,14 +221,14 @@ def test_room_monitor_toggle_opens_and_closes_and_gates_streaming(
 
 
 def test_room_monitor_start_failure_reverts_the_checkbox(
-    qtbot, design_session, monkeypatch, silence_dialogs
+    qtbot, headless_session, monkeypatch, silence_dialogs
 ):
     def boom(*args, **kwargs):
         raise RuntimeError("no mic")
 
     monkeypatch.setattr(meter.sd, "InputStream", boom)
-    design_session.devices.bindings["bedroom_mic_1"] = "Mic (Test)"
-    panel = AudioCueWindow(design_session)
+    headless_session.devices.bindings["bedroom_mic_1"] = "Mic (Test)"
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     panel.monitorCheckBox.setChecked(True)
     assert not panel.monitorCheckBox.isChecked()  # reverted on failure
@@ -236,16 +236,16 @@ def test_room_monitor_start_failure_reverts_the_checkbox(
 
 
 def test_room_monitor_with_no_bound_mic_errors_and_reverts(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
     # #139: unbound monitor equipment refuses to open (instead of listening on the
     # system default input) and the checkbox reverts.
     monkeypatch.setattr(meter.sd, "InputStream", _FakeInput)
     errors = []
     monkeypatch.setattr(
-        design_session, "show_error_popup", lambda *a, **k: errors.append(a)
+        headless_session, "show_error_popup", lambda *a, **k: errors.append(a)
     )
-    panel = AudioCueWindow(design_session)
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     panel.monitorCheckBox.setChecked(True)
     assert not panel.monitorCheckBox.isChecked()

--- a/tests/test_panels_base.py
+++ b/tests/test_panels_base.py
@@ -16,15 +16,15 @@ from smacc.panels import base
 # ----- describe_action -------------------------------------------------------
 
 
-def _session_with(design_session, bindings, routing=None):
-    design_session.devices = devices.DeviceConfig(
+def _session_with(headless_session, bindings, routing=None):
+    headless_session.devices = devices.DeviceConfig(
         bindings=dict(bindings), routing=dict(routing or {})
     )
-    return design_session
+    return headless_session
 
 
-def test_describe_target_bound_device_reads_role_arrow_device(design_session):
-    session = _session_with(design_session, {"bedroom_speaker": "Speakers (USB)"})
+def test_describe_target_bound_device_reads_role_arrow_device(headless_session):
+    session = _session_with(headless_session, {"bedroom_speaker": "Speakers (USB)"})
     # play_audio_cue defaults to the bedroom_speaker equipment, which is bound above.
     assert (
         base.describe_action(session, "play_audio_cue")
@@ -32,31 +32,31 @@ def test_describe_target_bound_device_reads_role_arrow_device(design_session):
     )
 
 
-def test_describe_target_unbound_audio_reads_not_set(design_session):
+def test_describe_target_unbound_audio_reads_not_set(headless_session):
     # No silent system-default fallback (#139): an unbound equipment reads "(not set)".
-    session = _session_with(design_session, {})
+    session = _session_with(headless_session, {})
     assert (
         base.describe_action(session, "record_dream_report")
         == "Bedroom mic 1 (not set)"
     )
 
 
-def test_describe_target_unbound_visual_reads_not_set(design_session):
-    session = _session_with(design_session, {})
+def test_describe_target_unbound_visual_reads_not_set(headless_session):
+    session = _session_with(headless_session, {})
     assert (
         base.describe_action(session, "play_visual_cue") == "BlinkStick light (not set)"
     )
 
 
-def test_describe_target_off_route_reads_off(design_session):
+def test_describe_target_off_route_reads_off(headless_session):
     # listen_audio_cue is an optional route whose default equipment is "" (off).
-    session = _session_with(design_session, {})
+    session = _session_with(headless_session, {})
     assert base.describe_action(session, "listen_audio_cue") == "off"
 
 
-def test_describe_role_bound_and_unbound(design_session):
+def test_describe_role_bound_and_unbound(headless_session):
     # The Talk/Listen source mics (#160) are described directly, without an action.
-    session = _session_with(design_session, {"control_mic": "Headset Mic"})
+    session = _session_with(headless_session, {"control_mic": "Headset Mic"})
     assert (
         base.describe_equipment(session, devices.TALK_SOURCE)
         == "Control-room mic → Headset Mic"
@@ -77,9 +77,9 @@ def _capture_errors(monkeypatch, session) -> list[tuple]:
 
 
 def test_require_device_unbound_role_pops_error_and_returns_none(
-    design_session, monkeypatch
+    headless_session, monkeypatch
 ):
-    session = _session_with(design_session, {})
+    session = _session_with(headless_session, {})
     errors = _capture_errors(monkeypatch, session)
     got = base.require_device(
         session,
@@ -94,10 +94,10 @@ def test_require_device_unbound_role_pops_error_and_returns_none(
 
 
 def test_require_device_off_route_pops_error_and_returns_none(
-    design_session, monkeypatch
+    headless_session, monkeypatch
 ):
     # listen_audio_cue's default route is off — no equipment to resolve through.
-    session = _session_with(design_session, {})
+    session = _session_with(headless_session, {})
     errors = _capture_errors(monkeypatch, session)
     got = base.require_device(
         session,
@@ -110,10 +110,12 @@ def test_require_device_off_route_pops_error_and_returns_none(
     assert errors and "not routed" in errors[0][1]
 
 
-def test_require_device_bound_role_resolves_without_error(design_session, monkeypatch):
+def test_require_device_bound_role_resolves_without_error(
+    headless_session, monkeypatch
+):
     _patch_sd(monkeypatch)
     session = _session_with(
-        design_session, {"bedroom_speaker": "Speakers (Realtek(R) Audio)"}
+        headless_session, {"bedroom_speaker": "Speakers (Realtek(R) Audio)"}
     )
     errors = _capture_errors(monkeypatch, session)
     got = base.require_device(
@@ -128,9 +130,9 @@ def test_require_device_bound_role_resolves_without_error(design_session, monkey
 
 
 def test_require_role_device_unbound_pops_error_and_returns_none(
-    design_session, monkeypatch
+    headless_session, monkeypatch
 ):
-    session = _session_with(design_session, {})
+    session = _session_with(headless_session, {})
     errors = _capture_errors(monkeypatch, session)
     got = base.require_equipment_device(
         session,

--- a/tests/test_panels_biocals.py
+++ b/tests/test_panels_biocals.py
@@ -44,8 +44,8 @@ class FakeClock:
         return self.t
 
 
-def test_default_stack_builds(qtbot, design_session):
-    panel = _make_panel(qtbot, design_session)
+def test_default_stack_builds(qtbot, headless_session):
+    panel = _make_panel(qtbot, headless_session)
     assert [row.key for row in panel.rows] == [r.key for r in biocals.default_rows()]
     assert panel.rows[0].seqCheckBox.isChecked()  # standard: in the sequence
     lrlr = next(row for row in panel.rows if row.key == "lrlr_open")
@@ -55,9 +55,9 @@ def test_default_stack_builds(qtbot, design_session):
     assert panel.sequenceButton.isEnabled()
 
 
-def test_press_runs_and_press_again_cancels(qtbot, design_session):
-    panel = _make_panel(qtbot, design_session)
-    records = _capture(design_session)
+def test_press_runs_and_press_again_cancels(qtbot, headless_session):
+    panel = _make_panel(qtbot, headless_session)
+    records = _capture(headless_session)
     row = panel.rows[0]  # Eyes Open
     row.voiceCheckBox.setChecked(False)
     panel._on_row_button(row)
@@ -75,7 +75,7 @@ def test_press_runs_and_press_again_cancels(qtbot, design_session):
 
 
 def test_missing_voice_skips_straight_to_the_window(
-    qtbot, design_session, monkeypatch, tmp_path
+    qtbot, headless_session, monkeypatch, tmp_path
 ):
     # Voice enabled but no recording anywhere (override nor bundle): warn, then
     # open the task window immediately — a lost WAV must never block a calibration.
@@ -83,8 +83,8 @@ def test_missing_voice_skips_straight_to_the_window(
         "smacc.panels.biocals.resolve_biocal_voice",
         lambda filename: tmp_path / filename,  # an empty dir == no recording
     )
-    panel = _make_panel(qtbot, design_session)
-    records = _capture(design_session)
+    panel = _make_panel(qtbot, headless_session)
+    records = _capture(headless_session)
     row = panel.rows[0]
     assert row.voiceCheckBox.isChecked()
     panel._on_row_button(row)
@@ -95,11 +95,11 @@ def test_missing_voice_skips_straight_to_the_window(
     assert "Biocal: Eyes Open - portcode 110" in messages
 
 
-def test_sequence_runs_skips_and_completes(qtbot, design_session):
-    panel = _make_panel(qtbot, design_session)
+def test_sequence_runs_skips_and_completes(qtbot, headless_session):
+    panel = _make_panel(qtbot, headless_session)
     clock = FakeClock()
     panel._run = biocals.BiocalRun(clock)  # deterministic time
-    records = _capture(design_session)
+    records = _capture(headless_session)
     for row in panel.rows:
         row.seqCheckBox.setChecked(False)
         row.voiceCheckBox.setChecked(False)
@@ -129,9 +129,9 @@ def test_sequence_runs_skips_and_completes(qtbot, design_session):
     assert "Biocal sequence stopped: completed - portcode 106" in messages
 
 
-def test_sequence_button_aborts_the_rest(qtbot, design_session):
-    panel = _make_panel(qtbot, design_session)
-    records = _capture(design_session)
+def test_sequence_button_aborts_the_rest(qtbot, headless_session):
+    panel = _make_panel(qtbot, headless_session)
+    records = _capture(headless_session)
     for row in panel.rows:
         row.voiceCheckBox.setChecked(False)
     panel._on_sequence_button()  # standard rows are checked by default
@@ -143,8 +143,8 @@ def test_sequence_button_aborts_the_rest(qtbot, design_session):
     assert all(not row.button.isChecked() for row in panel.rows)
 
 
-def test_stack_editing_reorders_adds_and_removes(qtbot, design_session):
-    panel = _make_panel(qtbot, design_session)
+def test_stack_editing_reorders_adds_and_removes(qtbot, headless_session):
+    panel = _make_panel(qtbot, headless_session)
     second = panel.rows[1]
     panel._move_row(second, -1)
     assert panel.rows[0] is second
@@ -156,9 +156,9 @@ def test_stack_editing_reorders_adds_and_removes(qtbot, design_session):
     assert len(panel.rows) == 18
 
 
-def test_cleanup_cancels_an_active_run_honestly(qtbot, design_session):
-    panel = _make_panel(qtbot, design_session)
-    records = _capture(design_session)
+def test_cleanup_cancels_an_active_run_honestly(qtbot, headless_session):
+    panel = _make_panel(qtbot, headless_session)
+    records = _capture(headless_session)
     row = panel.rows[0]
     row.voiceCheckBox.setChecked(False)
     panel._on_row_button(row)

--- a/tests/test_panels_chat.py
+++ b/tests/test_panels_chat.py
@@ -67,11 +67,11 @@ def test_sanitize_neutralizes_a_marker_lookalike_tail():
 # ----- the logging contract ---------------------------------------------------
 
 
-def test_chat_message_is_a_debug_line_and_no_marker_by_default(design_session):
-    records = _capture_session_log(design_session)
+def test_chat_message_is_a_debug_line_and_no_marker_by_default(headless_session):
+    records = _capture_session_log(headless_session)
     transcript = ChatTranscript()
     posted = post_chat_message(
-        design_session, transcript, EXPERIMENTER, "  hello\nthere  "
+        headless_session, transcript, EXPERIMENTER, "  hello\nthere  "
     )
     assert posted == "hello there"
     assert transcript.messages == [(EXPERIMENTER, "hello there")]
@@ -81,10 +81,10 @@ def test_chat_message_is_a_debug_line_and_no_marker_by_default(design_session):
     assert not any("portcode" in m for m in messages)  # log-only by default
 
 
-def test_empty_message_posts_nothing(design_session):
-    records = _capture_session_log(design_session)
+def test_empty_message_posts_nothing(headless_session):
+    records = _capture_session_log(headless_session)
     transcript = ChatTranscript()
-    assert post_chat_message(design_session, transcript, PARTICIPANT, "  \n ") is None
+    assert post_chat_message(headless_session, transcript, PARTICIPANT, "  \n ") is None
     assert transcript.messages == []
     assert records == []
 
@@ -112,8 +112,8 @@ def test_flipped_on_trigger_fires_a_bare_marker(live_session):
 # ----- participant window -----------------------------------------------------
 
 
-def test_participant_window_defaults_and_state_round_trip(qtbot, design_session):
-    window = ParticipantChatWindow(design_session)
+def test_participant_window_defaults_and_state_round_trip(qtbot, headless_session):
+    window = ParticipantChatWindow(headless_session)
     qtbot.addWidget(window)
     assert window.gather_state() == {
         "chat_font_size": FONT_DEFAULT,
@@ -124,8 +124,8 @@ def test_participant_window_defaults_and_state_round_trip(qtbot, design_session)
     assert window.view.font().pointSize() == 24
 
 
-def test_participant_window_tolerates_malformed_state(qtbot, design_session):
-    window = ParticipantChatWindow(design_session)
+def test_participant_window_tolerates_malformed_state(qtbot, headless_session):
+    window = ParticipantChatWindow(headless_session)
     qtbot.addWidget(window)
     window.apply_state({"chat_font_size": "huge"})  # hand-edited study: keep default
     assert window.gather_state()["chat_font_size"] == FONT_DEFAULT
@@ -133,8 +133,8 @@ def test_participant_window_tolerates_malformed_state(qtbot, design_session):
     assert window.gather_state()["chat_font_size"] == FONT_MAX
 
 
-def test_participant_window_is_always_dark_and_red_shiftable(qtbot, design_session):
-    window = ParticipantChatWindow(design_session)
+def test_participant_window_is_always_dark_and_red_shiftable(qtbot, headless_session):
+    window = ParticipantChatWindow(headless_session)
     qtbot.addWidget(window)
     assert "#c8c8c8" in window.styleSheet()  # dim neutral gray on near-black
     window._red_action.setChecked(True)
@@ -142,9 +142,9 @@ def test_participant_window_is_always_dark_and_red_shiftable(qtbot, design_sessi
 
 
 def test_participant_window_banner_tracks_keyboard_focus(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
-    window = ParticipantChatWindow(design_session)
+    window = ParticipantChatWindow(headless_session)
     qtbot.addWidget(window)
     monkeypatch.setattr(ParticipantChatWindow, "isActiveWindow", lambda self: True)
     window._refresh_keyboard_banner()
@@ -154,8 +154,8 @@ def test_participant_window_banner_tracks_keyboard_focus(
     assert "not here" in window.keyboardBanner.text()
 
 
-def test_participant_enter_sends_and_clears(qtbot, design_session):
-    window = ParticipantChatWindow(design_session)
+def test_participant_enter_sends_and_clears(qtbot, headless_session):
+    window = ParticipantChatWindow(headless_session)
     qtbot.addWidget(window)
     window.entry.setText("I'm awake")
     qtbot.keyClick(window.entry, QtCore.Qt.Key.Key_Return)
@@ -167,8 +167,8 @@ def test_participant_enter_sends_and_clears(qtbot, design_session):
 # ----- experimenter view (Chat window) + the shared transcript -----------------
 
 
-def test_chat_send_clears_entry_and_renders(qtbot, design_session):
-    panel = ChatWindow(design_session)
+def test_chat_send_clears_entry_and_renders(qtbot, headless_session):
+    panel = ChatWindow(headless_session)
     qtbot.addWidget(panel)
     panel.chatEntry.setText("hello")
     panel.send_chat_message()
@@ -176,8 +176,8 @@ def test_chat_send_clears_entry_and_renders(qtbot, design_session):
     assert "You:  hello" in panel.chatView.toPlainText()
 
 
-def test_chat_pass_keyboard_emits_even_with_empty_entry(qtbot, design_session):
-    panel = ChatWindow(design_session)
+def test_chat_pass_keyboard_emits_even_with_empty_entry(qtbot, headless_session):
+    panel = ChatWindow(headless_session)
     qtbot.addWidget(panel)
     fired: list[bool] = []
     panel.open_participant_chat.connect(lambda: fired.append(True))
@@ -186,10 +186,10 @@ def test_chat_pass_keyboard_emits_even_with_empty_entry(qtbot, design_session):
     assert panel.chatView.toPlainText() == ""
 
 
-def test_transcript_is_shared_between_both_views(qtbot, design_session):
+def test_transcript_is_shared_between_both_views(qtbot, headless_session):
     transcript = ChatTranscript()
-    chat = ChatWindow(design_session, transcript)
-    participant = ParticipantChatWindow(design_session, transcript)
+    chat = ChatWindow(headless_session, transcript)
+    participant = ParticipantChatWindow(headless_session, transcript)
     qtbot.addWidget(chat)
     qtbot.addWidget(participant)
     chat.chatEntry.setText("Are you awake?")
@@ -233,11 +233,11 @@ def test_chat_presets_cap_participant_and_tolerate_garbage():
     assert presets.experimenter == []  # coerced to empty rather than crashing a load
 
 
-def test_chat_preset_button_sends_through_chat_path(design_session):
-    records = _capture_session_log(design_session)
+def test_chat_preset_button_sends_through_chat_path(headless_session):
+    records = _capture_session_log(headless_session)
     presets = ChatPresets()
     presets.set(["Are you awake?"], [])
-    panel = ChatWindow(design_session, presets=presets)
+    panel = ChatWindow(headless_session, presets=presets)
     assert len(panel._preset_buttons) == 1
     panel._preset_buttons[0].click()
     assert "You:  Are you awake?" in panel.chatView.toPlainText()
@@ -246,10 +246,10 @@ def test_chat_preset_button_sends_through_chat_path(design_session):
     assert all(r.levelno == logging.DEBUG for r in records)  # log-only by default
 
 
-def test_participant_number_key_sends_only_when_entry_empty(qtbot, design_session):
+def test_participant_number_key_sends_only_when_entry_empty(qtbot, headless_session):
     presets = ChatPresets()
     presets.set([], ["I'm awake", "Got it"])
-    window = ParticipantChatWindow(design_session, presets=presets)
+    window = ParticipantChatWindow(headless_session, presets=presets)
     qtbot.addWidget(window)
     assert len(window._preset_buttons) == 2
     # Empty entry: a bare number key sends the matching reply (key not typed).
@@ -263,10 +263,10 @@ def test_participant_number_key_sends_only_when_entry_empty(qtbot, design_sessio
     assert window.entry.text() == "31"
 
 
-def test_presets_shared_object_updates_both_views(qtbot, design_session):
+def test_presets_shared_object_updates_both_views(qtbot, headless_session):
     presets = ChatPresets()
-    chat = ChatWindow(design_session, presets=presets)
-    participant = ParticipantChatWindow(design_session, presets=presets)
+    chat = ChatWindow(headless_session, presets=presets)
+    participant = ParticipantChatWindow(headless_session, presets=presets)
     qtbot.addWidget(chat)
     qtbot.addWidget(participant)
     presets.set(["Are you awake?"], ["Yes", "No"])
@@ -280,11 +280,11 @@ def test_presets_shared_object_updates_both_views(qtbot, design_session):
 
 
 def test_window_wires_chat_panel_without_launcher_button(
-    qtbot, design_session, mock_devices, silence_dialogs, monkeypatch
+    qtbot, headless_session, mock_devices, silence_dialogs, monkeypatch
 ):
     monkeypatch.setattr(winvolume, "endpoint_volume", lambda: None)
     monkeypatch.setattr(winvolume, "app_volume", lambda: None)
-    window = SmaccWindow(design_session)
+    window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     # The participant window has no Tools-column button; the Chat window does.
     assert "participant_chat" not in SmaccWindow.PANEL_LABELS

--- a/tests/test_panels_chat_voice.py
+++ b/tests/test_panels_chat_voice.py
@@ -111,14 +111,14 @@ def _bind_devices(session):
     session.devices.routing["listen_to_participant"] = "control_speaker"
 
 
-def test_toggle_talk_starts_the_bridge_and_marks(qtbot, design_session, monkeypatch):
+def test_toggle_talk_starts_the_bridge_and_marks(qtbot, headless_session, monkeypatch):
     calls = _stub_bridges(monkeypatch)
-    _bind_devices(design_session)
-    window = ChatWindow(design_session)
+    _bind_devices(headless_session)
+    window = ChatWindow(headless_session)
     qtbot.addWidget(window)
     emitted = []
     monkeypatch.setattr(
-        design_session, "emit_event", lambda key, **k: emitted.append(key)
+        headless_session, "emit_event", lambda key, **k: emitted.append(key)
     )
 
     window.talkButton.setChecked(True)
@@ -133,15 +133,15 @@ def test_toggle_talk_starts_the_bridge_and_marks(qtbot, design_session, monkeypa
 
 
 def test_talk_start_failure_reverts_the_button(
-    qtbot, design_session, monkeypatch, silence_dialogs
+    qtbot, headless_session, monkeypatch, silence_dialogs
 ):
     _stub_bridges(monkeypatch, fail=True)
-    _bind_devices(design_session)
-    window = ChatWindow(design_session)
+    _bind_devices(headless_session)
+    window = ChatWindow(headless_session)
     qtbot.addWidget(window)
     emitted = []
     monkeypatch.setattr(
-        design_session, "emit_event", lambda key, **k: emitted.append(key)
+        headless_session, "emit_event", lambda key, **k: emitted.append(key)
     )
     window.talkButton.setChecked(True)
     assert not window.talkButton.isChecked()  # reverted by the error path
@@ -149,14 +149,14 @@ def test_talk_start_failure_reverts_the_button(
     window.cleanup()
 
 
-def test_listen_toggles_without_markers(qtbot, design_session, monkeypatch):
+def test_listen_toggles_without_markers(qtbot, headless_session, monkeypatch):
     calls = _stub_bridges(monkeypatch)
-    _bind_devices(design_session)
-    window = ChatWindow(design_session)
+    _bind_devices(headless_session)
+    window = ChatWindow(headless_session)
     qtbot.addWidget(window)
     emitted = []
     monkeypatch.setattr(
-        design_session, "emit_event", lambda key, **k: emitted.append(key)
+        headless_session, "emit_event", lambda key, **k: emitted.append(key)
     )
     window.listenButton.setChecked(True)
     window.listenButton.setChecked(False)
@@ -165,16 +165,16 @@ def test_listen_toggles_without_markers(qtbot, design_session, monkeypatch):
     window.cleanup()
 
 
-def test_listen_with_route_off_errors_and_reverts(qtbot, design_session, monkeypatch):
+def test_listen_with_route_off_errors_and_reverts(qtbot, headless_session, monkeypatch):
     # #139: the listen route is off by default; toggling it must refuse (instead
     # of opening the participant mix on the system default output) and revert.
     calls = _stub_bridges(monkeypatch)
-    design_session.devices.bindings["bedroom_mic_1"] = "Mic (Test)"
+    headless_session.devices.bindings["bedroom_mic_1"] = "Mic (Test)"
     errors = []
     monkeypatch.setattr(
-        design_session, "show_error_popup", lambda *a, **k: errors.append(a)
+        headless_session, "show_error_popup", lambda *a, **k: errors.append(a)
     )
-    window = ChatWindow(design_session)
+    window = ChatWindow(headless_session)
     qtbot.addWidget(window)
     window.listenButton.setChecked(True)
     assert not window.listenButton.isChecked()
@@ -184,21 +184,21 @@ def test_listen_with_route_off_errors_and_reverts(qtbot, design_session, monkeyp
 
 
 def test_talk_with_no_bound_output_errors_and_reverts(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
     # #139: an unbound participant output refuses to talk (instead of speaking
     # through the system default device) and the button reverts, unmarked.
     calls = _stub_bridges(monkeypatch)
-    design_session.devices.bindings["control_mic"] = "Headset Mic (Test)"
+    headless_session.devices.bindings["control_mic"] = "Headset Mic (Test)"
     errors = []
     monkeypatch.setattr(
-        design_session, "show_error_popup", lambda *a, **k: errors.append(a)
+        headless_session, "show_error_popup", lambda *a, **k: errors.append(a)
     )
     emitted = []
     monkeypatch.setattr(
-        design_session, "emit_event", lambda key, **k: emitted.append(key)
+        headless_session, "emit_event", lambda key, **k: emitted.append(key)
     )
-    window = ChatWindow(design_session)
+    window = ChatWindow(headless_session)
     qtbot.addWidget(window)
     window.talkButton.setChecked(True)
     assert not window.talkButton.isChecked()
@@ -208,20 +208,22 @@ def test_talk_with_no_bound_output_errors_and_reverts(
     window.cleanup()
 
 
-def test_talk_with_no_bound_mic_errors_and_reverts(qtbot, design_session, monkeypatch):
+def test_talk_with_no_bound_mic_errors_and_reverts(
+    qtbot, headless_session, monkeypatch
+):
     # #160: an unbound control-room mic refuses to talk (instead of capturing
     # from the system default input) and the button reverts, unmarked.
     calls = _stub_bridges(monkeypatch)
-    design_session.devices.bindings["bedroom_speaker"] = "Speakers (Test)"
+    headless_session.devices.bindings["bedroom_speaker"] = "Speakers (Test)"
     errors = []
     monkeypatch.setattr(
-        design_session, "show_error_popup", lambda *a, **k: errors.append(a)
+        headless_session, "show_error_popup", lambda *a, **k: errors.append(a)
     )
     emitted = []
     monkeypatch.setattr(
-        design_session, "emit_event", lambda key, **k: emitted.append(key)
+        headless_session, "emit_event", lambda key, **k: emitted.append(key)
     )
-    window = ChatWindow(design_session)
+    window = ChatWindow(headless_session)
     qtbot.addWidget(window)
     window.talkButton.setChecked(True)
     assert not window.talkButton.isChecked()
@@ -237,10 +239,10 @@ def _space_event(etype) -> QtGui.QKeyEvent:
     )
 
 
-def test_spacebar_push_to_talk_holds_and_releases(qtbot, design_session, monkeypatch):
+def test_spacebar_push_to_talk_holds_and_releases(qtbot, headless_session, monkeypatch):
     _stub_bridges(monkeypatch)
-    _bind_devices(design_session)
-    window = ChatWindow(design_session)
+    _bind_devices(headless_session)
+    window = ChatWindow(headless_session)
     qtbot.addWidget(window)
     monkeypatch.setattr(
         ChatWindow, "_is_text_widget_focused", staticmethod(lambda: False)
@@ -253,10 +255,10 @@ def test_spacebar_push_to_talk_holds_and_releases(qtbot, design_session, monkeyp
     window.cleanup()
 
 
-def test_spacebar_passes_through_while_typing(qtbot, design_session, monkeypatch):
+def test_spacebar_passes_through_while_typing(qtbot, headless_session, monkeypatch):
     _stub_bridges(monkeypatch)
-    _bind_devices(design_session)
-    window = ChatWindow(design_session)
+    _bind_devices(headless_session)
+    window = ChatWindow(headless_session)
     qtbot.addWidget(window)
     monkeypatch.setattr(
         ChatWindow, "_is_text_widget_focused", staticmethod(lambda: True)
@@ -267,8 +269,8 @@ def test_spacebar_passes_through_while_typing(qtbot, design_session, monkeypatch
     window.cleanup()
 
 
-def test_send_chat_message_posts_and_clears_the_entry(qtbot, design_session):
-    window = ChatWindow(design_session)
+def test_send_chat_message_posts_and_clears_the_entry(qtbot, headless_session):
+    window = ChatWindow(headless_session)
     qtbot.addWidget(window)
     window.chatEntry.setText("  Are you comfortable?  ")
     window.send_chat_message()
@@ -277,8 +279,8 @@ def test_send_chat_message_posts_and_clears_the_entry(qtbot, design_session):
     window.cleanup()
 
 
-def test_empty_chat_message_is_not_posted(qtbot, design_session):
-    window = ChatWindow(design_session)
+def test_empty_chat_message_is_not_posted(qtbot, headless_session):
+    window = ChatWindow(headless_session)
     qtbot.addWidget(window)
     window.chatEntry.setText("   ")
     window.send_chat_message()
@@ -286,8 +288,8 @@ def test_empty_chat_message_is_not_posted(qtbot, design_session):
     window.cleanup()
 
 
-def test_preset_buttons_rebuild_and_send_verbatim(qtbot, design_session):
-    window = ChatWindow(design_session)
+def test_preset_buttons_rebuild_and_send_verbatim(qtbot, headless_session):
+    window = ChatWindow(headless_session)
     qtbot.addWidget(window)
     long = "Please describe everything that was going through your mind just now."
     window._presets.set([long], [])
@@ -300,12 +302,12 @@ def test_preset_buttons_rebuild_and_send_verbatim(qtbot, design_session):
     window.cleanup()
 
 
-def test_preset_state_round_trips(qtbot, design_session):
-    window = ChatWindow(design_session)
+def test_preset_state_round_trips(qtbot, headless_session):
+    window = ChatWindow(headless_session)
     qtbot.addWidget(window)
     window._presets.set(["Prompt one"], ["Yes", "No"])
     state = window.gather_state()
-    other = ChatWindow(design_session)
+    other = ChatWindow(headless_session)
     qtbot.addWidget(other)
     other.apply_state(state)
     assert other._presets.experimenter == ["Prompt one"]

--- a/tests/test_panels_devices.py
+++ b/tests/test_panels_devices.py
@@ -14,9 +14,9 @@ from smacc.panels.devices import DevicesWindow
 
 
 def test_equipment_combos_populate_from_enumeration(
-    qtbot, design_session, mock_devices
+    qtbot, headless_session, mock_devices
 ):
-    window = DevicesWindow(design_session)
+    window = DevicesWindow(headless_session)
     qtbot.addWidget(window)
     out_combo = window._equipment_combos["bedroom_speaker"]
     # Index 0 is the "(none)" entry, then one row per advertised output.
@@ -30,17 +30,17 @@ def test_equipment_combos_populate_from_enumeration(
     assert blink_combo.itemData(1) == mock_devices["blinksticks"][0][1]
 
 
-def test_reload_from_config_selects_bound_device(qtbot, design_session, mock_devices):
+def test_reload_from_config_selects_bound_device(qtbot, headless_session, mock_devices):
     bound = mock_devices["outputs"][1]
-    design_session.devices.bindings["bedroom_speaker"] = bound
-    window = DevicesWindow(design_session)
+    headless_session.devices.bindings["bedroom_speaker"] = bound
+    window = DevicesWindow(headless_session)
     qtbot.addWidget(window)
     window.reload_from_config()
     assert window._equipment_combos["bedroom_speaker"].currentText() == bound
 
 
-def test_set_binding_writes_to_session(qtbot, design_session, mock_devices):
-    window = DevicesWindow(design_session)
+def test_set_binding_writes_to_session(qtbot, headless_session, mock_devices):
+    window = DevicesWindow(headless_session)
     qtbot.addWidget(window)
     changed = []
     window.changed.connect(lambda: changed.append(True))
@@ -48,29 +48,30 @@ def test_set_binding_writes_to_session(qtbot, design_session, mock_devices):
     # Selecting a real device row binds it to the equipment.
     window._equipment_combos["bedroom_speaker"].setCurrentIndex(1)
     assert (
-        design_session.devices.bindings["bedroom_speaker"] == mock_devices["outputs"][0]
+        headless_session.devices.bindings["bedroom_speaker"]
+        == mock_devices["outputs"][0]
     )
     assert changed  # the changed signal fired
 
     # Returning to the "(none)" entry clears the binding.
     window._equipment_combos["bedroom_speaker"].setCurrentIndex(0)
-    assert "bedroom_speaker" not in design_session.devices.bindings
+    assert "bedroom_speaker" not in headless_session.devices.bindings
 
 
-def test_set_routing_writes_to_session(qtbot, design_session, mock_devices):
-    window = DevicesWindow(design_session)
+def test_set_routing_writes_to_session(qtbot, headless_session, mock_devices):
+    window = DevicesWindow(headless_session)
     qtbot.addWidget(window)
     combo = window._action_combos["play_audio_cue"]
     # Point play_audio_cue at the control-room output equipment instead of its default.
     index = combo.findData("control_speaker")
     assert index >= 0
     combo.setCurrentIndex(index)
-    assert design_session.devices.routing["play_audio_cue"] == "control_speaker"
+    assert headless_session.devices.routing["play_audio_cue"] == "control_speaker"
 
 
-def test_reload_flags_missing_bound_device(qtbot, design_session, mock_devices):
-    design_session.devices.bindings["bedroom_speaker"] = "Unplugged speaker"
-    window = DevicesWindow(design_session)
+def test_reload_flags_missing_bound_device(qtbot, headless_session, mock_devices):
+    headless_session.devices.bindings["bedroom_speaker"] = "Unplugged speaker"
+    window = DevicesWindow(headless_session)
     qtbot.addWidget(window)
     window.reload_from_config()
     # The bound device isn't among the advertised ones, so it's flagged and shown
@@ -78,14 +79,16 @@ def test_reload_flags_missing_bound_device(qtbot, design_session, mock_devices):
     combo = window._equipment_combos["bedroom_speaker"]
     assert combo.currentText() == "Unplugged speaker (not connected)"
     assert combo.currentData() == "Unplugged speaker"
-    assert design_session.devices.bindings["bedroom_speaker"] == "Unplugged speaker"
-    assert any("Unplugged speaker" in entry for entry in design_session.missing_devices)
+    assert headless_session.devices.bindings["bedroom_speaker"] == "Unplugged speaker"
+    assert any(
+        "Unplugged speaker" in entry for entry in headless_session.missing_devices
+    )
 
 
-def test_refresh_button_emits_refresh_requested(qtbot, design_session, mock_devices):
+def test_refresh_button_emits_refresh_requested(qtbot, headless_session, mock_devices):
     # The in-window Refresh button defers to the session window's rescan via this
     # signal (rather than duplicating the PortAudio re-init).
-    window = DevicesWindow(design_session)
+    window = DevicesWindow(headless_session)
     qtbot.addWidget(window)
     button = window.findChild(QtWidgets.QPushButton)
     assert button is not None and button.text() == "Refresh devices (F5)"
@@ -94,13 +97,13 @@ def test_refresh_button_emits_refresh_requested(qtbot, design_session, mock_devi
 
 
 def test_hue_combo_lists_bridge_targets(
-    qtbot, design_session, mock_devices, monkeypatch
+    qtbot, headless_session, mock_devices, monkeypatch
 ):
     from smacc import hue
 
-    design_session.hue_config = hue.HueConfig("192.168.1.50", "key")
+    headless_session.hue_config = hue.HueConfig("192.168.1.50", "key")
     monkeypatch.setattr(hue, "targets", lambda cfg: [("Bed lamp (light 1)", "light:1")])
-    window = DevicesWindow(design_session)
+    window = DevicesWindow(headless_session)
     qtbot.addWidget(window)
     combo = window._equipment_combos["philips_hue_light"]
     assert [combo.itemText(i) for i in range(combo.count())] == [
@@ -108,21 +111,23 @@ def test_hue_combo_lists_bridge_targets(
         "Bed lamp (light 1)",
     ]
     combo.setCurrentIndex(1)  # bind the lamp
-    assert design_session.devices.bindings["philips_hue_light"] == "light:1"
+    assert headless_session.devices.bindings["philips_hue_light"] == "light:1"
 
 
-def test_hue_combo_says_no_bridge_without_one(qtbot, design_session, mock_devices):
-    window = DevicesWindow(design_session)
+def test_hue_combo_says_no_bridge_without_one(qtbot, headless_session, mock_devices):
+    window = DevicesWindow(headless_session)
     qtbot.addWidget(window)
     combo = window._equipment_combos["philips_hue_light"]
     assert [combo.itemText(i) for i in range(combo.count())] == ["No bridge paired"]
 
 
-def test_empty_enumeration_says_no_device_found(qtbot, design_session, mock_no_devices):
+def test_empty_enumeration_says_no_device_found(
+    qtbot, headless_session, mock_no_devices
+):
     # With nothing connected, each combo's sole row says so (#139) instead of an
     # ambiguous "(none)" (or the old "(system default)", which implied an output
     # exists when none does).
-    window = DevicesWindow(design_session)
+    window = DevicesWindow(headless_session)
     qtbot.addWidget(window)
     texts = {
         key: [combo.itemText(i) for i in range(combo.count())]
@@ -137,13 +142,13 @@ def test_empty_enumeration_says_no_device_found(qtbot, design_session, mock_no_d
 
 
 def test_paired_bridge_with_no_targets_says_no_lights(
-    qtbot, design_session, mock_devices, monkeypatch
+    qtbot, headless_session, mock_devices, monkeypatch
 ):
     from smacc import hue
 
-    design_session.hue_config = hue.HueConfig("192.168.1.50", "key")
+    headless_session.hue_config = hue.HueConfig("192.168.1.50", "key")
     monkeypatch.setattr(hue, "targets", lambda cfg: [])
-    window = DevicesWindow(design_session)
+    window = DevicesWindow(headless_session)
     qtbot.addWidget(window)
     combo = window._equipment_combos["philips_hue_light"]
     assert [combo.itemText(i) for i in range(combo.count())] == ["No lights found"]
@@ -171,12 +176,14 @@ def test_autobind_defaults_pins_the_required_equipment(
     assert out_combo.currentData() == mock_devices["default_output"]
 
 
-def test_autobind_defaults_is_a_noop_in_the_editor(qtbot, design_session, mock_devices):
-    window = DevicesWindow(design_session)
+def test_autobind_defaults_is_a_noop_in_the_editor(
+    qtbot, headless_session, mock_devices
+):
+    window = DevicesWindow(headless_session)
     qtbot.addWidget(window)
     window.autobind_defaults()
     # The editor often runs on a non-rig machine; the rig binds its own defaults.
-    assert design_session.devices.bindings == {}
+    assert headless_session.devices.bindings == {}
 
 
 def test_autobind_defaults_keeps_existing_bindings(qtbot, live_session, mock_devices):
@@ -194,10 +201,10 @@ def test_autobind_defaults_keeps_existing_bindings(qtbot, live_session, mock_dev
     assert live_session.devices.bindings["control_mic"] == mock_devices["default_input"]
 
 
-def test_combos_carry_description_tooltips(qtbot, design_session, mock_devices):
+def test_combos_carry_description_tooltips(qtbot, headless_session, mock_devices):
     from smacc import devices
 
-    window = DevicesWindow(design_session)
+    window = DevicesWindow(headless_session)
     qtbot.addWidget(window)
     for equipment in devices.EQUIPMENT:
         assert (
@@ -207,8 +214,10 @@ def test_combos_carry_description_tooltips(qtbot, design_session, mock_devices):
         assert window._action_combos[action.key].toolTip() == action.description
 
 
-def test_route_indicators_show_the_resolved_device(qtbot, design_session, mock_devices):
-    window = DevicesWindow(design_session)
+def test_route_indicators_show_the_resolved_device(
+    qtbot, headless_session, mock_devices
+):
+    window = DevicesWindow(headless_session)
     qtbot.addWidget(window)
     # A default route on an unbound equipment is honest about it...
     cue = window._action_indicators["play_audio_cue"]

--- a/tests/test_panels_events.py
+++ b/tests/test_panels_events.py
@@ -15,7 +15,7 @@ from smacc.session import SmaccSession
 
 
 def _events_window(tmp_path, qtbot):
-    session = SmaccSession(tmp_path / "s", design=True)
+    session = SmaccSession(tmp_path / "s", headless=True)
     win = EventsWindow(session)
     qtbot.addWidget(win)
     return win, session

--- a/tests/test_panels_markers.py
+++ b/tests/test_panels_markers.py
@@ -21,8 +21,8 @@ def stub_serial_ports(monkeypatch):
 
 
 @pytest.fixture
-def window(qtbot, design_session):
-    win = MarkersWindow(design_session)
+def window(qtbot, headless_session):
+    win = MarkersWindow(headless_session)
     qtbot.addWidget(win)
     return win
 
@@ -45,26 +45,26 @@ def _index_of(win: MarkersWindow, key: str) -> int:
 # ----- registry table ---------------------------------------------------------
 
 
-def test_window_stages_the_whole_registry_grouped(window, design_session):
+def test_window_stages_the_whole_registry_grouped(window, headless_session):
     # Every event is staged (one widget set per event)...
-    assert len(window._events) == len(design_session.events)
+    assert len(window._events) == len(headless_session.events)
     assert all(spin is not None for spin in window._code_spins)
     # ...and the table carries one extra (spanned header) row per category group.
-    categories = {e.category for e in design_session.events.values()}
-    assert window.table.rowCount() == len(design_session.events) + len(categories)
+    categories = {e.category for e in headless_session.events.values()}
+    assert window.table.rowCount() == len(headless_session.events) + len(categories)
     # The header rows are not mapped to events (not editable/selectable rows).
-    assert len(window._row_event) == len(design_session.events)
+    assert len(window._row_event) == len(headless_session.events)
 
 
-def test_apply_commits_staged_edits_and_logs_loudly(window, design_session):
-    records = _capture_session_log(design_session)
+def test_apply_commits_staged_edits_and_logs_loudly(window, headless_session):
+    records = _capture_session_log(headless_session)
     i = _index_of(window, "REMDetected")
     window._code_spins[i].setValue(99)
     window._lsl_boxes[i].setChecked(False)
     window.apply()
-    assert design_session.events["REMDetected"].code == 99
-    assert design_session.events["REMDetected"].lsl is False
-    assert design_session.events["REMDetected"].ttl is True
+    assert headless_session.events["REMDetected"].code == 99
+    assert headless_session.events["REMDetected"].lsl is False
+    assert headless_session.events["REMDetected"].ttl is True
     changed = [
         r for r in records if r.getMessage().startswith("Port code changed: REM")
     ]
@@ -73,7 +73,7 @@ def test_apply_commits_staged_edits_and_logs_loudly(window, design_session):
     assert "LSL off" in changed[0].getMessage()
 
 
-def test_apply_blocks_on_validation_errors(window, design_session, monkeypatch):
+def test_apply_blocks_on_validation_errors(window, headless_session, monkeypatch):
     warned: list[str] = []
     monkeypatch.setattr(
         QtWidgets.QMessageBox,
@@ -84,11 +84,11 @@ def test_apply_blocks_on_validation_errors(window, design_session, monkeypatch):
     window._code_spins[_index_of(window, "REMDetected")].setValue(49)
     window.apply()
     assert warned and "49" in warned[0]
-    assert design_session.events["REMDetected"].code == 41  # unchanged
+    assert headless_session.events["REMDetected"].code == 41  # unchanged
 
 
-def test_safe_max_round_trips_and_logs(window, design_session):
-    records = _capture_session_log(design_session)
+def test_safe_max_round_trips_and_logs(window, headless_session):
+    records = _capture_session_log(headless_session)
     window.safeMaxSpin.setValue(127)
     # 127 would warn on the biocal/dream codes above it; keep them TTL-off so the
     # apply is clean (the point here is the safe-max commit, not the warning).
@@ -96,22 +96,22 @@ def test_safe_max_round_trips_and_logs(window, design_session):
         if event.code > 127:
             window._ttl_boxes[i].setChecked(False)
     window.apply()
-    assert design_session.event_code_safe_max == 127
+    assert headless_session.event_code_safe_max == 127
     assert any("safe max changed" in r.getMessage() for r in records)
 
 
-def test_revert_discards_staged_edits(window, design_session):
+def test_revert_discards_staged_edits(window, headless_session):
     i = _index_of(window, "REMDetected")
     window._code_spins[i].setValue(99)
     window._revert()
     i = _index_of(window, "REMDetected")
     assert window._code_spins[i].value() == 41
-    assert design_session.events["REMDetected"].code == 41
+    assert headless_session.events["REMDetected"].code == 41
 
 
-def test_reload_from_session_picks_up_external_changes(window, design_session):
-    new = events.make_custom_event("Door knock", 150, design_session.events.keys())
-    design_session.events[new.key] = new
+def test_reload_from_session_picks_up_external_changes(window, headless_session):
+    new = events.make_custom_event("Door knock", 150, headless_session.events.keys())
+    headless_session.events[new.key] = new
     window.reload_from_session()
     assert any(e.key == new.key for e in window._events)
 
@@ -134,7 +134,7 @@ def test_add_event_stages_a_custom_event(window, monkeypatch):
     assert any(e.label == "New event" for e in window._events)
 
 
-def test_remove_only_removes_custom_events(window, design_session, monkeypatch):
+def test_remove_only_removes_custom_events(window, headless_session, monkeypatch):
     infos: list[str] = []
     monkeypatch.setattr(
         QtWidgets.QMessageBox,
@@ -149,8 +149,8 @@ def test_remove_only_removes_custom_events(window, design_session, monkeypatch):
     window._remove_selected()
     assert infos and "Built-in" in infos[0]
     # ...while a staged custom event goes away.
-    new = events.make_custom_event("Door knock", 150, design_session.events.keys())
-    design_session.events[new.key] = new
+    new = events.make_custom_event("Door knock", 150, headless_session.events.keys())
+    headless_session.events[new.key] = new
     window.reload_from_session()
     custom_row = next(
         row for row, i in window._row_event.items() if not window._events[i].builtin
@@ -160,7 +160,7 @@ def test_remove_only_removes_custom_events(window, design_session, monkeypatch):
     assert not any(e.key == new.key for e in window._events)
 
 
-def test_show_reloads_but_minimize_restore_keeps_edits(window, design_session, qtbot):
+def test_show_reloads_but_minimize_restore_keeps_edits(window, headless_session, qtbot):
     i = _index_of(window, "REMDetected")
     window._code_spins[i].setValue(99)
     window.hide()
@@ -186,10 +186,10 @@ def test_ttl_column_grays_out_without_a_transport(window):
 
 
 def test_no_serial_ports_shows_the_hint_but_gates_nothing(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
     monkeypatch.setattr(triggers, "list_serial_ports", lambda: [])
-    win = MarkersWindow(design_session)
+    win = MarkersWindow(headless_session)
     qtbot.addWidget(win)
     assert not win.portStatusLabel.isHidden()
     # A hint, not a gate: the per-event TTL routing is untouched (not emptied).
@@ -209,16 +209,16 @@ def test_refresh_updates_the_port_hint(window, monkeypatch):
     assert window.portStatusLabel.isHidden()
 
 
-def test_missing_inpout_driver_shows_the_hint(qtbot, design_session, monkeypatch):
+def test_missing_inpout_driver_shows_the_hint(qtbot, headless_session, monkeypatch):
     monkeypatch.setattr(triggers, "parallel_driver_available", lambda: False)
-    win = MarkersWindow(design_session)
+    win = MarkersWindow(headless_session)
     qtbot.addWidget(win)
     assert not win.driverStatusLabel.isHidden()
 
 
-def test_present_inpout_driver_hides_the_hint(qtbot, design_session, monkeypatch):
+def test_present_inpout_driver_hides_the_hint(qtbot, headless_session, monkeypatch):
     monkeypatch.setattr(triggers, "parallel_driver_available", lambda: True)
-    win = MarkersWindow(design_session)
+    win = MarkersWindow(headless_session)
     qtbot.addWidget(win)
     assert win.driverStatusLabel.isHidden()
 
@@ -239,17 +239,17 @@ def test_transport_config_round_trips(window, stub_serial_ports):
     assert window._gather_trigger_config() == cfg
 
 
-def test_transport_applies_to_the_session(window, design_session, stub_serial_ports):
-    records = _capture_session_log(design_session)
+def test_transport_applies_to_the_session(window, headless_session, stub_serial_ports):
+    records = _capture_session_log(headless_session)
     window.enabledBox.setChecked(True)
     window._select_data(window.transportCombo, "serial")
     window.portCombo.setEditText("COM4")
     window.apply()
-    assert design_session.trigger_config.enabled is True
-    assert design_session.trigger_config.port == "COM4"
+    assert headless_session.trigger_config.enabled is True
+    assert headless_session.trigger_config.port == "COM4"
     assert any("Trigger output changed" in r.getMessage() for r in records)
     # A design session opens no hardware (set_trigger_output is a no-op there).
-    assert design_session.trigger_out is None
+    assert headless_session.trigger_out is None
 
 
 def test_selecting_listed_port_returns_device(window, stub_serial_ports):
@@ -267,11 +267,11 @@ def test_unlisted_saved_port_survives_as_free_text(window, stub_serial_ports):
     assert window._gather_trigger_config().port == "COM9"
 
 
-def test_test_button_reports_result(window, design_session, monkeypatch):
-    monkeypatch.setattr(design_session, "test_trigger", lambda cfg: None)
+def test_test_button_reports_result(window, headless_session, monkeypatch):
+    monkeypatch.setattr(headless_session, "test_trigger", lambda cfg: None)
     window._on_test()
     assert "test pulse" in window.testResult.text()
-    monkeypatch.setattr(design_session, "test_trigger", lambda cfg: "no such port")
+    monkeypatch.setattr(headless_session, "test_trigger", lambda cfg: "no such port")
     window._on_test()
     assert "no such port" in window.testResult.text()
 

--- a/tests/test_panels_noise.py
+++ b/tests/test_panels_noise.py
@@ -48,11 +48,11 @@ def _bind_output(session):
 
 
 def test_play_then_stop_builds_buffer_and_updates_status(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
     _stub_output(monkeypatch)
-    _bind_output(design_session)
-    window = NoiseWindow(design_session)
+    _bind_output(headless_session)
+    window = NoiseWindow(headless_session)
     qtbot.addWidget(window)
     assert not window.is_streaming()
 
@@ -70,14 +70,16 @@ def test_play_then_stop_builds_buffer_and_updates_status(
     assert _FakeOutput.last.aborted and _FakeOutput.last.closed
 
 
-def test_play_marks_once_but_not_on_silent_restart(qtbot, design_session, monkeypatch):
+def test_play_marks_once_but_not_on_silent_restart(
+    qtbot, headless_session, monkeypatch
+):
     _stub_output(monkeypatch)
-    _bind_output(design_session)
-    window = NoiseWindow(design_session)
+    _bind_output(headless_session)
+    window = NoiseWindow(headless_session)
     qtbot.addWidget(window)
     emitted = []
     monkeypatch.setattr(
-        design_session, "emit_event", lambda key, **k: emitted.append(key)
+        headless_session, "emit_event", lambda key, **k: emitted.append(key)
     )
 
     window.on_play_noise_clicked()
@@ -94,21 +96,21 @@ def test_play_marks_once_but_not_on_silent_restart(qtbot, design_session, monkey
     assert emitted == ["NoiseStarted", "NoiseStopped"]
 
 
-def test_callback_loops_the_buffer_and_applies_gain_and_cap(qtbot, design_session):
-    window = NoiseWindow(design_session)
+def test_callback_loops_the_buffer_and_applies_gain_and_cap(qtbot, headless_session):
+    window = NoiseWindow(headless_session)
     qtbot.addWidget(window)
     window._noise_buffer = np.array([0.0, 1.0, 2.0, 3.0], dtype="float32")
     window._noise_pos = 2
     window.noise_stream_volume = 0.5
-    design_session.volume_cap = 0.5  # the master safety cap is the final gain stage
+    headless_session.volume_cap = 0.5  # the master safety cap is the final gain stage
     out = np.zeros((6, 1), dtype="float32")
     window._noise_callback(out, 6, None, None)
     # Reads wrap around the loop seam; gain = volume * cap = 0.25.
     np.testing.assert_allclose(out[:, 0], np.array([2, 3, 0, 1, 2, 3]) * 0.25)
 
 
-def test_callback_outputs_silence_without_a_buffer(qtbot, design_session):
-    window = NoiseWindow(design_session)
+def test_callback_outputs_silence_without_a_buffer(qtbot, headless_session):
+    window = NoiseWindow(headless_session)
     qtbot.addWidget(window)
     out = np.ones((8, 1), dtype="float32")
     window._noise_callback(out, 8, None, None)
@@ -116,11 +118,11 @@ def test_callback_outputs_silence_without_a_buffer(qtbot, design_session):
 
 
 def test_file_source_without_a_file_shows_error_and_no_stream(
-    qtbot, design_session, monkeypatch, silence_dialogs
+    qtbot, headless_session, monkeypatch, silence_dialogs
 ):
     _stub_output(monkeypatch)
-    _bind_output(design_session)
-    window = NoiseWindow(design_session)
+    _bind_output(headless_session)
+    window = NoiseWindow(headless_session)
     qtbot.addWidget(window)
     window.fileRadio.setChecked(True)
     window.play_noise()
@@ -129,14 +131,14 @@ def test_file_source_without_a_file_shows_error_and_no_stream(
 
 
 def test_failed_stream_start_clears_the_buffer(
-    qtbot, design_session, monkeypatch, silence_dialogs
+    qtbot, headless_session, monkeypatch, silence_dialogs
 ):
     def boom(*args, **kwargs):
         raise RuntimeError("no output device")
 
     _stub_output(monkeypatch, stream_cls=boom)
-    _bind_output(design_session)
-    window = NoiseWindow(design_session)
+    _bind_output(headless_session)
+    window = NoiseWindow(headless_session)
     qtbot.addWidget(window)
     window.play_noise()
     assert not window.is_streaming()
@@ -145,16 +147,16 @@ def test_failed_stream_start_clears_the_buffer(
 
 
 def test_play_with_no_bound_device_errors_and_keeps_quiet(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
     # #139: unbound equipment refuses to play (with an error pointing at the
     # Devices window) instead of falling back to the system default device.
     _stub_output(monkeypatch)
     errors = []
     monkeypatch.setattr(
-        design_session, "show_error_popup", lambda *a, **k: errors.append(a)
+        headless_session, "show_error_popup", lambda *a, **k: errors.append(a)
     )
-    window = NoiseWindow(design_session)
+    window = NoiseWindow(headless_session)
     qtbot.addWidget(window)
     window.on_play_noise_clicked()
     assert not window.is_streaming()
@@ -163,8 +165,8 @@ def test_play_with_no_bound_device_errors_and_keeps_quiet(
 
 
 @pytest.mark.parametrize("color", ["white", "pink", "brown"])
-def test_each_builtin_color_builds_a_normalized_buffer(qtbot, design_session, color):
-    window = NoiseWindow(design_session)
+def test_each_builtin_color_builds_a_normalized_buffer(qtbot, headless_session, color):
+    window = NoiseWindow(headless_session)
     qtbot.addWidget(window)
     idx = window.available_noisecolors_dropdown.findText(color)
     window.available_noisecolors_dropdown.setCurrentIndex(idx)
@@ -174,8 +176,8 @@ def test_each_builtin_color_builds_a_normalized_buffer(qtbot, design_session, co
     assert np.abs(buf).max() <= 1.0  # normalized for the volume/cap gain stage
 
 
-def test_state_round_trips_between_windows(qtbot, design_session):
-    first = NoiseWindow(design_session)
+def test_state_round_trips_between_windows(qtbot, headless_session):
+    first = NoiseWindow(headless_session)
     qtbot.addWidget(first)
     first.noisevolumeSpinBox.setValue(0.42)
     first.fileRadio.setChecked(True)
@@ -184,7 +186,7 @@ def test_state_round_trips_between_windows(qtbot, design_session):
     first.available_noisecolors_dropdown.setCurrentIndex(idx)
     state = first.gather_state()
 
-    second = NoiseWindow(design_session)
+    second = NoiseWindow(headless_session)
     qtbot.addWidget(second)
     second.apply_state(state)
     assert second.noisevolumeSpinBox.value() == pytest.approx(0.42)

--- a/tests/test_panels_recording.py
+++ b/tests/test_panels_recording.py
@@ -43,8 +43,8 @@ def _stub_recorder(monkeypatch, stream_cls=_FakeInput, rate=8000.0):
     monkeypatch.setattr(recording.sd, "InputStream", stream_cls)
 
 
-def test_designer_disables_the_record_button(qtbot, design_session):
-    window = RecordingWindow(design_session)
+def test_designer_disables_the_record_button(qtbot, headless_session):
+    window = RecordingWindow(headless_session)
     qtbot.addWidget(window)
     assert not window.micrecordButton.isEnabled()
     window.cleanup()
@@ -186,8 +186,8 @@ def test_open_unknown_in_app_survey_shows_error_not_a_window(
     window.cleanup()
 
 
-def test_survey_state_round_trips_web_urls_only(qtbot, design_session):
-    window = RecordingWindow(design_session)
+def test_survey_state_round_trips_web_urls_only(qtbot, headless_session):
+    window = RecordingWindow(headless_session)
     qtbot.addWidget(window)
     options = {"Post survey": "https://example.com/post"}
     window.apply_state(
@@ -199,8 +199,8 @@ def test_survey_state_round_trips_web_urls_only(qtbot, design_session):
     window.cleanup()
 
 
-def test_typed_url_wins_over_blank_preset(qtbot, design_session):
-    window = RecordingWindow(design_session)
+def test_typed_url_wins_over_blank_preset(qtbot, headless_session):
+    window = RecordingWindow(headless_session)
     qtbot.addWidget(window)
     window.surveyComboBox.setEditText("  example.com/typed  ")
     assert window.current_survey_url() == "example.com/typed"

--- a/tests/test_panels_state.py
+++ b/tests/test_panels_state.py
@@ -28,8 +28,8 @@ from smacc.panels.volume import VolumeWindow
 # ----- stateful panels -------------------------------------------------------
 
 
-def test_audio_panel_round_trips_cues_and_envelope(qtbot, design_session):
-    panel = AudioCueWindow(design_session)
+def test_audio_panel_round_trips_cues_and_envelope(qtbot, headless_session):
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     state = {
         "cues": [
@@ -51,8 +51,8 @@ def test_audio_panel_round_trips_cues_and_envelope(qtbot, design_session):
     assert got["cues"][1]["loop"] is False
 
 
-def test_audio_panel_ignores_malformed_numeric_settings(qtbot, design_session):
-    panel = AudioCueWindow(design_session)
+def test_audio_panel_ignores_malformed_numeric_settings(qtbot, headless_session):
+    panel = AudioCueWindow(headless_session)
     qtbot.addWidget(panel)
     before = panel.gather_state()
     panel.apply_state(
@@ -68,8 +68,8 @@ def test_audio_panel_ignores_malformed_numeric_settings(qtbot, design_session):
     assert got["cues"][0]["volume"] == before["cues"][0]["volume"]
 
 
-def test_noise_panel_round_trips(qtbot, design_session):
-    panel = NoiseWindow(design_session)
+def test_noise_panel_round_trips(qtbot, headless_session):
+    panel = NoiseWindow(headless_session)
     qtbot.addWidget(panel)
     state = {
         "noise_volume": 0.30,
@@ -85,16 +85,16 @@ def test_noise_panel_round_trips(qtbot, design_session):
     assert got["noise_file"] == "loop.wav"
 
 
-def test_noise_panel_ignores_malformed_numeric_settings(qtbot, design_session):
-    panel = NoiseWindow(design_session)
+def test_noise_panel_ignores_malformed_numeric_settings(qtbot, headless_session):
+    panel = NoiseWindow(headless_session)
     qtbot.addWidget(panel)
     before = panel.gather_state()["noise_volume"]
     panel.apply_state({"noise_volume": "loud"})
     assert panel.gather_state()["noise_volume"] == before
 
 
-def test_recording_panel_round_trips_surveys(qtbot, design_session):
-    panel = RecordingWindow(design_session)
+def test_recording_panel_round_trips_surveys(qtbot, headless_session):
+    panel = RecordingWindow(headless_session)
     qtbot.addWidget(panel)
     state = {
         "survey_url": "https://survey.example/post",
@@ -107,10 +107,10 @@ def test_recording_panel_round_trips_surveys(qtbot, design_session):
 
 
 def test_recording_panel_offers_builtin_surveys_without_persisting_them(
-    qtbot, design_session
+    qtbot, headless_session
 ):
     """Built-ins (#114) show in the dropdown and menu but never enter the study."""
-    panel = RecordingWindow(design_session)
+    panel = RecordingWindow(headless_session)
     qtbot.addWidget(panel)
     available = panel.available_surveys()
     assert available.get("DLQ") == "smacc://survey/dlq"
@@ -122,9 +122,9 @@ def test_recording_panel_offers_builtin_surveys_without_persisting_them(
     assert got["survey_options"] == {}
 
 
-def test_chat_panel_round_trips_chat_presets(qtbot, design_session):
+def test_chat_panel_round_trips_chat_presets(qtbot, headless_session):
     # The Chat window persists the shared chat quick-reply presets (#112).
-    panel = ChatWindow(design_session)
+    panel = ChatWindow(headless_session)
     qtbot.addWidget(panel)
     panel.apply_state(
         {
@@ -137,10 +137,10 @@ def test_chat_panel_round_trips_chat_presets(qtbot, design_session):
     assert got["chat_participant_presets"] == ["Yes", "No"]
 
 
-def test_chat_meters_track_each_live_bridge(qtbot, design_session):
+def test_chat_meters_track_each_live_bridge(qtbot, headless_session):
     # Each direction has a level meter fed from its bridge's input callback; an
     # idle direction's meter reads empty, a live one shows the stashed level.
-    panel = ChatWindow(design_session)
+    panel = ChatWindow(headless_session)
     qtbot.addWidget(panel)
     panel._render_levels()
     assert panel.talkMeter.value() == 0  # both idle
@@ -155,8 +155,8 @@ def test_chat_meters_track_each_live_bridge(qtbot, design_session):
     panel._talk._input = None
 
 
-def test_visual_panel_round_trips(qtbot, design_session):
-    panel = VisualWindow(design_session)
+def test_visual_panel_round_trips(qtbot, headless_session):
+    panel = VisualWindow(headless_session)
     qtbot.addWidget(panel)
     panel.apply_state(
         {
@@ -192,8 +192,8 @@ def test_visual_panel_round_trips(qtbot, design_session):
     assert got["visual_release"] == pytest.approx(1.5)
 
 
-def test_visual_panel_ignores_malformed_numeric_settings(qtbot, design_session):
-    panel = VisualWindow(design_session)
+def test_visual_panel_ignores_malformed_numeric_settings(qtbot, headless_session):
+    panel = VisualWindow(headless_session)
     qtbot.addWidget(panel)
     before = panel.gather_state()
     panel.apply_state(
@@ -218,12 +218,12 @@ def test_visual_panel_ignores_malformed_numeric_settings(qtbot, design_session):
     assert got["visual_cues"][0]["length"] == before["visual_cues"][0]["length"]
 
 
-def test_volume_panel_round_trips_cap(qtbot, design_session, monkeypatch):
+def test_volume_panel_round_trips_cap(qtbot, headless_session, monkeypatch):
     # The read-only Windows volume read-out uses COM; stub it so the panel builds
     # deterministically off any audio endpoint.
     monkeypatch.setattr(winvolume, "endpoint_volume", lambda: None)
     monkeypatch.setattr(winvolume, "app_volume", lambda: None)
-    panel = VolumeWindow(design_session)
+    panel = VolumeWindow(headless_session)
     qtbot.addWidget(panel)
     panel.apply_state({"volume_cap": 0.50, "output_latency": "low"})
     assert panel.gather_state() == {
@@ -232,25 +232,25 @@ def test_volume_panel_round_trips_cap(qtbot, design_session, monkeypatch):
     }
     # apply_state also drives the live session state: the cap (read by the audio
     # callbacks) and the latency mode (read when a stimulus stream opens).
-    assert design_session.volume_cap == pytest.approx(0.50)
-    assert design_session.output_latency == "low"
+    assert headless_session.volume_cap == pytest.approx(0.50)
+    assert headless_session.output_latency == "low"
 
 
 def test_volume_panel_ignores_malformed_numeric_settings(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
     monkeypatch.setattr(winvolume, "endpoint_volume", lambda: None)
     monkeypatch.setattr(winvolume, "app_volume", lambda: None)
-    panel = VolumeWindow(design_session)
+    panel = VolumeWindow(headless_session)
     qtbot.addWidget(panel)
     before = panel.gather_state()["volume_cap"]
     panel.apply_state({"volume_cap": "full"})
     assert panel.gather_state()["volume_cap"] == before
-    assert design_session.volume_cap == before
+    assert headless_session.volume_cap == before
 
 
-def test_biocals_panel_round_trips_stack(qtbot, design_session):
-    panel = BiocalsWindow(design_session)
+def test_biocals_panel_round_trips_stack(qtbot, headless_session):
+    panel = BiocalsWindow(headless_session)
     qtbot.addWidget(panel)
     state = {
         "biocals": {
@@ -295,9 +295,9 @@ def test_biocals_panel_round_trips_stack(qtbot, design_session):
     assert got["rows"][1]["duration"] == 20
 
 
-def test_biocals_panel_keeps_default_stack_for_older_studies(qtbot, design_session):
+def test_biocals_panel_keeps_default_stack_for_older_studies(qtbot, headless_session):
     # A pre-v7 state has no biocals block; the default 18-row stack stands.
-    panel = BiocalsWindow(design_session)
+    panel = BiocalsWindow(headless_session)
     qtbot.addWidget(panel)
     panel.apply_state({"noise_volume": 0.3})
     assert len(panel.gather_state()["biocals"]["rows"]) == 18
@@ -326,16 +326,16 @@ def _capture_session_log(session) -> list[logging.LogRecord]:
 
 
 def test_volume_panel_logs_windows_levels_on_refresh(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
     # Each actual read of the Windows volumes is logged for reproducibility — at
     # DEBUG, per the level convention (housekeeping detail: in the file, out of the
     # default preview).
     monkeypatch.setattr(winvolume, "endpoint_volume", lambda: 0.85)
     monkeypatch.setattr(winvolume, "app_volume", lambda: 0.50)
-    panel = VolumeWindow(design_session)  # constructor calls refresh_levels() once
+    panel = VolumeWindow(headless_session)  # constructor calls refresh_levels() once
     qtbot.addWidget(panel)
-    records = _capture_session_log(design_session)
+    records = _capture_session_log(headless_session)
     panel.refresh_levels()
     windows_lines = [
         r for r in records if r.getMessage().startswith("Windows output volume:")
@@ -348,15 +348,15 @@ def test_volume_panel_logs_windows_levels_on_refresh(
 
 
 def test_volume_panel_refresh_reports_unavailable_levels(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
     # When the COM read fails (non-Windows / no endpoint), the log says so rather
     # than crashing on a None percentage.
     monkeypatch.setattr(winvolume, "endpoint_volume", lambda: None)
     monkeypatch.setattr(winvolume, "app_volume", lambda: None)
-    panel = VolumeWindow(design_session)
+    panel = VolumeWindow(headless_session)
     qtbot.addWidget(panel)
-    records = _capture_session_log(design_session)
+    records = _capture_session_log(headless_session)
     panel.refresh_levels()
     messages = [r.getMessage() for r in records]
     assert (
@@ -368,14 +368,14 @@ def test_volume_panel_refresh_reports_unavailable_levels(
 # ----- stateless panels (their config lives at window/session level) ---------
 
 
-def test_events_panel_has_no_persisted_state(qtbot, design_session):
-    panel = EventsWindow(design_session)
+def test_events_panel_has_no_persisted_state(qtbot, headless_session):
+    panel = EventsWindow(headless_session)
     qtbot.addWidget(panel)
     assert panel.gather_state() == {}
 
 
-def test_devices_panel_has_no_persisted_state(qtbot, design_session, mock_devices):
-    panel = DevicesWindow(design_session)
+def test_devices_panel_has_no_persisted_state(qtbot, headless_session, mock_devices):
+    panel = DevicesWindow(headless_session)
     qtbot.addWidget(panel)
     assert panel.gather_state() == {}
 
@@ -383,8 +383,8 @@ def test_devices_panel_has_no_persisted_state(qtbot, design_session, mock_device
 # ----- per-window always-on-top (PanelWindow base) ------------------------
 
 
-def test_tool_window_always_on_top_toggle(qtbot, design_session):
-    panel = NoiseWindow(design_session)
+def test_tool_window_always_on_top_toggle(qtbot, headless_session):
+    panel = NoiseWindow(headless_session)
     qtbot.addWidget(panel)
     assert panel.is_always_on_top() is False  # default off
     # Every window binds the same window-scoped shortcut to its own toggle.
@@ -401,14 +401,14 @@ def test_tool_window_always_on_top_toggle(qtbot, design_session):
     assert not bool(panel.windowFlags() & QtCore.Qt.WindowType.WindowStaysOnTopHint)
 
 
-def test_tool_window_stays_visible_across_always_on_top_toggle(qtbot, design_session):
+def test_tool_window_stays_visible_across_always_on_top_toggle(qtbot, headless_session):
     """Toggling always-on-top must not hide a visible window (regression).
 
     setWindowFlag natively hides the window, so the re-show guard has to read
     visibility before applying the flag — checking after always saw False and the
     window vanished on every toggle.
     """
-    panel = NoiseWindow(design_session)
+    panel = NoiseWindow(headless_session)
     qtbot.addWidget(panel)
     panel.show()
     qtbot.waitExposed(panel)
@@ -422,10 +422,10 @@ def test_tool_window_stays_visible_across_always_on_top_toggle(qtbot, design_ses
     assert not panel.isVisible()
 
 
-def test_tool_window_file_menu_close_hides_the_window(qtbot, design_session):
+def test_tool_window_file_menu_close_hides_the_window(qtbot, headless_session):
     # Every tool window carries File → Close window (Ctrl+W); closing only hides
     # the window (the session keeps running), exactly like the title-bar X.
-    panel = NoiseWindow(design_session)
+    panel = NoiseWindow(headless_session)
     qtbot.addWidget(panel)
     panel.show()
     qtbot.waitExposed(panel)
@@ -445,10 +445,10 @@ def test_tool_window_file_menu_close_hides_the_window(qtbot, design_session):
     assert panel.isVisible()
 
 
-def test_tool_window_has_a_single_file_menu(qtbot, design_session):
+def test_tool_window_has_a_single_file_menu(qtbot, headless_session):
     # One flat File menu carries Close window and Always on top (#185) — the
     # old two one-item menus (File, View) were a lot of chrome for two actions.
-    panel = NoiseWindow(design_session)
+    panel = NoiseWindow(headless_session)
     qtbot.addWidget(panel)
     menus = [a for a in panel.menuBar().actions() if a.menu() is not None]
     assert [m.text() for m in menus] == ["&File"]

--- a/tests/test_panels_visual.py
+++ b/tests/test_panels_visual.py
@@ -68,9 +68,9 @@ def _spies(panel, monkeypatch):
     return events, popups
 
 
-def _board(qtbot, design_session, monkeypatch, backend=None):
+def _board(qtbot, headless_session, monkeypatch, backend=None):
     """A board with a fake clock + backend + sync writer, plus its spies."""
-    panel = VisualWindow(design_session)
+    panel = VisualWindow(headless_session)
     qtbot.addWidget(panel)
     clock = {"t": 0.0}
     panel._clock = lambda: clock["t"]
@@ -80,8 +80,8 @@ def _board(qtbot, design_session, monkeypatch, backend=None):
     return panel, clock, events, popups
 
 
-def test_defaults_are_one_playable_red_steady_slot(qtbot, design_session):
-    panel = VisualWindow(design_session)
+def test_defaults_are_one_playable_red_steady_slot(qtbot, headless_session):
+    panel = VisualWindow(headless_session)
     qtbot.addWidget(panel)
     assert len(panel.slots) == 1
     slot = panel.slots[0]
@@ -95,9 +95,9 @@ def test_defaults_are_one_playable_red_steady_slot(qtbot, design_session):
 
 
 def test_play_without_a_device_pops_an_error_and_marks_nothing(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
-    panel = VisualWindow(design_session)
+    panel = VisualWindow(headless_session)
     qtbot.addWidget(panel)
     events, popups = _spies(panel, monkeypatch)
     assert panel._backend is None  # the default equipment has no device bound
@@ -107,9 +107,9 @@ def test_play_without_a_device_pops_an_error_and_marks_nothing(
 
 
 def test_play_lights_the_first_frame_then_marks_with_the_slot_name(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
-    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel, clock, events, popups = _board(qtbot, headless_session, monkeypatch)
     panel.play_slot(panel.slots[0])
     backend = panel._active_backend
     assert backend.frames == [(255, 0, 0)]  # frame applied before the marker
@@ -119,9 +119,9 @@ def test_play_lights_the_first_frame_then_marks_with_the_slot_name(
 
 
 def test_cue_ends_on_its_own_with_an_off_and_a_stop_marker(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
-    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel, clock, events, popups = _board(qtbot, headless_session, monkeypatch)
     slot = panel.slots[0]
     slot.lengthSpinBox.setValue(2.0)
     panel.play_slot(slot)
@@ -138,9 +138,9 @@ def test_cue_ends_on_its_own_with_an_off_and_a_stop_marker(
 
 
 def test_stop_button_turns_off_immediately_without_a_fade(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
-    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel, clock, events, popups = _board(qtbot, headless_session, monkeypatch)
     slot = panel.slots[0]
     panel.play_slot(slot)
     backend = panel._active_backend
@@ -154,9 +154,9 @@ def test_stop_button_turns_off_immediately_without_a_fade(
 
 
 def test_stop_with_a_release_fades_before_the_marker(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
-    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel, clock, events, popups = _board(qtbot, headless_session, monkeypatch)
     panel.releaseSpinBox.setValue(1.0)
     slot = panel.slots[0]
     slot.lengthSpinBox.setValue(60.0)
@@ -176,9 +176,9 @@ def test_stop_with_a_release_fades_before_the_marker(
 
 
 def test_playing_another_slot_stops_the_lit_one_first(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
-    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel, clock, events, popups = _board(qtbot, headless_session, monkeypatch)
     panel.add_slot()
     first, second = panel.slots
     panel.play_slot(first)
@@ -191,9 +191,9 @@ def test_playing_another_slot_stops_the_lit_one_first(
 
 
 def test_replay_of_the_lit_slot_restarts_without_a_stop_marker(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
-    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel, clock, events, popups = _board(qtbot, headless_session, monkeypatch)
     slot = panel.slots[0]
     panel.play_slot(slot)
     clock["t"] = 0.5
@@ -202,9 +202,9 @@ def test_replay_of_the_lit_slot_restarts_without_a_stop_marker(
 
 
 def test_brightness_and_loop_edits_apply_to_the_lit_cue(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
-    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel, clock, events, popups = _board(qtbot, headless_session, monkeypatch)
     slot = panel.slots[0]
     slot.loopCheckBox.setChecked(True)
     panel.play_slot(slot)
@@ -220,9 +220,9 @@ def test_brightness_and_loop_edits_apply_to_the_lit_cue(
 
 
 def test_failed_write_mid_cue_stops_marks_and_reports(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
-    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel, clock, events, popups = _board(qtbot, headless_session, monkeypatch)
     panel.play_slot(panel.slots[0])
     # The device vanishes mid-cue: the writer captures the failure on its thread
     # and the next tick polls it.
@@ -234,11 +234,13 @@ def test_failed_write_mid_cue_stops_marks_and_reports(
     assert not panel._timer.isActive()
 
 
-def test_failed_first_frame_reports_without_markers(qtbot, design_session, monkeypatch):
+def test_failed_first_frame_reports_without_markers(
+    qtbot, headless_session, monkeypatch
+):
     # The first frame is applied synchronously, so an unreachable device is
     # reported at the click and no start marker fires for a cue that never lit.
     panel, clock, events, popups = _board(
-        qtbot, design_session, monkeypatch, backend=_DeadLight()
+        qtbot, headless_session, monkeypatch, backend=_DeadLight()
     )
     panel.play_slot(panel.slots[0])
     assert popups and not events
@@ -246,9 +248,9 @@ def test_failed_first_frame_reports_without_markers(qtbot, design_session, monke
 
 
 def test_cleanup_forces_the_light_off_without_a_marker(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
-    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel, clock, events, popups = _board(qtbot, headless_session, monkeypatch)
     panel.play_slot(panel.slots[0])
     backend = panel._active_backend
     panel.cleanup()  # app quit mid-cue
@@ -257,8 +259,8 @@ def test_cleanup_forces_the_light_off_without_a_marker(
     assert not panel._timer.isActive()
 
 
-def test_add_and_remove_slots_respect_the_bounds(qtbot, design_session, monkeypatch):
-    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+def test_add_and_remove_slots_respect_the_bounds(qtbot, headless_session, monkeypatch):
+    panel, clock, events, popups = _board(qtbot, headless_session, monkeypatch)
     panel.add_slot()
     assert [s.nameEdit.text() for s in panel.slots] == ["Light 1", "Light 2"]
     assert all(s.removeButton.isEnabled() for s in panel.slots)
@@ -272,9 +274,9 @@ def test_add_and_remove_slots_respect_the_bounds(qtbot, design_session, monkeypa
 
 
 def test_removing_the_lit_slot_darkens_without_a_marker(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
-    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel, clock, events, popups = _board(qtbot, headless_session, monkeypatch)
     panel.add_slot()
     second = panel.slots[1]
     panel.play_slot(second)
@@ -285,9 +287,9 @@ def test_removing_the_lit_slot_darkens_without_a_marker(
 
 
 def test_rate_warning_appears_only_for_fast_patterned_slots(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
-    panel, clock, events, popups = _board(qtbot, design_session, monkeypatch)
+    panel, clock, events, popups = _board(qtbot, headless_session, monkeypatch)
     slot = panel.slots[0]
     assert not panel.rateWarningLabel.isVisibleTo(panel)
     slot.rateSpinBox.setValue(12.0)  # fast, but the pattern is steady
@@ -299,8 +301,8 @@ def test_rate_warning_appears_only_for_fast_patterned_slots(
     assert not panel.rateWarningLabel.isVisibleTo(panel)
 
 
-def test_color_can_be_picked_with_no_device(qtbot, design_session, monkeypatch):
-    panel = VisualWindow(design_session)
+def test_color_can_be_picked_with_no_device(qtbot, headless_session, monkeypatch):
+    panel = VisualWindow(headless_session)
     qtbot.addWidget(panel)
     events, popups = _spies(panel, monkeypatch)
     monkeypatch.setattr(
@@ -312,24 +314,24 @@ def test_color_can_be_picked_with_no_device(qtbot, design_session, monkeypatch):
     assert not popups  # choosing a color never needs hardware
 
 
-def test_visual_route_to_hue_resolves_a_hue_backend(qtbot, design_session):
-    design_session.hue_config = hue.HueConfig("192.168.1.50", "key")
-    design_session.devices.bindings["philips_hue_light"] = "light:1"
-    design_session.devices.routing["play_visual_cue"] = "philips_hue_light"
-    panel = VisualWindow(design_session)
+def test_visual_route_to_hue_resolves_a_hue_backend(qtbot, headless_session):
+    headless_session.hue_config = hue.HueConfig("192.168.1.50", "key")
+    headless_session.devices.bindings["philips_hue_light"] = "light:1"
+    headless_session.devices.routing["play_visual_cue"] = "philips_hue_light"
+    panel = VisualWindow(headless_session)
     qtbot.addWidget(panel)
     assert isinstance(panel._backend, hue.HueBackend)
     assert "Philips Hue" in panel.deviceLabel.text()
 
 
 def test_flash_is_refused_on_a_backend_without_flash_support(
-    qtbot, design_session, monkeypatch
+    qtbot, headless_session, monkeypatch
 ):
     class _NoFlashLight(_FakeLight):
         supports_flash = False
 
     panel, clock, events, popups = _board(
-        qtbot, design_session, monkeypatch, backend=_NoFlashLight()
+        qtbot, headless_session, monkeypatch, backend=_NoFlashLight()
     )
     panel.add_slot()
     steady, flashy = panel.slots

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -59,10 +59,10 @@ def test_live_session_log_is_named_session_log(live_session):
     assert log_path.is_file()
 
 
-def test_design_session_creates_no_run_artifacts(tmp_path):
+def test_headless_session_creates_no_run_artifacts(tmp_path):
     # Design mode writes nothing — it doesn't even create the data directory.
-    sess = SmaccSession(tmp_path / "s", design=True)
-    assert sess.design is True
+    sess = SmaccSession(tmp_path / "s", headless=True)
+    assert sess.headless is True
     assert sess.can_record is False
     assert sess.session_dir is None
     assert sess.log_path is None
@@ -71,8 +71,8 @@ def test_design_session_creates_no_run_artifacts(tmp_path):
     sess.close()  # safe no-op: nothing to release
 
 
-def test_design_session_emit_event_is_safe_without_outlet(tmp_path):
-    sess = SmaccSession(tmp_path / "s", design=True)
+def test_headless_session_emit_event_is_safe_without_outlet(tmp_path):
+    sess = SmaccSession(tmp_path / "s", headless=True)
     sess.emit_event("REMDetected")  # triggers, but no outlet to push to
     assert sess.outlet is None  # still no outlet; no crash
 
@@ -80,8 +80,8 @@ def test_design_session_emit_event_is_safe_without_outlet(tmp_path):
 def test_design_logger_does_not_accumulate_handlers(tmp_path):
     # Each new session clears the shared logger first, so handlers never pile up
     # across the many sessions the launcher can open in one process.
-    SmaccSession(tmp_path / "a", design=True)
-    SmaccSession(tmp_path / "b", design=True)
+    SmaccSession(tmp_path / "a", headless=True)
+    SmaccSession(tmp_path / "b", headless=True)
     assert len(logging.getLogger("smacc").handlers) == 1
 
 
@@ -134,7 +134,7 @@ def _stub_session():
     sess.recording_start_time = None
     sess.outlet = _FakeOutlet()
     sess.trigger_out = None  # no hardware transport unless a test sets one
-    sess.design = False
+    sess.headless = False
     sess.trigger_config = triggers.TriggerConfig()
     logger = logging.getLogger("smacc-test-emit")
     logger.handlers.clear()
@@ -291,7 +291,7 @@ def test_set_trigger_output_disabled_or_design_opens_nothing():
     sess, _ = _stub_session()
     assert sess.set_trigger_output(triggers.TriggerConfig(enabled=False)) is None
     assert sess.trigger_out is None
-    sess.design = True
+    sess.headless = True
     cfg = triggers.TriggerConfig(enabled=True, port="COM3")
     assert sess.set_trigger_output(cfg) is None  # design mode never opens hardware
     assert sess.trigger_out is None

--- a/tests/test_studyconfig.py
+++ b/tests/test_studyconfig.py
@@ -181,6 +181,21 @@ def test_round_trip_is_byte_stable():
     assert _yaml(pass1) == _yaml(pass2)  # deterministic order + stable values
 
 
+def test_smacc_file_round_trips_byte_stable_through_the_model(tmp_path):
+    # The keystone the Study Editor relies on (#301): a complete study saved as a
+    # .smacc, then loaded and re-saved through the model, is byte-identical. Proves
+    # "the editor's save is a faithful, stable .smacc" before the editor exists.
+    full = _full_settings()
+    meta = {"subject": "", "session": "", "notes": ""}
+    path1 = tmp_path / "study.smacc"
+    settings.save_settings(str(path1), full, meta)
+    raw, loaded_meta = settings.load_settings(str(path1))
+    rebuilt = StudyConfig.from_settings_dict(raw).to_settings_dict()
+    path2 = tmp_path / "study2.smacc"
+    settings.save_settings(str(path2), rebuilt, loaded_meta)
+    assert path1.read_text(encoding="utf-8") == path2.read_text(encoding="utf-8")
+
+
 # ----- the shipped default.smacc --------------------------------------------
 
 

--- a/tests/test_survey_window.py
+++ b/tests/test_survey_window.py
@@ -44,14 +44,14 @@ def test_preview_without_session_disables_submit(qtbot, demo_survey):
     assert not window.submitButton.isEnabled()
 
 
-def test_designer_session_disables_submit(qtbot, demo_survey, design_session):
-    window = SurveyWindow(demo_survey, design_session)
+def test_designer_session_disables_submit(qtbot, demo_survey, headless_session):
+    window = SurveyWindow(demo_survey, headless_session)
     qtbot.addWidget(window)
     assert not window.submitButton.isEnabled()
 
 
-def test_responses_track_radio_state(qtbot, demo_survey, design_session):
-    window = SurveyWindow(demo_survey, design_session)
+def test_responses_track_radio_state(qtbot, demo_survey, headless_session):
+    window = SurveyWindow(demo_survey, headless_session)
     qtbot.addWidget(window)
     assert window.responses() == [None, None]
     _answer(window, 0, 2)
@@ -157,8 +157,8 @@ def _control(window: SurveyWindow, item_type: str):
     return next(c for it, c, _ in window._fields if it.type == item_type)
 
 
-def test_mixed_survey_builds_typed_widgets(qtbot, mixed_survey, design_session):
-    window = SurveyWindow(mixed_survey, design_session)
+def test_mixed_survey_builds_typed_widgets(qtbot, mixed_survey, headless_session):
+    window = SurveyWindow(mixed_survey, headless_session)
     qtbot.addWidget(window)
     kinds = {it.type: type(control) for it, control, _ in window._fields}
     assert kinds["likert"] is QtWidgets.QButtonGroup
@@ -170,8 +170,8 @@ def test_mixed_survey_builds_typed_widgets(qtbot, mixed_survey, design_session):
     assert len(window._fields) == 4
 
 
-def test_mixed_survey_responses_read_each_widget(qtbot, mixed_survey, design_session):
-    window = SurveyWindow(mixed_survey, design_session)
+def test_mixed_survey_responses_read_each_widget(qtbot, mixed_survey, headless_session):
+    window = SurveyWindow(mixed_survey, headless_session)
     qtbot.addWidget(window)
     assert window.responses() == [None, None, None, None]
     window._groups[0].button(2).setChecked(True)
@@ -183,8 +183,8 @@ def test_mixed_survey_responses_read_each_widget(qtbot, mixed_survey, design_ses
     assert window.responses() == [2, 42, "scientist", 1]
 
 
-def test_number_left_blank_is_unanswered(qtbot, mixed_survey, design_session):
-    window = SurveyWindow(mixed_survey, design_session)
+def test_number_left_blank_is_unanswered(qtbot, mixed_survey, headless_session):
+    window = SurveyWindow(mixed_survey, headless_session)
     qtbot.addWidget(window)
     spin = _control(window, "number")
     assert spin.value() == spin.minimum()  # starts on the "—" special-value slot


### PR DESCRIPTION
The foundation for the hardware-free Study Editor (#301): rename `SmaccSession`'s
`design` flag to `headless` so its name says what it does — an offline session with
no run folder, log file, or LSL outlet — and add the model round-trip keystone test.

`design` was dual-role: it triggered the editor chrome in `SmaccWindow` AND it is the
test harness's offline-construction mechanism (the `design_session` fixture used
across ~395 sites in 15 test files). #301 deletes the editor chrome but must keep the
offline-construction path, so this **renames, never deletes** — first and atomic,
before any editor code.

- `session.py`: `design`→`headless` (parameter, attribute, `init_headless_logger`,
  `can_record = not headless`); construction and the trigger-skip gates unchanged.
- `gui.py`/`panels/devices.py`: read `session.headless`. `launcher.py`: `headless=True`.
- Tests: `design_session`→`headless_session` fixture + sweep; `SmaccSession(design=…)`
  →`headless=…`; `sess.design`→`sess.headless`.
- **Kept:** `SmaccWindow.self.design` (the editor-mode attribute) is unchanged — it is
  removed when the `gui.py` chrome is deleted at the end of #301; for now it is just
  sourced from `session.headless`.
- New test: a complete study saved as a `.smacc`, loaded, and re-saved through
  `StudyConfig` is byte-identical — the keystone the editor's save relies on.

Behavior is unchanged. Full suite green (1172), ruff and mypy clean.

Part of #301 (steps 1–3: model contract + the `design`→`headless` rename).
