### PR TITLE
feat: the hardware-free Study Editor (#301, steps 5-8)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,15 +146,14 @@ include_external_packages = true
 
 # The Study Editor authors a study by editing the pure StudyConfig model; it must
 # never be able to open an audio stream, meter a mic, or fire an LSL marker. We
-# make that true *by construction* rather than by discipline: forbid the model
-# (and, once it exists, the editor window) from importing the run-time stack at
-# all. With no import path to sounddevice/pylsl/the session, no code path can
-# reach the hardware — the guarantee can't be forgotten in a future edit. The
-# editor module joins source_modules when it lands (#301, step 5).
+# make that true *by construction* rather than by discipline: forbid both the model
+# and the editor window from importing the run-time stack at all. With no import
+# path to sounddevice/pylsl/the session, no code path can reach the hardware — the
+# guarantee can't be forgotten in a future edit.
 [[tool.importlinter.contracts]]
-name = "The Study Editor model never reaches the hardware/run-time stack"
+name = "The Study Editor never reaches the hardware/run-time stack"
 type = "forbidden"
-source_modules = ["smacc.studyconfig"]
+source_modules = ["smacc.studyconfig", "smacc.studyeditor"]
 forbidden_modules = [
     "smacc.session",
     "smacc.gui",

--- a/src/smacc/dialogs.py
+++ b/src/smacc/dialogs.py
@@ -1,5 +1,6 @@
 """Dialogs shown by SMACC outside the main window."""
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import cast
 
@@ -552,6 +553,7 @@ class ManageSurveysDialog(QtWidgets.QDialog):
         options: dict[str, str],
         builtin_dir=None,
         user_dir=None,
+        preview_builtin: Callable[[surveys.SurveyDef], None] | None = None,
         parent=None,
     ) -> None:
         super().__init__(parent)
@@ -563,7 +565,10 @@ class ManageSurveysDialog(QtWidgets.QDialog):
         self._builtin_dir = builtin_dir
         self._user_dir = user_dir
         self.files_changed = False  # any custom-survey file built/edited/removed
-        self._previews: list[QtWidgets.QDialog] = []  # keep built-in views alive
+        # Previewing a built-in survey opens the real (panel) survey window; the
+        # caller injects that capability so this module imports no panels — the
+        # Study Editor reuses this dialog and stays hardware-free by design (#301).
+        self._preview_builtin = preview_builtin
 
         hint = QtWidgets.QLabel(
             "Built-in surveys ship with SMACC and open in a SMACC window; build "
@@ -724,12 +729,16 @@ class ManageSurveysDialog(QtWidgets.QDialog):
             buildDialog = BuildSurveyDialog(survey, existing_keys=existing, parent=self)
             if buildDialog.exec():
                 self._save_custom(buildDialog.get_survey())
-        else:  # builtin: read-only preview of the real window, no session attached
-            from .panels.survey import SurveyWindow  # deferred: dialogs stay Qt-light
-
-            preview = SurveyWindow(survey, None, parent=self)
-            self._previews.append(preview)
-            preview.show()
+        else:  # builtin: preview the real survey window via the injected capability
+            if self._preview_builtin is not None:
+                self._preview_builtin(survey)
+            else:  # no previewer (the editor): point at where preview lives
+                QtWidgets.QMessageBox.information(
+                    self,
+                    "Manage surveys",
+                    "Previewing a built-in survey opens it in a SMACC window, "
+                    "available from a session.",
+                )
 
     def _remove_selected(self) -> None:
         selected = self._selected()

--- a/src/smacc/eventregistry.py
+++ b/src/smacc/eventregistry.py
@@ -1,0 +1,293 @@
+"""The event-code registry table, shared by the Markers window and Study Editor.
+
+A session-free :class:`QtWidgets.QWidget` that edits a study's event registry — the
+per-event port code, LSL/TTL/preview/increment routing, plus custom-event add/remove
+and the TTL safe-max. It operates purely on a list of :class:`smacc.events.EventDef`
+(via :meth:`load` / :meth:`current_events`), so the same table backs both the live
+:class:`~smacc.panels.markers.MarkersWindow` (which loads from / applies to the
+running session) and the hardware-free Study Editor's Markers section (which loads
+from / commits to a :class:`~smacc.studyconfig.StudyConfig`).
+
+It imports no session, panels, ``sounddevice`` or ``pylsl`` — only the pure event
+model and the (panels-free) Add-event dialog — so the editor can embed it and stay
+hardware-free by construction (enforced by the import-linter contract via #301).
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from . import events
+from .dialogs import AddEventDialog
+from .fonts import mono_font
+
+# Registry table grouping: category key -> the group header shown in the table.
+# Unknown categories (a hand-edited custom event) are appended after these.
+_CATEGORY_LABELS = (
+    ("manual", "Event grid"),
+    ("control", "Controls & lights"),
+    ("biocal", "Biocals"),
+    ("system", "System"),
+)
+
+
+class EventRegistryTable(QtWidgets.QWidget):
+    """An editor for a study's event registry: codes, routing, add/remove, safe-max."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._events: list[events.EventDef] = []
+
+        self.table = QtWidgets.QTableWidget(0, 6, self)
+        self.table.setHorizontalHeaderLabels(
+            ["Event", "Code", "LSL", "TTL", "Preview", "Increment"]
+        )
+        for col, tip in (
+            (1, "The 8-bit port code (1-255) sent when the event fires."),
+            (2, "Send this event's code over the LSL marker stream."),
+            (
+                3,
+                "Send this event's code over the hardware TTL trigger "
+                "(when one is configured).",
+            ),
+            (
+                4,
+                "Show this event in the live log viewer (the log file always records it).",
+            ),
+            (5, "Advance the code on each firing (e.g. dream reports: 201, 202, …)."),
+        ):
+            header_item = self.table.horizontalHeaderItem(col)
+            if header_item is not None:
+                header_item.setToolTip(tip)
+        vheader = self.table.verticalHeader()
+        assert vheader is not None
+        vheader.setVisible(False)
+        self.table.setSelectionMode(
+            QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
+        )
+        self.table.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        self.table.setEditTriggers(
+            QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers
+        )
+        header = self.table.horizontalHeader()
+        assert header is not None
+        header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeMode.Stretch)
+        for col in range(1, 6):
+            header.setSectionResizeMode(
+                col, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
+            )
+
+        self.addButton = QtWidgets.QPushButton("Add event…", self)
+        self.addButton.setStatusTip("Add a custom event button.")
+        self.addButton.clicked.connect(self._add_event)
+        self.removeButton = QtWidgets.QPushButton("Remove", self)
+        self.removeButton.setStatusTip("Remove the selected custom event.")
+        self.removeButton.clicked.connect(self._remove_selected)
+        self.safeMaxSpin = QtWidgets.QSpinBox(self)
+        self.safeMaxSpin.setRange(events.CODE_MIN, events.CODE_MAX)
+        self.safeMaxSpin.setStatusTip(
+            "TTL-routed codes above this raise a soft warning (some older trigger "
+            "hardware accepts only a limited range; LSL carries any code)."
+        )
+        buttonRow = QtWidgets.QHBoxLayout()
+        buttonRow.addWidget(self.addButton)
+        buttonRow.addWidget(self.removeButton)
+        buttonRow.addStretch(1)
+        buttonRow.addWidget(QtWidgets.QLabel("TTL safe max code:"))
+        buttonRow.addWidget(self.safeMaxSpin)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.table, 1)
+        layout.addLayout(buttonRow)
+
+    # ----- load / read --------------------------------------------------------
+
+    def load(self, registry: list[events.EventDef], safe_max: int) -> None:
+        """Replace the staged registry and rebuild the table."""
+        self._events = [replace(e) for e in registry]
+        self.safeMaxSpin.setValue(int(safe_max))
+        self._populate()
+
+    def current_events(self) -> list[events.EventDef]:
+        """The staged registry, with the table's edits folded in (fresh copies)."""
+        self._sync()
+        return [replace(e) for e in self._events]
+
+    def current_safe_max(self) -> int:
+        return self.safeMaxSpin.value()
+
+    def set_ttl_enabled(self, enabled: bool) -> None:
+        """Gray the TTL column while no hardware transport is enabled.
+
+        The checkbox values are kept (they persist with the study and re-arm when
+        a transport is enabled); the disabled state just makes plain that nothing
+        reaches a TTL line until a transport is configured.
+        """
+        tip = (
+            "Send this event's code over the hardware TTL trigger."
+            if enabled
+            else "No hardware transport is enabled, so nothing is sent over TTL; "
+            "the routing is kept for when one is."
+        )
+        for box in self._ttl_boxes:
+            box.setEnabled(enabled)
+            box.setToolTip(tip)
+
+    # ----- table build --------------------------------------------------------
+
+    def _populate(self) -> None:
+        """(Re)build the table rows from ``self._events``, grouped by category.
+
+        Widgets are kept in lists *aligned with* ``self._events`` (not with table
+        rows — the group-header rows offset those); ``self._row_event`` maps a
+        table row back to its event index for selection-based actions.
+        """
+        self._code_spins: list[QtWidgets.QSpinBox] = []
+        self._lsl_boxes: list[QtWidgets.QCheckBox] = []
+        self._ttl_boxes: list[QtWidgets.QCheckBox] = []
+        self._preview_boxes: list[QtWidgets.QCheckBox] = []
+        self._increment_boxes: list[QtWidgets.QCheckBox] = []
+        self._label_edits: list[QtWidgets.QLineEdit | None] = []
+        self._row_event: dict[int, int] = {}
+
+        grouped: dict[str, list[int]] = {}
+        for i, event in enumerate(self._events):
+            grouped.setdefault(event.category, []).append(i)
+        ordered: list[tuple[str, list[int]]] = []
+        for key, label in _CATEGORY_LABELS:
+            if key in grouped:
+                ordered.append((label, grouped.pop(key)))
+        for key in list(grouped):  # any unknown category lands after the known ones
+            ordered.append((key.title(), grouped.pop(key)))
+
+        self.table.clearContents()
+        self.table.setRowCount(sum(len(indices) + 1 for _, indices in ordered))
+        for _ in self._events:
+            self._code_spins.append(None)  # type: ignore[arg-type]  # filled below
+            self._lsl_boxes.append(None)  # type: ignore[arg-type]
+            self._ttl_boxes.append(None)  # type: ignore[arg-type]
+            self._preview_boxes.append(None)  # type: ignore[arg-type]
+            self._increment_boxes.append(None)  # type: ignore[arg-type]
+            self._label_edits.append(None)
+
+        row = 0
+        bold = QtGui.QFont()
+        bold.setBold(True)
+        for group_label, indices in ordered:
+            header_item = QtWidgets.QTableWidgetItem(group_label)
+            header_item.setFont(bold)
+            header_item.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled)
+            self.table.setItem(row, 0, header_item)
+            self.table.setSpan(row, 0, 1, self.table.columnCount())
+            row += 1
+            for i in indices:
+                self._build_event_row(row, i)
+                self._row_event[row] = i
+                row += 1
+
+    def _build_event_row(self, row: int, i: int) -> None:
+        """Fill table ``row`` with the widgets for event index ``i``."""
+        event = self._events[i]
+        if event.builtin:
+            label_item = QtWidgets.QTableWidgetItem(event.label)
+            label_item.setFlags(label_item.flags() & ~QtCore.Qt.ItemFlag.ItemIsEditable)
+            if event.tooltip:
+                label_item.setToolTip(event.tooltip)
+            self.table.setItem(row, 0, label_item)
+        else:
+            label_edit = QtWidgets.QLineEdit(event.label, self)
+            label_edit.setPlaceholderText("Custom event label")
+            self.table.setCellWidget(row, 0, label_edit)
+            self._label_edits[i] = label_edit
+
+        code_spin = QtWidgets.QSpinBox(self)
+        code_spin.setRange(events.CODE_MIN, events.CODE_MAX)
+        code_spin.setValue(event.code)
+        code_spin.setFont(mono_font())  # B612 Mono for the numeric port code (#279)
+        self.table.setCellWidget(row, 1, code_spin)
+        self._code_spins[i] = code_spin
+
+        for col, checked, boxes in (
+            (2, event.lsl, self._lsl_boxes),
+            (3, event.ttl, self._ttl_boxes),
+            (4, event.preview, self._preview_boxes),
+            (5, event.increment, self._increment_boxes),
+        ):
+            cell, box = self._checkbox_cell(checked)
+            self.table.setCellWidget(row, col, cell)
+            boxes[i] = box
+
+    @staticmethod
+    def _checkbox_cell(checked: bool) -> tuple[QtWidgets.QWidget, QtWidgets.QCheckBox]:
+        """Return a ``(container, checkbox)`` with the box centered in its cell."""
+        container = QtWidgets.QWidget()
+        box = QtWidgets.QCheckBox(container)
+        box.setChecked(checked)
+        lay = QtWidgets.QHBoxLayout(container)
+        lay.addWidget(box)
+        lay.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        lay.setContentsMargins(0, 0, 0, 0)
+        return container, box
+
+    def _sync(self) -> None:
+        """Read widget values back into ``self._events`` before add/remove/read."""
+        for i, event in enumerate(self._events):
+            label = event.label
+            edit = self._label_edits[i]
+            if edit is not None:
+                label = edit.text().strip() or event.label
+            self._events[i] = replace(
+                event,
+                label=label,
+                code=self._code_spins[i].value(),
+                lsl=self._lsl_boxes[i].isChecked(),
+                ttl=self._ttl_boxes[i].isChecked(),
+                preview=self._preview_boxes[i].isChecked(),
+                increment=self._increment_boxes[i].isChecked(),
+            )
+
+    # ----- add / remove -------------------------------------------------------
+
+    def _suggested_code(self) -> int:
+        """A free-ish default code for a new event (one past the current max)."""
+        used = [e.code for e in self._events if isinstance(e.code, int)]
+        return min((max(used) + 1) if used else events.CODE_MIN, events.CODE_MAX)
+
+    def _add_event(self) -> None:
+        self._sync()
+        dialog = AddEventDialog(self._suggested_code(), parent=self)
+        if not dialog.exec():
+            return
+        label, code, tooltip, increment = dialog.get_inputs()
+        event = events.make_custom_event(
+            label,
+            code,
+            [e.key for e in self._events],
+            tooltip=tooltip,
+            increment=increment,
+        )
+        self._events.append(event)
+        self._populate()
+        for row, i in self._row_event.items():
+            if i == len(self._events) - 1:
+                self.table.selectRow(row)
+                break
+
+    def _remove_selected(self) -> None:
+        row = self.table.currentRow()
+        i = self._row_event.get(row)
+        if i is None:
+            return
+        self._sync()
+        if self._events[i].builtin:
+            QtWidgets.QMessageBox.information(
+                self, "Markers", "Built-in events can't be removed."
+            )
+            return
+        del self._events[i]
+        self._populate()

--- a/src/smacc/launcher.py
+++ b/src/smacc/launcher.py
@@ -27,6 +27,7 @@ from .gui import SmaccWindow
 from .paths import DEFAULT_DATA_DIR, DEFAULT_SETTINGS_PATH, LOGO_PATH, preferences_path
 from .rigsetup import RigSetupWindow
 from .session import SmaccSession
+from .studyeditor import StudyEditorWindow
 from .toolwindow import ToolWindow
 
 # Stable id for the launcher's geometry entry in the per-window preferences map.
@@ -254,18 +255,16 @@ class LauncherWindow(QtWidgets.QMainWindow):
         self._open_tool(window)
 
     def _open_editor(self) -> None:
-        """Open the Editor on a new SMACC file or an existing one (from "Editor…")."""
+        """Open the Study Editor on a new SMACC file or an existing one (from "Editor…").
+
+        The editor is hardware-free (#301): it edits a StudyConfig directly and never
+        opens a session, so — unlike a live run — it needs no data directory or rig.
+        """
         dialog = dialogs.EditorFileDialog(parent=self)
         if not dialog.exec():
             return
         path = None if dialog.is_new() else dialog.chosen_path()
-        data_dir = (
-            settings.load_data_directory(path, DEFAULT_DATA_DIR)
-            if path
-            else DEFAULT_DATA_DIR
-        )
-        session = SmaccSession(data_dir, headless=True)
-        self._open_tool(SmaccWindow(session, settings_path=path))
+        self._open_tool(StudyEditorWindow(settings_path=path))
 
     def design_cues(self) -> None:
         """Open the standalone Audio Cue Designer (exports WAVs to the cues folder)."""
@@ -388,10 +387,10 @@ class LauncherWindow(QtWidgets.QMainWindow):
         dialog offers and preselects it.
         """
         tool = self._tool
-        if isinstance(tool, SmaccWindow) and not tool.design:
-            self.close()  # persists launcher geometry, then quits the app
+        if isinstance(tool, SmaccWindow):
+            self.close()  # a live session ended: persist geometry, then quit the app
             return
-        if isinstance(tool, SmaccWindow) and tool.settings_path:
+        if isinstance(tool, StudyEditorWindow) and tool.settings_path:
             dialogs.remember_settings(tool.settings_path)
             preferences.update_preferences(
                 preferences_path, {"last_settings": tool.settings_path}

--- a/src/smacc/panels/markers.py
+++ b/src/smacc/panels/markers.py
@@ -26,22 +26,12 @@ from dataclasses import replace
 from PyQt6 import QtCore, QtGui, QtWidgets
 
 from .. import events, triggers
-from ..dialogs import AddEventDialog
-from ..fonts import mono_font
+from ..eventregistry import EventRegistryTable
 from ..session import SmaccSession
 from .base import PanelWindow, make_section_title
 
 # Common serial baud rates offered in the dropdown (it stays editable for any other).
 _COMMON_BAUDS = (9600, 19200, 38400, 57600, 115200, 230400)
-
-# Registry table grouping: category key -> the group header shown in the table.
-# Unknown categories (a hand-edited custom event) are appended after these.
-_CATEGORY_LABELS = (
-    ("manual", "Event grid"),
-    ("control", "Controls & lights"),
-    ("biocal", "Biocals"),
-    ("system", "System"),
-)
 
 # What governs each destination — the read-only legend at the top of the window.
 _LEGEND_ROWS = (
@@ -67,71 +57,8 @@ class MarkersWindow(PanelWindow):
     def __init__(self, session: SmaccSession, parent: QtWidgets.QWidget | None = None):
         super().__init__(session, parent)
         self.resize(900, 640)
-        self._events: list[events.EventDef] = []
-
-        self.table = QtWidgets.QTableWidget(0, 6, self)
-        self.table.setHorizontalHeaderLabels(
-            ["Event", "Code", "LSL", "TTL", "Preview", "Increment"]
-        )
-        for col, tip in (
-            (1, "The 8-bit port code (1-255) sent when the event fires."),
-            (2, "Send this event's code over the LSL marker stream."),
-            (
-                3,
-                "Send this event's code over the hardware TTL trigger "
-                "(when one is configured).",
-            ),
-            (
-                4,
-                "Show this event in the live log viewer (the log file always records it).",
-            ),
-            (5, "Advance the code on each firing (e.g. dream reports: 201, 202, …)."),
-        ):
-            header_item = self.table.horizontalHeaderItem(col)
-            if header_item is not None:
-                header_item.setToolTip(tip)
-        vheader = self.table.verticalHeader()
-        assert vheader is not None
-        vheader.setVisible(False)
-        self.table.setSelectionMode(
-            QtWidgets.QAbstractItemView.SelectionMode.SingleSelection
-        )
-        self.table.setSelectionBehavior(
-            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
-        )
-        self.table.setEditTriggers(
-            QtWidgets.QAbstractItemView.EditTrigger.NoEditTriggers
-        )
-        header = self.table.horizontalHeader()
-        assert header is not None
-        header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeMode.Stretch)
-        for col in range(1, 6):
-            header.setSectionResizeMode(
-                col, QtWidgets.QHeaderView.ResizeMode.ResizeToContents
-            )
-
-        addButton = QtWidgets.QPushButton("Add event…", self)
-        addButton.setStatusTip("Add a custom event button.")
-        addButton.clicked.connect(self._add_event)
-        self.removeButton = QtWidgets.QPushButton("Remove", self)
-        self.removeButton.setStatusTip("Remove the selected custom event.")
-        self.removeButton.clicked.connect(self._remove_selected)
-        self.safeMaxSpin = QtWidgets.QSpinBox(self)
-        self.safeMaxSpin.setRange(events.CODE_MIN, events.CODE_MAX)
-        self.safeMaxSpin.setStatusTip(
-            "TTL-routed codes above this raise a soft warning (some older trigger "
-            "hardware accepts only a limited range; LSL carries any code)."
-        )
-        tableButtonRow = QtWidgets.QHBoxLayout()
-        tableButtonRow.addWidget(addButton)
-        tableButtonRow.addWidget(self.removeButton)
-        tableButtonRow.addStretch(1)
-        tableButtonRow.addWidget(QtWidgets.QLabel("TTL safe max code:"))
-        tableButtonRow.addWidget(self.safeMaxSpin)
-
-        registryColumn = QtWidgets.QVBoxLayout()
-        registryColumn.addWidget(self.table, 1)
-        registryColumn.addLayout(tableButtonRow)
+        # The session-free registry table, shared with the Study Editor (#301).
+        self.registry = EventRegistryTable(self)
 
         self.applyButton = QtWidgets.QPushButton("Apply", self)
         self.applyButton.setStatusTip(
@@ -155,7 +82,7 @@ class MarkersWindow(PanelWindow):
         sideColumn.addLayout(applyRow)
 
         columns = QtWidgets.QHBoxLayout()
-        columns.addLayout(registryColumn, 1)
+        columns.addWidget(self.registry, 1)
         columns.addLayout(sideColumn)
 
         container = QtWidgets.QWidget()
@@ -326,25 +253,7 @@ class MarkersWindow(PanelWindow):
 
     def _update_enabled_state(self) -> None:
         self._config_widget.setEnabled(self.enabledBox.isChecked())
-        self._update_ttl_boxes()
-
-    def _update_ttl_boxes(self) -> None:
-        """Gray the TTL column while no hardware transport is enabled.
-
-        The checkbox values are kept (they persist with the study and re-arm when
-        a transport is enabled); the disabled state just makes plain that nothing
-        reaches a TTL line until the transport below is configured.
-        """
-        enabled = self.enabledBox.isChecked()
-        tip = (
-            "Send this event's code over the hardware TTL trigger."
-            if enabled
-            else "No hardware transport is enabled (see Hardware TTL transport), "
-            "so nothing is sent over TTL; the routing is kept for when one is."
-        )
-        for box in self._ttl_boxes:
-            box.setEnabled(enabled)
-            box.setToolTip(tip)
+        self.registry.set_ttl_enabled(self.enabledBox.isChecked())
 
     def _current_port(self) -> str:
         """Resolve the chosen port to its device name.
@@ -405,170 +314,13 @@ class MarkersWindow(PanelWindow):
         self._update_pulse_enabled()
         self._update_enabled_state()
 
-    # ----- registry table -----------------------------------------------------
-
-    def _populate(self) -> None:
-        """(Re)build the table rows from ``self._events``, grouped by category.
-
-        Widgets are kept in lists *aligned with* ``self._events`` (not with table
-        rows — the group-header rows offset those); ``self._row_event`` maps a
-        table row back to its event index for selection-based actions.
-        """
-        self._code_spins: list[QtWidgets.QSpinBox] = []
-        self._lsl_boxes: list[QtWidgets.QCheckBox] = []
-        self._ttl_boxes: list[QtWidgets.QCheckBox] = []
-        self._preview_boxes: list[QtWidgets.QCheckBox] = []
-        self._increment_boxes: list[QtWidgets.QCheckBox] = []
-        self._label_edits: list[QtWidgets.QLineEdit | None] = []
-        self._row_event: dict[int, int] = {}
-
-        grouped: dict[str, list[int]] = {}
-        for i, event in enumerate(self._events):
-            grouped.setdefault(event.category, []).append(i)
-        ordered: list[tuple[str, list[int]]] = []
-        for key, label in _CATEGORY_LABELS:
-            if key in grouped:
-                ordered.append((label, grouped.pop(key)))
-        for key in list(grouped):  # any unknown category lands after the known ones
-            ordered.append((key.title(), grouped.pop(key)))
-
-        self.table.clearContents()
-        self.table.setRowCount(sum(len(indices) + 1 for _, indices in ordered))
-        # The per-event widget lists are appended in event order below, so seed
-        # them index-aligned first.
-        for _ in self._events:
-            self._code_spins.append(None)  # type: ignore[arg-type]  # filled below
-            self._lsl_boxes.append(None)  # type: ignore[arg-type]
-            self._ttl_boxes.append(None)  # type: ignore[arg-type]
-            self._preview_boxes.append(None)  # type: ignore[arg-type]
-            self._increment_boxes.append(None)  # type: ignore[arg-type]
-            self._label_edits.append(None)
-
-        row = 0
-        bold = QtGui.QFont()
-        bold.setBold(True)
-        for group_label, indices in ordered:
-            header_item = QtWidgets.QTableWidgetItem(group_label)
-            header_item.setFont(bold)
-            header_item.setFlags(QtCore.Qt.ItemFlag.ItemIsEnabled)
-            self.table.setItem(row, 0, header_item)
-            self.table.setSpan(row, 0, 1, self.table.columnCount())
-            row += 1
-            for i in indices:
-                self._build_event_row(row, i)
-                self._row_event[row] = i
-                row += 1
-        self._update_ttl_boxes()
-
-    def _build_event_row(self, row: int, i: int) -> None:
-        """Fill table ``row`` with the widgets for event index ``i``."""
-        event = self._events[i]
-        if event.builtin:
-            label_item = QtWidgets.QTableWidgetItem(event.label)
-            label_item.setFlags(label_item.flags() & ~QtCore.Qt.ItemFlag.ItemIsEditable)
-            if event.tooltip:
-                label_item.setToolTip(event.tooltip)
-            self.table.setItem(row, 0, label_item)
-        else:
-            label_edit = QtWidgets.QLineEdit(event.label, self)
-            label_edit.setPlaceholderText("Custom event label")
-            self.table.setCellWidget(row, 0, label_edit)
-            self._label_edits[i] = label_edit
-
-        code_spin = QtWidgets.QSpinBox(self)
-        code_spin.setRange(events.CODE_MIN, events.CODE_MAX)
-        code_spin.setValue(event.code)
-        code_spin.setFont(mono_font())  # B612 Mono for the numeric port code (#279)
-        self.table.setCellWidget(row, 1, code_spin)
-        self._code_spins[i] = code_spin
-
-        for col, checked, boxes in (
-            (2, event.lsl, self._lsl_boxes),
-            (3, event.ttl, self._ttl_boxes),
-            (4, event.preview, self._preview_boxes),
-            (5, event.increment, self._increment_boxes),
-        ):
-            cell, box = self._checkbox_cell(checked)
-            self.table.setCellWidget(row, col, cell)
-            boxes[i] = box
-
-    @staticmethod
-    def _checkbox_cell(checked: bool) -> tuple[QtWidgets.QWidget, QtWidgets.QCheckBox]:
-        """Return a ``(container, checkbox)`` with the box centered in its cell."""
-        container = QtWidgets.QWidget()
-        box = QtWidgets.QCheckBox(container)
-        box.setChecked(checked)
-        lay = QtWidgets.QHBoxLayout(container)
-        lay.addWidget(box)
-        lay.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-        lay.setContentsMargins(0, 0, 0, 0)
-        return container, box
-
-    def _sync(self) -> None:
-        """Read widget values back into ``self._events`` before add/remove/apply."""
-        for i, event in enumerate(self._events):
-            label = event.label
-            edit = self._label_edits[i]
-            if edit is not None:
-                label = edit.text().strip() or event.label
-            self._events[i] = replace(
-                event,
-                label=label,
-                code=self._code_spins[i].value(),
-                lsl=self._lsl_boxes[i].isChecked(),
-                ttl=self._ttl_boxes[i].isChecked(),
-                preview=self._preview_boxes[i].isChecked(),
-                increment=self._increment_boxes[i].isChecked(),
-            )
-
-    # ----- add / remove -------------------------------------------------------
-
-    def _suggested_code(self) -> int:
-        """A free-ish default code for a new event (one past the current max)."""
-        used = [e.code for e in self._events if isinstance(e.code, int)]
-        return min((max(used) + 1) if used else events.CODE_MIN, events.CODE_MAX)
-
-    def _add_event(self) -> None:
-        self._sync()
-        dialog = AddEventDialog(self._suggested_code(), parent=self)
-        if not dialog.exec():
-            return
-        label, code, tooltip, increment = dialog.get_inputs()
-        event = events.make_custom_event(
-            label,
-            code,
-            [e.key for e in self._events],
-            tooltip=tooltip,
-            increment=increment,
-        )
-        self._events.append(event)
-        self._populate()
-        for row, i in self._row_event.items():
-            if i == len(self._events) - 1:
-                self.table.selectRow(row)
-                break
-
-    def _remove_selected(self) -> None:
-        row = self.table.currentRow()
-        i = self._row_event.get(row)
-        if i is None:
-            return
-        self._sync()
-        if self._events[i].builtin:
-            QtWidgets.QMessageBox.information(
-                self, self.TITLE, "Built-in events can't be removed."
-            )
-            return
-        del self._events[i]
-        self._populate()
-
     # ----- session sync (reload / apply) ----------------------------------------
 
     def reload_from_session(self) -> None:
         """Replace all staged edits with the session's current marker setup."""
-        self._events = [replace(e) for e in self.session.events.values()]
-        self.safeMaxSpin.setValue(int(self.session.event_code_safe_max))
-        self._populate()
+        registry = [replace(e) for e in self.session.events.values()]
+        self.registry.load(registry, int(self.session.event_code_safe_max))
+        self.registry.set_ttl_enabled(self.session.trigger_config.enabled)
         self._load_trigger_config(self.session.trigger_config)
 
     def _revert(self) -> None:
@@ -586,9 +338,8 @@ class MarkersWindow(PanelWindow):
         from the new config; a failure is surfaced but never blocks the registry
         apply (the session falls back to LSL-only, as at load).
         """
-        self._sync()
-        candidate = [replace(e) for e in self._events]
-        safe_max = self.safeMaxSpin.value()
+        candidate = self.registry.current_events()
+        safe_max = self.registry.current_safe_max()
         errors, warnings = events.validate_events(candidate, safe_max)
         if errors:
             QtWidgets.QMessageBox.warning(

--- a/src/smacc/panels/recording.py
+++ b/src/smacc/panels/recording.py
@@ -359,6 +359,18 @@ class RecordingWindow(PanelWindow):
         out.update(self._current_survey_options())
         return out
 
+    def _preview_builtin_survey(self, survey: surveys.SurveyDef) -> None:
+        """Open a built-in survey read-only (no session) — the previewer the
+        Manage-surveys dialog calls back into.
+
+        Lives here, on a panel, so :mod:`smacc.dialogs` imports no ``panels`` and
+        stays safe for the hardware-free Study Editor to reuse (#301). Kept alive
+        in ``_survey_windows`` alongside the operator-opened survey windows.
+        """
+        preview = SurveyWindow(survey, None, parent=self)
+        self._survey_windows.append(preview)
+        preview.show()
+
     def manage_surveys(self) -> None:
         """View/build/remove surveys and URLs, then rebuild the dropdown in place.
 
@@ -369,6 +381,7 @@ class RecordingWindow(PanelWindow):
             self._current_survey_options(),
             builtin_dir=BUNDLED_SURVEYS_DIR,
             user_dir=SURVEYS_DIR,
+            preview_builtin=self._preview_builtin_survey,
             parent=self,
         )
         accepted = dialog.exec()

--- a/src/smacc/studyeditor.py
+++ b/src/smacc/studyeditor.py
@@ -30,11 +30,13 @@ from .dialogs import SessionInfoDialog, ask_initial_or_final
 from .paths import DEFAULT_DATA_DIR, LOGO_PATH, is_default_settings
 from .studyconfig import StudyConfig
 from .studyforms import (
+    AudioCuesForm,
     DataDirectoryForm,
     InterfaceForm,
     NoiseForm,
     RoutingForm,
     SectionForm,
+    VisualCuesForm,
     section_title,
 )
 from .toolwindow import ToolWindow
@@ -57,6 +59,8 @@ _SECTIONS: tuple[tuple[str, str], ...] = (
 _FORM_TYPES: dict[str, type[SectionForm]] = {
     "data": DataDirectoryForm,
     "routing": RoutingForm,
+    "audio": AudioCuesForm,
+    "visual": VisualCuesForm,
     "noise": NoiseForm,
     "interface": InterfaceForm,
 }

--- a/src/smacc/studyeditor.py
+++ b/src/smacc/studyeditor.py
@@ -33,6 +33,7 @@ from .studyforms import (
     DataDirectoryForm,
     InterfaceForm,
     NoiseForm,
+    RoutingForm,
     SectionForm,
     section_title,
 )
@@ -42,6 +43,7 @@ from .toolwindow import ToolWindow
 # form page (those without one yet show a placeholder).
 _SECTIONS: tuple[tuple[str, str], ...] = (
     ("data", "Data directory"),
+    ("routing", "Routing"),
     ("audio", "Audio cues"),
     ("visual", "Visual cues"),
     ("noise", "Noise"),
@@ -54,6 +56,7 @@ _SECTIONS: tuple[tuple[str, str], ...] = (
 # The form class for each section that has one (the rest fall back to a placeholder).
 _FORM_TYPES: dict[str, type[SectionForm]] = {
     "data": DataDirectoryForm,
+    "routing": RoutingForm,
     "noise": NoiseForm,
     "interface": InterfaceForm,
 }

--- a/src/smacc/studyeditor.py
+++ b/src/smacc/studyeditor.py
@@ -34,6 +34,7 @@ from .studyforms import (
     BiocalsForm,
     DataDirectoryForm,
     InterfaceForm,
+    MarkersForm,
     NoiseForm,
     RoutingForm,
     SectionForm,
@@ -65,6 +66,7 @@ _FORM_TYPES: dict[str, type[SectionForm]] = {
     "visual": VisualCuesForm,
     "noise": NoiseForm,
     "biocals": BiocalsForm,
+    "markers": MarkersForm,
     "surveys": SurveysForm,
     "interface": InterfaceForm,
 }

--- a/src/smacc/studyeditor.py
+++ b/src/smacc/studyeditor.py
@@ -31,6 +31,7 @@ from .paths import DEFAULT_DATA_DIR, LOGO_PATH, is_default_settings
 from .studyconfig import StudyConfig
 from .studyforms import (
     AudioCuesForm,
+    BiocalsForm,
     DataDirectoryForm,
     InterfaceForm,
     NoiseForm,
@@ -62,6 +63,7 @@ _FORM_TYPES: dict[str, type[SectionForm]] = {
     "audio": AudioCuesForm,
     "visual": VisualCuesForm,
     "noise": NoiseForm,
+    "biocals": BiocalsForm,
     "interface": InterfaceForm,
 }
 

--- a/src/smacc/studyeditor.py
+++ b/src/smacc/studyeditor.py
@@ -1,0 +1,379 @@
+"""The Study Editor: author a SMACC study file without any hardware.
+
+A launcher tool (#301) that edits a :class:`~smacc.studyconfig.StudyConfig` — the
+pure model of a ``.smacc`` — through per-section forms, and loads/saves it with
+:mod:`smacc.settings` so files stay byte-compatible with what a live session
+writes. It replaces the old editor, which ran the session window in a stripped
+``headless`` mode and reused the run-time panels to author settings.
+
+It is **hardware-free by construction**: this module imports none of the session,
+the run-time panels, ``sounddevice`` or ``pylsl`` (enforced by the import-linter
+contract in ``pyproject.toml``), so no code path here can open an audio stream,
+meter a microphone, or fire a marker. Authoring a study never touches the rig: the
+machine-local equipment→device bindings live in the Rig setup tool (#300), and cue
+audition happens only in a live session.
+
+The window is a navigation tree of study sections beside a stacked panel of forms.
+This shell wires the file lifecycle (load/save/import, unsaved-changes prompt) over
+the model; the per-section forms are filled in incrementally (#301).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from . import bids, settings
+from .dialogs import SessionInfoDialog, ask_initial_or_final
+from .paths import DEFAULT_DATA_DIR, LOGO_PATH, is_default_settings
+from .studyconfig import StudyConfig
+from .toolwindow import ToolWindow
+
+# The study sections shown in the navigation tree, in authoring order. Each gets a
+# form page (filled in incrementally — placeholders until then).
+_SECTIONS: tuple[tuple[str, str], ...] = (
+    ("data", "Data directory"),
+    ("audio", "Audio cues"),
+    ("visual", "Visual cues"),
+    ("noise", "Noise"),
+    ("biocals", "Biocals"),
+    ("markers", "Markers"),
+    ("surveys", "Surveys"),
+    ("interface", "Interface"),
+)
+
+# Study metadata rides at the file envelope, not inside StudyConfig (so one config
+# re-runs under a new subject); the editor edits these three via Session info.
+_METADATA_KEYS = ("subject", "session", "notes")
+
+
+def _section_title(text: str) -> QtWidgets.QLabel:
+    """A centered 18pt header.
+
+    A panel-free copy of :func:`smacc.panels.base.make_section_title`, duplicated
+    rather than imported because ``panels.base`` pulls in ``sounddevice`` — which
+    this module must never reach (see the module docstring and the import contract).
+    """
+    label = QtWidgets.QLabel(text)
+    label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+    font = QtGui.QFont()
+    font.setPointSize(18)
+    label.setFont(font)
+    return label
+
+
+class StudyEditorWindow(ToolWindow):
+    """Author a SMACC study file (a :class:`StudyConfig`) with no hardware attached."""
+
+    def __init__(self, settings_path: str | None = None) -> None:
+        super().__init__()
+        self.settings_path = settings_path
+        self.metadata: dict = dict.fromkeys(_METADATA_KEYS, "")
+        self.config = StudyConfig()
+        # Where Save-As defaults and Import dialogs open; updated from a loaded file.
+        self.data_dir = Path(DEFAULT_DATA_DIR)
+        self._pages: dict[str, QtWidgets.QWidget] = {}
+
+        self.setWindowTitle("SMACC — Editor")
+        if LOGO_PATH.is_file():
+            self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
+        self._build_menu()
+        self.setCentralWidget(self._build_body())
+        self.statusBar()
+
+        if settings_path:
+            self._load_file(settings_path)
+        # The clean baseline: closing now (or after undoing every edit) prompts for
+        # nothing. Compared as serialized bytes, never widget identity (see _snapshot).
+        self._saved_snapshot = self._snapshot()
+        self.show()
+
+    # ----- construction -----------------------------------------------------
+
+    def _build_menu(self) -> None:
+        menu_bar = self.menuBar()
+        assert menu_bar is not None
+        file_menu = menu_bar.addMenu("&File")
+        assert file_menu is not None
+
+        save = QtGui.QAction("&Save SMACC file", self)
+        save.setShortcut("Ctrl+S")
+        save.setStatusTip("Save to the current SMACC file (or choose a name if new).")
+        save.triggered.connect(self.save_in_place)
+        save_as = QtGui.QAction("Save SMACC file &as…", self)
+        save_as.setStatusTip("Save these settings to a new SMACC file.")
+        save_as.triggered.connect(self.save_as)
+        import_smacc = QtGui.QAction("&Import SMACC file…", self)
+        import_smacc.setStatusTip(
+            "Load another SMACC file's settings into the editor as a starting point."
+        )
+        import_smacc.triggered.connect(self.import_smacc)
+        import_log = QtGui.QAction("Import settings from &log…", self)
+        import_log.setStatusTip(
+            "Load the settings recorded in a SMACC .log into the editor."
+        )
+        import_log.triggered.connect(self.import_from_log)
+        for action in (save, save_as, import_smacc, import_log):
+            file_menu.addAction(action)
+
+        file_menu.addSeparator()
+        info = QtGui.QAction("Session &info…", self)
+        info.setStatusTip(
+            "Edit optional subject/session/notes metadata saved with the study."
+        )
+        info.triggered.connect(self.edit_metadata)
+        file_menu.addAction(info)
+
+        file_menu.addSeparator()
+        close = QtGui.QAction("&Close editor", self)
+        close.setShortcut("Ctrl+W")
+        close.setStatusTip("Close the editor and return to the SMACC Launcher.")
+        close.triggered.connect(self.close)
+        file_menu.addAction(close)
+
+    def _build_body(self) -> QtWidgets.QWidget:
+        """A navigation tree of sections beside a stacked panel of forms."""
+        self.tree = QtWidgets.QTreeWidget()
+        self.tree.setHeaderHidden(True)
+        self.tree.setStatusTip("Choose a part of the study to edit.")
+        self.stack = QtWidgets.QStackedWidget()
+        for key, label in _SECTIONS:
+            item = QtWidgets.QTreeWidgetItem([label])
+            item.setData(0, QtCore.Qt.ItemDataRole.UserRole, key)
+            self.tree.addTopLevelItem(item)
+            page = self._placeholder_page(label)
+            self._pages[key] = page
+            self.stack.addWidget(page)
+        self.tree.currentItemChanged.connect(self._on_section_changed)
+
+        splitter = QtWidgets.QSplitter()
+        splitter.addWidget(self.tree)
+        splitter.addWidget(self.stack)
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        splitter.setSizes([180, 520])
+        self.tree.setCurrentItem(self.tree.topLevelItem(0))
+        return splitter
+
+    def _placeholder_page(self, label: str) -> QtWidgets.QWidget:
+        """A stand-in page until the section's form lands (#301)."""
+        page = QtWidgets.QWidget()
+        layout = QtWidgets.QVBoxLayout(page)
+        layout.addWidget(_section_title(label))
+        note = QtWidgets.QLabel(f"The {label} form goes here.")
+        note.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+        layout.addWidget(note)
+        layout.addStretch(1)
+        return page
+
+    def _on_section_changed(
+        self,
+        current: QtWidgets.QTreeWidgetItem | None,
+        _previous: QtWidgets.QTreeWidgetItem | None,
+    ) -> None:
+        if current is None:
+            return
+        key = current.data(0, QtCore.Qt.ItemDataRole.UserRole)
+        self.stack.setCurrentWidget(self._pages[key])
+
+    # ----- load / import ----------------------------------------------------
+
+    def _load_file(self, path: str) -> None:
+        """Load the file given at construction and adopt it as the initial study."""
+        try:
+            state, metadata = settings.load_settings(path)
+            state = settings.resolve_paths(state, Path(path).parent)
+        except (OSError, ValueError) as exc:
+            self._error("Could not open settings file.", str(exc))
+            return
+        self.data_dir = settings.data_directory_of(
+            state, Path(path).parent, DEFAULT_DATA_DIR
+        )
+        self._adopt_settings(state, metadata)
+
+    def _adopt_settings(self, state: dict, metadata: dict) -> None:
+        """Replace the model from a settings mapping and adopt the file's metadata.
+
+        Unlike a live session (whose metadata comes from the start-of-session
+        prompt), the editor has no prompt, so it takes the loaded file's values —
+        but only non-empty ones, so importing a study that left them blank doesn't
+        wipe what the operator entered via Session info.
+        """
+        self.config = StudyConfig.from_settings_dict(state)
+        for key in _METADATA_KEYS:
+            value = metadata.get(key)
+            if value:
+                self.metadata[key] = value
+
+    def import_smacc(self) -> None:
+        """Load another .smacc file's settings into the editor as a starting point."""
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Open SMACC file", str(self.data_dir), "SMACC file (*.smacc)"
+        )
+        if not path:
+            return
+        try:
+            state, metadata = settings.load_settings(path)
+            state = settings.resolve_paths(state, Path(path).parent)
+        except (OSError, ValueError) as exc:
+            self._error("Could not open settings.", str(exc))
+            return
+        self._adopt_settings(state, metadata)
+
+    def import_from_log(self) -> None:
+        """Load the initial or final settings recorded in a SMACC .log file."""
+        path, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Load settings from log", str(self.data_dir), "SMACC log (*.log)"
+        )
+        if not path:
+            return
+        which = ask_initial_or_final(self, title="Load settings from log")
+        if which is None:
+            return
+        try:
+            log_text = Path(path).read_text(encoding="utf-8")
+        except OSError as exc:
+            self._error("Could not read log.", str(exc))
+            return
+        payload = bids.extract_settings_from_log(log_text, which)
+        if payload is None:
+            self._error(
+                f"No {which} settings found in that log.",
+                "The log may predate settings recording, or the session may have "
+                "ended before its final settings were written.",
+            )
+            return
+        try:
+            state, metadata = settings.parse_settings_mapping(payload)
+        except ValueError as exc:
+            self._error("Could not load settings from log.", str(exc))
+            return
+        self._adopt_settings(state, metadata)
+
+    # ----- save -------------------------------------------------------------
+
+    def save_in_place(self) -> bool:
+        """Save to the current file without prompting; fall back to Save-As if new.
+
+        SMACC's seeded ``default.smacc`` is a read-only template, so saving it
+        redirects to Save-As (it stays a known-good starting point).
+        """
+        if self.settings_path and not is_default_settings(self.settings_path):
+            return self._write(self.settings_path)
+        return self.save_as()
+
+    def save_as(self) -> bool:
+        """Prompt for a path and write the settings there. Returns success."""
+        if self.settings_path and not is_default_settings(self.settings_path):
+            default = self.settings_path
+        else:
+            default = str(self.data_dir / "settings.smacc")
+        path, _ = QtWidgets.QFileDialog.getSaveFileName(
+            self, "Save SMACC file", str(default), "SMACC file (*.smacc)"
+        )
+        if not path:
+            return False
+        return self._write(path)
+
+    def _write(self, path: str) -> bool:
+        """Write the current model to ``path`` (relativizing media paths). Returns success."""
+        if is_default_settings(path):
+            self._error(
+                "Can’t overwrite the default settings.",
+                "default.smacc is SMACC's built-in template and stays read-only so it "
+                "remains a reliable starting point. Save your changes to a new .smacc "
+                "file instead.",
+            )
+            return False
+        portable = settings.relativize_paths(
+            self.config.to_settings_dict(), Path(path).parent
+        )
+        try:
+            settings.save_settings(path, portable, self.metadata)
+        except (OSError, ValueError) as exc:
+            self._error("Could not save settings.", str(exc))
+            return False
+        self.settings_path = path  # subsequent saves update this file
+        self._saved_snapshot = self._snapshot()  # the editor is clean again
+        bar = self.statusBar()
+        if bar is not None:
+            bar.showMessage(f"Saved settings to {Path(path).name}", 5000)
+        return True
+
+    # ----- metadata ---------------------------------------------------------
+
+    def edit_metadata(self) -> None:
+        """Edit the study's optional subject/session/notes metadata."""
+        dialog = SessionInfoDialog(
+            self.metadata.get("subject", ""),
+            self.metadata.get("session", ""),
+            self.metadata.get("notes", ""),
+            parent=self,
+        )
+        if dialog.exec():
+            subject, session, notes = dialog.get_inputs()
+            self.metadata["subject"] = subject
+            self.metadata["session"] = session
+            self.metadata["notes"] = notes
+
+    # ----- unsaved-changes / close ------------------------------------------
+
+    def _snapshot(self) -> str:
+        """A stable serialization of the savable state, for unsaved-changes detection.
+
+        Compared as the *serialized* study (model → settings dict → YAML) plus
+        metadata, never widget or model identity: the model's ``None`` sentinels
+        (``biocals.rows``, the chat-preset lists) mean two equal studies can differ
+        as objects, so only the bytes that would be written are authoritative (#301).
+        """
+        payload = {
+            "settings": self.config.to_settings_dict(),
+            "metadata": dict(self.metadata),
+        }
+        return yaml.safe_dump(payload, sort_keys=False, allow_unicode=True)
+
+    def has_unsaved_changes(self) -> bool:
+        """True if the study differs from what was last loaded or saved."""
+        return self._snapshot() != self._saved_snapshot
+
+    def closeEvent(self, event: QtGui.QCloseEvent | None) -> None:
+        """Prompt to save unsaved changes, then close and return to the launcher."""
+        if self.has_unsaved_changes():
+            box = QtWidgets.QMessageBox(self)
+            box.setWindowTitle("Close editor")
+            box.setText("Save changes to the SMACC file before closing?")
+            box.setStandardButtons(
+                QtWidgets.QMessageBox.StandardButton.Save
+                | QtWidgets.QMessageBox.StandardButton.Discard
+                | QtWidgets.QMessageBox.StandardButton.Cancel
+            )
+            box.setDefaultButton(QtWidgets.QMessageBox.StandardButton.Save)
+            choice = box.exec()
+            if choice == QtWidgets.QMessageBox.StandardButton.Cancel:
+                if event is not None:
+                    event.ignore()
+                return
+            if (
+                choice == QtWidgets.QMessageBox.StandardButton.Save
+                and not self.save_in_place()
+            ):
+                if event is not None:
+                    event.ignore()  # save cancelled/failed → keep the editor open
+                return
+        if event is not None:
+            event.accept()
+        self.closed.emit()
+
+    # ----- helpers ----------------------------------------------------------
+
+    def _error(self, text: str, detail: str = "") -> None:
+        """Show a non-fatal warning dialog (the editor has no session log to write to)."""
+        box = QtWidgets.QMessageBox(self)
+        box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
+        box.setWindowTitle("SMACC Editor")
+        box.setText(text)
+        if detail:
+            box.setInformativeText(detail)
+        box.exec()

--- a/src/smacc/studyeditor.py
+++ b/src/smacc/studyeditor.py
@@ -37,6 +37,7 @@ from .studyforms import (
     NoiseForm,
     RoutingForm,
     SectionForm,
+    SurveysForm,
     VisualCuesForm,
     section_title,
 )
@@ -64,6 +65,7 @@ _FORM_TYPES: dict[str, type[SectionForm]] = {
     "visual": VisualCuesForm,
     "noise": NoiseForm,
     "biocals": BiocalsForm,
+    "surveys": SurveysForm,
     "interface": InterfaceForm,
 }
 

--- a/src/smacc/studyeditor.py
+++ b/src/smacc/studyeditor.py
@@ -29,10 +29,17 @@ from . import bids, settings
 from .dialogs import SessionInfoDialog, ask_initial_or_final
 from .paths import DEFAULT_DATA_DIR, LOGO_PATH, is_default_settings
 from .studyconfig import StudyConfig
+from .studyforms import (
+    DataDirectoryForm,
+    InterfaceForm,
+    NoiseForm,
+    SectionForm,
+    section_title,
+)
 from .toolwindow import ToolWindow
 
 # The study sections shown in the navigation tree, in authoring order. Each gets a
-# form page (filled in incrementally — placeholders until then).
+# form page (those without one yet show a placeholder).
 _SECTIONS: tuple[tuple[str, str], ...] = (
     ("data", "Data directory"),
     ("audio", "Audio cues"),
@@ -44,24 +51,16 @@ _SECTIONS: tuple[tuple[str, str], ...] = (
     ("interface", "Interface"),
 )
 
+# The form class for each section that has one (the rest fall back to a placeholder).
+_FORM_TYPES: dict[str, type[SectionForm]] = {
+    "data": DataDirectoryForm,
+    "noise": NoiseForm,
+    "interface": InterfaceForm,
+}
+
 # Study metadata rides at the file envelope, not inside StudyConfig (so one config
 # re-runs under a new subject); the editor edits these three via Session info.
 _METADATA_KEYS = ("subject", "session", "notes")
-
-
-def _section_title(text: str) -> QtWidgets.QLabel:
-    """A centered 18pt header.
-
-    A panel-free copy of :func:`smacc.panels.base.make_section_title`, duplicated
-    rather than imported because ``panels.base`` pulls in ``sounddevice`` — which
-    this module must never reach (see the module docstring and the import contract).
-    """
-    label = QtWidgets.QLabel(text)
-    label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
-    font = QtGui.QFont()
-    font.setPointSize(18)
-    label.setFont(font)
-    return label
 
 
 class StudyEditorWindow(ToolWindow):
@@ -75,16 +74,19 @@ class StudyEditorWindow(ToolWindow):
         # Where Save-As defaults and Import dialogs open; updated from a loaded file.
         self.data_dir = Path(DEFAULT_DATA_DIR)
         self._pages: dict[str, QtWidgets.QWidget] = {}
+        self._forms: dict[str, SectionForm] = {}
 
         self.setWindowTitle("SMACC — Editor")
         if LOGO_PATH.is_file():
             self.setWindowIcon(QtGui.QIcon(str(LOGO_PATH)))
         self._build_menu()
-        self.setCentralWidget(self._build_body())
+        self.setCentralWidget(self._build_body())  # populates self._forms
         self.statusBar()
 
         if settings_path:
-            self._load_file(settings_path)
+            self._load_file(settings_path)  # -> _adopt_settings -> _load_forms
+        else:
+            self._load_forms()  # populate the forms from the default config
         # The clean baseline: closing now (or after undoing every edit) prompts for
         # nothing. Compared as serialized bytes, never widget identity (see _snapshot).
         self._saved_snapshot = self._snapshot()
@@ -143,7 +145,13 @@ class StudyEditorWindow(ToolWindow):
             item = QtWidgets.QTreeWidgetItem([label])
             item.setData(0, QtCore.Qt.ItemDataRole.UserRole, key)
             self.tree.addTopLevelItem(item)
-            page = self._placeholder_page(label)
+            form_type = _FORM_TYPES.get(key)
+            if form_type is None:
+                page: QtWidgets.QWidget = self._placeholder_page(label)
+            else:
+                form = form_type()
+                self._forms[key] = form
+                page = form
             self._pages[key] = page
             self.stack.addWidget(page)
         self.tree.currentItemChanged.connect(self._on_section_changed)
@@ -161,7 +169,7 @@ class StudyEditorWindow(ToolWindow):
         """A stand-in page until the section's form lands (#301)."""
         page = QtWidgets.QWidget()
         layout = QtWidgets.QVBoxLayout(page)
-        layout.addWidget(_section_title(label))
+        layout.addWidget(section_title(label))
         note = QtWidgets.QLabel(f"The {label} form goes here.")
         note.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
         layout.addWidget(note)
@@ -177,6 +185,21 @@ class StudyEditorWindow(ToolWindow):
             return
         key = current.data(0, QtCore.Qt.ItemDataRole.UserRole)
         self.stack.setCurrentWidget(self._pages[key])
+
+    def _load_forms(self) -> None:
+        """Populate every section form from the current model."""
+        for form in self._forms.values():
+            form.load(self.config)
+
+    def _commit_forms(self) -> None:
+        """Write every section form's widget values back into the model.
+
+        The single sync point between widgets and ``self.config``; the model is the
+        source of truth for save and unsaved-change detection, so this runs before
+        either reads it.
+        """
+        for form in self._forms.values():
+            form.commit(self.config)
 
     # ----- load / import ----------------------------------------------------
 
@@ -206,6 +229,7 @@ class StudyEditorWindow(ToolWindow):
             value = metadata.get(key)
             if value:
                 self.metadata[key] = value
+        self._load_forms()
 
     def import_smacc(self) -> None:
         """Load another .smacc file's settings into the editor as a starting point."""
@@ -287,6 +311,7 @@ class StudyEditorWindow(ToolWindow):
                 "file instead.",
             )
             return False
+        self._commit_forms()  # fold the latest widget edits into the model
         portable = settings.relativize_paths(
             self.config.to_settings_dict(), Path(path).parent
         )
@@ -328,6 +353,7 @@ class StudyEditorWindow(ToolWindow):
         (``biocals.rows``, the chat-preset lists) mean two equal studies can differ
         as objects, so only the bytes that would be written are authoritative (#301).
         """
+        self._commit_forms()  # reflect the live widget state before serializing
         payload = {
             "settings": self.config.to_settings_dict(),
             "metadata": dict(self.metadata),

--- a/src/smacc/studyforms.py
+++ b/src/smacc/studyforms.py
@@ -1,0 +1,242 @@
+"""Section forms for the hardware-free Study Editor (#301).
+
+Each form is a :class:`SectionForm` — a ``QWidget`` view over one leaf of a
+:class:`~smacc.studyconfig.StudyConfig`. :meth:`SectionForm.load` populates its
+widgets from the model; :meth:`SectionForm.commit` writes the widget values back.
+The editor commits every form into the model before saving or checking for unsaved
+changes, so a form owns exactly the fields it surfaces and leaves the rest
+untouched (a section without a form preserves its model values verbatim).
+
+For a well-formed study, ``load`` then ``commit`` is the identity on the model, so
+opening a file reads as clean. A malformed value the form can't represent (an
+out-of-range number, an unknown noise color) is normalized on load and so reads as
+an unsaved change — the editor offering to persist the cleanup, which is intended.
+
+Like the editor window, this module is hardware-free by construction: it imports
+only Qt and the pure model — never the session, the run-time panels, ``sounddevice``
+or ``pylsl`` (the import-linter contract proves it transitively via
+``smacc.studyeditor``).
+"""
+
+from __future__ import annotations
+
+from PyQt6 import QtCore, QtGui, QtWidgets
+
+from .studyconfig import StudyConfig
+
+# The spectral colors the built-in noise generator can synthesize (mirrors the
+# live Noise panel's dropdown).
+NOISE_COLORS = ("white", "pink", "brown")
+
+
+def section_title(text: str) -> QtWidgets.QLabel:
+    """A centered 18pt header.
+
+    A panel-free copy of :func:`smacc.panels.base.make_section_title` (that module
+    pulls in ``sounddevice``, which the editor must never reach).
+    """
+    label = QtWidgets.QLabel(text)
+    label.setAlignment(QtCore.Qt.AlignmentFlag.AlignCenter)
+    font = QtGui.QFont()
+    font.setPointSize(18)
+    label.setFont(font)
+    return label
+
+
+class SectionForm(QtWidgets.QWidget):
+    """Base for an editor section form: a view over one part of a StudyConfig."""
+
+    def load(self, config: StudyConfig) -> None:
+        """Populate this form's widgets from the model."""
+        raise NotImplementedError
+
+    def commit(self, config: StudyConfig) -> None:
+        """Write this form's widget values back into the model."""
+        raise NotImplementedError
+
+
+class DataDirectoryForm(SectionForm):
+    """The folder a study's session recordings are written to (``data_directory``)."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.edit = QtWidgets.QLineEdit(self)
+        self.edit.setStatusTip(
+            "Folder where sessions started from this study write their recordings."
+        )
+        browse = QtWidgets.QPushButton("Browse…", self)
+        browse.setStatusTip("Choose the data directory.")
+        browse.clicked.connect(self._browse)
+        row = QtWidgets.QHBoxLayout()
+        row.addWidget(self.edit, 1)
+        row.addWidget(browse)
+
+        form = QtWidgets.QFormLayout()
+        form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        form.addRow("Data directory:", row)
+
+        hint = QtWidgets.QLabel(
+            "Stored relative to the SMACC file when the folder sits beside it, so a "
+            "study folder stays portable; otherwise an absolute path is kept."
+        )
+        hint.setWordWrap(True)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(section_title("Data directory"))
+        layout.addWidget(hint)
+        layout.addLayout(form)
+        layout.addStretch(1)
+
+    def load(self, config: StudyConfig) -> None:
+        self.edit.setText(config.data_directory)
+
+    def commit(self, config: StudyConfig) -> None:
+        config.data_directory = self.edit.text().strip() or "data"
+
+    def _browse(self) -> None:
+        chosen = QtWidgets.QFileDialog.getExistingDirectory(
+            self, "Choose data directory", self.edit.text().strip()
+        )
+        if chosen:
+            self.edit.setText(chosen)
+
+
+class NoiseForm(SectionForm):
+    """Background noise: volume, color, and a built-in generator vs a WAV file."""
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.volume = QtWidgets.QDoubleSpinBox(self)
+        self.volume.setRange(0, 1)
+        self.volume.setSingleStep(0.01)
+        self.volume.setDecimals(2)
+        self.volume.setStatusTip(
+            "Background-noise level (0-1); multiplied by the output safety cap."
+        )
+
+        self.color = QtWidgets.QComboBox(self)
+        for color in NOISE_COLORS:
+            self.color.addItem(color)
+        self.color.setStatusTip("Spectral color of the built-in noise generator.")
+
+        self.builtinRadio = QtWidgets.QRadioButton("Built-in generator", self)
+        self.fileRadio = QtWidgets.QRadioButton("WAV file", self)
+        self.builtinRadio.toggled.connect(self._sync_source_enabled)
+        source_row = QtWidgets.QHBoxLayout()
+        source_row.addWidget(self.builtinRadio)
+        source_row.addWidget(self.fileRadio)
+        source_row.addStretch(1)
+
+        self.fileEdit = QtWidgets.QLineEdit(self)
+        self.fileEdit.setStatusTip("WAV file played as the noise source.")
+        self.browseButton = QtWidgets.QPushButton("Browse…", self)
+        self.browseButton.setStatusTip("Choose the noise WAV file.")
+        self.browseButton.clicked.connect(self._browse)
+        file_row = QtWidgets.QHBoxLayout()
+        file_row.addWidget(self.fileEdit, 1)
+        file_row.addWidget(self.browseButton)
+
+        form = QtWidgets.QFormLayout()
+        form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        form.addRow("Volume:", self.volume)
+        form.addRow("Color:", self.color)
+        form.addRow("Source:", source_row)
+        form.addRow("File:", file_row)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(section_title("Noise"))
+        layout.addLayout(form)
+        layout.addStretch(1)
+
+    def load(self, config: StudyConfig) -> None:
+        noise = config.cueing.noise
+        self.volume.setValue(noise.volume)
+        index = self.color.findText(noise.color)
+        self.color.setCurrentIndex(index if index >= 0 else 0)
+        self.fileEdit.setText(noise.file)
+        target = self.fileRadio if noise.source == "file" else self.builtinRadio
+        target.setChecked(True)
+        self._sync_source_enabled()
+
+    def commit(self, config: StudyConfig) -> None:
+        noise = config.cueing.noise
+        noise.volume = self.volume.value()
+        noise.color = self.color.currentText()
+        noise.source = "file" if self.fileRadio.isChecked() else "builtin"
+        noise.file = self.fileEdit.text().strip()
+
+    def _sync_source_enabled(self) -> None:
+        use_file = self.fileRadio.isChecked()
+        self.fileEdit.setEnabled(use_file)
+        self.browseButton.setEnabled(use_file)
+
+    def _browse(self) -> None:
+        chosen, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Choose noise WAV", self.fileEdit.text().strip(), "WAV file (*.wav)"
+        )
+        if chosen:
+            self.fileEdit.setText(chosen)
+
+
+class InterfaceForm(SectionForm):
+    """Interface choices that travel with the study: output cap/latency, chat text.
+
+    The runtime-only interface fields (the live-log preview levels, the always-on-top
+    toggles) and the chat presets are intentionally not surfaced here; they round-trip
+    untouched because :meth:`commit` writes only the four fields this form owns.
+    """
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.volumeCap = QtWidgets.QDoubleSpinBox(self)
+        self.volumeCap.setRange(0, 1)
+        self.volumeCap.setSingleStep(0.01)
+        self.volumeCap.setDecimals(2)
+        self.volumeCap.setStatusTip(
+            "Master ceiling on cue + noise output (1.00 = no cap): a safety limit so "
+            "a full-volume cue can't blast the participant."
+        )
+
+        self.latency = QtWidgets.QComboBox(self)
+        self.latency.addItem("High (robust)", "high")
+        self.latency.addItem("Low (less delay)", "low")
+        self.latency.setStatusTip(
+            "Output buffer for cue + noise: High is robust; Low trims marker-to-sound "
+            "delay but risks underruns."
+        )
+
+        self.fontSize = QtWidgets.QSpinBox(self)
+        self.fontSize.setRange(8, 72)
+        self.fontSize.setStatusTip("Font size of the participant/experimenter chat.")
+
+        self.redText = QtWidgets.QCheckBox("Red chat text", self)
+        self.redText.setStatusTip(
+            "Show chat in red (dimmer on a dark-adapted eye than white)."
+        )
+
+        form = QtWidgets.QFormLayout()
+        form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        form.addRow("Output safety cap:", self.volumeCap)
+        form.addRow("Output latency:", self.latency)
+        form.addRow("Chat font size:", self.fontSize)
+        form.addRow("", self.redText)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(section_title("Interface"))
+        layout.addLayout(form)
+        layout.addStretch(1)
+
+    def load(self, config: StudyConfig) -> None:
+        ui = config.interface
+        self.volumeCap.setValue(ui.volume_cap)
+        index = self.latency.findData(ui.output_latency)
+        self.latency.setCurrentIndex(index if index >= 0 else 0)
+        self.fontSize.setValue(ui.chat_font_size)
+        self.redText.setChecked(ui.chat_red_text)
+
+    def commit(self, config: StudyConfig) -> None:
+        ui = config.interface
+        ui.volume_cap = self.volumeCap.value()
+        ui.output_latency = self.latency.currentData()
+        ui.chat_font_size = self.fontSize.value()
+        ui.chat_red_text = self.redText.isChecked()

--- a/src/smacc/studyforms.py
+++ b/src/smacc/studyforms.py
@@ -24,7 +24,7 @@ from typing import cast
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from . import devices
+from . import biocals, devices
 from .studyconfig import AudioCue, StudyConfig, VisualCue
 
 # The spectral colors the built-in noise generator can synthesize (mirrors the
@@ -400,6 +400,164 @@ class VisualCuesForm(_CueTableForm):
         config.cueing.visual.cues = cues
         config.cueing.visual.attack = self.attack.value()
         config.cueing.visual.release = self.release.value()
+
+
+class BiocalsForm(SectionForm):
+    """The study's biocalibration stack: voice volume plus the per-row table.
+
+    The stack uses the model's ``None`` sentinel: a study that doesn't customize it
+    keeps the app default at runtime. The "Customize the stack" toggle preserves
+    that — left off, the study omits the stack (``rows`` stays ``None``) and
+    round-trips untouched; turned on, the table's rows are written explicitly (an
+    empty table is a deliberate empty stack).
+    """
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.voiceVolume = QtWidgets.QDoubleSpinBox(self)
+        self.voiceVolume.setRange(0, 1)
+        self.voiceVolume.setSingleStep(0.01)
+        self.voiceVolume.setDecimals(2)
+        self.voiceVolume.setStatusTip("Volume of the spoken biocal instructions (0-1).")
+        form = QtWidgets.QFormLayout()
+        form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        form.addRow("Voice volume:", self.voiceVolume)
+
+        self.customize = QtWidgets.QCheckBox("Customize the biocal stack", self)
+        self.customize.setStatusTip(
+            "Off: use SMACC's default stack at runtime. On: author the stack here."
+        )
+        self.customize.toggled.connect(self._sync_enabled)
+
+        self.table = QtWidgets.QTableWidget(0, 4, self)
+        self.table.setHorizontalHeaderLabels(
+            ["Biocal", "In sequence", "Voice", "Duration (s)"]
+        )
+        self.table.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        vheader = self.table.verticalHeader()
+        assert vheader is not None
+        vheader.setVisible(False)
+        header = self.table.horizontalHeader()
+        assert header is not None
+        header.setSectionResizeMode(0, QtWidgets.QHeaderView.ResizeMode.Stretch)
+
+        self.picker = QtWidgets.QComboBox(self)
+        for b in biocals.default_biocals():
+            self.picker.addItem(b.label, b.key)
+        self.picker.setStatusTip("Choose a biocal to add as a row.")
+        add = QtWidgets.QPushButton("Add", self)
+        add.setStatusTip("Add the chosen biocal to the stack.")
+        add.clicked.connect(self._add_selected_biocal)
+        remove = QtWidgets.QPushButton("Remove", self)
+        remove.setStatusTip("Remove the selected row.")
+        remove.clicked.connect(self._remove_selected)
+        up = QtWidgets.QPushButton("Move up", self)
+        up.clicked.connect(lambda: self._move(-1))
+        down = QtWidgets.QPushButton("Move down", self)
+        down.clicked.connect(lambda: self._move(1))
+        self._row_controls = [self.table, self.picker, add, remove, up, down]
+        buttons = QtWidgets.QHBoxLayout()
+        for widget in (self.picker, add, remove, up, down):
+            buttons.addWidget(widget)
+        buttons.addStretch(1)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(section_title("Biocals"))
+        layout.addLayout(form)
+        layout.addWidget(self.customize)
+        layout.addWidget(self.table, 1)
+        layout.addLayout(buttons)
+
+    def _add_row(self, row: biocals.BiocalRow) -> None:
+        b = biocals.BIOCALS_BY_KEY.get(row.key)
+        r = self.table.rowCount()
+        self.table.insertRow(r)
+        item = QtWidgets.QTableWidgetItem(b.label if b else row.key)
+        item.setData(QtCore.Qt.ItemDataRole.UserRole, row.key)
+        item.setFlags(item.flags() & ~QtCore.Qt.ItemFlag.ItemIsEditable)
+        self.table.setItem(r, 0, item)
+        sequence = QtWidgets.QCheckBox()
+        sequence.setChecked(row.sequence)
+        self.table.setCellWidget(r, 1, sequence)
+        voice = QtWidgets.QCheckBox()
+        voice.setChecked(row.voice)
+        self.table.setCellWidget(r, 2, voice)
+        duration = QtWidgets.QSpinBox()
+        duration.setRange(biocals.MIN_DURATION_S, biocals.MAX_DURATION_S)
+        duration.setValue(row.duration_s)
+        self.table.setCellWidget(r, 3, duration)
+
+    def _add_selected_biocal(self) -> None:
+        key = self.picker.currentData()
+        b = biocals.BIOCALS_BY_KEY[key]
+        self._add_row(
+            biocals.BiocalRow(
+                key, sequence=b.standard, voice=True, duration_s=b.duration_s
+            )
+        )
+
+    def _read_rows(self) -> list[biocals.BiocalRow]:
+        rows = []
+        for r in range(self.table.rowCount()):
+            item = self.table.item(r, 0)
+            key = item.data(QtCore.Qt.ItemDataRole.UserRole) if item else ""
+            sequence = cast(QtWidgets.QCheckBox, self.table.cellWidget(r, 1))
+            voice = cast(QtWidgets.QCheckBox, self.table.cellWidget(r, 2))
+            duration = cast(QtWidgets.QSpinBox, self.table.cellWidget(r, 3))
+            rows.append(
+                biocals.BiocalRow(
+                    key,
+                    sequence=sequence.isChecked(),
+                    voice=voice.isChecked(),
+                    duration_s=duration.value(),
+                )
+            )
+        return rows
+
+    def _set_rows(self, rows: list[biocals.BiocalRow]) -> None:
+        self.table.setRowCount(0)
+        for row in rows:
+            self._add_row(row)
+
+    def _remove_selected(self) -> None:
+        row = self.table.currentRow()
+        if row >= 0:
+            self.table.removeRow(row)
+
+    def _move(self, delta: int) -> None:
+        row = self.table.currentRow()
+        if row < 0:
+            return
+        rows = self._read_rows()
+        target = row + delta
+        if not 0 <= target < len(rows):
+            return
+        rows[row], rows[target] = rows[target], rows[row]
+        self._set_rows(rows)
+        self.table.setCurrentCell(target, 0)
+
+    def _sync_enabled(self) -> None:
+        on = self.customize.isChecked()
+        for widget in self._row_controls:
+            widget.setEnabled(on)
+
+    def load(self, config: StudyConfig) -> None:
+        bio = config.cueing.biocals
+        self.voiceVolume.setValue(bio.voice_volume)
+        if bio.rows is None:
+            self.customize.setChecked(False)
+            self._set_rows(biocals.default_rows())  # a starting point if customized
+        else:
+            self.customize.setChecked(True)
+            self._set_rows(bio.rows)
+        self._sync_enabled()
+
+    def commit(self, config: StudyConfig) -> None:
+        bio = config.cueing.biocals
+        bio.voice_volume = self.voiceVolume.value()
+        bio.rows = self._read_rows() if self.customize.isChecked() else None
 
 
 class NoiseForm(SectionForm):

--- a/src/smacc/studyforms.py
+++ b/src/smacc/studyforms.py
@@ -22,11 +22,15 @@ from __future__ import annotations
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
+from . import devices
 from .studyconfig import StudyConfig
 
 # The spectral colors the built-in noise generator can synthesize (mirrors the
 # live Noise panel's dropdown).
 NOISE_COLORS = ("white", "pink", "brown")
+
+# The combo entry for an action routed to nothing (matches the Devices panel).
+_NONE_LABEL = "(none)"
 
 
 def section_title(text: str) -> QtWidgets.QLabel:
@@ -99,6 +103,57 @@ class DataDirectoryForm(SectionForm):
         )
         if chosen:
             self.edit.setText(chosen)
+
+
+class RoutingForm(SectionForm):
+    """Route each action to a piece of equipment — the portable device config.
+
+    This is the *study* half of the device split (#300): which equipment each action
+    uses (the bedroom speaker, a mic, a light). It never enumerates this machine's
+    real devices — equipment→device binding is the rig's job (the Rig setup tool) —
+    so the editor authoring routing stays hardware-free. Mirrors the routing column
+    of the live Devices window: one combo per action, offering the equipment of the
+    matching kind, plus ``(none)`` for the optional (monitoring) routes.
+    """
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._combos: dict[str, QtWidgets.QComboBox] = {}
+        form = QtWidgets.QFormLayout()
+        form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        for action in devices.ACTIONS:
+            combo = QtWidgets.QComboBox(self)
+            if action.optional:
+                combo.addItem(_NONE_LABEL, "")
+            for equipment in devices.EQUIPMENT:
+                if equipment.kind == action.kind:
+                    combo.addItem(equipment.label, equipment.key)
+            combo.setStatusTip(action.description)
+            self._combos[action.key] = combo
+            form.addRow(f"{action.label} using:", combo)
+
+        hint = QtWidgets.QLabel(
+            "Route each action to a piece of equipment. This routing travels with the "
+            "study; which real device each piece of equipment is depends on the "
+            "machine and is set once in Rig setup."
+        )
+        hint.setWordWrap(True)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(section_title("Routing"))
+        layout.addWidget(hint)
+        layout.addLayout(form)
+        layout.addStretch(1)
+
+    def load(self, config: StudyConfig) -> None:
+        cfg = config.devices
+        for action_key, combo in self._combos.items():
+            index = combo.findData(cfg.equipment_for(action_key))
+            combo.setCurrentIndex(index if index >= 0 else 0)
+
+    def commit(self, config: StudyConfig) -> None:
+        for action_key, combo in self._combos.items():
+            config.devices.routing[action_key] = combo.currentData() or ""
 
 
 class NoiseForm(SectionForm):

--- a/src/smacc/studyforms.py
+++ b/src/smacc/studyforms.py
@@ -20,14 +20,22 @@ or ``pylsl`` (the import-linter contract proves it transitively via
 
 from __future__ import annotations
 
+from typing import cast
+
 from PyQt6 import QtCore, QtGui, QtWidgets
 
 from . import devices
-from .studyconfig import StudyConfig
+from .studyconfig import AudioCue, StudyConfig, VisualCue
 
 # The spectral colors the built-in noise generator can synthesize (mirrors the
 # live Noise panel's dropdown).
 NOISE_COLORS = ("white", "pink", "brown")
+
+# Visual-cue pattern keys and labels (mirror lights.STEADY/PULSE/FLASH; hardcoded
+# so the editor needs no import of the light-rendering module).
+_VISUAL_PATTERNS = (("steady", "Steady"), ("pulse", "Pulse"), ("flash", "Flash"))
+# UI ceiling for the pulse/flash rate, mirroring the Visual panel (RATE_MAX_HZ).
+_RATE_MAX_HZ = 20.0
 
 # The combo entry for an action routed to nothing (matches the Devices panel).
 _NONE_LABEL = "(none)"
@@ -154,6 +162,244 @@ class RoutingForm(SectionForm):
     def commit(self, config: StudyConfig) -> None:
         for action_key, combo in self._combos.items():
             config.devices.routing[action_key] = combo.currentData() or ""
+
+
+class _ColorButton(QtWidgets.QPushButton):
+    """A table-cell button that shows a cue's color and opens a picker on click."""
+
+    def __init__(self, hex_color: str, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.set_hex(hex_color)
+        self.clicked.connect(self._pick)
+
+    def set_hex(self, hex_color: str) -> None:
+        self.hex = hex_color or "#ff0000"
+        self.setText(self.hex)
+        # A readable label whatever the swatch: contrast the text against the fill.
+        color = QtGui.QColor(self.hex)
+        ink = "#000000" if color.lightnessF() > 0.5 else "#ffffff"
+        self.setStyleSheet(f"background-color: {self.hex}; color: {ink};")
+
+    def _pick(self) -> None:
+        chosen = QtWidgets.QColorDialog.getColor(
+            QtGui.QColor(self.hex), self, "Pick cue color"
+        )
+        if chosen.isValid():
+            self.set_hex(chosen.name())
+
+
+class _CueTableForm(SectionForm):
+    """Shared scaffold for the audio/visual cue tables: a table + add/remove + fades.
+
+    Subclasses define the columns, how a row is built from / read back into a cue,
+    and which cue list and fade fields on the model they own.
+    """
+
+    TITLE = ""
+    COLUMNS: tuple[str, ...] = ()
+    STRETCH_COLUMN = 0  # the column that expands to fill width
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.table = QtWidgets.QTableWidget(0, len(self.COLUMNS), self)
+        self.table.setHorizontalHeaderLabels(list(self.COLUMNS))
+        self.table.setSelectionBehavior(
+            QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        vheader = self.table.verticalHeader()
+        assert vheader is not None
+        vheader.setVisible(False)
+        header = self.table.horizontalHeader()
+        assert header is not None
+        header.setSectionResizeMode(
+            self.STRETCH_COLUMN, QtWidgets.QHeaderView.ResizeMode.Stretch
+        )
+
+        add = QtWidgets.QPushButton("Add cue", self)
+        add.setStatusTip("Add a new cue.")
+        add.clicked.connect(self._add_default_row)
+        self.remove = QtWidgets.QPushButton("Remove selected", self)
+        self.remove.setStatusTip("Remove the selected cue.")
+        self.remove.clicked.connect(self._remove_selected)
+        buttons = QtWidgets.QHBoxLayout()
+        buttons.addWidget(add)
+        buttons.addWidget(self.remove)
+        self._extra_buttons(buttons)
+        buttons.addStretch(1)
+
+        self.attack = self._fade_spin("Fade-in (attack) before each cue, in seconds.")
+        self.release = self._fade_spin("Fade-out (release) after each cue, in seconds.")
+        fades = QtWidgets.QFormLayout()
+        fades.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        fades.addRow("Attack (s):", self.attack)
+        fades.addRow("Release (s):", self.release)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(section_title(self.TITLE))
+        layout.addWidget(self.table, 1)
+        layout.addLayout(buttons)
+        layout.addLayout(fades)
+
+    @staticmethod
+    def _fade_spin(tip: str) -> QtWidgets.QDoubleSpinBox:
+        spin = QtWidgets.QDoubleSpinBox()
+        spin.setRange(0, 10)
+        spin.setSingleStep(0.01)
+        spin.setDecimals(2)
+        spin.setStatusTip(tip)
+        return spin
+
+    @staticmethod
+    def _spin(
+        low: float, high: float, value: float, *, step: float = 0.01, suffix: str = ""
+    ) -> QtWidgets.QDoubleSpinBox:
+        spin = QtWidgets.QDoubleSpinBox()
+        spin.setRange(low, high)
+        spin.setSingleStep(step)
+        spin.setDecimals(2)
+        spin.setSuffix(suffix)
+        spin.setValue(value)
+        return spin
+
+    def _extra_buttons(self, layout: QtWidgets.QHBoxLayout) -> None:
+        """Hook for a subclass to add buttons (e.g. Browse) to the action row."""
+
+    def _add_default_row(self) -> None:
+        raise NotImplementedError
+
+    def _remove_selected(self) -> None:
+        row = self.table.currentRow()
+        if row >= 0:
+            self.table.removeRow(row)
+
+
+class AudioCuesForm(_CueTableForm):
+    """The audio cues a study can play: name, WAV file, volume, loop — plus fades."""
+
+    TITLE = "Audio cues"
+    COLUMNS = ("Name", "File", "Volume", "Loop")
+    STRETCH_COLUMN = 1
+
+    def _extra_buttons(self, layout: QtWidgets.QHBoxLayout) -> None:
+        browse = QtWidgets.QPushButton("Browse file…", self)
+        browse.setStatusTip("Choose the WAV file for the selected cue.")
+        browse.clicked.connect(self._browse_file)
+        layout.addWidget(browse)
+
+    def _add_default_row(self) -> None:
+        self._add_row(AudioCue())
+
+    def _add_row(self, cue: AudioCue) -> None:
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+        self.table.setItem(row, 0, QtWidgets.QTableWidgetItem(cue.name))
+        self.table.setItem(row, 1, QtWidgets.QTableWidgetItem(cue.file))
+        self.table.setCellWidget(row, 2, self._spin(0, 1, cue.volume))
+        loop = QtWidgets.QCheckBox()
+        loop.setChecked(cue.loop)
+        self.table.setCellWidget(row, 3, loop)
+
+    def _browse_file(self) -> None:
+        row = self.table.currentRow()
+        if row < 0:
+            return
+        item = self.table.item(row, 1)
+        chosen, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, "Choose cue WAV", item.text() if item else "", "WAV file (*.wav)"
+        )
+        if chosen:
+            self.table.setItem(row, 1, QtWidgets.QTableWidgetItem(chosen))
+
+    def load(self, config: StudyConfig) -> None:
+        audio = config.cueing.audio
+        self.table.setRowCount(0)
+        for cue in audio.cues:
+            self._add_row(cue)
+        self.attack.setValue(audio.attack)
+        self.release.setValue(audio.release)
+
+    def commit(self, config: StudyConfig) -> None:
+        cues = []
+        for row in range(self.table.rowCount()):
+            name = self.table.item(row, 0)
+            file = self.table.item(row, 1)
+            volume = cast(QtWidgets.QDoubleSpinBox, self.table.cellWidget(row, 2))
+            loop = cast(QtWidgets.QCheckBox, self.table.cellWidget(row, 3))
+            cues.append(
+                AudioCue(
+                    name=name.text() if name else "",
+                    file=file.text() if file else "",
+                    volume=volume.value(),
+                    loop=loop.isChecked(),
+                )
+            )
+        config.cueing.audio.cues = cues
+        config.cueing.audio.attack = self.attack.value()
+        config.cueing.audio.release = self.release.value()
+
+
+class VisualCuesForm(_CueTableForm):
+    """The visual cues a study can play: color, brightness, pattern, rate, length."""
+
+    TITLE = "Visual cues"
+    COLUMNS = ("Name", "Color", "Brightness", "Pattern", "Rate", "Length", "Loop")
+    STRETCH_COLUMN = 0
+
+    def _add_default_row(self) -> None:
+        self._add_row(VisualCue())
+
+    def _add_row(self, cue: VisualCue) -> None:
+        row = self.table.rowCount()
+        self.table.insertRow(row)
+        self.table.setItem(row, 0, QtWidgets.QTableWidgetItem(cue.name))
+        self.table.setCellWidget(row, 1, _ColorButton(cue.color))
+        self.table.setCellWidget(row, 2, self._spin(0, 1, cue.brightness))
+        pattern = QtWidgets.QComboBox()
+        for key, label in _VISUAL_PATTERNS:
+            pattern.addItem(label, key)
+        index = pattern.findData(cue.pattern)
+        pattern.setCurrentIndex(index if index >= 0 else 0)
+        self.table.setCellWidget(row, 3, pattern)
+        self.table.setCellWidget(
+            row, 4, self._spin(0.1, _RATE_MAX_HZ, cue.rate, step=0.1, suffix=" Hz")
+        )
+        self.table.setCellWidget(row, 5, self._spin(0, 600, cue.length, step=0.1))
+        loop = QtWidgets.QCheckBox()
+        loop.setChecked(cue.loop)
+        self.table.setCellWidget(row, 6, loop)
+
+    def load(self, config: StudyConfig) -> None:
+        visual = config.cueing.visual
+        self.table.setRowCount(0)
+        for cue in visual.cues:
+            self._add_row(cue)
+        self.attack.setValue(visual.attack)
+        self.release.setValue(visual.release)
+
+    def commit(self, config: StudyConfig) -> None:
+        cues = []
+        for row in range(self.table.rowCount()):
+            name = self.table.item(row, 0)
+            color = cast(_ColorButton, self.table.cellWidget(row, 1))
+            brightness = cast(QtWidgets.QDoubleSpinBox, self.table.cellWidget(row, 2))
+            pattern = cast(QtWidgets.QComboBox, self.table.cellWidget(row, 3))
+            rate = cast(QtWidgets.QDoubleSpinBox, self.table.cellWidget(row, 4))
+            length = cast(QtWidgets.QDoubleSpinBox, self.table.cellWidget(row, 5))
+            loop = cast(QtWidgets.QCheckBox, self.table.cellWidget(row, 6))
+            cues.append(
+                VisualCue(
+                    name=name.text() if name else "",
+                    color=color.hex,
+                    brightness=brightness.value(),
+                    pattern=pattern.currentData(),
+                    rate=rate.value(),
+                    length=length.value(),
+                    loop=loop.isChecked(),
+                )
+            )
+        config.cueing.visual.cues = cues
+        config.cueing.visual.attack = self.attack.value()
+        config.cueing.visual.release = self.release.value()
 
 
 class NoiseForm(SectionForm):

--- a/src/smacc/studyforms.py
+++ b/src/smacc/studyforms.py
@@ -24,7 +24,9 @@ from typing import cast
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
-from . import biocals, devices
+from . import biocals, devices, surveys
+from .dialogs import ManageSurveysDialog
+from .paths import BUNDLED_SURVEYS_DIR, SURVEYS_DIR
 from .studyconfig import AudioCue, StudyConfig, VisualCue
 
 # The spectral colors the built-in noise generator can synthesize (mirrors the
@@ -558,6 +560,87 @@ class BiocalsForm(SectionForm):
         bio = config.cueing.biocals
         bio.voice_volume = self.voiceVolume.value()
         bio.rows = self._read_rows() if self.customize.isChecked() else None
+
+
+class SurveysForm(SectionForm):
+    """The study's surveys: the default survey to open plus the web-URL presets.
+
+    Web-survey URL presets (name→URL) travel with the study (``survey_options``);
+    in-app surveys come from files and are managed through the Manage dialog. The
+    default survey (``survey_url``) is chosen from the available surveys or typed.
+
+    The Manage dialog is opened with *no* built-in previewer, so the editor never
+    imports a panel survey window — keeping it hardware-free (see Slice A / #301).
+    """
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._options: dict[str, str] = {}
+
+        self.defaultCombo = QtWidgets.QComboBox(self)
+        self.defaultCombo.setEditable(True)
+        self.defaultCombo.setStatusTip(
+            "The survey opened with each dream report (pick one, or type a URL)."
+        )
+        manage = QtWidgets.QPushButton("Manage surveys…", self)
+        manage.setStatusTip("Add or edit web-survey URLs and build in-app surveys.")
+        manage.clicked.connect(self._manage)
+
+        form = QtWidgets.QFormLayout()
+        form.setLabelAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
+        form.addRow("Default survey:", self.defaultCombo)
+
+        hint = QtWidgets.QLabel(
+            "Web-survey URLs added here travel with the study; in-app surveys are "
+            "files, managed in the dialog. The default survey opens with each report."
+        )
+        hint.setWordWrap(True)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(section_title("Surveys"))
+        layout.addLayout(form)
+        layout.addWidget(manage, 0, QtCore.Qt.AlignmentFlag.AlignLeft)
+        layout.addWidget(hint)
+        layout.addStretch(1)
+
+    def _rebuild_combo(self, url: str) -> None:
+        """List every available survey (in-app + web presets); select ``url``."""
+        self.defaultCombo.clear()
+        registry, _problems = surveys.all_surveys(BUNDLED_SURVEYS_DIR, SURVEYS_DIR)
+        for survey in registry.values():
+            self.defaultCombo.addItem(survey.name, survey.url)
+        for name, opt_url in self._options.items():
+            self.defaultCombo.addItem(name, opt_url)
+        index = self.defaultCombo.findData(url)
+        if index >= 0:
+            self.defaultCombo.setCurrentIndex(index)
+        else:  # an empty or unlisted URL: show it as typed text, no selection
+            self.defaultCombo.setCurrentIndex(-1)
+            self.defaultCombo.setEditText(url)
+
+    def _current_url(self) -> str:
+        data = self.defaultCombo.currentData()
+        if data:
+            return str(data)
+        return self.defaultCombo.currentText().strip()
+
+    def _manage(self) -> None:
+        dialog = ManageSurveysDialog(
+            self._options, BUNDLED_SURVEYS_DIR, SURVEYS_DIR, parent=self
+        )
+        accepted = dialog.exec()
+        if accepted:
+            self._options = dialog.get_options()
+        if accepted or dialog.files_changed:  # custom-survey files may have changed
+            self._rebuild_combo(self._current_url())
+
+    def load(self, config: StudyConfig) -> None:
+        self._options = dict(config.surveys.options)
+        self._rebuild_combo(config.surveys.url)
+
+    def commit(self, config: StudyConfig) -> None:
+        config.surveys.options = dict(self._options)
+        config.surveys.url = self._current_url()
 
 
 class NoiseForm(SectionForm):

--- a/src/smacc/studyforms.py
+++ b/src/smacc/studyforms.py
@@ -20,12 +20,14 @@ or ``pylsl`` (the import-linter contract proves it transitively via
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import cast
 
 from PyQt6 import QtCore, QtGui, QtWidgets
 
 from . import biocals, devices, surveys
 from .dialogs import ManageSurveysDialog
+from .eventregistry import EventRegistryTable
 from .paths import BUNDLED_SURVEYS_DIR, SURVEYS_DIR
 from .studyconfig import AudioCue, StudyConfig, VisualCue
 
@@ -560,6 +562,99 @@ class BiocalsForm(SectionForm):
         bio = config.cueing.biocals
         bio.voice_volume = self.voiceVolume.value()
         bio.rows = self._read_rows() if self.customize.isChecked() else None
+
+
+class MarkersForm(SectionForm):
+    """The event-code registry plus the portable hardware-trigger behavior.
+
+    The registry is the shared :class:`~smacc.eventregistry.EventRegistryTable` — the
+    same widget the live Markers window uses. The trigger sub-form edits only the
+    portable behavior (enabled / transport / mode / pulse width); the machine-local
+    port, baud, and address are set per machine in Rig setup (#300), never here, and
+    there is no Test button — firing a pulse is a hardware action, absent here by
+    construction.
+    """
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.registry = EventRegistryTable(self)
+
+        self.enabled = QtWidgets.QCheckBox("Enable hardware trigger output", self)
+        self.enabled.setStatusTip(
+            "Also drive a physical TTL trigger (the LSL stream is independent)."
+        )
+        self.enabled.toggled.connect(self.registry.set_ttl_enabled)
+        self.enabled.toggled.connect(self._sync_enabled)
+
+        self.transport = QtWidgets.QComboBox(self)
+        self.transport.addItem("Serial (USB trigger box)", "serial")
+        self.transport.addItem("Parallel port (LPT)", "parallel")
+        self.mode = QtWidgets.QComboBox(self)
+        self.mode.addItem("Pulsed (SMACC times the pulse)", "pulsed")
+        self.mode.addItem("Set-and-hold (until next event)", "hold")
+        self.mode.currentIndexChanged.connect(self._sync_pulse)
+        self.pulse = QtWidgets.QSpinBox(self)
+        self.pulse.setRange(1, 1000)
+        self.pulse.setSuffix(" ms")
+
+        self._trigger_form = QtWidgets.QWidget(self)
+        trigger_form = QtWidgets.QFormLayout(self._trigger_form)
+        trigger_form.setContentsMargins(0, 0, 0, 0)
+        trigger_form.addRow("Transport", self.transport)
+        trigger_form.addRow("Mode", self.mode)
+        trigger_form.addRow("Pulse width", self.pulse)
+
+        note = QtWidgets.QLabel(
+            "The port / baud / address for this machine are set in Rig setup, not here."
+        )
+        note.setWordWrap(True)
+        trigger_box = QtWidgets.QGroupBox("Hardware TTL transport", self)
+        box_layout = QtWidgets.QVBoxLayout(trigger_box)
+        box_layout.addWidget(self.enabled)
+        box_layout.addWidget(self._trigger_form)
+        box_layout.addWidget(note)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.addWidget(section_title("Markers"))
+        layout.addWidget(self.registry, 1)
+        layout.addWidget(trigger_box)
+
+    @staticmethod
+    def _select(combo: QtWidgets.QComboBox, value: str) -> None:
+        index = combo.findData(value)
+        if index >= 0:
+            combo.setCurrentIndex(index)
+
+    def _sync_enabled(self) -> None:
+        self._trigger_form.setEnabled(self.enabled.isChecked())
+
+    def _sync_pulse(self) -> None:
+        self.pulse.setEnabled(self.mode.currentData() == "pulsed")
+
+    def load(self, config: StudyConfig) -> None:
+        markers = config.markers
+        self.registry.load(markers.event_codes, markers.event_code_safe_max)
+        trigger = markers.trigger
+        self.enabled.setChecked(trigger.enabled)
+        self._select(self.transport, trigger.transport)
+        self._select(self.mode, trigger.mode)
+        self.pulse.setValue(trigger.pulse_ms)
+        self.registry.set_ttl_enabled(trigger.enabled)
+        self._sync_enabled()
+        self._sync_pulse()
+
+    def commit(self, config: StudyConfig) -> None:
+        markers = config.markers
+        markers.event_codes = self.registry.current_events()
+        markers.event_code_safe_max = self.registry.current_safe_max()
+        # Preserve the (rig-local, non-serialized) port/baud/address; edit behavior.
+        markers.trigger = replace(
+            markers.trigger,
+            enabled=self.enabled.isChecked(),
+            transport=self.transport.currentData(),
+            mode=self.mode.currentData(),
+            pulse_ms=self.pulse.value(),
+        )
 
 
 class SurveysForm(SectionForm):

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -209,6 +209,42 @@ def test_manage_surveys_lists_files_and_persists_urls_only(qtbot, tmp_path):
     assert dialog.files_changed is False
 
 
+def test_manage_surveys_previews_builtin_via_injected_capability(qtbot, tmp_path):
+    # A built-in survey is previewed by opening the real (panel) survey window.
+    # The dialog imports no panels — the caller injects that capability — so this
+    # asserts View/Edit hands the selected survey to the injected previewer (and
+    # opens nothing itself). This seam keeps the dialog reusable by the
+    # hardware-free Study Editor (#301).
+    builtin_dir = tmp_path / "builtin"
+    surveys.save_survey(_demo_survey(), builtin_dir)
+    previewed = []
+    dialog = dialogs.ManageSurveysDialog(
+        {}, builtin_dir, tmp_path / "user", preview_builtin=previewed.append
+    )
+    qtbot.addWidget(dialog)
+    dialog.listWidget.setCurrentRow(0)
+    dialog._view_or_edit_selected()
+    assert len(previewed) == 1 and previewed[0].key == "demo"
+
+
+def test_manage_surveys_without_previewer_points_at_a_session(
+    qtbot, tmp_path, monkeypatch
+):
+    # With no previewer injected (the editor's case), View/Edit on a built-in
+    # explains where preview lives rather than importing a panel survey window.
+    builtin_dir = tmp_path / "builtin"
+    surveys.save_survey(_demo_survey(), builtin_dir)
+    informed = []
+    monkeypatch.setattr(
+        QtWidgets.QMessageBox, "information", lambda *a, **k: informed.append(a)
+    )
+    dialog = dialogs.ManageSurveysDialog({}, builtin_dir, tmp_path / "user")
+    qtbot.addWidget(dialog)
+    dialog.listWidget.setCurrentRow(0)
+    dialog._view_or_edit_selected()
+    assert informed
+
+
 def test_manage_surveys_builtin_cannot_be_removed(qtbot, tmp_path, monkeypatch):
     builtin_dir = tmp_path / "builtin"
     path = surveys.save_survey(_demo_survey(), builtin_dir)

--- a/tests/test_gui_window.py
+++ b/tests/test_gui_window.py
@@ -315,8 +315,10 @@ def test_markers_apply_rebuilds_the_event_grid(
     window = SmaccWindow(headless_session)
     qtbot.addWidget(window)
     markers = window.panels["markers"]
-    i = next(i for i, e in enumerate(markers._events) if e.key == "REMDetected")
-    markers._code_spins[i].setValue(99)
+    i = next(
+        i for i, e in enumerate(markers.registry._events) if e.key == "REMDetected"
+    )
+    markers.registry._code_spins[i].setValue(99)
     markers.apply()
     grid = window.panels["events"]
     # findChildren still sees the replaced button (deleteLater is only serviced
@@ -343,7 +345,7 @@ def test_grid_add_event_refreshes_the_markers_staging(
     )
     window.panels["events"].add_custom_event()
     markers = window.panels["markers"]
-    assert any(e.label == "Door knock" for e in markers._events)
+    assert any(e.label == "Door knock" for e in markers.registry._events)
 
 
 # ----- theme / lights and owned preferences ----------------------------------

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -165,14 +165,9 @@ def test_open_editor_new_opens_a_blank_editor(qtbot, tmp_path, monkeypatch):
     _patch_prefs(monkeypatch, tmp_path)
     captured = {}
     monkeypatch.setattr(
-        launcher, "SmaccSession", lambda data_dir, headless=False: object()
-    )
-    monkeypatch.setattr(
         launcher,
-        "SmaccWindow",
-        lambda session, settings_path=None: (
-            captured.update(path=settings_path) or ToolWindow()
-        ),
+        "StudyEditorWindow",
+        lambda settings_path=None: captured.update(path=settings_path) or ToolWindow(),
     )
     monkeypatch.setattr(dialogs.EditorFileDialog, "exec", lambda self: True)
     monkeypatch.setattr(dialogs.EditorFileDialog, "is_new", lambda self: True)
@@ -191,14 +186,9 @@ def test_open_editor_existing_opens_that_file(qtbot, tmp_path, monkeypatch):
     settings.save_settings(good, {}, {})
     captured = {}
     monkeypatch.setattr(
-        launcher, "SmaccSession", lambda data_dir, headless=False: object()
-    )
-    monkeypatch.setattr(
         launcher,
-        "SmaccWindow",
-        lambda session, settings_path=None: (
-            captured.update(path=settings_path) or ToolWindow()
-        ),
+        "StudyEditorWindow",
+        lambda settings_path=None: captured.update(path=settings_path) or ToolWindow(),
     )
     monkeypatch.setattr(dialogs.EditorFileDialog, "exec", lambda self: True)
     monkeypatch.setattr(dialogs.EditorFileDialog, "is_new", lambda self: False)
@@ -207,6 +197,32 @@ def test_open_editor_existing_opens_that_file(qtbot, tmp_path, monkeypatch):
     qtbot.addWidget(win)
     win._open_editor()
     assert captured["path"] == str(good)
+
+
+def test_editor_close_remembers_the_saved_file(
+    qtbot, tmp_path, monkeypatch, silence_dialogs
+):
+    # Closing an editor that has a settings file returns to the launcher and
+    # remembers that file (recents + last_settings) for the next Session…/Editor….
+    from smacc import dialogs, preferences, settings
+    from smacc.studyeditor import StudyEditorWindow
+
+    prefs_path = _patch_prefs(monkeypatch, tmp_path)
+    saved = tmp_path / "study.smacc"
+    settings.save_settings(saved, {}, {})
+    remembered: list[str] = []
+    monkeypatch.setattr(dialogs, "remember_settings", remembered.append)
+
+    win = LauncherWindow()
+    qtbot.addWidget(win)
+    editor = StudyEditorWindow(settings_path=str(saved))
+    qtbot.addWidget(editor)
+    win._tool = editor
+    win._on_tool_closed()
+
+    assert remembered == [str(saved)]
+    assert preferences.load_preferences(prefs_path).get("last_settings") == str(saved)
+    assert win.isVisible()  # the launcher came back (not quit, as a session would)
 
 
 # ----- Rig setup: a standalone launcher tool (#300) ---------------------------

--- a/tests/test_panels_markers.py
+++ b/tests/test_panels_markers.py
@@ -7,8 +7,7 @@ import logging
 import pytest
 from PyQt6 import QtWidgets
 
-from smacc import events, triggers
-from smacc.panels import markers as markers_module
+from smacc import eventregistry, events, triggers
 from smacc.panels.markers import MarkersWindow
 
 
@@ -39,7 +38,7 @@ def _capture_session_log(session) -> list[logging.LogRecord]:
 
 
 def _index_of(win: MarkersWindow, key: str) -> int:
-    return next(i for i, e in enumerate(win._events) if e.key == key)
+    return next(i for i, e in enumerate(win.registry._events) if e.key == key)
 
 
 # ----- registry table ---------------------------------------------------------
@@ -47,20 +46,22 @@ def _index_of(win: MarkersWindow, key: str) -> int:
 
 def test_window_stages_the_whole_registry_grouped(window, headless_session):
     # Every event is staged (one widget set per event)...
-    assert len(window._events) == len(headless_session.events)
-    assert all(spin is not None for spin in window._code_spins)
+    assert len(window.registry._events) == len(headless_session.events)
+    assert all(spin is not None for spin in window.registry._code_spins)
     # ...and the table carries one extra (spanned header) row per category group.
     categories = {e.category for e in headless_session.events.values()}
-    assert window.table.rowCount() == len(headless_session.events) + len(categories)
+    assert window.registry.table.rowCount() == len(headless_session.events) + len(
+        categories
+    )
     # The header rows are not mapped to events (not editable/selectable rows).
-    assert len(window._row_event) == len(headless_session.events)
+    assert len(window.registry._row_event) == len(headless_session.events)
 
 
 def test_apply_commits_staged_edits_and_logs_loudly(window, headless_session):
     records = _capture_session_log(headless_session)
     i = _index_of(window, "REMDetected")
-    window._code_spins[i].setValue(99)
-    window._lsl_boxes[i].setChecked(False)
+    window.registry._code_spins[i].setValue(99)
+    window.registry._lsl_boxes[i].setChecked(False)
     window.apply()
     assert headless_session.events["REMDetected"].code == 99
     assert headless_session.events["REMDetected"].lsl is False
@@ -81,7 +82,7 @@ def test_apply_blocks_on_validation_errors(window, headless_session, monkeypatch
         lambda *a, **k: warned.append(a[2]) or QtWidgets.QMessageBox.StandardButton.Ok,
     )
     # Stage a duplicate routed code: REMDetected takes Clapper's 49.
-    window._code_spins[_index_of(window, "REMDetected")].setValue(49)
+    window.registry._code_spins[_index_of(window, "REMDetected")].setValue(49)
     window.apply()
     assert warned and "49" in warned[0]
     assert headless_session.events["REMDetected"].code == 41  # unchanged
@@ -89,12 +90,12 @@ def test_apply_blocks_on_validation_errors(window, headless_session, monkeypatch
 
 def test_safe_max_round_trips_and_logs(window, headless_session):
     records = _capture_session_log(headless_session)
-    window.safeMaxSpin.setValue(127)
+    window.registry.safeMaxSpin.setValue(127)
     # 127 would warn on the biocal/dream codes above it; keep them TTL-off so the
     # apply is clean (the point here is the safe-max commit, not the warning).
-    for i, event in enumerate(window._events):
+    for i, event in enumerate(window.registry._events):
         if event.code > 127:
-            window._ttl_boxes[i].setChecked(False)
+            window.registry._ttl_boxes[i].setChecked(False)
     window.apply()
     assert headless_session.event_code_safe_max == 127
     assert any("safe max changed" in r.getMessage() for r in records)
@@ -102,10 +103,10 @@ def test_safe_max_round_trips_and_logs(window, headless_session):
 
 def test_revert_discards_staged_edits(window, headless_session):
     i = _index_of(window, "REMDetected")
-    window._code_spins[i].setValue(99)
+    window.registry._code_spins[i].setValue(99)
     window._revert()
     i = _index_of(window, "REMDetected")
-    assert window._code_spins[i].value() == 41
+    assert window.registry._code_spins[i].value() == 41
     assert headless_session.events["REMDetected"].code == 41
 
 
@@ -113,7 +114,7 @@ def test_reload_from_session_picks_up_external_changes(window, headless_session)
     new = events.make_custom_event("Door knock", 150, headless_session.events.keys())
     headless_session.events[new.key] = new
     window.reload_from_session()
-    assert any(e.key == new.key for e in window._events)
+    assert any(e.key == new.key for e in window.registry._events)
 
 
 def test_add_event_stages_a_custom_event(window, monkeypatch):
@@ -127,11 +128,11 @@ def test_add_event_stages_a_custom_event(window, monkeypatch):
         def get_inputs(self):
             return ("New event", 199, "tip", False)
 
-    monkeypatch.setattr(markers_module, "AddEventDialog", _StubAddDialog)
-    before = len(window._events)
-    window._add_event()
-    assert len(window._events) == before + 1
-    assert any(e.label == "New event" for e in window._events)
+    monkeypatch.setattr(eventregistry, "AddEventDialog", _StubAddDialog)
+    before = len(window.registry._events)
+    window.registry._add_event()
+    assert len(window.registry._events) == before + 1
+    assert any(e.label == "New event" for e in window.registry._events)
 
 
 def test_remove_only_removes_custom_events(window, headless_session, monkeypatch):
@@ -143,29 +144,33 @@ def test_remove_only_removes_custom_events(window, headless_session, monkeypatch
     )
     # A built-in row refuses removal...
     builtin_row = next(
-        row for row, i in window._row_event.items() if window._events[i].builtin
+        row
+        for row, i in window.registry._row_event.items()
+        if window.registry._events[i].builtin
     )
-    window.table.selectRow(builtin_row)
-    window._remove_selected()
+    window.registry.table.selectRow(builtin_row)
+    window.registry._remove_selected()
     assert infos and "Built-in" in infos[0]
     # ...while a staged custom event goes away.
     new = events.make_custom_event("Door knock", 150, headless_session.events.keys())
     headless_session.events[new.key] = new
     window.reload_from_session()
     custom_row = next(
-        row for row, i in window._row_event.items() if not window._events[i].builtin
+        row
+        for row, i in window.registry._row_event.items()
+        if not window.registry._events[i].builtin
     )
-    window.table.selectRow(custom_row)
-    window._remove_selected()
-    assert not any(e.key == new.key for e in window._events)
+    window.registry.table.selectRow(custom_row)
+    window.registry._remove_selected()
+    assert not any(e.key == new.key for e in window.registry._events)
 
 
 def test_show_reloads_but_minimize_restore_keeps_edits(window, headless_session, qtbot):
     i = _index_of(window, "REMDetected")
-    window._code_spins[i].setValue(99)
+    window.registry._code_spins[i].setValue(99)
     window.hide()
     window.show()  # programmatic (re)open -> reload from the session
-    assert window._code_spins[_index_of(window, "REMDetected")].value() == 41
+    assert window.registry._code_spins[_index_of(window, "REMDetected")].value() == 41
 
 
 # ----- TTL column gating --------------------------------------------------------
@@ -173,13 +178,13 @@ def test_show_reloads_but_minimize_restore_keeps_edits(window, headless_session,
 
 def test_ttl_column_grays_out_without_a_transport(window):
     assert window.enabledBox.isChecked() is False
-    assert all(not box.isEnabled() for box in window._ttl_boxes)
+    assert all(not box.isEnabled() for box in window.registry._ttl_boxes)
     # The values are kept (they persist and re-arm with a transport)...
     i = _index_of(window, "REMDetected")
-    assert window._ttl_boxes[i].isChecked() is True
+    assert window.registry._ttl_boxes[i].isChecked() is True
     # ...and enabling the transport re-arms the column.
     window.enabledBox.setChecked(True)
-    assert all(box.isEnabled() for box in window._ttl_boxes)
+    assert all(box.isEnabled() for box in window.registry._ttl_boxes)
 
 
 # ----- hardware detection hints ---------------------------------------------------
@@ -193,7 +198,7 @@ def test_no_serial_ports_shows_the_hint_but_gates_nothing(
     qtbot.addWidget(win)
     assert not win.portStatusLabel.isHidden()
     # A hint, not a gate: the per-event TTL routing is untouched (not emptied).
-    assert win._ttl_boxes[_index_of(win, "REMDetected")].isChecked() is True
+    assert win.registry._ttl_boxes[_index_of(win, "REMDetected")].isChecked() is True
 
 
 def test_attached_serial_ports_hide_the_hint(stub_serial_ports, window):

--- a/tests/test_studyeditor.py
+++ b/tests/test_studyeditor.py
@@ -85,13 +85,13 @@ def test_editor_save_round_trips_byte_stable(qtbot, silence_dialogs, tmp_path):
 def test_editing_an_unformed_section_marks_unsaved_then_save_clears_it(
     qtbot, silence_dialogs, tmp_path
 ):
-    # surveys has no form yet, so a programmatic edit there isn't overwritten by a
+    # markers has no form yet, so a programmatic edit there isn't overwritten by a
     # form commit — this exercises the snapshot/dirty machinery for sections whose
     # values round-trip untouched.
     editor = StudyEditorWindow()
     qtbot.addWidget(editor)
     assert not editor.has_unsaved_changes()
-    editor.config.surveys.url = "smacc://survey/lusk"
+    editor.config.markers.event_code_safe_max = 200
     assert editor.has_unsaved_changes()
     assert editor._write(str(tmp_path / "s.smacc")) is True
     assert not editor.has_unsaved_changes()  # saving rebaselines the snapshot
@@ -252,3 +252,29 @@ def test_biocals_customizing_writes_an_explicit_stack(qtbot, silence_dialogs, tm
     assert reloaded.config.cueing.biocals.rows is not None  # now explicit
     assert reloaded.config.cueing.biocals.voice_volume == 0.4
     assert reloaded._forms["biocals"].customize.isChecked() is True
+
+
+def test_surveys_form_round_trips_url_and_options(qtbot, silence_dialogs, tmp_path):
+    raw = {
+        "survey_url": "https://example.com/post",
+        "survey_options": {"Post survey": "https://example.com/post"},
+    }
+    full = StudyConfig.from_settings_dict(raw).to_settings_dict()
+    path = tmp_path / "surv.smacc"
+    _write_smacc(path, full, {"subject": "", "session": "", "notes": ""}, tmp_path)
+
+    editor = StudyEditorWindow(str(path))
+    qtbot.addWidget(editor)
+    form = editor._forms["surveys"]
+    assert form._current_url() == "https://example.com/post"
+    assert form._options == {"Post survey": "https://example.com/post"}
+    assert not editor.has_unsaved_changes()
+
+    path2 = tmp_path / "surv2.smacc"
+    assert editor._write(str(path2)) is True
+    reloaded = StudyEditorWindow(str(path2))
+    qtbot.addWidget(reloaded)
+    assert reloaded.config.surveys.url == "https://example.com/post"
+    assert reloaded.config.surveys.options == {
+        "Post survey": "https://example.com/post"
+    }

--- a/tests/test_studyeditor.py
+++ b/tests/test_studyeditor.py
@@ -82,16 +82,15 @@ def test_editor_save_round_trips_byte_stable(qtbot, silence_dialogs, tmp_path):
     assert path1.read_text(encoding="utf-8") == path2.read_text(encoding="utf-8")
 
 
-def test_editing_an_unformed_section_marks_unsaved_then_save_clears_it(
+def test_editing_metadata_marks_unsaved_then_save_clears_it(
     qtbot, silence_dialogs, tmp_path
 ):
-    # markers has no form yet, so a programmatic edit there isn't overwritten by a
-    # form commit — this exercises the snapshot/dirty machinery for sections whose
-    # values round-trip untouched.
+    # Metadata rides outside the forms (it's edited via Session info), so the
+    # snapshot must fold it in — editing it marks the study unsaved.
     editor = StudyEditorWindow()
     qtbot.addWidget(editor)
     assert not editor.has_unsaved_changes()
-    editor.config.markers.event_code_safe_max = 200
+    editor.metadata["subject"] = "p01"
     assert editor.has_unsaved_changes()
     assert editor._write(str(tmp_path / "s.smacc")) is True
     assert not editor.has_unsaved_changes()  # saving rebaselines the snapshot
@@ -278,3 +277,41 @@ def test_surveys_form_round_trips_url_and_options(qtbot, silence_dialogs, tmp_pa
     assert reloaded.config.surveys.options == {
         "Post survey": "https://example.com/post"
     }
+
+
+def test_markers_form_round_trips_a_code_edit(qtbot, silence_dialogs, tmp_path):
+    editor = StudyEditorWindow()
+    qtbot.addWidget(editor)
+    registry = editor._forms["markers"].registry
+    registry._code_spins[0].setValue(77)  # retune the first event's port code
+    target_key = registry._events[0].key
+    assert editor.has_unsaved_changes()
+
+    path = tmp_path / "m.smacc"
+    assert editor._write(str(path)) is True
+    reloaded = StudyEditorWindow(str(path))
+    qtbot.addWidget(reloaded)
+    code = {e.key: e.code for e in reloaded.config.markers.event_codes}[target_key]
+    assert code == 77
+
+
+def test_markers_trigger_behavior_round_trips_without_machine_fields(
+    qtbot, silence_dialogs, tmp_path
+):
+    editor = StudyEditorWindow()
+    qtbot.addWidget(editor)
+    form = editor._forms["markers"]
+    form.enabled.setChecked(True)
+    form._select(form.mode, "hold")
+    assert editor.has_unsaved_changes()
+
+    path = tmp_path / "trig.smacc"
+    assert editor._write(str(path)) is True
+    reloaded = StudyEditorWindow(str(path))
+    qtbot.addWidget(reloaded)
+    trigger = reloaded.config.markers.trigger
+    assert trigger.enabled is True
+    assert trigger.mode == "hold"
+    # The saved study carries trigger behavior only — never machine port/baud/address.
+    study_trigger = reloaded.config.to_settings_dict()["trigger_output"]
+    assert not {"port", "baud", "address"} & set(study_trigger)

--- a/tests/test_studyeditor.py
+++ b/tests/test_studyeditor.py
@@ -146,3 +146,20 @@ def test_editing_a_form_widget_round_trips_through_save(
     assert reloaded.config.cueing.noise.volume == 0.55
     assert reloaded.config.interface.chat_red_text is True
     assert reloaded._forms["noise"].volume.value() == 0.55
+
+
+def test_routing_form_round_trips_an_action_reroute(qtbot, silence_dialogs, tmp_path):
+    editor = StudyEditorWindow()
+    qtbot.addWidget(editor)
+    # Reroute "play audio cue" from the bedroom speaker to the control-room speaker.
+    combo = editor._forms["routing"]._combos["play_audio_cue"]
+    combo.setCurrentIndex(combo.findData("control_speaker"))
+    assert editor.has_unsaved_changes()
+
+    path = tmp_path / "routed.smacc"
+    assert editor._write(str(path)) is True
+    reloaded = StudyEditorWindow(str(path))
+    qtbot.addWidget(reloaded)
+    assert reloaded.config.devices.equipment_for("play_audio_cue") == "control_speaker"
+    # The study carries routing only — never this machine's equipment→device bindings.
+    assert "bindings" not in reloaded.config.devices.to_study_dict()

--- a/tests/test_studyeditor.py
+++ b/tests/test_studyeditor.py
@@ -1,0 +1,108 @@
+"""Tests for the hardware-free Study Editor window (#301).
+
+These build the real :class:`~smacc.studyeditor.StudyEditorWindow` with no session
+and no hardware — the whole point of the editor — and exercise its file lifecycle:
+load a ``.smacc`` into the model, save it back byte-stable, track unsaved changes,
+and refuse to clobber the bundled template.
+"""
+
+from __future__ import annotations
+
+from smacc import settings, studyconfig
+from smacc.paths import DEFAULT_SETTINGS_PATH
+from smacc.studyconfig import StudyConfig
+from smacc.studyeditor import StudyEditorWindow
+
+
+def _sample_settings(base) -> dict:
+    """A representative study with path-bearing slots, in canonical model form.
+
+    Paths are absolute under ``base`` so :func:`settings.relativize_paths` resolves
+    them deterministically (independent of the test's working directory).
+    """
+    raw = {
+        "cues": [
+            studyconfig.cue_to_dict(
+                studyconfig.AudioCue("Buzz", str(base / "cues" / "buzz.wav"), 0.3, True)
+            )
+        ],
+        "noise_color": "pink",
+        "noise_source": "file",
+        "noise_file": str(base / "noise" / "pink.wav"),
+        "survey_options": {"Morning": "https://example.com/m"},
+        "chat_font_size": 22,
+        "data_directory": str(base / "data"),
+        "event_code_safe_max": 200,
+    }
+    return StudyConfig.from_settings_dict(raw).to_settings_dict()
+
+
+def _write_smacc(path, settings_map, meta, base) -> None:
+    settings.save_settings(
+        str(path), settings.relativize_paths(settings_map, base), meta
+    )
+
+
+def test_fresh_editor_has_default_config_and_no_file(qtbot, silence_dialogs):
+    editor = StudyEditorWindow()
+    qtbot.addWidget(editor)
+    assert editor.settings_path is None
+    assert editor.config.to_settings_dict() == StudyConfig().to_settings_dict()
+    assert not editor.has_unsaved_changes()
+
+
+def test_editor_loads_a_smacc_file_into_the_model(qtbot, silence_dialogs, tmp_path):
+    full = _sample_settings(tmp_path)
+    meta = {"subject": "s1", "session": "n1", "notes": ""}
+    path = tmp_path / "study.smacc"
+    _write_smacc(path, full, meta, tmp_path)
+
+    editor = StudyEditorWindow(str(path))
+    qtbot.addWidget(editor)
+    assert editor.settings_path == str(path)
+    assert editor.config.cueing.audio.cues[0].name == "Buzz"
+    assert editor.config.cueing.noise.color == "pink"
+    assert editor.config.interface.chat_font_size == 22
+    assert editor.metadata["subject"] == "s1"  # file metadata adopted
+    assert not editor.has_unsaved_changes()  # freshly loaded ⇒ clean
+
+
+def test_editor_save_round_trips_byte_stable(qtbot, silence_dialogs, tmp_path):
+    # The window-level keystone: a study loaded then re-saved through the editor is
+    # byte-identical, so the editor's save is a faithful, stable .smacc.
+    full = _sample_settings(tmp_path)
+    meta = {"subject": "s1", "session": "n1", "notes": ""}
+    path1 = tmp_path / "study.smacc"
+    _write_smacc(path1, full, meta, tmp_path)
+
+    editor = StudyEditorWindow(str(path1))
+    qtbot.addWidget(editor)
+    path2 = tmp_path / "study2.smacc"
+    assert editor._write(str(path2)) is True
+    assert path1.read_text(encoding="utf-8") == path2.read_text(encoding="utf-8")
+
+
+def test_editing_the_model_marks_unsaved_then_save_clears_it(
+    qtbot, silence_dialogs, tmp_path
+):
+    editor = StudyEditorWindow()
+    qtbot.addWidget(editor)
+    assert not editor.has_unsaved_changes()
+    editor.config.cueing.noise.volume = 0.99  # an edit a form would make
+    assert editor.has_unsaved_changes()
+    assert editor._write(str(tmp_path / "s.smacc")) is True
+    assert not editor.has_unsaved_changes()  # saving rebaselines the snapshot
+
+
+def test_editor_refuses_to_overwrite_the_default_template(qtbot, silence_dialogs):
+    editor = StudyEditorWindow()
+    qtbot.addWidget(editor)
+    assert editor._write(str(DEFAULT_SETTINGS_PATH)) is False
+    assert editor.settings_path is None  # nothing was written; path unchanged
+
+
+def test_editor_emits_closed_when_clean(qtbot, silence_dialogs):
+    editor = StudyEditorWindow()
+    qtbot.addWidget(editor)
+    with qtbot.waitSignal(editor.closed, timeout=1000):
+        editor.close()

--- a/tests/test_studyeditor.py
+++ b/tests/test_studyeditor.py
@@ -219,3 +219,36 @@ def test_removing_a_cue_marks_unsaved(qtbot, silence_dialogs, tmp_path):
     assert editor.has_unsaved_changes()
     editor._commit_forms()
     assert editor.config.cueing.audio.cues == []
+
+
+def test_biocals_default_stack_stays_unspecified(qtbot, silence_dialogs, tmp_path):
+    # A fresh study leaves the stack at the None sentinel (use the app default); the
+    # editor must not materialize it, or every saved study would carry the full
+    # default stack and read dirty on open.
+    editor = StudyEditorWindow()
+    qtbot.addWidget(editor)
+    assert editor._forms["biocals"].customize.isChecked() is False
+    assert not editor.has_unsaved_changes()
+    path = tmp_path / "bio.smacc"
+    assert editor._write(str(path)) is True
+
+    reloaded = StudyEditorWindow(str(path))
+    qtbot.addWidget(reloaded)
+    assert reloaded.config.cueing.biocals.rows is None
+    assert "rows" not in reloaded.config.to_settings_dict()["biocals"]
+
+
+def test_biocals_customizing_writes_an_explicit_stack(qtbot, silence_dialogs, tmp_path):
+    editor = StudyEditorWindow()
+    qtbot.addWidget(editor)
+    editor._forms["biocals"].customize.setChecked(True)
+    editor._forms["biocals"].voiceVolume.setValue(0.4)
+    assert editor.has_unsaved_changes()
+    path = tmp_path / "bio2.smacc"
+    assert editor._write(str(path)) is True
+
+    reloaded = StudyEditorWindow(str(path))
+    qtbot.addWidget(reloaded)
+    assert reloaded.config.cueing.biocals.rows is not None  # now explicit
+    assert reloaded.config.cueing.biocals.voice_volume == 0.4
+    assert reloaded._forms["biocals"].customize.isChecked() is True

--- a/tests/test_studyeditor.py
+++ b/tests/test_studyeditor.py
@@ -163,3 +163,59 @@ def test_routing_form_round_trips_an_action_reroute(qtbot, silence_dialogs, tmp_
     assert reloaded.config.devices.equipment_for("play_audio_cue") == "control_speaker"
     # The study carries routing only — never this machine's equipment→device bindings.
     assert "bindings" not in reloaded.config.devices.to_study_dict()
+
+
+def test_audio_cue_table_adds_and_round_trips(qtbot, silence_dialogs, tmp_path):
+    editor = StudyEditorWindow()
+    qtbot.addWidget(editor)
+    form = editor._forms["audio"]
+    form._add_row(studyconfig.AudioCue("Buzz", "cues/buzz.wav", 0.3, loop=True))
+    assert editor.has_unsaved_changes()
+
+    path = tmp_path / "cued.smacc"
+    assert editor._write(str(path)) is True
+    reloaded = StudyEditorWindow(str(path))
+    qtbot.addWidget(reloaded)
+    cues = reloaded.config.cueing.audio.cues
+    assert len(cues) == 1
+    assert (cues[0].name, cues[0].volume, cues[0].loop) == ("Buzz", 0.3, True)
+    # The reloaded table mirrors the saved cue.
+    assert reloaded._forms["audio"].table.item(0, 0).text() == "Buzz"
+
+
+def test_visual_cue_table_round_trips_color_and_pattern(
+    qtbot, silence_dialogs, tmp_path
+):
+    editor = StudyEditorWindow()
+    qtbot.addWidget(editor)
+    form = editor._forms["visual"]
+    form._add_row(
+        studyconfig.VisualCue("Glow", "#00ff00", 0.8, "pulse", 2.0, 1.5, loop=True)
+    )
+    path = tmp_path / "glow.smacc"
+    assert editor._write(str(path)) is True
+
+    reloaded = StudyEditorWindow(str(path))
+    qtbot.addWidget(reloaded)
+    cues = reloaded.config.cueing.visual.cues
+    assert len(cues) == 1
+    assert cues[0].color == "#00ff00"
+    assert cues[0].pattern == "pulse"
+    assert cues[0].rate == 2.0
+    assert not reloaded.has_unsaved_changes()  # reload is clean
+
+
+def test_removing_a_cue_marks_unsaved(qtbot, silence_dialogs, tmp_path):
+    full = _sample_settings(tmp_path)  # carries one audio cue
+    path = tmp_path / "study.smacc"
+    _write_smacc(path, full, {"subject": "", "session": "", "notes": ""}, tmp_path)
+    editor = StudyEditorWindow(str(path))
+    qtbot.addWidget(editor)
+    assert editor._forms["audio"].table.rowCount() == 1
+    assert not editor.has_unsaved_changes()
+
+    editor._forms["audio"].table.setCurrentCell(0, 0)
+    editor._forms["audio"]._remove_selected()
+    assert editor.has_unsaved_changes()
+    editor._commit_forms()
+    assert editor.config.cueing.audio.cues == []

--- a/tests/test_studyeditor.py
+++ b/tests/test_studyeditor.py
@@ -82,13 +82,16 @@ def test_editor_save_round_trips_byte_stable(qtbot, silence_dialogs, tmp_path):
     assert path1.read_text(encoding="utf-8") == path2.read_text(encoding="utf-8")
 
 
-def test_editing_the_model_marks_unsaved_then_save_clears_it(
+def test_editing_an_unformed_section_marks_unsaved_then_save_clears_it(
     qtbot, silence_dialogs, tmp_path
 ):
+    # surveys has no form yet, so a programmatic edit there isn't overwritten by a
+    # form commit — this exercises the snapshot/dirty machinery for sections whose
+    # values round-trip untouched.
     editor = StudyEditorWindow()
     qtbot.addWidget(editor)
     assert not editor.has_unsaved_changes()
-    editor.config.cueing.noise.volume = 0.99  # an edit a form would make
+    editor.config.surveys.url = "smacc://survey/lusk"
     assert editor.has_unsaved_changes()
     assert editor._write(str(tmp_path / "s.smacc")) is True
     assert not editor.has_unsaved_changes()  # saving rebaselines the snapshot
@@ -106,3 +109,40 @@ def test_editor_emits_closed_when_clean(qtbot, silence_dialogs):
     qtbot.addWidget(editor)
     with qtbot.waitSignal(editor.closed, timeout=1000):
         editor.close()
+
+
+# ----- section forms ---------------------------------------------------------
+
+
+def test_forms_reflect_a_loaded_study(qtbot, silence_dialogs, tmp_path):
+    full = _sample_settings(tmp_path)
+    path = tmp_path / "study.smacc"
+    _write_smacc(path, full, {"subject": "", "session": "", "notes": ""}, tmp_path)
+
+    editor = StudyEditorWindow(str(path))
+    qtbot.addWidget(editor)
+    assert editor._forms["data"].edit.text() == str(tmp_path / "data")
+    assert editor._forms["noise"].color.currentText() == "pink"
+    assert editor._forms["noise"].fileRadio.isChecked()  # source == file
+    assert editor._forms["interface"].fontSize.value() == 22
+    assert not editor.has_unsaved_changes()  # load → commit is the identity
+
+
+def test_editing_a_form_widget_round_trips_through_save(
+    qtbot, silence_dialogs, tmp_path
+):
+    editor = StudyEditorWindow()
+    qtbot.addWidget(editor)
+    editor._forms["noise"].volume.setValue(0.55)
+    editor._forms["interface"].redText.setChecked(True)
+    assert editor.has_unsaved_changes()
+
+    path = tmp_path / "edited.smacc"
+    assert editor._write(str(path)) is True
+    assert not editor.has_unsaved_changes()
+
+    reloaded = StudyEditorWindow(str(path))
+    qtbot.addWidget(reloaded)
+    assert reloaded.config.cueing.noise.volume == 0.55
+    assert reloaded.config.interface.chat_red_text is True
+    assert reloaded._forms["noise"].volume.value() == 0.55


### PR DESCRIPTION
The payoff of the [study-config redesign](https://github.com/remrama/smacc/issues/298): a standalone **Study Editor** that authors a `.smacc` by editing the pure `StudyConfig` model through per-section forms — replacing the old editor, which ran the session window in a stripped `headless` mode and reused the run-time panels. Creating or editing a study no longer touches the session/panels/audio stack at all.

> Rebased onto `main` now that the import-guard ([#311](https://github.com/remrama/smacc/pull/311)) has merged — this is the editor work on its own (9 commits).

## Hardware-free by construction
The editor (and every form) imports none of `session` / `gui` / `panels` / `sounddevice` / `pylsl`. That's not a convention — the import-linter contract (#311) covers `smacc.studyeditor`, so CI rejects any import path to the run-time stack. On a system whose failure mode is *audio on a sleeping participant*, "the editor can't open a stream" is a property the build proves, not a discipline to remember.

## What's here (9 commits)
1. **dialogs.py decoupling** — `ManageSurveysDialog` previewed a built-in survey by importing `panels.survey` (→ `session`/`sounddevice`). That edge is now an injected `preview_builtin` capability the panel supplies and the editor doesn't, so `dialogs.py` is panels-free and the editor can reuse it.
2. **Editor shell** — `StudyEditorWindow` (a launcher `ToolWindow`): a section tree + stacked forms, File menu (Save/Save-As/Import/Import-from-log/Session info), default-template guard, and an unsaved-changes prompt compared on *serialized study bytes* (so the model's `None` sentinels don't read a clean study as dirty). Load/save reuse `settings.py` verbatim → files stay byte-compatible with what a session writes.
3–7. **Section forms** — data directory, routing (action→equipment, never enumerating this machine's devices), audio + visual cue tables, noise, biocals (the "Customize the stack" toggle preserves the `None`-means-default sentinel), surveys, interface, and markers.
8. **Markers extraction** — the event-code registry table was inline in the live Markers window but is session-free; it moves to `smacc.eventregistry.EventRegistryTable`, embedded by **both** the Markers window (keeps Apply/Test + the hardware transport) and the editor (registry + portable trigger behavior only — no machine port/baud/address, no Test).
9. **Cutover** — the launcher's "Editor…" opens `StudyEditorWindow`; `_on_tool_closed` quits on a live session's close and returns-and-remembers on the editor's.

## Form contract
Each form is a `SectionForm` with `load(config)` / `commit(config)` over one model leaf. The editor commits every form into the model before saving or checking for changes, so a form owns exactly the fields it surfaces and untouched sections round-trip verbatim. For a well-formed study, load→commit is the identity (no false-dirty); a malformed value the form can't represent normalizes and reads as an unsaved change (the editor offering to persist the fix).

## Tests
Full suite **green (1192)**, ruff/mypy/import-linter clean. New `test_studyeditor.py` covers load-into-model, byte-stable save round-trips, unsaved-change tracking, and every form's round-trip; the markers-panel and launcher tests were updated for the extraction and cutover.

## Deliberate scope
- The Interface form surfaces volume cap / latency / chat font + red text, **not** chat presets / preview levels / always-on-top — those are runtime prefs and round-trip untouched (the step-10 leaf-coverage test will either bind or explicitly exclude them).
- No cue/survey *audition* — authoring numeric values only; previewing live components stays a session affordance.

The old `gui.py` editor chrome (the `if self.design` branches) is now **dormant** — unreachable from the launcher — and is deleted, with its tests rewritten, in the follow-up teardown PR (kept separate because it's the one change that touches the live-session path). Then #302 (validate CLI + JSON Schema) closes the milestone.

Part of #301.