### PR TITLE
feat: SMACC validate CLI + model-derived settings JSON Schema (#302)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ dependencies = [
     # BlinkStick LED device (visual cues). Its backend, pywinusb, is Windows-only,
     # so scope to win32 to keep the cross-platform lock resolving everywhere.
     "blinkstick; sys_platform == 'win32'",
+    # Validates a .smacc against the model-derived JSON Schema in `SMACC validate`
+    # (#302). Imported lazily and optionally — the command degrades to the model's
+    # own validators if it (or its rpds-py backend) isn't available in a build.
+    "jsonschema>=4.26.0",
     "numpy",
     # Read-only view of the Windows volume mixer (Core Audio COM); Windows-only, so
     # scope to win32 like blinkstick. Pulls in comtypes.

--- a/src/smacc/__main__.py
+++ b/src/smacc/__main__.py
@@ -239,6 +239,12 @@ def main() -> None:
         if sys.stdout is not None:  # absent in a --noconsole build
             print(f"SMACC {display_version()}")
         return
+    if sys.argv[1:2] == ["validate"]:
+        # Headless `SMACC validate <file>`: check a .smacc and exit with its code,
+        # opening no window. Imported here so the GUI path never pays for it.
+        from smacc.validate import main as validate_main
+
+        sys.exit(validate_main(sys.argv[2:]))
     # Crash capture first, before any Qt: a native crash during Qt startup is
     # exactly what the persistent crash log exists to record (#149). The
     # excepthook's dialog arms itself once the QApplication below exists.

--- a/src/smacc/assets/default.smacc
+++ b/src/smacc/assets/default.smacc
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/remrama/smacc/main/src/smacc/assets/smacc-schema.json
 # SMACC settings — YAML (.smacc). Edit with care.
 kind: smacc/settings
 schema_version: 1

--- a/src/smacc/assets/smacc-schema.json
+++ b/src/smacc/assets/smacc-schema.json
@@ -1,0 +1,323 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/remrama/smacc/main/src/smacc/assets/smacc-schema.json",
+  "title": "SMACC settings file",
+  "description": "A SMACC study configuration (.smacc). Generated from the StudyConfig model; edit the model, not this file.",
+  "type": "object",
+  "properties": {
+    "kind": {
+      "const": "smacc/settings"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "smacc_version": {
+      "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "subject": {
+          "type": "string"
+        },
+        "session": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "settings": {
+      "type": "object",
+      "properties": {
+        "biocals": {
+          "type": "object",
+          "properties": {
+            "voice_volume": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            "rows": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "biocal": {
+                    "type": "string"
+                  },
+                  "sequence": {
+                    "type": "boolean"
+                  },
+                  "voice": {
+                    "type": "boolean"
+                  },
+                  "duration": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 600
+                  }
+                },
+                "required": [
+                  "biocal"
+                ]
+              }
+            }
+          }
+        },
+        "visual_cues": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "color": {
+                "type": "string",
+                "pattern": "^#[0-9a-fA-F]{6}$"
+              },
+              "brightness": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "pattern": {
+                "enum": [
+                  "steady",
+                  "pulse",
+                  "flash"
+                ]
+              },
+              "rate": {
+                "type": "number",
+                "exclusiveMinimum": 0
+              },
+              "length": {
+                "type": "number",
+                "minimum": 0
+              },
+              "loop": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "visual_attack": {
+          "type": "number",
+          "minimum": 0
+        },
+        "visual_release": {
+          "type": "number",
+          "minimum": 0
+        },
+        "cues": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "file": {
+                "type": "string"
+              },
+              "volume": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "loop": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "cue_attack": {
+          "type": "number",
+          "minimum": 0
+        },
+        "cue_release": {
+          "type": "number",
+          "minimum": 0
+        },
+        "noise_volume": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "noise_color": {
+          "type": "string",
+          "enum": [
+            "white",
+            "pink",
+            "brown"
+          ]
+        },
+        "noise_source": {
+          "type": "string",
+          "enum": [
+            "builtin",
+            "file"
+          ]
+        },
+        "noise_file": {
+          "type": "string"
+        },
+        "survey_url": {
+          "type": "string"
+        },
+        "survey_options": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "chat_experimenter_presets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "chat_participant_presets": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "chat_font_size": {
+          "type": "integer",
+          "minimum": 8,
+          "maximum": 72
+        },
+        "chat_red_text": {
+          "type": "boolean"
+        },
+        "volume_cap": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "output_latency": {
+          "type": "string",
+          "enum": [
+            "high",
+            "low"
+          ]
+        },
+        "devices": {
+          "type": "object",
+          "properties": {
+            "routing": {
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "event_codes": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "code": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 255
+              },
+              "lsl": {
+                "type": "boolean"
+              },
+              "ttl": {
+                "type": "boolean"
+              },
+              "preview": {
+                "type": "boolean"
+              },
+              "increment": {
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "key",
+              "code"
+            ]
+          }
+        },
+        "event_code_safe_max": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 255
+        },
+        "trigger_output": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "transport": {
+              "enum": [
+                "serial",
+                "parallel"
+              ]
+            },
+            "mode": {
+              "enum": [
+                "pulsed",
+                "hold"
+              ]
+            },
+            "pulse_ms": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "port": {
+              "type": "string"
+            },
+            "baud": {
+              "type": "integer"
+            },
+            "address": {
+              "type": "string"
+            }
+          }
+        },
+        "data_directory": {
+          "type": "string"
+        },
+        "preview_levels": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "DEBUG",
+              "INFO",
+              "WARNING",
+              "ERROR",
+              "CRITICAL"
+            ]
+          }
+        },
+        "always_on_top": {
+          "type": "boolean"
+        },
+        "tool_always_on_top": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "boolean"
+          }
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "settings"
+  ]
+}

--- a/src/smacc/config.py
+++ b/src/smacc/config.py
@@ -7,6 +7,16 @@ from smacc import __version__
 
 VERSION = __version__
 
+# Public URL of the .smacc JSON Schema (#302), served as the committed file on the
+# default branch. The settings header's yaml-language-server modeline and the
+# schema's own $id both point here, so an editor fetches the schema for autocomplete
+# and validation. Defined here (the lowest-level module) so settings.py and
+# schema.py can share it without an import cycle.
+SCHEMA_URL = (
+    "https://raw.githubusercontent.com/remrama/smacc/main/"
+    "src/smacc/assets/smacc-schema.json"
+)
+
 # A rolling `dev` build (#251) is stamped with the git commit it was built from:
 # the release workflow writes smacc._build on main-push builds only. It is absent
 # in a tagged release, a PR build, or a source checkout — then BUILD is None and

--- a/src/smacc/paths.py
+++ b/src/smacc/paths.py
@@ -23,6 +23,10 @@ BUNDLED_BIOCALS_DIR = _asset_dir / "biocals"
 # Shipped example/default settings, copied to the SMACC root on first run so the
 # defaults live in a readable .smacc file (not in Python) — see smacc.settings.
 BUNDLED_DEFAULT_SETTINGS = _asset_dir / "default.smacc"
+# The JSON Schema for a .smacc file (#302), generated from the StudyConfig model
+# (see smacc.schema). Committed here so the template's modeline can point at it and
+# CI can check it hasn't drifted; packaged so the validate CLI can read it frozen.
+BUNDLED_SCHEMA_PATH = _asset_dir / "smacc-schema.json"
 # Built-in survey definitions shipped with SMACC (#114); loaded straight from the
 # bundle (never copied out), so updates reach every install.
 BUNDLED_SURVEYS_DIR = _asset_dir / "surveys"

--- a/src/smacc/schema.py
+++ b/src/smacc/schema.py
@@ -1,0 +1,214 @@
+"""A JSON Schema for a ``.smacc`` file, generated from the StudyConfig model (#302).
+
+Power users edit ``.smacc`` files by hand; this schema gives their editor
+autocomplete and validation. It is **derived from the model**, not a second
+hand-maintained copy that could drift: the set of settings keys and each key's base
+JSON type come straight from :meth:`StudyConfig.to_settings_dict` (the canonical
+flat projection), and only *refinements* — enums, numeric ranges, and the shapes of
+the cue/event/biocal array items — are declared here. The committed schema file
+(``assets/smacc-schema.json``) is regenerated from :func:`build_schema` and a test
+fails if it drifts (see ``tests/test_schema.py``), so the model stays the single
+source of truth.
+
+Pure and Qt-free, like the model: imported by the headless ``SMACC validate`` CLI.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from . import biocals, events
+from .config import SCHEMA_URL
+from .paths import BUNDLED_SCHEMA_PATH
+from .settings import KIND, SCHEMA_VERSION
+from .studyconfig import StudyConfig
+
+# JSON Schema dialect this schema targets. The public URL it is served at (and that
+# the template's modeline points to) is SCHEMA_URL, shared from smacc.config.
+SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema"
+SCHEMA_PATH = BUNDLED_SCHEMA_PATH
+
+# A 0-1 software gain; a hex color; an 8-bit port code. Reused across refinements.
+_UNIT = {"type": "number", "minimum": 0, "maximum": 1}
+_HEX_COLOR = {"type": "string", "pattern": "^#[0-9a-fA-F]{6}$"}
+_CODE = {"type": "integer", "minimum": events.CODE_MIN, "maximum": events.CODE_MAX}
+_LOG_LEVELS = ["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
+
+_CUE_ITEM = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "file": {"type": "string"},
+        "volume": _UNIT,
+        "loop": {"type": "boolean"},
+    },
+    "additionalProperties": False,
+}
+_VISUAL_CUE_ITEM = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string"},
+        "color": _HEX_COLOR,
+        "brightness": _UNIT,
+        "pattern": {"enum": ["steady", "pulse", "flash"]},
+        "rate": {"type": "number", "exclusiveMinimum": 0},
+        "length": {"type": "number", "minimum": 0},
+        "loop": {"type": "boolean"},
+    },
+    "additionalProperties": False,
+}
+_EVENT_ITEM = {
+    "type": "object",
+    "properties": {
+        "key": {"type": "string"},
+        "code": _CODE,
+        "lsl": {"type": "boolean"},
+        "ttl": {"type": "boolean"},
+        "preview": {"type": "boolean"},
+        "increment": {"type": "boolean"},
+    },
+    "required": ["key", "code"],
+}
+_BIOCAL_ROW = {
+    "type": "object",
+    "properties": {
+        "biocal": {"type": "string"},
+        "sequence": {"type": "boolean"},
+        "voice": {"type": "boolean"},
+        "duration": {
+            "type": "integer",
+            "minimum": biocals.MIN_DURATION_S,
+            "maximum": biocals.MAX_DURATION_S,
+        },
+    },
+    "required": ["biocal"],
+}
+
+# Per-key refinements layered onto the base type derived from the model's own
+# output. Keys not listed keep just their base type. Every key here must be a real
+# settings key (guarded by tests/test_schema.py).
+_REFINEMENTS: dict[str, dict[str, Any]] = {
+    "biocals": {
+        "properties": {
+            "voice_volume": _UNIT,
+            "rows": {"type": "array", "items": _BIOCAL_ROW},
+        }
+    },
+    "visual_cues": {"items": _VISUAL_CUE_ITEM},
+    "visual_attack": {"minimum": 0},
+    "visual_release": {"minimum": 0},
+    "cues": {"items": _CUE_ITEM},
+    "cue_attack": {"minimum": 0},
+    "cue_release": {"minimum": 0},
+    "noise_volume": dict(_UNIT),
+    "noise_color": {"enum": ["white", "pink", "brown"]},
+    "noise_source": {"enum": ["builtin", "file"]},
+    "survey_options": {"additionalProperties": {"type": "string"}},
+    "chat_experimenter_presets": {"items": {"type": "string"}},
+    "chat_participant_presets": {"items": {"type": "string"}},
+    "chat_font_size": {"minimum": 8, "maximum": 72},
+    "volume_cap": dict(_UNIT),
+    "output_latency": {"enum": ["high", "low"]},
+    "devices": {
+        "properties": {
+            "routing": {"type": "object", "additionalProperties": {"type": "string"}}
+        }
+    },
+    "event_codes": {"items": _EVENT_ITEM},
+    "event_code_safe_max": {"minimum": events.CODE_MIN, "maximum": events.CODE_MAX},
+    "trigger_output": {
+        "properties": {
+            "enabled": {"type": "boolean"},
+            "transport": {"enum": ["serial", "parallel"]},
+            "mode": {"enum": ["pulsed", "hold"]},
+            "pulse_ms": {"type": "integer", "minimum": 1},
+            "port": {"type": "string"},
+            "baud": {"type": "integer"},
+            "address": {"type": "string"},
+        }
+    },
+    "preview_levels": {"items": {"enum": _LOG_LEVELS}},
+    "tool_always_on_top": {"additionalProperties": {"type": "boolean"}},
+}
+
+# JSON type for each Python type the flat projection emits.
+_JSON_TYPE = {bool: "boolean", int: "integer", float: "number", str: "string"}
+
+
+def _base_type(value: object) -> dict[str, Any]:
+    """The base JSON Schema type for a settings value (derived from the model)."""
+    if isinstance(value, bool):  # bool before int (bool is an int subclass)
+        return {"type": "boolean"}
+    for py_type, json_type in _JSON_TYPE.items():
+        if type(value) is py_type:
+            return {"type": json_type}
+    if isinstance(value, list):
+        return {"type": "array"}
+    return {"type": "object"}
+
+
+def _maximal_settings() -> dict[str, Any]:
+    """``to_settings_dict`` with the optional blocks present, for the full key set."""
+    cfg = StudyConfig()
+    cfg.interface.chat_experimenter_presets = []
+    cfg.interface.chat_participant_presets = []
+    cfg.cueing.biocals.rows = []
+    return cfg.to_settings_dict()
+
+
+def _settings_properties() -> dict[str, Any]:
+    """The ``settings`` object's properties: base type per key, refined where known."""
+    props: dict[str, Any] = {}
+    for key, value in _maximal_settings().items():
+        schema = _base_type(value)
+        schema.update(_REFINEMENTS.get(key, {}))
+        props[key] = schema
+    return props
+
+
+def build_schema() -> dict[str, Any]:
+    """Build the JSON Schema for a ``.smacc`` file from the StudyConfig model."""
+    return {
+        "$schema": SCHEMA_DIALECT,
+        "$id": SCHEMA_URL,
+        "title": "SMACC settings file",
+        "description": "A SMACC study configuration (.smacc). Generated from the "
+        "StudyConfig model; edit the model, not this file.",
+        "type": "object",
+        "properties": {
+            "kind": {"const": KIND},
+            "schema_version": {"const": SCHEMA_VERSION},
+            "smacc_version": {"type": "string"},
+            "metadata": {
+                "type": "object",
+                "properties": {
+                    "subject": {"type": "string"},
+                    "session": {"type": "string"},
+                    "notes": {"type": "string"},
+                },
+            },
+            "settings": {
+                "type": "object",
+                "properties": _settings_properties(),
+                "additionalProperties": False,
+            },
+        },
+        "required": ["settings"],
+    }
+
+
+def dumps() -> str:
+    """The committed schema text: pretty, stable key order, trailing newline."""
+    return json.dumps(build_schema(), indent=2, sort_keys=False) + "\n"
+
+
+def write_schema(path: Path = SCHEMA_PATH) -> None:
+    """Regenerate the committed schema file (run from a small CI/dev command).
+
+    Writes raw bytes (LF), not text, so the file is byte-identical whatever platform
+    regenerates it — and the drift test (which reads back with universal newlines)
+    stays stable across Windows and Linux.
+    """
+    path.write_bytes(dumps().encode("utf-8"))

--- a/src/smacc/settings.py
+++ b/src/smacc/settings.py
@@ -38,15 +38,20 @@ from typing import Any
 
 import yaml
 
-from .config import VERSION
+from .config import SCHEMA_URL, VERSION
 
 # The discriminator written at the top of every settings file. A loaded mapping
 # is rejected when it carries a different ``kind``.
 KIND = "smacc/settings"
 
 # Prepended to every saved file so it self-identifies even before parsing (YAML
-# ignores ``#`` comments, so this round-trips cleanly through ``safe_load``).
-_FILE_HEADER = "# SMACC settings — YAML (.smacc). Edit with care.\n"
+# ignores ``#`` comments, so this round-trips cleanly through ``safe_load``). The
+# first line is a yaml-language-server modeline (#302): an editor that supports it
+# fetches the JSON Schema for autocomplete and validation while hand-editing.
+_FILE_HEADER = (
+    f"# yaml-language-server: $schema={SCHEMA_URL}\n"
+    "# SMACC settings — YAML (.smacc). Edit with care.\n"
+)
 
 # v1 is the v0.0.9 baseline (pre-release schemas were retired without migration).
 # Bump this when the layout changes incompatibly — and when you do, update the

--- a/src/smacc/validate.py
+++ b/src/smacc/validate.py
@@ -1,0 +1,94 @@
+"""The headless ``SMACC validate <file>`` command (#302).
+
+Checks a ``.smacc`` file without opening any window — for a power user who edits the
+YAML by hand, or for CI on a study repository. It reports **graded** issues and exits
+non-zero only when there are hard errors:
+
+* **structural** — the file parses as a SMACC settings file (``kind`` / schema
+  version / shape), via :func:`smacc.settings.load_settings`;
+* **schema** — the settings conform to the model-derived JSON Schema (types, enums,
+  ranges, unknown-key typos), when :mod:`jsonschema` is available (it is in a normal
+  install; the command degrades to the checks below if a build lacks it);
+* **registry** — the safety-critical event-code checks from the model's own
+  :func:`smacc.events.validate_events` (duplicate/out-of-range codes are errors; a
+  TTL code above the safe max is a warning).
+
+Pure and Qt-free: dispatched from ``smacc.__main__`` before any QApplication.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from . import events, settings
+from .studyconfig import StudyConfig
+
+
+def _schema_issues(state: dict) -> list[str]:
+    """Schema-validation messages for the settings mapping (``[]`` if unavailable).
+
+    Optional by design: if :mod:`jsonschema` (or its native ``rpds`` backend) isn't
+    importable in this build, schema checks are skipped and the structural/registry
+    checks still run. Editors get the same validation from the published schema.
+    """
+    try:
+        import jsonschema
+
+        from .schema import build_schema
+
+        settings_schema = build_schema()["properties"]["settings"]
+        validator = jsonschema.Draft202012Validator(settings_schema)
+        errors = sorted(validator.iter_errors(state), key=lambda e: list(e.path))
+    except Exception:
+        # jsonschema (or its native rpds/specifications data) absent or unusable in
+        # this build: skip schema checks; the structural/registry checks still run.
+        return []
+    return [
+        f"{'.'.join(str(p) for p in e.path) or 'settings'}: {e.message}" for e in errors
+    ]
+
+
+def validate_file(path: str | Path) -> tuple[list[str], list[str]]:
+    """Return ``(errors, warnings)`` for the ``.smacc`` file at ``path``.
+
+    A structural failure is fatal and returned on its own — the later checks need a
+    parsed mapping. Schema violations are errors (the file doesn't match the model's
+    shape); the registry's soft checks contribute warnings.
+    """
+    try:
+        state, _metadata = settings.load_settings(path)
+    except (OSError, ValueError) as exc:
+        return [str(exc)], []
+
+    errors = _schema_issues(state)
+    config = StudyConfig.from_settings_dict(state)
+    registry_errors, registry_warnings = events.validate_events(
+        config.markers.event_codes, config.markers.event_code_safe_max
+    )
+    errors.extend(registry_errors)
+    return errors, registry_warnings
+
+
+def main(argv: list[str] | None = None) -> int:
+    """``SMACC validate <file>``: print graded issues, return the exit code."""
+    parser = argparse.ArgumentParser(
+        prog="SMACC validate", description="Validate a SMACC (.smacc) study file."
+    )
+    parser.add_argument("file", help="the .smacc file to validate")
+    args = parser.parse_args(argv)
+
+    errors, warnings = validate_file(args.file)
+    name = Path(args.file).name
+    for warning in warnings:
+        print(f"warning: {warning}")
+    for error in errors:
+        print(f"error: {error}")
+    if errors:
+        print(f"{name}: invalid ({len(errors)} error(s), {len(warnings)} warning(s)).")
+        return 1
+    if warnings:
+        print(f"{name}: valid, with {len(warnings)} warning(s).")
+        return 0
+    print(f"{name}: valid.")
+    return 0

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,47 @@
+"""Tests for the model-derived .smacc JSON Schema (#302)."""
+
+from __future__ import annotations
+
+import jsonschema
+
+from smacc import schema, settings
+from smacc.paths import BUNDLED_DEFAULT_SETTINGS, BUNDLED_SCHEMA_PATH
+
+
+def test_build_schema_is_itself_a_valid_json_schema():
+    jsonschema.Draft202012Validator.check_schema(schema.build_schema())
+
+
+def test_committed_schema_file_is_up_to_date():
+    # The committed file is generated from the model. If this fails, regenerate it:
+    #   uv run python -c "from smacc.schema import write_schema; write_schema()"
+    committed = BUNDLED_SCHEMA_PATH.read_text(encoding="utf-8")
+    assert committed == schema.dumps()
+
+
+def test_schema_covers_every_settings_key():
+    # The properties are built from the model's own flat projection, so the schema
+    # cannot silently miss a key a study can carry.
+    props = schema.build_schema()["properties"]["settings"]["properties"]
+    assert set(props) == set(schema._maximal_settings())
+
+
+def test_every_refinement_targets_a_real_settings_key():
+    # Guards a typo in a refinement key (which would silently do nothing).
+    assert set(schema._REFINEMENTS) <= set(schema._maximal_settings())
+
+
+def test_schema_validates_the_bundled_default_smacc():
+    state, _meta = settings.load_settings(BUNDLED_DEFAULT_SETTINGS)
+    settings_schema = schema.build_schema()["properties"]["settings"]
+    jsonschema.validate(state, settings_schema)  # raises if the template is invalid
+
+
+def test_schema_flags_bad_values_and_unknown_keys():
+    settings_schema = schema.build_schema()["properties"]["settings"]
+    validator = jsonschema.Draft202012Validator(settings_schema)
+    bad = {"noise_volume": 2.0, "noise_color": "chartreuse", "typo_key": 1}
+    messages = " ".join(e.message for e in validator.iter_errors(bad))
+    assert "maximum" in messages  # noise_volume 2.0 > 1
+    assert "chartreuse" in messages  # noise_color not in the enum
+    assert "typo_key" in messages  # unknown key (additionalProperties: false)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,66 @@
+"""Tests for the headless `SMACC validate` command (#302)."""
+
+from __future__ import annotations
+
+from smacc import events, settings, validate
+from smacc.paths import BUNDLED_DEFAULT_SETTINGS
+
+
+def test_the_bundled_default_is_valid():
+    errors, _warnings = validate.validate_file(BUNDLED_DEFAULT_SETTINGS)
+    assert errors == []
+
+
+def test_main_returns_zero_and_reports_valid(capsys):
+    assert validate.main([str(BUNDLED_DEFAULT_SETTINGS)]) == 0
+    assert "valid" in capsys.readouterr().out
+
+
+def test_malformed_values_and_unknown_keys_are_errors(tmp_path):
+    path = tmp_path / "bad.smacc"
+    settings.save_settings(
+        str(path), {"noise_volume": 9.0, "noise_color": "blue", "oops": 1}, {}
+    )
+    errors, _warnings = validate.validate_file(path)
+    joined = " ".join(errors)
+    assert "noise_volume" in joined
+    assert "noise_color" in joined
+    assert "oops" in joined
+
+
+def test_main_returns_one_for_an_invalid_file(tmp_path, capsys):
+    path = tmp_path / "bad.smacc"
+    settings.save_settings(str(path), {"noise_volume": 9.0}, {})
+    assert validate.main([str(path)]) == 1
+    assert "error" in capsys.readouterr().out
+
+
+def test_a_non_smacc_file_is_a_structural_error(tmp_path):
+    path = tmp_path / "x.smacc"
+    path.write_text("just: some\nrandom: yaml\n", encoding="utf-8")
+    errors, _warnings = validate.validate_file(path)
+    assert errors  # missing kind/schema_version/settings → fatal structural error
+
+
+def test_a_duplicate_event_code_is_a_registry_error(tmp_path):
+    # Uniqueness is the registry validator's job, not the per-item schema's: two
+    # routed events sharing a code collide on the marker channel.
+    rows = events.events_to_list(events.default_events())
+    rows[1]["code"] = rows[0]["code"]  # force a duplicate among routed events
+    path = tmp_path / "dup.smacc"
+    settings.save_settings(str(path), {"event_codes": rows}, {})
+    errors, _warnings = validate.validate_file(path)
+    assert any("duplicate" in e.lower() for e in errors)
+
+
+def test_a_ttl_code_above_the_safe_max_is_a_warning(tmp_path):
+    rows = events.events_to_list(events.default_events())
+    path = tmp_path / "warn.smacc"
+    # A low safe max turns the routed default codes into soft TTL warnings, with no
+    # hard error — the file is valid but flagged.
+    settings.save_settings(
+        str(path), {"event_codes": rows, "event_code_safe_max": 1}, {}
+    )
+    errors, warnings = validate.validate_file(path)
+    assert errors == []
+    assert warnings

--- a/uv.lock
+++ b/uv.lock
@@ -56,6 +56,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "blinkstick"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -517,6 +526,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -1398,6 +1434,19 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1423,6 +1472,101 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/32/14c961ad295f490eb0849ada8b79683e93a59b9de3afdd983eaf55fa6867/rpds_py-2026.5.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:efef4ac29c6ff495531eb17ee705b62841ecaa291b7c7077e848ea03e237164d", size = 352787, upload-time = "2026-05-28T11:59:33.655Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/bb/d1b85117967c11191441a7274ae616c65d93901d082c588f89a50a8da5ae/rpds_py-2026.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c39f5b67a8a2e67179ada2a954227d670fe65fa9098457f698f56ddf248709b3", size = 345179, upload-time = "2026-05-28T11:59:35Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/46/d84105f062e626a1b233f863907288a4708c2d833b8b4c6fb2764bc080c0/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5c30f3f04eef4fbd362226a6f31d7c8895ca4fbb6e0b790f6890a98d8da8559", size = 376173, upload-time = "2026-05-28T11:59:36.43Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/469d7959ce5b1201e1de135dc735b86db3b35dd0d1734f6a44246d5f061c/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:277f6c82f0580848796c7ecc8a7173aa3bfb928e4ff831261c2f60a81dc270db", size = 383162, upload-time = "2026-05-28T11:59:37.995Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/a2/57853d31a1116a561aa072794602ad3f6341e18d70a8523f1bd5b9fc1e5a/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63c2c4c213f1a4e3f3de28ecab029dbdee976324e729c0d7a55211be72576b02", size = 495093, upload-time = "2026-05-28T11:59:39.453Z" },
+    { url = "https://files.pythonhosted.org/packages/99/63/3a8eabcad9314b7daf5c65f451d2c33d989235cd8a5762186cf2c3f5a4f8/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3350ec808fb538fe71a1f94dfaa0e29c598dfad805ce49f0caec5ae3183c652b", size = 389829, upload-time = "2026-05-28T11:59:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/05678d97fc25e2622df14dc530fb82023174ecfff6733991ed0d78f167bd/rpds_py-2026.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b1b964e3ab599e718dc46c018d104b1ebc007cbc6567d827c94a687fca56d77e", size = 374786, upload-time = "2026-05-28T11:59:42.626Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/8c90b6431e80a3b91b284a5c7c8c0c4f9c006444d90477a740d6e0f9c694/rpds_py-2026.5.1-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:19cb09fab7b7fc96b2a6e28f2e34b72a3705ff27b37edb77455316e5d3f3dc9b", size = 386920, upload-time = "2026-05-28T11:59:44.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/99/4638f672ab356682d633ee0da9255f5b67ce6efd0b85eb94ad3e255e65a5/rpds_py-2026.5.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:abe76bcdba31e576cb83eeb8797aa0d882b738fef6dc65d0601fc753806a5b46", size = 405059, upload-time = "2026-05-28T11:59:47.177Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3f/3546524b6eb4cc2e1f363a3d638fa52f6c24faae3500c25fb488b02f1740/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8bff7073db3899158fff55ebf57b113a67030af26f80a18978f9f0aa60250ddf", size = 553030, upload-time = "2026-05-28T11:59:48.603Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c3/7b3388c796fcf471bd17194242d4dc1a7608567c0fa422bcc1c5e79f9c1e/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8ba264fa49be666cd9cc56bf34ec7002fb3d27a4aee5bcb4d43d0d18feb1bb6f", size = 618975, upload-time = "2026-05-28T11:59:50.314Z" },
+    { url = "https://files.pythonhosted.org/packages/61/1e/a3cb07f2795075d1d88efddae2f541359fde5f08c81ee114c29c2949c90a/rpds_py-2026.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4860b603ddda0475a8885499b3729e90229d480105b42651962a5397d995fa89", size = 581178, upload-time = "2026-05-28T11:59:51.673Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/74/e758c03a5ef46f04c37f2651a2893db846d569ba8a7bca469d4b58939bcd/rpds_py-2026.5.1-cp313-cp313-win32.whl", hash = "sha256:7944270ae71383f6e2657dd7d5ce4eeb4ac2d0059a6738f0510583d462ab4842", size = 212481, upload-time = "2026-05-28T11:59:53.148Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ec/a2aca432db9c7359b40fa393eeeaa0d166c2f70175be956e75fa24197c44/rpds_py-2026.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:88647f43a73c4e01be19b04ceef0c8d3a1958153604d13c773becd8016f2a0cf", size = 228519, upload-time = "2026-05-28T11:59:54.505Z" },
+    { url = "https://files.pythonhosted.org/packages/29/60/a73bfdd45b096574556acf303bbd9fa9eed36ca8a818b514e2a5d5fe2b9d/rpds_py-2026.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:453895624ecf7db7063b1004e44037522bbaef9ff6a945e59bc71662d7a03abd", size = 223446, upload-time = "2026-05-28T11:59:56.081Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e2/408105fd611823f00882aea810f3989a30d26b1bab8b6beb20f98c724e0e/rpds_py-2026.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:b4e4bc98639ec915f512fde3aa7a95e0041d95d9c3cc86eea841fa63cb1e8600", size = 355287, upload-time = "2026-05-28T11:59:57.448Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/58/5c4a43436843c90d0f6d19f82c200c80e3843ca9fa07b237623327f6d384/rpds_py-2026.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:cacedb7a6e167680acba45ad5716e89067d225dc80da0d7040cae8c81d4572fa", size = 347033, upload-time = "2026-05-28T11:59:58.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/c2/1a71acdacaf4e259b10278fb87b039ded3cf80041bcd89dd8a3ea702ded6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:68700371c5d7ae1412862ddfa719090925c93ecf351c566d66f09d04b136ea00", size = 376891, upload-time = "2026-05-28T12:00:00.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c8/535f3d9b65addd8e28aa87b83c6e526799c3717a88273db8ea795beeef7a/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:296c799becfa849c779c8725494fe9ed94959ed886787df4364b058465bad7f0", size = 385646, upload-time = "2026-05-28T12:00:02.394Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/91/dc033f313345c354ade914dbe73cdb90b615a4409ea02430d5356794f3d8/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d3858b908218ee108d0bbfb2095ccc237648053c9bf98affad7cb079acaf1d97", size = 498830, upload-time = "2026-05-28T12:00:04.189Z" },
+    { url = "https://files.pythonhosted.org/packages/27/fc/90fcbea459dbb8ddc18a2e0fd1de9412b48bc84ffff2db771cf714bacfd6/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4fb8d2e7cb2f850b169806d61d1b991738acec96500a75c30f49caf064ce7cef", size = 392830, upload-time = "2026-05-28T12:00:05.797Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/1d/46cd11a228c9750684a798d98f878be6f614aa762438da7378f035e79e35/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27b74c10ed6a8f190f4287f53bcfea348b92a84a9c9f70d30183d1e6172d580d", size = 379613, upload-time = "2026-05-28T12:00:07.433Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4a/d9b0c6af3a1de03eb93741bbe8be2bdce84d8fda8224f3005451d86df389/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:b9a6528956191c48c52294a592dbd4a8386d7048bdb25c0efcb6b966466c6d83", size = 388183, upload-time = "2026-05-28T12:00:09.227Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b4/db7aaabdda6d020afc87d981bcc2f57a434c7dec60ecfc2ab3dd50b20351/rpds_py-2026.5.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:af03e34e860047bc7a352b842856fcf78798fbb81132cc98bd2f907ab4eb9cd2", size = 408578, upload-time = "2026-05-28T12:00:10.779Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d6/070f6a41cbb343e2ac4171859bf3f3623e0ab002f72619d6d505313ec2de/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fea6e836d10abbe191d557d33bd58bd5987725fe63aa1eefe557d230209855bd", size = 553573, upload-time = "2026-05-28T12:00:12.443Z" },
+    { url = "https://files.pythonhosted.org/packages/75/ab/1a71ea3589c4345dac0a0518f0e6a031cb42689277851b683c46d27463a5/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:fc0c0f878ea770a0a8a462456c5ad36fc9fe6358e6b76fdadc7f17575e0b8bf1", size = 620861, upload-time = "2026-05-28T12:00:14.09Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/22/9bf80a56069c0c443fcfefac639a86a744550a2898817a6dfd3e26654924/rpds_py-2026.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e0b360f316d966b048b085857630b3cc51f3db2f07b06f440eac8f695374d1e3", size = 585633, upload-time = "2026-05-28T12:00:15.66Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/3b2c0a75c9e04125696f84ebdbbf304acf5a40b58ba4481cdb98a922c3ba/rpds_py-2026.5.1-cp313-cp313t-win32.whl", hash = "sha256:a2999883eedf72fdfb7520b92c7d4ec2572a71ff40239377aa604cc529eecafc", size = 210074, upload-time = "2026-05-28T12:00:17.291Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/8b/609157d5a25d37d4f29f92840ba531f416907c34ae5c5739dd21fc2bef98/rpds_py-2026.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:e07be2a9d7122bd6e82dea89814ef8dc893feb1aae97fec1630f3263bbb30e55", size = 228635, upload-time = "2026-05-28T12:00:18.73Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/6f/19c1918a4b590d8de87e712e4abe4b3875771eff60216fb6153cf6665c68/rpds_py-2026.5.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:1f2c391c3059798093b65df23aca2cac150460ae9c630d99dec83d703d9485b9", size = 349756, upload-time = "2026-05-28T12:00:20.217Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/60/a06fe7da34eca79dacbf958a2ba0c6eea85bc2b29de20080bf40f72f66fa/rpds_py-2026.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:413b424f7c4ee65ab5e5be91f5731be0f8b41a1ee2b12dfe810d716312e95a78", size = 343831, upload-time = "2026-05-28T12:00:21.711Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/ec/b2333b97b90e2a6ef6ca8ad386ee284968e74bcfe113b3f1a8d9036429a9/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2c595a1d9255dce0599e13130d1440ab2506654f2b50294226ee06402f8fef63", size = 375127, upload-time = "2026-05-28T12:00:23.326Z" },
+    { url = "https://files.pythonhosted.org/packages/14/7f/e00aae54067f2b488c4637961d5f58204d470795fc791085fa3f15060d2e/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:1c27c5f6102eac8c03e7595a00827a53b271ba40a53b59ff8709170e0855ea4a", size = 379034, upload-time = "2026-05-28T12:00:24.89Z" },
+    { url = "https://files.pythonhosted.org/packages/be/cc/423999bbb8ae8dc93c77fc1d5e984ade5eb89d237d3bb884ccfa72ae2890/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c7fcf61d44cacecaf3aea542b0e053db77972a4573e7ceda16fb2b399161195", size = 490823, upload-time = "2026-05-28T12:00:26.676Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/aa/c671bf660f12e68d3c52ff86c7066ed1372df5a0f4f2ff584e419b8207e7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2c817a189d4ee14290420e5ff051e4dd6baa13f3edf84685071dee07a6d538ee", size = 388144, upload-time = "2026-05-28T12:00:28.577Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c8/d63bb75b68afe77b229e3021c6031bcaf01da5db5b0e69d0d10f9ba679a7/rpds_py-2026.5.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21846aac0ed2e0589f38c12dc44e77bb64e494b771eadbcf169cba00566ba7ba", size = 371959, upload-time = "2026-05-28T12:00:30.304Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/c51122014d8274ff37dc606d60049c3db7d83da02b5b282511e5a906a9a6/rpds_py-2026.5.1-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b317c87a13f769a4e787819bd508aaa5d69aa09b0880de9af6d3a8a54571cdec", size = 383558, upload-time = "2026-05-28T12:00:31.764Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f9/2790cb99c136a5363acdeacf5c27c56f3de0d4118a1f48fca83404c99c89/rpds_py-2026.5.1-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ce87129d9f2c14fa6c4a8601fb80eb4488c80d38a20cd13758ef11123e14995d", size = 402789, upload-time = "2026-05-28T12:00:33.247Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1b/e4fb584f8c75d35c38150ff6a332cda949e6f97acba1f4fd123b14ab56fe/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9cdddb6c1207d284d94fd1530adf57fbd797fe7c4b8704ba85f49414f2557e7d", size = 551405, upload-time = "2026-05-28T12:00:34.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f7/a6731b4216cb3793ea1af5391da240f5683dacc0d13e034fe5fc3503f240/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4e237e139f94d3c036fd28eb9f564c99055476ff4ff05cd42be55ce349b5aa02", size = 616975, upload-time = "2026-05-28T12:00:36.268Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/2e051a81d95d8e63f4b35a1c463a87e8766bc3d083c067c5dfb6bf220747/rpds_py-2026.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ed0954b524873214369184a9c82b0eaa45a3fbb9a798cd95b17e0d98499e7ea0", size = 578701, upload-time = "2026-05-28T12:00:37.82Z" },
+    { url = "https://files.pythonhosted.org/packages/65/56/b5f6fdb2083e32bca8a8993d89e70db114b4756c9e2c38421328126689d2/rpds_py-2026.5.1-cp314-cp314-win32.whl", hash = "sha256:2d88621d6a7d4dfa633d21abe90f280bb205274e16b1d1e61c6ad4640b2453b7", size = 209806, upload-time = "2026-05-28T12:00:39.492Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/80/65a5aa96c155e611d1ed844e4e1f57f3e36b021f396d9f8585d756e6b90d/rpds_py-2026.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:cef8ac28d26f4dda3533060c20fbf80a325458fa9fd23ea72a73cdfa8e978838", size = 225985, upload-time = "2026-05-28T12:00:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/27/7c/ad185212e87b05f196daef92bc5f3caf07298eb47c295b5585c3dd3093ac/rpds_py-2026.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:eaaea962c68cdc68d4a533ba985ab8e9484277910bbfaa2ab3ef7732667bfed8", size = 221219, upload-time = "2026-05-28T12:00:43.15Z" },
+    { url = "https://files.pythonhosted.org/packages/23/58/e14ae18759020334646b031e708ab4158d653a938822bfb7b95ef2e93aa3/rpds_py-2026.5.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:21942f52dbbd5f8758bf021213d28bd45c39e873e65e2407faf5f1846f5761ad", size = 352148, upload-time = "2026-05-28T12:00:44.638Z" },
+    { url = "https://files.pythonhosted.org/packages/31/9b/5f4a1e2f960bca3ac5d052b139dd31eed97b259f9d909173821760d542e8/rpds_py-2026.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f414556f6e3958300ff941e40c9f97e3dc9774ddd1b3434c475d73dd354bbed3", size = 345196, upload-time = "2026-05-28T12:00:46.14Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/71/1d9574d6a2fa20ab60eaa55c7467f5aa20cbc770f341a05f09c0876f59e2/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef1013a8625c74043210190b246f5b1551e09757c1f356c6e4160ef96c5bc081", size = 374981, upload-time = "2026-05-28T12:00:47.531Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/9a/37e99f4915a80aa71670263c1267f7ae0af95f53a3f61e6c3bdc016d4515/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cc68e231a77a5f0d774ae278a1f8e55c0456501820847c1e4efb3829f3441df6", size = 379961, upload-time = "2026-05-28T12:00:49.216Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ff/6e73f74b89d2e0715e0fc86b7dde893f9a61ae2f9b256ff3bdfe41ac4e94/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9baffb505aff33acc69b422a19f77806680f3c8632227d79f48de8a810d1c2c5", size = 495965, upload-time = "2026-05-28T12:00:51.111Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/e0/425faba25f59d74d4638b267f7c7a80e8649d2ef4db10a19b0c4a71e6e6f/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b8d2f912928d426e8cfa396f7f3f8d29a59e6689c86dcca3c420730c1096322b", size = 389526, upload-time = "2026-05-28T12:00:52.77Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/76/7a41960e3fddae47fab43a28684d5da981401dffd88253de0944148654cb/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90f628283be835db980c941767d41c9a27b5239e54ba0a9c1335247e82406964", size = 376190, upload-time = "2026-05-28T12:00:54.215Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/5f38dc70824fc6951b51d35377e577a3a3a4c81a6769cc5a2de25ebe0ad1/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:1ebb2f0ab7e16132995a72de805170e0203df0c3dd22e1ef1cd1fdd90bd7a131", size = 383921, upload-time = "2026-05-28T12:00:55.673Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1a/d60a38caa1505f4b9483c3fbbde12c94e1079154f4f401a6da96f7e77621/rpds_py-2026.5.1-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f3df3d16ded76f1f8c9cdebd0e1ea55fdf4c23b812de189814da7cf229c22a81", size = 404766, upload-time = "2026-05-28T12:00:57.518Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ff/602fd3f174d6425f0bce05ad0dfbec0e96b38d0f7d08a79af5aa20083885/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9af8905b8f854990e40d5206aa5ac58d9b0fe0b7f351ff2bb086c20f6c8c6a47", size = 551343, upload-time = "2026-05-28T12:00:58.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c1/1be13327acdbead3eca1fde03b6a34dbb011f1e864e217f0d32cc1779a7f/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:036a36a87fb1cd3b214d11c4b3c4f7d2ddad933625dca1c900b56a057c07740a", size = 618502, upload-time = "2026-05-28T12:01:00.656Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d7/afb49b49d7f2be8b7ba1a9f0977fa5168003437b93086726f066544e8351/rpds_py-2026.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:62ae3853454fe9ef283a03c96c2d835d39e84b14643a9d62c82ef0fb87d702ca", size = 581916, upload-time = "2026-05-28T12:01:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/25/d1/dbef8c1f8a10f07beb62b5f054e20099fd9924b3ec001b8f0b6ac7813a85/rpds_py-2026.5.1-cp314-cp314t-win32.whl", hash = "sha256:6c3d771a46ec18b12af06ce36243a9a80b07a5d0515236332d90863ca8bb326a", size = 207855, upload-time = "2026-05-28T12:01:03.821Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/72/bfa4e61ab8e7dc1c8adf397e05e6cbdd4239357bd72b248d3de662f23915/rpds_py-2026.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c93c629be4636cf54337bd5f06c104d55e42ced54d681f6fe21ae510a65116f6", size = 225422, upload-time = "2026-05-28T12:01:05.194Z" },
+    { url = "https://files.pythonhosted.org/packages/27/3a/7b5da92b640f67b6717ccafc83cdd06bfa7ff2395c3685c68922bb54d703/rpds_py-2026.5.1-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:3574b55c604b8f75dacb007136508bbc0db406e626301778096a133327e7f2fb", size = 349576, upload-time = "2026-05-28T12:01:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/8a/2aafd7ad355a1bd48ca76e2262b74b15e6432b5a1efe150efd4d779cd55d/rpds_py-2026.5.1-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:94068eb3ae6d43f5a786b7db96a406a34e6d5c24489feef32fd6e8946ea7b291", size = 343640, upload-time = "2026-05-28T12:01:08.441Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7d/6c9523c1abbe840a1b7fba3c516d48e1d3487cc80fea4366c4071cf56784/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3a5b10e8ce894825f380a8f1b6444cf73c294dfea62afbb2d13e3a9e630cec1", size = 375322, upload-time = "2026-05-28T12:01:09.934Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5d/0b7b03fb1dc509321f01de3149784ab773e34c8573022029af8076afcb9c/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fc09f82e63d4bcd58149572f857a431bae851dc747e313c3b5bdf7abb907fda8", size = 379066, upload-time = "2026-05-28T12:01:11.48Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/e2/8ef6012999ebf1cb1c22f876d9ce5e63d960fd4631d2af3202d3f480aa25/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e10464d17df3b582745c25cec695cb9558bca2cb6ddb631aee1787fc72c767b2", size = 494586, upload-time = "2026-05-28T12:01:13.051Z" },
+    { url = "https://files.pythonhosted.org/packages/80/af/1eeb029bec67582c226b7809172207cd005073af4ebd906e65ff494f4983/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba05adbf15d994c38ec0b7ab32e858e5110c21e9009a00a86545fd220f84e038", size = 388415, upload-time = "2026-05-28T12:01:14.631Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/ffbe10711c4d766c1cab0557d6906c074f795814863c67b351355d29354a/rpds_py-2026.5.1-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77c004fdc7b891967106f78ddfd7b076bfe6813c6139c6fff6aed3bcaa960b26", size = 372427, upload-time = "2026-05-28T12:01:16.153Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3a/30ba4a6ad457e5b070c18d742a33fb77d8d922b565cc881f8a5313d63bfe/rpds_py-2026.5.1-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:83bcf894486c9d78dd290d3c0124ff6dd8875d3025e2090a8ec49fcc37c55fdd", size = 383615, upload-time = "2026-05-28T12:01:17.809Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/69/62e242b53ce39c0814bd24e1a6e6eba6c92be716277745f317f9540a2e7b/rpds_py-2026.5.1-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c3df104083952a0e0c6f10de33e440eabe98fb6317d23e1a58c68f6df08d01b9", size = 402786, upload-time = "2026-05-28T12:01:19.419Z" },
+    { url = "https://files.pythonhosted.org/packages/38/c1/a770b9c186928a1ed0f7e6d7ae50e7f3950ed23e3f9e366dbc8e38cb55de/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:980450826cf22e133c57e0835070bdd0dd3f73b9b708c3ce223def2cb9469e14", size = 551583, upload-time = "2026-05-28T12:01:21.013Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7c/68e8579b95375b70d2a963103c42e705856cdb98569258bd807f4423891c/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:205dde846f24332ab0c1188699a043b8d165b79bb84529ce272c45048ff6be01", size = 616941, upload-time = "2026-05-28T12:01:22.548Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a1/a6135aed5730ff03ab957182259987ac11e55fb392a28dc6f0592048a280/rpds_py-2026.5.1-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:3966b82dd563176396df030f3dd52a6e54cb69b718e95e78bd555ed3d1e0185d", size = 578349, upload-time = "2026-05-28T12:01:24.118Z" },
+    { url = "https://files.pythonhosted.org/packages/09/6e/f24201a76a84e6c49d0bdfdfcb735210e21701e9b21c5bfc0ba497dd62f6/rpds_py-2026.5.1-cp315-cp315-win32.whl", hash = "sha256:7818f8d0a415be74d2be3590b0a1c1f463a642f4d0217e7d10602dceef5b79aa", size = 209922, upload-time = "2026-05-28T12:01:25.522Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e4/966bc240bb0485fc265278f6de44d05834bf0b3618886e0b22e33d54c49a/rpds_py-2026.5.1-cp315-cp315-win_amd64.whl", hash = "sha256:b3cc20c0d800af78fd0fac68086e28c1856cec51ea528bb81ea851aa40d39325", size = 226003, upload-time = "2026-05-28T12:01:27.062Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5c/a15a59269cd5e74472734516c73795c15eccfc841b3d4b0228c3f53f19d0/rpds_py-2026.5.1-cp315-cp315-win_arm64.whl", hash = "sha256:3609e9939a8a76cd904cf98a3f1f13b5dc7e150adeaee89e0ea09652ea213e16", size = 221245, upload-time = "2026-05-28T12:01:28.51Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/135ce03804e179a71ceb13be095deda4a279bc88f7a6b8fa161c5ad44e12/rpds_py-2026.5.1-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:5d333a7127d4b307601ac37792bee01bb95c867cbfacf21b6375b804d6bbd723", size = 352015, upload-time = "2026-05-28T12:01:30.214Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/5f/f1f6d2652eb9d848f6eb369d8db83a2da6249bb49ad2c2a48f45d54538d3/rpds_py-2026.5.1-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:b5f077b44a4f7808520f66dae234988d867deb9aed9be5da057ce9ba831b2a41", size = 345016, upload-time = "2026-05-28T12:01:31.656Z" },
+    { url = "https://files.pythonhosted.org/packages/88/66/b74182775691ea2290c99e52ac8d5db844e56fbec90ce421f107658c8314/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55d8f9b7b78c9538fc9e04e82ec0e888ff0c3cffcfad152c77e57cd09351a98a", size = 374775, upload-time = "2026-05-28T12:01:33.136Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8f/15e5a61d9f0a43902d36561d4f07cae6ae9f4716be825159fd72717f33af/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e3a8ae58895ac107ed934a6bf51e5846f95c53b9b940c2c6d310838fd5846358", size = 380270, upload-time = "2026-05-28T12:01:34.574Z" },
+    { url = "https://files.pythonhosted.org/packages/02/c3/f859b12763a80540cdf2af0f15b19904cf756a71d7bdd3f82ff3e5b1bbf9/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0957cf3c2b8632ec7aaebffebea8005b353cc2a237b6e2ae3c2cac0820704cfb", size = 495285, upload-time = "2026-05-28T12:01:36.127Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c7/ff27c2ac8411d30b03b1829fd88cae8dad1a4d0da48dd25e57c4038042e6/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c396c1304de421050b3681ea70f371874b54d41b0151e96109758144c231e30b", size = 389581, upload-time = "2026-05-28T12:01:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/67/fe92ee32a6cc05c77228a2f8b1762e7124f386ec20ff83d0757b762d58d0/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aad1bff7f666b9598e573815affd666aac6a13a585dde336f843e33350c7fadc", size = 376041, upload-time = "2026-05-28T12:01:39.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/b4d6685c27aba55bd82f25b278be8237038117d05f9659a6213ad3408130/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:656a042550878f12d45752452d47094b7cfe5ad1e9d7b87b5a22ad3ae5ff8015", size = 383946, upload-time = "2026-05-28T12:01:41.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/79/2c1d832a53c8e0f8e98fc970ec257b950fecd4f62be2ab7182b500a0cbc8/rpds_py-2026.5.1-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:73c4bd4f70294737b5206a3e8e30ccadbf8a60301831c8ea23eec5dbeea1ecfa", size = 405526, upload-time = "2026-05-28T12:01:43.032Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c4/c98117b03c6a8581ab2c2dfccfe9a5ad82bd8128a3c28b46a6ad2d97c393/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:43bca78665423cabae77146f2fe7ce55272b6c8d55d82cca83effd42c7e13972", size = 551165, upload-time = "2026-05-28T12:01:44.648Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/c1/bc479ca069200af730881b1bd525e3114b2b391a351509fcb1b772f28086/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:42d0f20e85e549c870749d0e247f0c10d318a45b7e9676d575d2dcb04a1b2e66", size = 618778, upload-time = "2026-05-28T12:01:46.337Z" },
+    { url = "https://files.pythonhosted.org/packages/77/65/38ab2f90df44c2febfb63cc10ced40763d9b4bc94d173e734528663fe7f5/rpds_py-2026.5.1-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b1be5c35683684d5331b93600c210e8367c254683d8a6df6bd21bd2da3a334fb", size = 581839, upload-time = "2026-05-28T12:01:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/15/2d/ce1f605fe036aadd460e5822e578c6c7ec3a860936cca37d6e0f299daa77/rpds_py-2026.5.1-cp315-cp315t-win32.whl", hash = "sha256:75808f6c38ce7749bb68cc2770161aae5045e6c6f6781a9782e74b93304399df", size = 207866, upload-time = "2026-05-28T12:01:49.648Z" },
+    { url = "https://files.pythonhosted.org/packages/79/cb/966040123eb102371559746908ef2c9471f4d43e17ec9a645a2258dab64b/rpds_py-2026.5.1-cp315-cp315t-win_amd64.whl", hash = "sha256:90bd6630002a1c7f09e7843dd79f0d24f3d2897cc25a753480917865d14f15b3", size = 225441, upload-time = "2026-05-28T12:01:51.408Z" },
 ]
 
 [[package]]
@@ -1533,6 +1677,7 @@ name = "smacc"
 source = { editable = "." }
 dependencies = [
     { name = "blinkstick", marker = "sys_platform == 'win32'" },
+    { name = "jsonschema" },
     { name = "matplotlib" },
     { name = "mne" },
     { name = "numpy" },
@@ -1570,6 +1715,7 @@ docs = [
 requires-dist = [
     { name = "blinkstick", marker = "sys_platform == 'win32'" },
     { name = "import-linter", marker = "extra == 'dev'" },
+    { name = "jsonschema", specifier = ">=4.26.0" },
     { name = "matplotlib", specifier = ">=3.7" },
     { name = "mdformat", marker = "extra == 'docs'" },
     { name = "mdformat-frontmatter", marker = "extra == 'docs'" },


### PR DESCRIPTION
Serves the `.smacc` file as a first-class authoring surface for power users who edit the YAML directly — **derived from the model so it can't drift**. The last issue of milestone #7.

## JSON Schema, generated from `StudyConfig` (`smacc.schema`)
`build_schema()` builds the schema for a `.smacc` from the model: the settings keys and each key's base JSON type come straight from `StudyConfig.to_settings_dict` (the canonical flat projection); only **refinements** — enums, numeric ranges, and the cue/event/biocal item shapes — are declared. So there's no second hand-maintained schema to drift: the committed `assets/smacc-schema.json` is regenerated from `build_schema()`, and a test fails if it's out of date (the **"regenerated in CI"** check). Pure / Qt-free.

```console
$ SMACC validate study.smacc
study.smacc: valid.

$ SMACC validate broken.smacc
error: settings: Additional properties are not allowed ('bogus_key' was unexpected)
error: noise_color: 'chartreuse' is not one of ['white', 'pink', 'brown']
error: noise_volume: 2.5 is greater than the maximum of 1
broken.smacc: invalid (3 error(s), 0 warning(s)).   # exit 1
```

## Editor autocomplete (publishing)
A `# yaml-language-server: $schema=` modeline is written into **every saved file's header** and the shipped **`default.smacc`** template, pointing at the committed schema — so an editor that supports it gives autocomplete and validation while hand-editing. The URL lives in `smacc.config` (shared by `settings.py` and `schema.py` without an import cycle).

## `SMACC validate <file>` (`smacc.validate`)
Dispatched from `__main__` before any `QApplication`, it reports **graded** issues and exits non-zero only on errors:
- **structural** — the file is a SMACC settings file (`load_settings`);
- **schema** — types / enums / ranges / unknown-key typos, via the model-derived schema (`jsonschema`, imported optionally — the check degrades gracefully if a build lacks it, so the command never crashes);
- **registry** — the safety-critical event-code checks from `events.validate_events` (duplicate / out-of-range codes are errors; a TTL code above the safe max is a warning).

`jsonschema` added as a runtime dependency.

## Tests
Schema validity + drift + key-coverage; the CLI on valid / malformed / non-SMACC / duplicate-code / safe-max-warning files. Full suite **green (1200)**, ruff / mypy / import-linter clean.

## Deferred
The docs page describing the editor-agnostic workflow is left for your docs overhaul (no `docs/` pages touched here).

Closes #302.